### PR TITLE
feat: add product development workflow commands and skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,10 @@ node_modules/
 # .claude-plugin/ - tracked (for Claude Code marketplace)
 
 # Root-level build outputs (deprecated - use dist/)
-skills/
-agents/
-commands/
-hooks.json
+/skills/
+/agents/
+/commands/
+/hooks.json
 
 # OS files
 .DS_Store

--- a/dist/codex/skills/debugging/SKILL.md
+++ b/dist/codex/skills/debugging/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: debugging
+description: >-
+  Use for systematic bug investigation and diagnosis. Covers hypothesis-driven
+  debugging workflows, multi-hypothesis tracking, language-specific debugging
+  patterns (Python, TypeScript, Ruby), and test debugging (flaky tests,
+  isolation, state pollution). Activate when investigating failures, debugging
+  production issues, or diagnosing test problems.
+version: 1.11.0
+---
+
+# Systematic Debugging
+
+Hypothesis-driven investigation for efficient and traceable bug diagnosis.
+
+## Philosophy
+
+**Eliminate, don't guess.** Debugging is a process of elimination, not random modification. Each change should test a specific hypothesis and provide evidence to rule it out or confirm it.
+
+**Multiple hypotheses, ranked.** Never fixate on one theory. Generate 3-5 plausible hypotheses, rank by likelihood, and test the most likely first. Surprising evidence should trigger hypothesis revision.
+
+**Reproduce before investigating.** A bug you cannot reproduce is a bug you cannot fix with confidence. Establish reliable reproduction steps before diving into code.
+
+**Minimal changes, maximum information.** Each debugging step should change one variable and maximize the information gained. Shotgun debugging wastes time and obscures root causes.
+
+## Quick Reference
+
+| Situation | Approach | Key Technique |
+|-----------|----------|---------------|
+| **Unknown failure** | Generate hypotheses | List 3-5 possible causes, rank by likelihood |
+| **Intermittent bug** | Isolate variables | Binary search through conditions |
+| **Test flakiness** | Check state pollution | Run test in isolation, check fixtures |
+| **Production issue** | Preserve evidence | Capture logs/state before attempting fixes |
+
+## Topics
+
+| Topic | Reference | Use For |
+|-------|-----------|---------|
+| Hypothesis Tracking | `references/hypothesis-tracking.md` | Multi-hypothesis workflow, session templates, investigation logs |
+| Language Debugging | `references/language-debugging.md` | Python, TypeScript, Ruby debug patterns and tools |
+| Test Debugging | `references/test-debugging.md` | Flaky tests, isolation, state pollution, environment differences |
+
+## Critical Rules
+
+### Always
+
+- Generate multiple hypotheses before investigating
+- Document each hypothesis and its current status
+- Establish reproduction steps before attempting fixes
+- Test one variable at a time
+- Preserve evidence (logs, state, stack traces) before changes
+- Update hypothesis status based on evidence
+- Record failed attempts to avoid repeating them
+
+### Never
+
+- Make random changes hoping something works
+- Fix symptoms without understanding root cause
+- Assume the first hypothesis is correct
+- Skip reproduction verification after a "fix"
+- Delete logs or error output before analysis
+- Change multiple variables simultaneously
+- Ignore contradictory evidence
+
+## Debugging Workflow
+
+```
+1. REPRODUCE: Establish reliable reproduction steps
+2. HYPOTHESIZE: Generate 3-5 possible causes, rank by likelihood
+3. TEST: Design experiment to test highest-likelihood hypothesis
+4. EVALUATE: Analyze results, update hypothesis status
+5. ITERATE: Move to next hypothesis or refine based on evidence
+6. VERIFY: Confirm fix addresses root cause, not just symptoms
+```
+
+## Investigation Log Format
+
+Keep a timestamped log of investigation steps:
+
+```
+[HH:MM] Testing H2 (stale cache)
+        Action: Cleared Redis, restarted service
+        Result: Still failing
+        Evidence: Error occurs before cache read in stack trace
+        Status: H2 RULED OUT
+
+[HH:MM] Testing H3 (race condition)
+        Action: Added mutex around shared state
+        Result: SUCCESS - no failures in 100 runs
+        Evidence: Stack trace showed concurrent access
+        Status: H3 CONFIRMED
+```
+
+## Related Skills
+
+- `foundations` - Test patterns, error handling, logging standards
+- `python` - Python-specific debugging tools (pdb, logging)
+- `typescript` - TypeScript debugging (Chrome DevTools, source maps)
+- `ruby` - Ruby debugging (binding.irb, byebug)

--- a/dist/codex/skills/debugging/references/hypothesis-tracking.md
+++ b/dist/codex/skills/debugging/references/hypothesis-tracking.md
@@ -1,0 +1,168 @@
+# Hypothesis Tracking
+
+Systematic workflow for generating, testing, and tracking multiple debugging hypotheses.
+
+## Multi-Hypothesis Workflow
+
+### 1. Generate Hypotheses
+
+Before investigating, brainstorm 3-5 possible causes. Consider:
+
+- **Recent changes** - What changed since it last worked?
+- **Common culprits** - Race conditions, caching, state mutation, null references
+- **Environment differences** - Dev vs prod, different data, timing
+- **External dependencies** - API changes, network issues, third-party services
+
+### 2. Rank by Likelihood
+
+Assign likelihood based on:
+
+| Factor | Higher Likelihood | Lower Likelihood |
+|--------|-------------------|------------------|
+| Recency | Code changed recently | Untouched for months |
+| Complexity | Complex logic, many branches | Simple, well-tested |
+| Dependencies | External services involved | Self-contained |
+| Symptoms | Matches known failure pattern | Novel error |
+
+### 3. Test Systematically
+
+For each hypothesis (highest likelihood first):
+
+1. **Design minimal experiment** - What single change would confirm or rule out this hypothesis?
+2. **Predict outcome** - What result do you expect if hypothesis is correct?
+3. **Execute and observe** - Run experiment, capture results
+4. **Update status** - Mark CONFIRMED, RULED OUT, or NEEDS MORE DATA
+
+### 4. Revise Based on Evidence
+
+When evidence contradicts expectations:
+
+- Lower likelihood of current hypothesis
+- Consider what the evidence suggests instead
+- Add new hypotheses if needed
+- Re-rank based on new information
+
+## Session Template
+
+Use this template at the start of debugging sessions:
+
+```markdown
+## Debug Investigation
+
+**Symptom**: [What's failing - exact error message or behavior]
+**First observed**: [When did this start happening]
+**Reproduction**: [Steps to reliably reproduce]
+
+### Environment
+- OS/Platform:
+- Version:
+- Dependencies:
+- Data state:
+
+### Hypothesis Tracker
+
+| # | Hypothesis | Likelihood | Status | Evidence |
+|---|------------|------------|--------|----------|
+| H1 | [Description] | High/Med/Low | TESTING/RULED OUT/CONFIRMED | [What you learned] |
+| H2 | [Description] | High/Med/Low | PENDING | - |
+| H3 | [Description] | High/Med/Low | PENDING | - |
+
+### Investigation Log
+[Timestamped entries below]
+```
+
+## Example Investigation
+
+### Symptom
+API returns 500 error intermittently on `/api/orders` endpoint.
+
+### Reproduction
+1. Create 10+ concurrent requests to `/api/orders`
+2. ~30% return 500 errors
+3. Only happens under load
+
+### Hypothesis Tracker
+
+| # | Hypothesis | Likelihood | Status | Evidence |
+|---|------------|------------|--------|----------|
+| H1 | Database connection pool exhausted | High | RULED OUT | Pool metrics show 50% utilization during failures |
+| H2 | Race condition in order validation | High | TESTING | Errors correlate with concurrent creates |
+| H3 | Memory pressure causing timeouts | Medium | PENDING | - |
+| H4 | Third-party payment API rate limiting | Low | RULED OUT | Payment API logs show no rate limits |
+
+### Investigation Log
+
+```
+[14:32] Testing H1 (connection pool)
+        Action: Monitored pool metrics during load test
+        Result: Pool never exceeded 50% capacity
+        Evidence: Prometheus shows max 5/10 connections used
+        Status: H1 RULED OUT - pool is not the bottleneck
+
+[14:45] Testing H4 (payment API rate limiting)
+        Action: Checked payment provider dashboard
+        Result: No rate limit events in their logs
+        Evidence: All payment API calls successful
+        Status: H4 RULED OUT
+
+[15:01] Testing H2 (race condition)
+        Action: Added logging around order validation
+        Result: Found concurrent access to shared cart state
+        Evidence: Logs show two requests modifying same cart simultaneously
+        Status: H2 LIKELY - need to verify with fix
+
+[15:23] Verifying H2 fix
+        Action: Added mutex around cart validation
+        Result: 0 errors in 1000 concurrent requests
+        Evidence: Lock prevents concurrent modification
+        Status: H2 CONFIRMED - race condition was root cause
+```
+
+## Hypothesis Status Definitions
+
+| Status | Meaning | Next Action |
+|--------|---------|-------------|
+| PENDING | Not yet investigated | Move to TESTING when ready |
+| TESTING | Currently being investigated | Execute experiment, gather evidence |
+| NEEDS MORE DATA | Inconclusive results | Design better experiment |
+| RULED OUT | Evidence contradicts hypothesis | Document and move on |
+| LIKELY | Evidence supports but not conclusive | Verify with fix |
+| CONFIRMED | Root cause identified and verified | Document fix and close |
+
+## Common Hypothesis Categories
+
+### State-Related
+- Stale cache returning old data
+- Database transaction not committed
+- In-memory state mutation
+- Session/cookie corruption
+
+### Timing-Related
+- Race condition between concurrent operations
+- Timeout too short for slow operations
+- Clock skew between services
+- Event ordering assumptions violated
+
+### Environment-Related
+- Missing environment variable
+- Different library versions
+- File permissions
+- Network connectivity/latency
+
+### Data-Related
+- Null/undefined where unexpected
+- Type mismatch (string vs number)
+- Encoding issues (UTF-8, special characters)
+- Data exceeds expected bounds
+
+## Tips for Effective Hypothesis Tracking
+
+1. **Be specific** - "Something wrong with caching" is not a hypothesis. "Redis TTL set to 0 causing immediate expiration" is.
+
+2. **Make them testable** - Every hypothesis should have a clear experiment that could rule it out.
+
+3. **Update in real-time** - Log entries as you go, not from memory later.
+
+4. **Don't delete** - Ruled-out hypotheses are valuable documentation of what was tried.
+
+5. **Share context** - If handing off, the tracker should let someone else continue without starting over.

--- a/dist/codex/skills/debugging/references/language-debugging.md
+++ b/dist/codex/skills/debugging/references/language-debugging.md
@@ -1,0 +1,354 @@
+# Language-Specific Debugging
+
+Debug patterns and tools for Python, TypeScript, and Ruby.
+
+## Python Debugging
+
+### Interactive Debugging with pdb
+
+```python
+# Insert breakpoint in code
+import pdb; pdb.set_trace()
+
+# Python 3.7+ built-in
+breakpoint()
+
+# Conditional breakpoint
+if suspicious_condition:
+    breakpoint()
+```
+
+**Common pdb commands:**
+
+| Command | Action |
+|---------|--------|
+| `n` (next) | Execute next line |
+| `s` (step) | Step into function |
+| `c` (continue) | Continue to next breakpoint |
+| `p expr` | Print expression value |
+| `pp expr` | Pretty-print expression |
+| `l` (list) | Show current code context |
+| `w` (where) | Print stack trace |
+| `u` (up) | Move up stack frame |
+| `d` (down) | Move down stack frame |
+| `q` (quit) | Exit debugger |
+
+### Structured Logging
+
+```python
+import structlog
+
+logger = structlog.get_logger()
+
+# Add context that persists across log calls
+logger = logger.bind(request_id=request.id, user_id=user.id)
+
+# Log with structured data
+logger.info("order_created", order_id=order.id, total=order.total)
+logger.error("payment_failed",
+    order_id=order.id,
+    error_code=e.code,
+    error_message=str(e)
+)
+```
+
+### Traceback Analysis
+
+```python
+import traceback
+
+try:
+    risky_operation()
+except Exception as e:
+    # Full traceback as string
+    tb_str = traceback.format_exc()
+    logger.error("operation_failed", traceback=tb_str)
+
+    # Extract specific frame info
+    tb = traceback.extract_tb(e.__traceback__)
+    for frame in tb:
+        logger.debug("frame",
+            filename=frame.filename,
+            line=frame.lineno,
+            function=frame.name
+        )
+```
+
+### pytest Debugging
+
+```bash
+# Drop into debugger on failure
+pytest --pdb
+
+# Drop into debugger on first failure, then exit
+pytest -x --pdb
+
+# Show local variables in tracebacks
+pytest -l
+
+# Verbose output with print statements
+pytest -v -s
+
+# Run specific test
+pytest tests/test_orders.py::test_create_order -v
+```
+
+### Remote Debugging
+
+```python
+# Using debugpy (VS Code compatible)
+import debugpy
+debugpy.listen(5678)
+debugpy.wait_for_client()  # Pause until debugger attaches
+breakpoint()
+```
+
+## TypeScript Debugging
+
+### Console Methods
+
+```typescript
+// Basic logging
+console.log('value:', value);
+console.error('Error:', error);
+console.warn('Warning:', message);
+
+// Structured output
+console.table(arrayOfObjects);
+console.dir(complexObject, { depth: null });
+
+// Timing
+console.time('operation');
+// ... operation ...
+console.timeEnd('operation');
+
+// Grouping related logs
+console.group('Request Processing');
+console.log('Step 1');
+console.log('Step 2');
+console.groupEnd();
+
+// Conditional logging
+console.assert(condition, 'Condition failed:', data);
+
+// Stack trace without error
+console.trace('How did we get here?');
+```
+
+### Debugger Statement
+
+```typescript
+function processOrder(order: Order): void {
+  // Pauses execution when DevTools is open
+  debugger;
+
+  // Conditional debugger
+  if (order.total > 10000) {
+    debugger;
+  }
+}
+```
+
+### Source Maps
+
+Ensure `tsconfig.json` has source maps enabled:
+
+```json
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "inlineSources": true
+  }
+}
+```
+
+For debugging bundled code, verify source maps are generated and served:
+
+```typescript
+// webpack.config.js
+module.exports = {
+  devtool: 'source-map', // Full source maps for debugging
+};
+```
+
+### Node.js Debugging
+
+```bash
+# Start with inspector
+node --inspect dist/server.js
+
+# Break on first line
+node --inspect-brk dist/server.js
+
+# With ts-node
+node --inspect -r ts-node/register src/server.ts
+```
+
+### Chrome DevTools Tips
+
+1. **Breakpoints**: Click line number in Sources panel
+2. **Conditional breakpoints**: Right-click line number, add condition
+3. **Logpoints**: Right-click, add logpoint (logs without pausing)
+4. **Watch expressions**: Add variables to Watch panel
+5. **Call stack**: Navigate up/down the call stack
+6. **Scope**: Inspect local, closure, and global variables
+
+### Async Debugging
+
+```typescript
+// Capture async stack traces
+Error.stackTraceLimit = 50;
+
+// Label promises for debugging
+const result = await Promise.race([
+  fetchData().then(data => ({ source: 'fetch', data })),
+  timeout(5000).then(() => ({ source: 'timeout', data: null }))
+]);
+console.log('Winner:', result.source);
+```
+
+## Ruby Debugging
+
+### binding.irb (Ruby 2.5+)
+
+```ruby
+def process_order(order)
+  # Opens interactive console at this point
+  binding.irb
+
+  order.validate!
+end
+```
+
+**IRB commands in binding.irb:**
+
+| Command | Action |
+|---------|--------|
+| `exit` | Continue execution |
+| `exit!` | Exit program |
+| `whereami` | Show current code context |
+| `show_source method_name` | Show method source |
+
+### byebug
+
+```ruby
+# Gemfile
+gem 'byebug', group: [:development, :test]
+
+# In code
+require 'byebug'
+
+def process_order(order)
+  byebug  # Execution stops here
+  order.validate!
+end
+```
+
+**byebug commands:**
+
+| Command | Action |
+|---------|--------|
+| `n` (next) | Execute next line |
+| `s` (step) | Step into method |
+| `c` (continue) | Continue execution |
+| `f` (finish) | Run until current method returns |
+| `p expr` | Evaluate expression |
+| `info locals` | Show local variables |
+| `bt` (backtrace) | Show call stack |
+| `up` / `down` | Navigate stack frames |
+
+### Rails Console Debugging
+
+```ruby
+# Start console
+rails console
+
+# Reload after code changes
+reload!
+
+# Find and inspect objects
+user = User.find(123)
+user.attributes
+user.orders.to_sql  # See generated SQL
+
+# Test in sandbox (rollback on exit)
+rails console --sandbox
+```
+
+### Rails Logger
+
+```ruby
+# In application code
+Rails.logger.debug "Processing order: #{order.id}"
+Rails.logger.info "Order created", order_id: order.id
+Rails.logger.error "Payment failed", error: e.message
+
+# Tagged logging
+Rails.logger.tagged("OrderService", order.id) do
+  Rails.logger.info "Starting processing"
+end
+
+# Tail logs
+tail -f log/development.log
+```
+
+### pry-rails
+
+```ruby
+# Gemfile
+gem 'pry-rails', group: [:development, :test]
+
+# In code
+binding.pry  # Opens Pry console
+
+# Pry commands
+ls object          # List methods/variables
+cd object          # Change context to object
+show-source method # Show method definition
+show-doc method    # Show documentation
+wtf?               # Show last exception
+```
+
+### Exception Debugging
+
+```ruby
+begin
+  risky_operation
+rescue => e
+  # Full backtrace
+  puts e.backtrace.join("\n")
+
+  # Filtered backtrace (Rails)
+  puts Rails.backtrace_cleaner.clean(e.backtrace).join("\n")
+
+  # Re-raise with context
+  raise "Order processing failed for order #{order.id}: #{e.message}"
+end
+```
+
+## Cross-Language Tips
+
+### Binary Search Debugging
+
+When you have a long sequence of operations and don't know where the failure occurs:
+
+1. Add logging/breakpoint at the midpoint
+2. Determine if failure is before or after
+3. Repeat with the relevant half
+4. Continue until you isolate the exact line
+
+### Minimal Reproduction
+
+1. Remove code until bug disappears
+2. Add back the last removed piece
+3. That piece contains or triggers the bug
+4. Create minimal test case that reproduces
+
+### Rubber Duck Debugging
+
+When stuck:
+
+1. Explain the code line-by-line out loud
+2. Explain what you expect vs. what happens
+3. Explain your hypotheses and why each might be wrong
+4. Often, articulating the problem reveals the solution

--- a/dist/codex/skills/debugging/references/test-debugging.md
+++ b/dist/codex/skills/debugging/references/test-debugging.md
@@ -1,0 +1,326 @@
+# Test Debugging
+
+Strategies for diagnosing flaky tests, isolation failures, and environment-related test issues.
+
+## Flaky Test Diagnosis
+
+A flaky test passes sometimes and fails sometimes with the same code. Common causes:
+
+### Timing Dependencies
+
+**Symptoms:**
+- Test passes locally, fails in CI
+- Test fails more often under load
+- Adding `sleep()` makes it pass
+
+**Investigation:**
+```python
+# Bad: Depends on timing
+def test_async_operation():
+    start_async_job()
+    time.sleep(1)  # Hope it's done
+    assert job_completed()
+
+# Good: Wait for condition
+def test_async_operation():
+    start_async_job()
+    wait_for(lambda: job_completed(), timeout=5)
+    assert job_completed()
+```
+
+**Diagnosis steps:**
+1. Run test 100 times in a loop
+2. Monitor CPU/memory during failures
+3. Add timestamps to understand timing
+4. Check for hardcoded timeouts that are too short
+
+### Order Dependencies
+
+**Symptoms:**
+- Test passes when run alone, fails in suite
+- Test fails only when run after specific other test
+- Reordering tests changes results
+
+**Investigation:**
+```bash
+# pytest: Run in random order
+pytest --random-order
+
+# Find the guilty test pair
+pytest tests/test_a.py tests/test_b.py -v  # Passes
+pytest tests/test_b.py tests/test_a.py -v  # Fails?
+```
+
+**Common culprits:**
+- Global state modified by previous test
+- Database records not cleaned up
+- Cached values persisting
+- Module-level side effects
+
+### Non-Deterministic Data
+
+**Symptoms:**
+- Fails occasionally with no pattern
+- Different assertion failures each time
+- Works with specific seed/data
+
+**Investigation:**
+```python
+# Bad: Non-deterministic
+def test_random_selection():
+    items = get_random_items(10)
+    assert len(items) == 10  # What if source has < 10?
+
+# Good: Control randomness
+def test_random_selection():
+    random.seed(42)
+    items = get_random_items(10)
+    assert len(items) == 10
+```
+
+## Test Isolation Patterns
+
+### Database Isolation
+
+```python
+# pytest with transactions
+@pytest.fixture
+def db_session(engine):
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()
+```
+
+```ruby
+# Rails transactional tests
+class OrderTest < ActiveSupport::TestCase
+  # Each test runs in a transaction that rolls back
+  self.use_transactional_tests = true
+
+  test "creates order" do
+    order = Order.create!(total: 100)
+    assert order.persisted?
+  end  # Order is rolled back
+end
+```
+
+### External Service Isolation
+
+```python
+# Mock external services
+@pytest.fixture
+def mock_payment_api(mocker):
+    return mocker.patch(
+        'app.services.payment.PaymentAPI.charge',
+        return_value={'status': 'success', 'id': 'ch_123'}
+    )
+
+def test_order_payment(mock_payment_api):
+    order = create_order(total=100)
+    order.process_payment()
+
+    mock_payment_api.assert_called_once_with(amount=100)
+    assert order.payment_status == 'paid'
+```
+
+### Time Isolation
+
+```python
+# Freeze time for deterministic tests
+from freezegun import freeze_time
+
+@freeze_time("2024-01-15 12:00:00")
+def test_order_expiry():
+    order = create_order()
+    assert not order.expired
+
+    with freeze_time("2024-01-16 12:00:01"):
+        assert order.expired  # 24+ hours later
+```
+
+```typescript
+// Jest fake timers
+jest.useFakeTimers();
+
+test('order expires after 24 hours', () => {
+  const order = createOrder();
+  expect(order.expired).toBe(false);
+
+  jest.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
+  expect(order.expired).toBe(true);
+});
+```
+
+## State Pollution Detection
+
+### Symptoms
+
+- Test A passes alone, fails after test B
+- Test fails only when suite runs in specific order
+- "Works on my machine" syndrome
+
+### Detection Strategy
+
+```bash
+# 1. Run suspect test in isolation
+pytest tests/test_orders.py::test_specific -v
+
+# 2. Run with a known "polluter"
+pytest tests/test_other.py tests/test_orders.py::test_specific -v
+
+# 3. Binary search for the polluter
+pytest tests/test_orders.py::test_specific --last-failed
+```
+
+### Common State Pollution Sources
+
+| Source | Detection | Fix |
+|--------|-----------|-----|
+| Module globals | Check imports for mutations | Use fixtures, reset in teardown |
+| Class variables | Look for `cls.` modifications | Use instance variables |
+| Singletons | Check shared instances | Reset or mock singletons |
+| Environment variables | Print env in failing test | Restore in teardown |
+| File system | Check for temp files | Use tmp directories, clean up |
+| Database | Check for leftover records | Transaction rollback |
+| Caches | Check memoized values | Clear caches in setup |
+
+### Teardown Pattern
+
+```python
+@pytest.fixture(autouse=True)
+def reset_global_state():
+    # Setup: Save original state
+    original_config = app.config.copy()
+
+    yield
+
+    # Teardown: Restore original state
+    app.config = original_config
+    cache.clear()
+```
+
+## Environment Differences
+
+### Local vs CI Failures
+
+| Difference | Detection | Solution |
+|------------|-----------|----------|
+| Timing | CI slower, races more likely | Use proper waits, not sleeps |
+| Resources | CI has less memory/CPU | Check resource usage |
+| Parallelism | CI runs tests in parallel | Ensure isolation |
+| File paths | Different temp directories | Use portable paths |
+| Timezone | CI uses UTC | Freeze time or use UTC |
+| Locale | CI uses different locale | Set locale explicitly |
+
+### Debugging CI-Only Failures
+
+```yaml
+# GitHub Actions: Enable debug logging
+env:
+  ACTIONS_STEP_DEBUG: true
+  ACTIONS_RUNNER_DEBUG: true
+
+# Add verbose output
+steps:
+  - name: Run tests
+    run: |
+      echo "=== Environment ==="
+      env | sort
+      echo "=== Python version ==="
+      python --version
+      echo "=== Running tests ==="
+      pytest -v --tb=long
+```
+
+### Reproducing CI Environment Locally
+
+```bash
+# Docker: Use same image as CI
+docker run -it --rm -v $(pwd):/app -w /app python:3.11 bash
+pip install -r requirements.txt
+pytest
+
+# Act: Run GitHub Actions locally
+act -j test
+
+# Environment parity
+export CI=true
+export TZ=UTC
+pytest
+```
+
+## Test Debugging Workflow
+
+### 1. Isolate the Failure
+
+```bash
+# Run failing test alone
+pytest tests/test_orders.py::test_failing -v
+
+# If it passes alone, find the interaction
+pytest --collect-only | head -20  # See test order
+```
+
+### 2. Add Diagnostic Output
+
+```python
+def test_order_processing(caplog):
+    with caplog.at_level(logging.DEBUG):
+        order = process_order(data)
+
+    print(f"Captured logs: {caplog.text}")
+    print(f"Order state: {order.__dict__}")
+    assert order.status == "completed"
+```
+
+### 3. Minimize the Test
+
+```python
+# Start with failing test
+def test_order_processing():
+    user = create_user()
+    product = create_product()
+    cart = create_cart(user, product)
+    order = create_order(cart)
+    payment = process_payment(order)
+    shipment = create_shipment(order)
+    assert shipment.status == "ready"
+
+# Remove pieces until bug disappears
+def test_order_processing_minimal():
+    order = create_order()  # Minimal setup
+    assert order.status == "pending"  # Bug is here!
+```
+
+### 4. Check Assumptions
+
+```python
+def test_order_total():
+    order = create_order()
+
+    # Verify assumptions
+    print(f"Order items: {order.items}")
+    print(f"Item prices: {[i.price for i in order.items]}")
+    print(f"Expected total: {sum(i.price for i in order.items)}")
+    print(f"Actual total: {order.total}")
+
+    assert order.total == Decimal("100.00")
+```
+
+## Flaky Test Prevention
+
+| Practice | Why It Helps |
+|----------|--------------|
+| Use factories, not fixtures | Fresh data each test |
+| Avoid shared state | Tests can't pollute each other |
+| Mock time and randomness | Deterministic behavior |
+| Use transactions | Auto-cleanup |
+| Run tests in random order | Catch order dependencies |
+| Run tests in parallel | Catch isolation issues |
+| Set explicit timeouts | Fail fast on hangs |

--- a/dist/codex/skills/foundations/SKILL.md
+++ b/dist/codex/skills/foundations/SKILL.md
@@ -36,6 +36,7 @@ Engineering foundations for consistent, secure, and well-documented code.
 |-------|-----------|---------|
 | Code Style | `reference/code-style.md` | Python/TypeScript conventions, naming, patterns |
 | Commits | `reference/commits.md` | Commit messages, branches, PRs, Linear integration |
+| Diagrams | `reference/diagrams.md` | Mermaid syntax, when to diagram, storage patterns |
 | Documentation | `reference/documentation.md` | ADRs, API docs, changelogs |
 | Security | `reference/security.md` | Threat modeling, secrets, compliance |
 | Permissions | `reference/permissions.md` | Tool allowlists, sandbox config, agent permissions |

--- a/dist/codex/skills/foundations/references/diagrams.md
+++ b/dist/codex/skills/foundations/references/diagrams.md
@@ -1,0 +1,248 @@
+# Architecture Diagrams
+
+Guidelines for creating Mermaid diagrams to visualize system architecture and data flows.
+
+## When to Create Diagrams
+
+Create architecture diagrams when work involves:
+
+| Scenario | Diagram Type | Why |
+|----------|--------------|-----|
+| Multi-service changes | Component/flowchart | Shows interaction points and dependencies |
+| Data flow changes | Sequence/flowchart | Traces data through the system |
+| Schema modifications | ERD | Visualizes table relationships |
+| API design | Sequence | Documents request/response flows |
+| State machine logic | State diagram | Clarifies transitions and conditions |
+| Complex conditionals | Flowchart | Makes branching logic explicit |
+
+### Skip Diagrams When
+
+- Single-file changes with obvious scope
+- Bug fixes with no architectural impact
+- Configuration-only changes
+- Test additions (unless testing complex flows)
+
+## Mermaid Syntax Quick Reference
+
+### Flowchart (Most Common)
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Action 1]
+    B -->|No| D[Action 2]
+    C --> E[End]
+    D --> E
+```
+
+**Direction options:** `TD` (top-down), `LR` (left-right), `BT` (bottom-top), `RL` (right-left)
+
+**Node shapes:**
+- `[Rectangle]` - Process/action
+- `{Diamond}` - Decision
+- `([Stadium])` - Start/end
+- `[(Database)]` - Database
+- `((Circle))` - Connector
+
+### Sequence Diagram (API/Service Interaction)
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as API
+    participant D as Database
+
+    C->>A: POST /auth/login
+    A->>D: Query user
+    D-->>A: User record
+    A-->>C: JWT token
+```
+
+**Arrow types:**
+- `->>` Solid line with arrowhead (sync call)
+- `-->>` Dashed line with arrowhead (response)
+- `--)` Async message
+
+### Entity Relationship Diagram (Schema)
+
+```mermaid
+erDiagram
+    USER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT ||--o{ LINE_ITEM : "ordered in"
+
+    USER {
+        uuid id PK
+        string email
+        timestamp created_at
+    }
+    ORDER {
+        uuid id PK
+        uuid user_id FK
+        decimal total
+    }
+```
+
+**Relationship notation:**
+- `||` One (required)
+- `o|` Zero or one
+- `}|` One or many
+- `}o` Zero or many
+
+### State Diagram (State Machines)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Pending: submit
+    Pending --> Approved: approve
+    Pending --> Rejected: reject
+    Approved --> [*]
+    Rejected --> Draft: revise
+```
+
+### Component Diagram (System Architecture)
+
+```mermaid
+flowchart LR
+    subgraph Frontend
+        UI[Web App]
+    end
+
+    subgraph Backend
+        API[FastAPI]
+        Worker[Celery]
+    end
+
+    subgraph Data
+        DB[(PostgreSQL)]
+        Cache[(Redis)]
+    end
+
+    UI --> API
+    API --> DB
+    API --> Cache
+    API --> Worker
+    Worker --> DB
+```
+
+## Storage Patterns
+
+### Inline in Session File
+
+Best for: Diagrams specific to current work, temporary visualizations
+
+```markdown
+## Architecture Diagrams
+
+### Auth Flow
+```mermaid
+sequenceDiagram
+    User->>API: Login request
+    API->>DB: Validate credentials
+    DB-->>API: User record
+    API-->>User: JWT token
+```
+**Purpose**: Visualize the authentication flow being implemented
+**Files involved**: `backend/auth/`, `backend/models/user.py`
+```
+
+### Stored in `.agents/diagrams/`
+
+Best for: Reusable diagrams, cross-session reference, team documentation
+
+```
+.agents/diagrams/
+├── system-architecture.md
+├── auth-flow.md
+└── data-pipeline.md
+```
+
+**Diagram file format:**
+
+```markdown
+---
+created: 2025-01-23T14:00:00Z
+last_updated: 2025-01-23T14:00:00Z
+tags: [auth, api, security]
+---
+
+# Auth Flow Diagram
+
+## Overview
+
+Documents the authentication and authorization flow for the API.
+
+## Diagram
+
+```mermaid
+[diagram content]
+```
+
+## Related Files
+
+- `backend/auth/jwt.py` - JWT generation
+- `backend/middleware/auth.py` - Auth middleware
+- `backend/models/user.py` - User model
+
+## Notes
+
+Any additional context about this diagram.
+```
+
+### When to Store vs Inline
+
+| Store in `.agents/diagrams/` | Keep Inline in Session |
+|------------------------------|------------------------|
+| Referenced by multiple sessions | One-time visualization |
+| Documents stable architecture | Documents work-in-progress |
+| Shared across team members | Personal understanding aid |
+| Likely to be updated | Disposable after task |
+
+## Best Practices
+
+### Keep Diagrams Focused
+
+```markdown
+# Good: Single concern
+Auth flow diagram showing login -> validate -> token
+
+# Bad: Everything at once
+Entire system with auth, billing, notifications, logging...
+```
+
+### Use Consistent Naming
+
+```markdown
+# In diagrams, use actual names from code
+API[auth-service]  # Matches service name
+DB[(users)]        # Matches table name
+
+# Not generic placeholders
+API[Service A]
+DB[(Database)]
+```
+
+### Add Context
+
+Every diagram needs:
+1. **Purpose** - Why this diagram exists
+2. **Files involved** - What code it represents
+3. **Limitations** - What it does NOT show
+
+### Update When Code Changes
+
+Diagrams are documentation. When the code they represent changes:
+1. Update the diagram
+2. Update `last_updated` timestamp
+3. Note the change in session log
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Diagram everything | Diagram only complex flows |
+| Include implementation details | Show architectural relationships |
+| Create diagrams after code | Create during planning |
+| Leave stale diagrams | Update or delete |
+| Use inconsistent notation | Follow Mermaid conventions |

--- a/dist/codex/skills/orchestration/SKILL.md
+++ b/dist/codex/skills/orchestration/SKILL.md
@@ -37,11 +37,18 @@ Every release should be complete, polished, and delightful - no MVPs or quick ha
 | Stuck on task | Check circuit breaker, consider reshaping |
 | Pre-compaction | Spawn context-archiver to preserve state |
 | Low-priority work | Spawn background-runner with run_in_background |
+| New feature workflow | Research → Architecture → PRD → Specs → Tasks |
+| Create specification | Use `/specs` with requirement reference |
+| Break down spec | Use `/tasks` to generate atomic work items |
+| Task-coupled session | Use `/start-session TASK-XXX` for traceability |
 
 ## Topics
 
 | Topic | Reference | Key Content |
 |-------|-----------|-------------|
+| Product Development | [reference/product-development.md](reference/product-development.md) | Full workflow: Research → Vision → Architecture → Requirements → Specs → Tasks |
+| Specifications | [reference/specs.md](reference/specs.md) | Spec format, lifecycle, shaping, test conditions |
+| Local Tasks | [reference/local-tasks.md](reference/local-tasks.md) | Task format, abstraction layer, Linear/local backend |
 | Agent Delegation | [reference/delegation.md](reference/delegation.md) | Agent capabilities, spawn patterns, decision tree |
 | Background Agents | [reference/background-agents.md](reference/background-agents.md) | Non-interactive work, spawn with run_in_background |
 | Council Workflow | [reference/councils.md](reference/councils.md) | Composition, deliberation, synthesis, user approval |

--- a/dist/codex/skills/orchestration/SKILL.md
+++ b/dist/codex/skills/orchestration/SKILL.md
@@ -36,12 +36,14 @@ Every release should be complete, polished, and delightful - no MVPs or quick ha
 | Agent selection | Match domain expertise to task |
 | Stuck on task | Check circuit breaker, consider reshaping |
 | Pre-compaction | Spawn context-archiver to preserve state |
+| Low-priority work | Spawn background-runner with run_in_background |
 
 ## Topics
 
 | Topic | Reference | Key Content |
 |-------|-----------|-------------|
 | Agent Delegation | [reference/delegation.md](reference/delegation.md) | Agent capabilities, spawn patterns, decision tree |
+| Background Agents | [reference/background-agents.md](reference/background-agents.md) | Non-interactive work, spawn with run_in_background |
 | Council Workflow | [reference/councils.md](reference/councils.md) | Composition, deliberation, synthesis, user approval |
 | Session Management | [reference/sessions.md](reference/sessions.md) | Lifecycle, file format, handoffs, validation |
 | Session Resume | [reference/session-resume.md](reference/session-resume.md) | CLI flags, checkpoints, context recovery |

--- a/dist/codex/skills/orchestration/references/background-agents.md
+++ b/dist/codex/skills/orchestration/references/background-agents.md
@@ -1,0 +1,236 @@
+# Background Agents
+
+Background agents handle low-priority, long-running, or non-interactive work that can run independently while the user continues with other tasks.
+
+## When to Use Background Agents
+
+| Appropriate | Not Appropriate |
+|-------------|-----------------|
+| Security audits | Interactive debugging |
+| Code coverage analysis | User-facing questions |
+| Large-scale refactoring reports | Time-sensitive fixes |
+| Codebase-wide linting reports | Tasks requiring immediate feedback |
+| Documentation audits | Work needing user decisions mid-task |
+| Dependency vulnerability scans | Blocking tasks for current work |
+
+**Good candidates:**
+- Results can be processed later
+- No user interaction required
+- Task is well-defined with clear completion criteria
+- Output is a report or artifact, not a conversation
+
+**Poor candidates:**
+- Needs clarification mid-task
+- Time-sensitive (user waiting for result)
+- Requires real-time coordination with other agents
+
+## Spawning Background Agents
+
+### Claude Code
+
+Use the Task tool with `run_in_background: true`:
+
+```python
+Task(
+    subagent_type="background-runner",
+    prompt="""
+    Run full security audit on backend codebase.
+
+    Scope:
+    - src/api/
+    - src/services/
+
+    Write report to: .agents/reports/YYYYMMDD-HHMMSS-security-audit.md
+
+    Session: .agents/sessions/20260123-143000-auth-feature.md
+    """,
+    run_in_background=True
+)
+```
+
+### Cursor
+
+Background agents are configured via the `is_background: true` YAML property. When spawning:
+
+```
+@background-runner Run security audit on backend codebase.
+Write report to .agents/reports/
+```
+
+## Background Agent Tracking
+
+Track background agents in session frontmatter:
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security-scan"
+    agent: background-runner
+    task: "Full security audit of backend"
+    status: running  # running | completed | failed
+    result_location: null
+  - id: "bg-20260123-144500-coverage"
+    agent: background-runner
+    task: "Test coverage analysis"
+    status: completed
+    result_location: ".agents/reports/20260123-144500-coverage-report.md"
+```
+
+### Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `running` | Agent still executing |
+| `completed` | Work finished, results available |
+| `failed` | Agent encountered error |
+
+### ID Convention
+
+Background agent IDs follow: `bg-YYYYMMDD-HHMMSS-<description>`
+
+Generate with:
+```bash
+echo "bg-$(date -u +"%Y%m%d-%H%M%S")-<description>"
+```
+
+## Result Retrieval
+
+Background agents write results to `.agents/reports/` with standard frontmatter:
+
+```yaml
+---
+report:
+  title: "Security Audit Report"
+  type: background-agent-output
+  status: unprocessed  # unprocessed | processed | archived
+  created: "2026-01-23T14:30:00Z"
+  background_agent_id: "bg-20260123-143000-security-scan"
+  session_reference: "20260123-140000-auth-feature.md"
+---
+```
+
+### Processing Results
+
+1. SessionStart hook alerts user to completed background work
+2. User or PM reviews report in `.agents/reports/`
+3. PM updates session frontmatter:
+   - Change `status` from `running` to `completed`
+   - Set `result_location` to report path
+4. Process findings as needed (spawn agents, create issues)
+5. Set report `status` to `processed`
+
+## Workflow Example
+
+### 1. PM Identifies Low-Priority Work
+
+During auth feature implementation, PM identifies need for security audit but it is not blocking current work.
+
+### 2. PM Spawns Background Agent
+
+```python
+Task(
+    subagent_type="background-runner",
+    prompt="""
+    Run comprehensive security audit on auth implementation.
+
+    Files to audit:
+    - src/auth/endpoints.py
+    - src/auth/token.py
+    - src/auth/middleware.py
+
+    Check for:
+    - OWASP Top 10 vulnerabilities
+    - Secrets in code
+    - SQL injection risks
+    - Authentication bypasses
+
+    Write report to: .agents/reports/20260123-143000-auth-security.md
+
+    Session: .agents/sessions/20260123-140000-auth-feature.md
+    """,
+    run_in_background=True
+)
+```
+
+### 3. PM Updates Session Frontmatter
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-auth-security"
+    agent: background-runner
+    task: "Auth security audit"
+    status: running
+    result_location: null
+```
+
+### 4. Work Continues
+
+PM and other agents continue with main implementation while background agent works.
+
+### 5. Session Resumes Later
+
+SessionStart hook detects completed background work:
+
+```
+# Background Work Completed
+
+The following background agents have completed:
+
+- **bg-20260123-143000-auth-security** (background-runner)
+  - Task: Auth security audit
+  - Result: .agents/reports/20260123-143000-auth-security.md
+
+Review reports and update session frontmatter after processing.
+```
+
+### 6. Results Processed
+
+PM reads report, creates issues for findings, updates session.
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Use for blocking work | Keep blocking work in foreground |
+| Spawn without tracking | Always update session frontmatter |
+| Ignore completed results | Process results when alerted |
+| Use for interactive tasks | Reserve for autonomous work |
+| Spawn many concurrent background agents | Limit to 2-3 to avoid resource contention |
+| Skip result location in prompt | Always specify where to write output |
+
+## Integration Points
+
+### SessionStart Hook
+
+Checks session frontmatter for `background_agents` with `status: completed`. Alerts user to review results.
+
+### PreCompact Hook
+
+Includes background agent state in preservation. Context-archiver captures:
+- Active background agent list
+- Current status of each
+- Result locations for completed agents
+
+### Session Frontmatter
+
+Full template with background agents:
+
+```yaml
+---
+session:
+  title: "Feature implementation"
+  status: in_progress
+  # ... other session fields ...
+
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: completed
+    result_location: ".agents/reports/20260123-143000-security.md"
+  - id: "bg-20260123-150000-coverage"
+    agent: background-runner
+    task: "Coverage analysis"
+    status: running
+    result_location: null
+---
+```

--- a/dist/codex/skills/orchestration/references/cross-session.md
+++ b/dist/codex/skills/orchestration/references/cross-session.md
@@ -1,0 +1,200 @@
+# Cross-Session References
+
+Patterns for importing decisions and context from past sessions into current work without duplicating full context.
+
+## When to Reference Past Sessions
+
+### Good Reasons to Reference
+
+- **Continuing related work**: Building on previous feature decisions
+- **Consistency**: Ensuring alignment with prior architectural choices
+- **Avoiding re-deliberation**: Council decisions already made on similar topics
+- **Context recovery**: Picking up work after long gaps
+
+### Skip Referencing When
+
+- Starting genuinely new work unrelated to past sessions
+- Past decisions are documented in ADRs (use ADRs instead)
+- Context would create more noise than value
+- Decisions were superseded or invalidated
+
+## What to Import
+
+### Decisions Only (Default)
+
+Import the distilled outcomes:
+
+```markdown
+## Referenced Decisions
+
+### From: 20250115-140000-auth-jwt.md
+
+#### Decision: Token Rotation Strategy
+**Decision**: Rotate every 15 minutes
+**Rationale**: Security/UX balance
+```
+
+**Why decisions only:**
+- Minimal context footprint
+- Focus on outcomes, not process
+- Easy to scan and validate relevance
+
+### Context Summary (When Needed)
+
+Import broader context when:
+- Problem space is complex and unfamiliar
+- Technical approach was non-obvious
+- Multiple related decisions form a coherent strategy
+
+```markdown
+## Referenced Context
+
+### From: 20250115-140000-auth-jwt.md
+
+**Problem**: Session management for distributed services
+**Approach**: JWT with refresh token rotation
+**Key Files**: `src/auth/`, `src/middleware/auth.py`
+**Outcome**: Implemented, deployed to production 2025-01-20
+```
+
+## Session Frontmatter for Tracking
+
+Track all cross-session references in frontmatter:
+
+```yaml
+---
+session:
+  title: "Auth V2 Implementation"
+  status: in_progress
+  created: "2025-01-23T10:00:00Z"
+  last_updated: "2025-01-23T14:30:00Z"
+  linear_issue: "PLT-200"
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"
+      imported_at: "2025-01-23T14:30:00Z"
+      content_type: decisions
+      decisions_imported:
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+    - session: "20250110-090000-auth-oauth.md"
+      imported_at: "2025-01-23T14:35:00Z"
+      content_type: context
+      summary: "OAuth provider integration patterns"
+
+orchestration:
+  current_task: "Implement token refresh endpoint"
+---
+```
+
+## Decision Memory Format
+
+When sessions are archived, decisions are extracted to Serena memory:
+
+```markdown
+# Memory: session-auth-jwt-decisions.md
+
+## Session Context
+- **Session**: 20250115-140000-auth-jwt.md
+- **Archived**: 2025-01-15T18:00:00Z
+- **Linear Issue**: PLT-123
+
+## Key Decisions
+
+### Decision 1: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window refresh
+**Rationale**: Balances security (limited token lifetime) with UX (seamless refresh)
+**Council**: None - backend-dev recommendation accepted
+
+### Decision 2: Refresh Token Storage
+**Decision**: Store refresh tokens in HttpOnly cookies, not localStorage
+**Rationale**: Prevents XSS-based token theft; aligns with OWASP recommendations
+**Council**: Security council (5 agents) - unanimous
+
+### Decision 3: Token Validation Order
+**Decision**: Validate signature before parsing claims
+**Rationale**: Fail fast on tampered tokens; reduce processing for invalid requests
+**Council**: None - standard security practice
+```
+
+## Workflow
+
+### At Archive Time (context-archiver)
+
+1. Read session file
+2. Check for `## Decisions` section
+3. If present, run `extract-decisions.py`
+4. Write output to Serena memory via MCP
+
+### At Reference Time (/reference-session)
+
+1. Search Serena memories for matching sessions
+2. Read selected decision memory
+3. Import into current session
+4. Track in `referenced_sessions` frontmatter
+
+## Serena MCP Integration
+
+### List Available Decision Memories
+
+```python
+mcp__serena__list_memories()
+# Filter results for: session-*-decisions.md
+```
+
+### Read Decision Memory
+
+```python
+mcp__serena__read_memory(name="session-auth-jwt-decisions.md")
+```
+
+### Write Decision Memory (at archive time)
+
+```python
+mcp__serena__write_memory(
+    name="session-auth-jwt-decisions.md",
+    content=extracted_decisions_markdown
+)
+```
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Import entire session files | Import only decisions/summaries |
+| Import without tracking | Update `referenced_sessions` in frontmatter |
+| Import unrelated sessions | Search by topic, Linear issue, or keyword |
+| Duplicate ADR content | Reference the ADR directly |
+| Import stale decisions | Verify decisions are still relevant |
+| Over-reference | Import only what's needed for current work |
+| Reference without reading | Always review imported content for relevance |
+
+## When Decisions Conflict
+
+If imported decisions conflict with current approach:
+
+1. **Note the conflict** in session file
+2. **Assess if prior decision still applies**
+   - Different context? Proceed with new approach
+   - Same context? Consider why original decision was made
+3. **Document the change** if deviating
+4. **Consider council** if uncertainty remains
+5. **Update ADRs** if architectural decision changes
+
+## Best Practices
+
+1. **Reference early** - Import relevant decisions before planning
+2. **Validate relevance** - Review each decision's applicability
+3. **Track everything** - All imports go in frontmatter
+4. **Summarize in session log** - Note what was imported and why
+5. **Don't over-import** - Less is more for context management
+6. **Update if superseding** - Mark old decisions as superseded when creating new ones
+
+## Example Session Log Entry
+
+```markdown
+### 2025-01-23 14:30 - PM
+Referenced decisions from auth-jwt session (PLT-123):
+- Token rotation strategy (15-min window)
+- Refresh token storage (HttpOnly cookies)
+Relevant to current auth-v2 work; maintaining consistency.
+```

--- a/dist/codex/skills/orchestration/references/local-tasks.md
+++ b/dist/codex/skills/orchestration/references/local-tasks.md
@@ -1,0 +1,276 @@
+# Local Task Management
+
+Break specs into atomic tasks using local files when Linear isn't available.
+
+## Task Abstraction Layer
+
+Tasks work identically whether backed by Linear or local files.
+
+### Configuration
+
+```yaml
+# .agents/loaf.yaml
+task_management:
+  backend: linear  # or "local"
+
+  linear:
+    team: ProjectName
+    default_labels: []
+
+  local:
+    archive_completed: true
+    directory: .agents/tasks
+```
+
+### Abstracted Operations
+
+| Operation | Linear | Local |
+|-----------|--------|-------|
+| Create task | Create issue | Write `.agents/tasks/active/TASK-*.md` |
+| Fetch task | Get issue | Read task file |
+| Update status | Update issue | Edit frontmatter |
+| List tasks | List issues | Glob task files |
+| Complete | Move to Done | Move to archive |
+
+## Local Task Format
+
+```yaml
+---
+id: TASK-001
+title: OAuth Provider Integration
+spec: SPEC-001
+status: todo  # todo | in_progress | review | done
+priority: P1  # P0 (urgent) | P1 (high) | P2 (normal) | P3 (low)
+created: 2026-01-23T14:30:00Z
+updated: 2026-01-23T14:30:00Z
+files:
+  - src/auth/oauth.py
+  - tests/auth/test_oauth.py
+verify: pytest tests/auth/test_oauth.py
+done: OAuth flow works for Google and GitHub
+---
+
+# TASK-001: OAuth Provider Integration
+
+## Description
+
+Implement OAuth provider integration for Google and GitHub following
+the approach outlined in SPEC-001.
+
+## Acceptance Criteria
+
+- [ ] Google OAuth flow completes successfully
+- [ ] GitHub OAuth flow completes successfully
+- [ ] Tokens stored securely in session
+- [ ] Error handling for failed auth
+- [ ] Unit tests pass
+
+## Context
+
+See SPEC-001 for full context and constraints.
+Reference ADR-001 for session storage decisions.
+
+## Work Log
+
+<!-- Updated by session as work progresses -->
+```
+
+**Location:** `.agents/tasks/active/TASK-001-oauth-provider.md`
+
+## Task Lifecycle
+
+```
+todo → in_progress → review → done
+  │        │           │        │
+  └────────┴───────────┴────────┘
+           can return to earlier states
+```
+
+| Status | Meaning |
+|--------|---------|
+| `todo` | Ready to work, not started |
+| `in_progress` | Actively being worked |
+| `review` | Implementation complete, needs verification |
+| `done` | Verified complete, ready for archive |
+
+## Creating Tasks from Specs
+
+### Input
+
+- Spec ID (e.g., `SPEC-001`)
+- Optional: priority override
+
+### Task Breakdown Rules
+
+1. **One concern per task** - Don't mix backend + tests + frontend
+2. **Clear done condition** - Observable, verifiable outcome
+3. **Verification command** - How to prove it works
+4. **File hints** - Which files will likely be modified
+
+### Example Breakdown
+
+```
+SPEC-001: User Authentication with OAuth
+        ↓
+TASK-001: OAuth Provider Integration
+  - Google OAuth client setup
+  - GitHub OAuth client setup
+  - Token exchange logic
+  verify: pytest tests/auth/test_oauth.py
+
+TASK-002: Session Management
+  - Session cookie handling
+  - Session storage (Redis/DB)
+  - Session expiry logic
+  verify: pytest tests/auth/test_session.py
+
+TASK-003: Login UI Components
+  - Login page layout
+  - Provider buttons
+  - Error states
+  verify: npm run test:e2e -- auth
+```
+
+## Directory Structure
+
+```
+.agents/tasks/
+├── active/                    # Current work
+│   ├── TASK-001-oauth-provider.md
+│   ├── TASK-002-session-management.md
+│   └── TASK-003-login-ui.md
+└── archive/                   # Completed work
+    └── 2026-01/              # Organized by month
+        └── TASK-000-initial-setup.md
+```
+
+## Task ID Generation
+
+Format: `TASK-{number}-{slug}`
+
+```bash
+# Find next available number
+ls .agents/tasks/active/ .agents/tasks/archive/*/ 2>/dev/null | \
+  grep -oE 'TASK-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+## Archiving Tasks
+
+When a task is done:
+
+1. Update status to `done`
+2. Add completion timestamp
+3. Move to archive:
+
+```bash
+mkdir -p .agents/tasks/archive/$(date +%Y-%m)
+mv .agents/tasks/active/TASK-001-*.md .agents/tasks/archive/$(date +%Y-%m)/
+```
+
+## Session Integration
+
+When `/start-session TASK-001`:
+
+1. Read task file for context
+2. Read linked spec for full picture
+3. Create session with traceability:
+
+```yaml
+session:
+  title: "OAuth Provider Integration"
+  task: TASK-001
+  spec: SPEC-001
+  status: in_progress
+
+traceability:
+  requirement: "2.1 User Authentication"
+  architecture:
+    - "Session Management"
+  decisions:
+    - ADR-001
+```
+
+## Priority Levels
+
+| Priority | Meaning | Response |
+|----------|---------|----------|
+| P0 | Urgent/blocking | Drop everything |
+| P1 | High | Work next |
+| P2 | Normal | Scheduled work |
+| P3 | Low | When time permits |
+
+## Listing Tasks
+
+### All Active Tasks
+
+```bash
+for f in .agents/tasks/active/TASK-*.md; do
+  id=$(grep '^id:' "$f" | cut -d: -f2 | tr -d ' ')
+  title=$(grep '^title:' "$f" | cut -d: -f2-)
+  status=$(grep '^status:' "$f" | cut -d: -f2 | tr -d ' ')
+  echo "$id [$status] $title"
+done
+```
+
+### Tasks for a Spec
+
+```bash
+grep -l "spec: SPEC-001" .agents/tasks/active/*.md
+```
+
+## Work Log Updates
+
+As work progresses, append to the Work Log section:
+
+```markdown
+## Work Log
+
+### 2026-01-23 14:30 UTC
+Started OAuth integration. Set up Google OAuth client credentials.
+
+### 2026-01-23 15:45 UTC
+Google OAuth working. Moving to GitHub integration.
+
+### 2026-01-23 17:00 UTC
+Both providers working. Tests pass. Moving to review.
+```
+
+## Verification
+
+Before marking `done`:
+
+1. Run the `verify` command from frontmatter
+2. Check all acceptance criteria are checked
+3. Ensure no regressions in related tests
+
+```bash
+# Run task verification
+verify_cmd=$(grep '^verify:' TASK-001-*.md | cut -d: -f2-)
+eval "$verify_cmd"
+```
+
+## Local vs Linear Comparison
+
+| Feature | Local | Linear |
+|---------|-------|--------|
+| No external dependency | yes | no |
+| Rich UI | no | yes |
+| Team collaboration | git-based | native |
+| Notifications | none | email/slack |
+| Reporting | manual | built-in |
+| Offline work | yes | limited |
+
+**Use local when:**
+- Solo project
+- No Linear access
+- Offline development
+- Simple task tracking
+
+**Use Linear when:**
+- Team collaboration needed
+- Rich workflow automation
+- Integration with other tools
+- Reporting requirements

--- a/dist/codex/skills/orchestration/references/product-development.md
+++ b/dist/codex/skills/orchestration/references/product-development.md
@@ -1,0 +1,234 @@
+# Product Development Workflow
+
+A Research → Vision → Architecture → Requirements → Specs → Tasks → Session workflow for structured product development.
+
+## Core Insight
+
+**Separate permanent project knowledge from ephemeral orchestration.**
+
+```
+docs/                               # Permanent project knowledge
+├── VISION.md                       # Strategic direction (evolves rarely)
+├── ARCHITECTURE.md                 # Technical design (evolves with learnings)
+├── REQUIREMENTS.md                 # Business/product rules (evolves with feedback)
+├── decisions/                      # Architecture Decision Records
+│   └── ADR-001-database-choice.md
+└── specs/                          # Feature specifications (temporary)
+    ├── SPEC-001-user-auth.md
+    └── archive/                    # Completed specs
+
+.agents/                            # Ephemeral orchestration
+├── loaf.yaml                       # Project config (task backend, etc.)
+├── sessions/                       # Active work contexts
+├── plans/                          # Implementation plans
+├── councils/                       # Deliberation records
+├── transcripts/                    # Archived conversation transcripts
+├── tasks/                          # Local tasks (when not using Linear)
+│   ├── active/
+│   │   └── TASK-001-oauth-provider.md
+│   └── archive/
+└── debug/                          # Persistent debug sessions
+```
+
+## The Hierarchy
+
+```
+RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS → SESSION
+    │         │          │              │           │        │        │
+/research  (manual)  /architecture    /prd       /specs   /tasks  /start-session
+    │                    │              │           │        │
+    └─► evolves ─────────┴──────────────┴───────────┴────────┘
+        VISION                                      (feedback loops)
+```
+
+**Each level breaks down the one above:**
+- Research informs/evolves Vision
+- Vision shapes Architecture
+- Architecture constrains Requirements
+- Requirements break into Specs
+- Specs break into Tasks
+- Tasks become Sessions
+
+## Commands Overview
+
+| Command | Input | Output | Purpose |
+|---------|-------|--------|---------|
+| `/research` | Topic or "project state" | Insights, brainstorm | Zoom out, evolve VISION |
+| `/architecture` | Decision question | ARCHITECTURE.md + ADR | Technical decisions |
+| `/prd` | Feature area | REQUIREMENTS.md section | Product/business rules |
+| `/specs` | Requirement reference | SPEC-001-*.md | Feature specifications |
+| `/tasks` | Spec reference | TASK-* files/issues | Atomic work items |
+| `/start-session` | TASK-ID | Session file | Execute a task |
+
+## Document Formats
+
+### VISION.md
+
+Strategic direction that evolves rarely. Contains:
+- Product purpose and target users
+- Core principles and values
+- Long-term direction
+- What makes this product unique
+
+### ARCHITECTURE.md
+
+Technical design that evolves with learnings:
+- System architecture overview
+- Technology choices and rationale
+- Integration patterns
+- Deployment model
+
+### REQUIREMENTS.md
+
+Business and product rules organized by domain:
+
+```markdown
+## 2. Identity & Access
+
+### 2.1 User Authentication
+
+**Business Rules**
+- Users authenticate via OAuth (Google, GitHub)
+- Sessions expire after 24 hours of inactivity
+- Failed login attempts logged for security
+
+**Acceptance Criteria**
+- [ ] User can sign in with Google
+- [ ] User can sign in with GitHub
+- [ ] Session persists across browser refresh
+- [ ] Logout clears session completely
+```
+
+### Architecture Decision Records (ADRs)
+
+```yaml
+---
+id: ADR-001
+title: "PostgreSQL as Required Database"
+status: Accepted  # Proposed | Accepted | Deprecated | Superseded
+date: 2026-01-23
+---
+
+# ADR-001: PostgreSQL as Required Database
+
+## Context
+[Why this decision is needed]
+
+## Decision
+[What was decided]
+
+## Consequences
+[Tradeoffs and implications]
+```
+
+**Location:** `docs/decisions/ADR-001-*.md`
+
+## Configuration
+
+```yaml
+# .agents/loaf.yaml
+project:
+  name: "My Project"
+
+task_management:
+  backend: linear  # or "local"
+
+  linear:
+    team: ProjectName
+
+  local:
+    archive_completed: true
+
+docs:
+  vision: docs/VISION.md
+  architecture: docs/ARCHITECTURE.md
+  requirements: docs/REQUIREMENTS.md
+  decisions: docs/decisions/
+  specs: docs/specs/
+```
+
+## Workflow Examples
+
+### Full Workflow (New Feature)
+
+```bash
+# 1. Zoom out, check project state
+/research "project state"
+# → Lessons learned, ideas for auth improvement
+
+# 2. Make architecture decision
+/architecture "OAuth vs custom auth"
+# → Interview → ADR-001-auth-approach.md
+
+# 3. Capture requirements
+/prd "user authentication"
+# → Interview → REQUIREMENTS.md section 2.1
+
+# 4. Create specification
+/specs "2.1 User Authentication"
+# → Interview → SPEC-001-user-auth.md
+
+# 5. Generate tasks
+/tasks SPEC-001
+# → TASK-001, TASK-002, TASK-003
+
+# 6. Work on tasks
+/start-session TASK-001
+# → Session → Implementation → Done
+```
+
+### Quick Fix (Ad-hoc)
+
+```bash
+# Create task directly (bug report, small fix)
+/start-session TASK-099
+# PM: "No parent spec. Proceed?"
+# User: "Yes, small fix"
+# → Session → Fix → Done
+```
+
+## Feedback Loops
+
+The workflow is not rigid. Each level can feed back to higher levels:
+
+| Discovery | Action |
+|-----------|--------|
+| Implementation reveals design flaw | Update ARCHITECTURE.md |
+| Edge case invalidates requirement | Update REQUIREMENTS.md |
+| Spec too ambitious for appetite | Re-scope or split |
+| Task reveals missing requirement | Add to REQUIREMENTS.md |
+
+## Transcript Archival
+
+After `/compact` or `/clear`, archive conversation transcripts for future reference:
+
+1. **Copy transcript** to `.agents/transcripts/`
+2. **Link from session file** in frontmatter:
+
+```yaml
+session:
+  title: "Feature Implementation"
+  transcripts:
+    - 20260123-143500-pre-compact.jsonl
+    - 20260123-160000-final.jsonl
+```
+
+This preserves full context for debugging, knowledge extraction, and audit trails.
+
+## Flexibility Preserved
+
+1. **Skip steps** - Quick fixes don't need full workflow
+2. **Feedback loops** - Any level can evolve from learnings
+3. **Agents adapt** - Not a rigid harness
+
+## Critical Files
+
+| File | Purpose |
+|------|---------|
+| `docs/VISION.md` | Strategic direction |
+| `docs/ARCHITECTURE.md` | Technical design |
+| `docs/REQUIREMENTS.md` | Product rules |
+| `docs/decisions/ADR-*.md` | Architecture decisions |
+| `docs/specs/SPEC-*.md` | Feature specifications |
+| `.agents/tasks/active/TASK-*.md` | Local tasks |
+| `.agents/loaf.yaml` | Project configuration |

--- a/dist/codex/skills/orchestration/references/sessions.md
+++ b/dist/codex/skills/orchestration/references/sessions.md
@@ -68,6 +68,7 @@ session:
   branch: "username/back-123-feature"          # Optional: working branch
   transcripts: []                              # Archived Claude Code transcripts (filenames only)
                                                # Example: ["2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl"]
+  referenced_sessions: []                      # Cross-session references (see below)
 
 plans: []  # List of plan files in .agents/plans/ used by this session
            # Example: ["20251204-143500-api-design.md", "20251204-150000-frontend.md"]
@@ -79,8 +80,42 @@ orchestration:
       task: "Brief task description"
       status: completed                        # pending|in_progress|completed
       summary: "Outcome summary"
+
+background_agents:                             # Background work running independently
+  - id: "bg-20260123-143000-security-scan"     # ID: bg-YYYYMMDD-HHMMSS-description
+    agent: background-runner                   # Agent type
+    task: "Full security audit"                # Brief description
+    status: running                            # running|completed|failed
+    result_location: null                      # Path to report when complete
 ---
 ```
+
+### Cross-Session References
+
+Track decisions imported from past sessions via `/reference-session`:
+
+```yaml
+session:
+  # ... other fields ...
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"     # Source session filename
+      imported_at: "2025-01-23T14:30:00Z"        # When imported
+      content_type: decisions                     # decisions|context|all
+      decisions_imported:                         # List of decision titles
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+    - session: "20250110-090000-auth-oauth.md"
+      imported_at: "2025-01-23T14:35:00Z"
+      content_type: context
+      summary: "OAuth provider integration patterns"
+```
+
+**Why track references:**
+- Audit trail of where context came from
+- Avoids re-importing same decisions
+- Enables tracing decision lineage across sessions
+
+See `references/cross-session.md` for full patterns.
 
 ### Required Sections
 
@@ -160,6 +195,29 @@ Implementation plans for this session (stored in `.agents/plans/`):
 |------|--------|-------------|
 | [api-design](../plans/20251204-143500-api-design.md) | approved | API endpoint structure |
 | [frontend](../plans/20251204-150000-frontend.md) | pending | UI component design |
+
+## Architecture Diagrams
+
+### [Diagram Name]
+
+```mermaid
+[diagram content]
+```
+
+**Purpose**: Why this diagram helps understand the work
+**Files involved**: List of related file paths
+**Created**: When diagram was created (update if modified)
+
+<!--
+When to add diagrams:
+- Multi-service changes: Show interaction points
+- Data flow changes: Trace data through system
+- Schema modifications: Visualize relationships
+- API design: Document request/response flows
+
+For reusable diagrams, store in .agents/diagrams/ instead.
+See foundations skill reference/diagrams.md for Mermaid syntax.
+-->
 
 ## Council Outcomes
 

--- a/dist/codex/skills/orchestration/references/specs.md
+++ b/dist/codex/skills/orchestration/references/specs.md
@@ -1,0 +1,255 @@
+# Feature Specifications
+
+Break VISION + ARCHITECTURE + REQUIREMENTS into specific, implementable specs.
+
+## Philosophy
+
+**Specs are shaped solutions, not detailed designs.**
+
+A spec defines:
+- What problem we're solving
+- Boundaries (in/out of scope)
+- High-level approach
+- Test conditions
+
+A spec does NOT define:
+- Implementation details
+- Code structure
+- Exact UI layouts
+
+## Spec Format
+
+```yaml
+---
+id: SPEC-001
+title: "User Authentication with OAuth"
+requirement: "2.1 User Authentication"
+created: 2026-01-23T14:30:00Z
+status: drafting  # drafting | approved | implementing | complete
+appetite: "1 week"
+---
+
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+[From REQUIREMENTS 2.1 - why this matters to users and the business]
+
+## Proposed Solution
+
+[Shaped solution - high-level approach, not implementation details]
+
+## Scope
+
+### In Scope
+- OAuth: Google, GitHub
+- Session management with secure cookies
+- Login/logout UI
+
+### Out of Scope (Rabbit Holes)
+- Custom OAuth providers (avoid this complexity)
+- MFA (future spec if needed)
+- Password-based auth
+
+### No-Gos
+- Passwords in plaintext
+- Tokens in local storage
+- Session data in URLs
+
+## Test Conditions
+
+- [ ] OAuth flow completes for Google
+- [ ] OAuth flow completes for GitHub
+- [ ] Session persists across page refresh
+- [ ] Logout clears session completely
+- [ ] Invalid tokens are rejected
+
+## Implementation Notes
+
+[Architecture references, technical constraints, relevant ADRs]
+
+## Circuit Breaker
+
+At 50% appetite: if OAuth integration is problematic, simplify to single provider (Google only).
+```
+
+**Location:** `docs/specs/SPEC-001-feature-name.md`
+
+## Spec Lifecycle
+
+```
+drafting → approved → implementing → complete
+    │         │           │           │
+    └─────────┴───────────┴───────────┘
+              can return to drafting
+```
+
+| Status | Meaning |
+|--------|---------|
+| `drafting` | Being refined, not ready for work |
+| `approved` | User approved, ready for task breakdown |
+| `implementing` | Tasks created, work in progress |
+| `complete` | All tasks done, spec archived |
+
+## Creating Specs
+
+### Input Required
+
+1. **Requirement reference** - Which section of REQUIREMENTS.md
+2. **Appetite** - How much time is it worth (from Shape Up)
+
+### Interview Questions
+
+Before drafting, clarify:
+
+| Area | Questions |
+|------|-----------|
+| Scope | What's definitely in? What's definitely out? |
+| Rabbit holes | What seems related but should be avoided? |
+| No-gos | What approaches are forbidden? |
+| Test conditions | How do we know it works? |
+| Dependencies | What must exist first? |
+| Edge cases | What could go wrong? |
+
+### Writing the Spec
+
+1. **Start with Problem Statement** - Not "build X" but "solve Y"
+2. **Shape the solution** - Direction, not blueprint
+3. **Define boundaries explicitly** - In/out/no-gos
+4. **Write test conditions** - Observable outcomes
+5. **Set circuit breaker** - When to stop and reassess
+
+## Appetite Levels
+
+| Appetite | Size | Suitable For |
+|----------|------|--------------|
+| Small | 1-2 days | Bug fixes, minor enhancements |
+| Medium | 3-5 days | Feature additions, refactors |
+| Large | 1-2 weeks | Major features (rare) |
+
+If a spec can't fit the appetite, it needs more shaping or should be split.
+
+## Splitting Large Specs
+
+When a spec is too big:
+
+```
+SPEC-001-user-auth.md (large, 2 weeks)
+        ↓ split into
+SPEC-001a-oauth-integration.md (medium, 3 days)
+SPEC-001b-session-management.md (small, 2 days)
+SPEC-001c-login-ui.md (medium, 3 days)
+```
+
+Each sub-spec:
+- Has its own appetite
+- Can be worked independently
+- References the original requirement
+
+## Archiving Specs
+
+When all tasks for a spec are complete:
+
+1. Update status to `complete`
+2. Add completion date to frontmatter
+3. Move to `docs/specs/archive/`
+
+```bash
+mv docs/specs/SPEC-001-user-auth.md docs/specs/archive/
+```
+
+## Spec vs Plan
+
+| Spec | Plan |
+|------|------|
+| **What** to build | **How** to build it |
+| Lives in `docs/specs/` | Lives in `.agents/plans/` |
+| Survives sessions | Tied to session |
+| User-facing | Implementation detail |
+| Shape Up shaped | Tactical steps |
+
+Specs define the target. Plans define the route to get there.
+
+## Validation Checklist
+
+Before approving a spec:
+
+- [ ] Problem statement is clear and user-focused
+- [ ] Scope boundaries are explicit (in/out/no-gos)
+- [ ] Test conditions are observable and testable
+- [ ] Appetite is realistic for the scope
+- [ ] Circuit breaker is defined
+- [ ] Requirement reference is valid
+- [ ] No implementation details (those go in plans)
+
+## Example: Good vs Bad Specs
+
+### Bad Spec
+
+```markdown
+# SPEC-001: Add OAuth
+
+Add OAuth to the app.
+
+## Requirements
+- Add Google OAuth
+- Add session management
+- Add logout
+```
+
+Problems:
+- No problem statement
+- No scope boundaries
+- No test conditions
+- No appetite
+- Too vague to implement
+
+### Good Spec
+
+```markdown
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+Users currently can't access the application. We need a secure,
+frictionless login flow that leverages existing identity providers
+so users don't need to create yet another password.
+
+## Proposed Solution
+
+Implement OAuth 2.0 flow with Google and GitHub as initial providers.
+Store session in secure HTTP-only cookies. Provide clear login/logout UI.
+
+## Scope
+
+### In Scope
+- Google OAuth integration
+- GitHub OAuth integration
+- Session cookie management
+- Login page with provider buttons
+- Logout functionality
+
+### Out of Scope
+- Apple/Microsoft providers (future)
+- MFA (separate spec if needed)
+- Account linking (complex, avoid)
+
+### No-Gos
+- Storing tokens in localStorage
+- Custom password auth
+- Session data in URLs
+
+## Test Conditions
+
+- [ ] New user can sign in with Google
+- [ ] New user can sign in with GitHub
+- [ ] Session persists across browser tabs
+- [ ] Session survives page refresh
+- [ ] Logout clears all session data
+- [ ] Expired sessions redirect to login
+
+## Circuit Breaker
+
+At 50% appetite: if both providers are problematic, ship with Google only.
+GitHub can be a follow-up spec.
+```

--- a/dist/codex/skills/orchestration/scripts/extract-decisions.py
+++ b/dist/codex/skills/orchestration/scripts/extract-decisions.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Extract decisions from a session file and format as Serena memory.
+
+Usage: extract-decisions.py <session-file>
+
+Reads a session file, extracts the ## Decisions section, and outputs
+formatted Serena memory content to stdout. The output can be piped to
+Serena MCP's write_memory tool.
+
+Exit codes:
+  0 - Success (decisions extracted)
+  1 - Error (file not found, parse error)
+  2 - No decisions found
+"""
+
+import sys
+import re
+import yaml
+from pathlib import Path
+from datetime import datetime, timezone
+
+
+def parse_frontmatter(content: str) -> tuple[dict, str]:
+    """Extract YAML frontmatter from markdown content."""
+    if not content.startswith('---'):
+        return {}, content
+
+    parts = content.split('---', 2)
+    if len(parts) < 3:
+        return {}, content
+
+    try:
+        frontmatter = yaml.safe_load(parts[1])
+        body = parts[2]
+        return frontmatter or {}, body
+    except yaml.YAMLError as e:
+        print(f"Warning: Could not parse frontmatter: {e}", file=sys.stderr)
+        return {}, content
+
+
+def extract_decisions_section(body: str) -> str | None:
+    """Extract the ## Decisions section from markdown body."""
+    # Match ## Decisions followed by content until next ## or end
+    pattern = r'^## Decisions\s*\n(.*?)(?=^## |\Z)'
+    match = re.search(pattern, body, re.MULTILINE | re.DOTALL)
+
+    if match:
+        content = match.group(1).strip()
+        if content:
+            return content
+    return None
+
+
+def parse_decisions(decisions_text: str) -> list[dict]:
+    """Parse individual decisions from the decisions section."""
+    decisions = []
+
+    # Match ### Decision N: Title or ### Title patterns
+    pattern = r'^###\s+(?:Decision\s+\d+:\s+)?(.+?)\n(.*?)(?=^### |\Z)'
+    matches = re.findall(pattern, decisions_text, re.MULTILINE | re.DOTALL)
+
+    for title, content in matches:
+        decision = {
+            'title': title.strip(),
+            'decision': '',
+            'rationale': '',
+            'council': ''
+        }
+
+        # Extract **Decision**: value
+        decision_match = re.search(
+            r'\*\*Decision\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if decision_match:
+            decision['decision'] = decision_match.group(1).strip()
+
+        # Extract **Rationale**: value
+        rationale_match = re.search(
+            r'\*\*Rationale\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if rationale_match:
+            decision['rationale'] = rationale_match.group(1).strip()
+
+        # Extract **Council**: value (optional)
+        council_match = re.search(
+            r'\*\*Council\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if council_match:
+            decision['council'] = council_match.group(1).strip()
+
+        # Only add if we have at least a title and decision
+        if decision['title'] and decision['decision']:
+            decisions.append(decision)
+
+    return decisions
+
+
+def format_memory(
+    session_file: str,
+    frontmatter: dict,
+    decisions: list[dict]
+) -> str:
+    """Format decisions as Serena memory markdown."""
+    session = frontmatter.get('session', {})
+    title = session.get('title', 'Unknown Session')
+    linear_issue = session.get('linear_issue', 'N/A')
+    archived_at = session.get('archived_at', datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'))
+
+    # Generate slug from filename
+    filename = Path(session_file).stem
+    slug = re.sub(r'^\d{8}-\d{6}-', '', filename)
+
+    lines = [
+        f"# Memory: session-{slug}-decisions.md",
+        "",
+        "## Session Context",
+        f"- **Session**: {Path(session_file).name}",
+        f"- **Title**: {title}",
+        f"- **Archived**: {archived_at}",
+        f"- **Linear Issue**: {linear_issue}",
+        "",
+        "## Key Decisions",
+        ""
+    ]
+
+    for i, d in enumerate(decisions, 1):
+        lines.append(f"### Decision {i}: {d['title']}")
+        lines.append(f"**Decision**: {d['decision']}")
+        if d['rationale']:
+            lines.append(f"**Rationale**: {d['rationale']}")
+        if d['council']:
+            lines.append(f"**Council**: {d['council']}")
+        lines.append("")
+
+    return '\n'.join(lines)
+
+
+def generate_memory_name(session_file: str) -> str:
+    """Generate Serena memory name from session filename."""
+    filename = Path(session_file).stem
+    slug = re.sub(r'^\d{8}-\d{6}-', '', filename)
+    return f"session-{slug}-decisions.md"
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: extract-decisions.py <session-file>", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Extracts decisions from a session file and outputs Serena memory format.", file=sys.stderr)
+        print("The memory name will be: session-<slug>-decisions.md", file=sys.stderr)
+        sys.exit(1)
+
+    session_file = sys.argv[1]
+    filepath = Path(session_file)
+
+    if not filepath.exists():
+        print(f"Error: File not found: {session_file}", file=sys.stderr)
+        sys.exit(1)
+
+    content = filepath.read_text()
+    frontmatter, body = parse_frontmatter(content)
+
+    decisions_text = extract_decisions_section(body)
+    if not decisions_text:
+        print(f"No ## Decisions section found in: {session_file}", file=sys.stderr)
+        sys.exit(2)
+
+    decisions = parse_decisions(decisions_text)
+    if not decisions:
+        print(f"No parseable decisions found in: {session_file}", file=sys.stderr)
+        sys.exit(2)
+
+    # Output memory content to stdout
+    memory_content = format_memory(session_file, frontmatter, decisions)
+    print(memory_content)
+
+    # Output memory name to stderr for scripting
+    memory_name = generate_memory_name(session_file)
+    print(f"\n# Memory name: {memory_name}", file=sys.stderr)
+    print(f"# Decisions extracted: {len(decisions)}", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/dist/codex/skills/orchestration/scripts/git-context-summary.sh
+++ b/dist/codex/skills/orchestration/scripts/git-context-summary.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Generate git context summary for sessions
+# Usage: git-context-summary.sh [--brief]
+#
+# Output includes:
+#   - Current branch name
+#   - Uncommitted changes count
+#   - Recent commits (last 3-5)
+#   - Summary of changes from main/master (if on feature branch)
+#
+# Options:
+#   --brief   Output only branch and uncommitted changes (for hooks)
+
+set -e
+
+BRIEF_MODE=false
+if [[ "$1" == "--brief" ]]; then
+    BRIEF_MODE=true
+fi
+
+# Check if we're in a git repository
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+    echo "Not a git repository"
+    exit 0
+fi
+
+# Get current branch
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if [[ -z "$CURRENT_BRANCH" ]]; then
+    # Detached HEAD state
+    CURRENT_BRANCH="(detached HEAD at $(git rev-parse --short HEAD 2>/dev/null || echo 'unknown'))"
+fi
+
+# Count uncommitted changes (staged + unstaged + untracked)
+UNCOMMITTED_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+
+# Brief mode: just branch and changes
+if [[ "$BRIEF_MODE" == "true" ]]; then
+    echo "## Git Context"
+    echo "- **Branch**: $CURRENT_BRANCH"
+    echo "- **Uncommitted changes**: $UNCOMMITTED_COUNT file(s)"
+    exit 0
+fi
+
+# Full output
+echo "## Git Context"
+echo ""
+echo "**Branch**: \`$CURRENT_BRANCH\`"
+echo ""
+echo "**Uncommitted changes**: $UNCOMMITTED_COUNT file(s)"
+
+# Show brief status if there are changes
+if [[ "$UNCOMMITTED_COUNT" -gt 0 ]]; then
+    echo ""
+    echo "**Changed files**:"
+    # Show first 10 files max
+    git status --porcelain 2>/dev/null | head -10 | while read -r line; do
+        STATUS="${line:0:2}"
+        FILE="${line:3}"
+        case "$STATUS" in
+            "M "| " M"|"MM") echo "  - Modified: \`$FILE\`" ;;
+            "A ") echo "  - Added: \`$FILE\`" ;;
+            "D "| " D") echo "  - Deleted: \`$FILE\`" ;;
+            "R ") echo "  - Renamed: \`$FILE\`" ;;
+            "??") echo "  - Untracked: \`$FILE\`" ;;
+            *) echo "  - Changed: \`$FILE\`" ;;
+        esac
+    done
+    TOTAL=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$TOTAL" -gt 10 ]]; then
+        echo "  - ... and $((TOTAL - 10)) more"
+    fi
+fi
+
+# Recent commits (last 5)
+echo ""
+echo "**Recent commits**:"
+git log --oneline -5 2>/dev/null | while read -r line; do
+    echo "  - \`$line\`"
+done
+
+# Detect main branch (main or master)
+MAIN_BRANCH=""
+if git show-ref --verify --quiet refs/heads/main 2>/dev/null; then
+    MAIN_BRANCH="main"
+elif git show-ref --verify --quiet refs/heads/master 2>/dev/null; then
+    MAIN_BRANCH="master"
+fi
+
+# Summary of changes from main (if on feature branch)
+if [[ -n "$MAIN_BRANCH" && "$CURRENT_BRANCH" != "$MAIN_BRANCH" && "$CURRENT_BRANCH" != "(detached"* ]]; then
+    # Count commits ahead of main
+    COMMITS_AHEAD=$(git rev-list --count "$MAIN_BRANCH..$CURRENT_BRANCH" 2>/dev/null || echo "0")
+    COMMITS_BEHIND=$(git rev-list --count "$CURRENT_BRANCH..$MAIN_BRANCH" 2>/dev/null || echo "0")
+
+    echo ""
+    echo "**Relative to \`$MAIN_BRANCH\`**:"
+    echo "  - $COMMITS_AHEAD commit(s) ahead"
+    echo "  - $COMMITS_BEHIND commit(s) behind"
+
+    # Files changed from main
+    if [[ "$COMMITS_AHEAD" -gt 0 ]]; then
+        FILES_CHANGED=$(git diff --name-only "$MAIN_BRANCH...$CURRENT_BRANCH" 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "$FILES_CHANGED" -gt 0 ]]; then
+            echo "  - $FILES_CHANGED file(s) changed from \`$MAIN_BRANCH\`"
+        fi
+    fi
+fi

--- a/dist/codex/skills/orchestration/scripts/list-session-decisions.sh
+++ b/dist/codex/skills/orchestration/scripts/list-session-decisions.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# List available session decision memories from Serena.
+#
+# Usage: list-session-decisions.sh
+#
+# This script lists Serena memories matching the pattern session-*-decisions.md
+# and displays session name and metadata.
+#
+# Note: This is a helper script. In practice, agents should use Serena MCP
+# directly via mcp__serena__list_memories() for programmatic access.
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Session Decision Memories${NC}"
+echo "========================="
+echo ""
+
+# Check if .serena directory exists
+if [[ ! -d ".serena" ]]; then
+    echo -e "${YELLOW}No .serena directory found in current project.${NC}"
+    echo "Serena memories are stored per-project. Make sure you're in a Serena-enabled project."
+    exit 0
+fi
+
+# Check for memories directory
+MEMORIES_DIR=".serena/memories"
+if [[ ! -d "$MEMORIES_DIR" ]]; then
+    echo -e "${YELLOW}No memories directory found.${NC}"
+    echo "No session decisions have been extracted yet."
+    echo ""
+    echo "To extract decisions from a session:"
+    echo "  python3 extract-decisions.py <session-file>"
+    echo "  Then use Serena MCP to write the memory."
+    exit 0
+fi
+
+# Find session decision memories
+MEMORIES=$(find "$MEMORIES_DIR" -name "session-*-decisions.md" 2>/dev/null | sort -r)
+
+if [[ -z "$MEMORIES" ]]; then
+    echo -e "${YELLOW}No session decision memories found.${NC}"
+    echo ""
+    echo "Session decision memories are created when sessions are archived."
+    echo "Pattern: session-<slug>-decisions.md"
+    exit 0
+fi
+
+# Display memories
+count=0
+echo -e "${GREEN}Available Decision Memories:${NC}"
+echo ""
+
+for memory in $MEMORIES; do
+    count=$((count + 1))
+    filename=$(basename "$memory")
+
+    # Extract slug from filename
+    slug=$(echo "$filename" | sed 's/^session-//' | sed 's/-decisions\.md$//')
+
+    # Try to read session info from memory content
+    if [[ -f "$memory" ]]; then
+        session_name=$(grep -m1 "^\- \*\*Session\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "Unknown")
+        archived=$(grep -m1 "^\- \*\*Archived\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "Unknown")
+        linear=$(grep -m1 "^\- \*\*Linear Issue\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "N/A")
+        decision_count=$(grep -c "^### Decision" "$memory" 2>/dev/null || echo "0")
+
+        printf "  %2d. %s\n" "$count" "$slug"
+        printf "      Session:  %s\n" "$session_name"
+        printf "      Archived: %s\n" "$archived"
+        printf "      Linear:   %s\n" "$linear"
+        printf "      Decisions: %s\n" "$decision_count"
+        echo ""
+    else
+        printf "  %2d. %s (unreadable)\n" "$count" "$filename"
+    fi
+done
+
+echo "------------------------"
+echo "Total: $count decision memories"
+echo ""
+echo -e "${BLUE}Usage:${NC}"
+echo "  /reference-session <search-term>    # Import decisions to current session"
+echo "  mcp__serena__read_memory(name=...)  # Read memory directly via MCP"

--- a/dist/codex/skills/orchestration/scripts/validate-session.py
+++ b/dist/codex/skills/orchestration/scripts/validate-session.py
@@ -60,7 +60,7 @@ def validate_frontmatter(fm: dict) -> list[str]:
             errors.append(f"Empty required field: session.{field}")
 
     # Validate status values
-    valid_statuses = ['in_progress', 'paused', 'completed']
+    valid_statuses = ['in_progress', 'paused', 'completed', 'archived']
     if session.get('status') and session['status'] not in valid_statuses:
         errors.append(f"Invalid session.status: {session['status']} (must be one of: {', '.join(valid_statuses)})")
 
@@ -72,6 +72,20 @@ def validate_frontmatter(fm: dict) -> list[str]:
                 datetime.fromisoformat(value.replace('Z', '+00:00'))
             except ValueError:
                 errors.append(f"Invalid ISO 8601 timestamp in session.{field}: {value}")
+
+    # Validate branch field format if present (optional field)
+    branch = session.get('branch', '')
+    if branch:
+        # Branch names should be non-empty strings without spaces
+        # Common formats: feature/name, username/ticket-desc, bugfix/name, etc.
+        if not isinstance(branch, str):
+            errors.append(f"Invalid session.branch: must be a string, got {type(branch).__name__}")
+        elif ' ' in branch:
+            errors.append(f"Invalid session.branch: '{branch}' contains spaces (branch names cannot have spaces)")
+        elif branch.startswith('/') or branch.endswith('/'):
+            errors.append(f"Invalid session.branch: '{branch}' cannot start or end with '/'")
+        elif '//' in branch:
+            errors.append(f"Invalid session.branch: '{branch}' contains consecutive slashes")
 
     # Check orchestration block
     orch = fm.get('orchestration', {})

--- a/dist/codex/skills/research/SKILL.md
+++ b/dist/codex/skills/research/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: research
+description: >-
+  Use for project reflection, brainstorming, and vision evolution. Covers
+  assessing project state, exploring problem spaces, generating ideas, and
+  evolving strategic direction. Activate when stepping back to think,
+  researching topics, or updating VISION.md.
+version: 1.11.0
+---
+
+# Research
+
+Patterns for zooming out, brainstorming, and evolving project direction.
+
+## Philosophy
+
+**Research is about understanding before doing.**
+
+Research activities:
+1. Assess project state and lessons learned
+2. Explore problem spaces with structured inquiry
+3. Generate and refine ideas through brainstorming
+4. Evolve strategic direction when evidence supports it
+
+Research is NOT about:
+- Implementing solutions
+- Making tactical decisions
+- Writing code or specifications
+
+## Quick Reference
+
+| Need | Action |
+|------|--------|
+| Understand project state | Review sessions, docs, recent changes |
+| Explore a topic | Structured inquiry with confidence hierarchy |
+| Generate ideas | Brainstorm with interview and synthesis |
+| Evolve VISION | Propose changes with evidence |
+
+## Research Modes
+
+### Mode 1: Project State Assessment
+
+**Trigger:** "What's the current state?" / "Catch me up"
+
+**Process:**
+1. Read existing docs (VISION, ARCHITECTURE, REQUIREMENTS)
+2. Check recent sessions for lessons learned
+3. Review recent commits for context
+4. Identify gaps, contradictions, or stale information
+5. Summarize current state with recommendations
+
+**Output:** State assessment with actionable insights
+
+### Mode 2: Topic Exploration
+
+**Trigger:** "Research X" / "How should we approach Y?"
+
+**Process:**
+1. Interview user to understand the question deeply
+2. Apply confidence hierarchy for sources
+3. Synthesize findings with tradeoffs
+4. Present options with recommendations
+
+**Output:** Research findings with options and recommendation
+
+### Mode 3: Brainstorming
+
+**Trigger:** "Let's brainstorm" / "Ideas for X"
+
+**Process:**
+1. Interview to understand constraints and goals
+2. Generate diverse options (quantity over quality initially)
+3. Filter through constraints
+4. Refine promising directions
+5. Present shaped options for decision
+
+**Output:** Curated options with pros/cons
+
+### Mode 4: Vision Evolution
+
+**Trigger:** "Should we change direction?" / "Update VISION"
+
+**Process:**
+1. Gather evidence (sessions, feedback, market changes)
+2. Identify what's changed since last VISION update
+3. Propose specific changes with rationale
+4. Get user approval before any edits
+
+**Output:** VISION.md change proposal (not direct edit)
+
+## Confidence Hierarchy
+
+When researching, prioritize sources in this order:
+
+```
+1. Project context (highest confidence)
+   - VISION.md, ARCHITECTURE.md, REQUIREMENTS.md
+   - Session files and lessons learned
+   - Existing codebase patterns
+
+2. Authoritative documentation
+   - Context7 for library docs
+   - Official documentation sites
+   - RFCs and specifications
+
+3. Community knowledge
+   - Stack Overflow (verified answers)
+   - GitHub issues and discussions
+   - Blog posts from recognized experts
+
+4. General web (lowest confidence)
+   - Search results
+   - Forum posts
+   - Unverified sources
+```
+
+**Rule:** Always check project context first. External research should supplement, not replace, understanding of existing decisions.
+
+## Interview Patterns
+
+### Before Any Research
+
+Ask clarifying questions:
+
+| Area | Questions |
+|------|-----------|
+| Scope | What specifically are you trying to understand? |
+| Context | What do you already know? What have you tried? |
+| Constraints | What constraints should guide the research? |
+| Output | What decision will this research inform? |
+
+### For Topic Exploration
+
+```
+1. What problem are we trying to solve?
+2. What constraints exist (technical, time, team)?
+3. What would success look like?
+4. What have we already considered and rejected?
+5. Are there non-obvious angles to explore?
+```
+
+### For Brainstorming
+
+```
+1. What's the ideal outcome if constraints didn't exist?
+2. What's the minimum viable approach?
+3. What approaches have we seen work elsewhere?
+4. What would we do if we had 10x the resources? 1/10?
+5. What's the contrarian view?
+```
+
+## Output Formats
+
+### State Assessment
+
+```markdown
+## Project State Assessment
+
+**Date:** YYYY-MM-DD
+
+### Current Position
+- [Summary of where the project stands]
+
+### Recent Progress
+- [Key accomplishments from recent sessions]
+
+### Lessons Learned
+- [Insights from implementation feedback]
+
+### Open Questions
+- [Unresolved decisions or gaps]
+
+### Recommendations
+1. [Actionable next step]
+2. [Actionable next step]
+```
+
+### Research Findings
+
+```markdown
+## Research: [Topic]
+
+**Question:** [What we're trying to understand]
+
+### Summary
+[One-paragraph answer with confidence level]
+
+### Options Considered
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Best for:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Best for:** ...
+
+### Recommendation
+[Which option and why, with caveats]
+
+### Sources
+- [Source 1 with confidence level]
+- [Source 2 with confidence level]
+```
+
+### Vision Change Proposal
+
+```markdown
+## VISION.md Change Proposal
+
+**Proposed by:** [Session/Date]
+**Evidence:** [What prompted this]
+
+### Current State
+[Quote relevant VISION.md section]
+
+### Proposed Change
+[New text]
+
+### Rationale
+[Why this change is warranted]
+
+### Impact
+- [What this changes downstream]
+- [ADRs that may need updating]
+- [Requirements that may be affected]
+
+### Approval Required
+This proposal requires user approval before implementation.
+```
+
+## Integration with Workflow
+
+Research fits at the top of the product development hierarchy:
+
+```
+RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS
+    │         │
+    └─────────┘
+    evolves
+```
+
+**Research informs Vision changes.** Vision changes cascade down through Architecture, Requirements, and Specs.
+
+## When to Research
+
+| Situation | Research Mode |
+|-----------|---------------|
+| Starting new project | Project state + Topic exploration |
+| Stuck on approach | Topic exploration + Brainstorming |
+| Finishing major work | Project state (capture learnings) |
+| External change | Vision evolution |
+| Quarterly review | Project state + Vision evolution |
+
+## When NOT to Research
+
+- **When action is clear** - Don't research to avoid doing
+- **When already decided** - Check ADRs first
+- **When time-critical** - Act, then document learnings
+- **For trivial questions** - Just answer them
+
+## Critical Rules
+
+### Always
+- Interview before researching
+- Check project context first
+- Cite sources with confidence levels
+- Present options, let user decide
+- Get approval before editing VISION
+
+### Never
+- Edit VISION without explicit approval
+- Research indefinitely (set time bounds)
+- Ignore existing project decisions
+- Present research as implementation plan
+- Skip the interview step
+
+## Scripts
+
+| Script | Usage | Description |
+|--------|-------|-------------|
+| `check-sessions.sh` | Review recent sessions | Find lessons learned |
+| `git-context-summary.sh` | Summarize git history | Understand recent changes |
+
+## Related Skills
+
+- **orchestration** - For acting on research findings
+- **foundations** - For documentation standards

--- a/dist/cursor/agents/background-runner.md
+++ b/dist/cursor/agents/background-runner.md
@@ -1,0 +1,170 @@
+---
+model: inherit
+is_background: true
+name: background-runner
+description: >-
+  Lightweight background agent for non-interactive tasks. Use for security
+  audits, coverage analysis, code reviews, and other low-priority work that can
+  run independently.
+tools:
+  Read: true
+  Edit: true
+  Glob: true
+  Grep: true
+---
+# Background Runner
+
+You execute specific tasks in the background, writing results to a specified location without user interaction.
+
+## When You Run
+
+- Spawned by PM/orchestrator with `run_in_background: true`
+- For low-priority, non-interactive work
+- Results expected later, not immediately
+
+## What You Do
+
+1. **Execute assigned task** - Security audits, coverage analysis, code reviews, etc.
+2. **Write results** - Output to specified `.agents/reports/` location
+3. **Update session** - Mark your background agent entry as complete
+
+## Input You Receive
+
+The spawning agent provides:
+- Specific task to execute
+- Files or scope to analyze
+- Output location (`.agents/reports/YYYYMMDD-HHMMSS-<name>.md`)
+- Session reference
+
+## Execution Process
+
+### 1. Parse Task
+
+Extract from prompt:
+- What to do (audit, analyze, review)
+- Scope (files, directories)
+- Output location
+- Session file path
+
+### 2. Execute Work
+
+Perform the assigned task:
+- Read specified files
+- Run analysis
+- Generate findings
+- Compile report
+
+### 3. Write Report
+
+Create report at specified location:
+
+```yaml
+---
+report:
+  title: "Task Description"
+  type: background-agent-output
+  status: unprocessed
+  created: "2026-01-23T14:30:00Z"
+  background_agent_id: "bg-YYYYMMDD-HHMMSS-description"
+  session_reference: "YYYYMMDD-HHMMSS-session-name.md"
+---
+
+# Report Title
+
+## Summary
+
+Brief overview of findings.
+
+## Findings
+
+### Finding 1: Title
+**Severity**: High | Medium | Low | Info
+**Location**: `path/to/file.py:123`
+**Description**: What was found
+**Recommendation**: What to do
+
+## Recommendations
+
+Prioritized list of actions.
+
+## Files Analyzed
+
+- `path/to/file1.py`
+- `path/to/file2.py`
+```
+
+### 4. Update Session Frontmatter
+
+Read session file and update your background agent entry:
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: completed  # Changed from running
+    result_location: ".agents/reports/20260123-143000-security.md"  # Set path
+```
+
+## Constraints
+
+- **No user interaction** - You cannot ask questions or request clarification
+- **No blocking work** - Complete task with available information
+- **No spawning agents** - Work independently
+- **Write to specified location** - Do not create files elsewhere
+
+## Quality Checklist
+
+Before completing:
+
+- [ ] Task executed per prompt instructions
+- [ ] Report written to specified location
+- [ ] Report has valid frontmatter with `background_agent_id`
+- [ ] Session frontmatter updated with `status: completed`
+- [ ] Session frontmatter updated with `result_location`
+- [ ] No user interaction attempted
+
+## Error Handling
+
+If task cannot be completed:
+
+1. Write partial report with what was accomplished
+2. Document blockers in report
+3. Update session frontmatter with `status: failed`
+4. Include error details in report
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: failed
+    result_location: ".agents/reports/20260123-143000-security-partial.md"
+```
+
+## Example Task
+
+**Prompt received:**
+```
+Run security audit on auth module.
+
+Files:
+- src/auth/endpoints.py
+- src/auth/token.py
+
+Check for OWASP Top 10 vulnerabilities.
+
+Write report to: .agents/reports/20260123-143000-auth-security.md
+
+Session: .agents/sessions/20260123-140000-auth-feature.md
+Background Agent ID: bg-20260123-143000-auth-security
+```
+
+**Actions:**
+1. Read `src/auth/endpoints.py` and `src/auth/token.py`
+2. Analyze for OWASP vulnerabilities
+3. Write findings to `.agents/reports/20260123-143000-auth-security.md`
+4. Update `.agents/sessions/20260123-140000-auth-feature.md` frontmatter
+
+---
+version: 1.11.0

--- a/dist/cursor/agents/context-archiver.md
+++ b/dist/cursor/agents/context-archiver.md
@@ -99,13 +99,66 @@ The agent resuming work should:
 Pre-compaction archive. Preserved: [brief summary of what was captured].
 ```
 
-## Serena Memory (Optional)
+## Serena Memory for Decisions
 
-Write memory ONLY when session has significant decisions:
+Write decision memory when session has significant decisions for cross-session reference.
 
-- Check if `## Decisions` section has content
-- If yes, write to `session-{session-slug}-decisions.md`
-- Include decision rationale and context
+### 5. Extract and Store Decisions
+
+Check if `## Decisions` section has content. If yes:
+
+**Step A: Extract decisions using the extraction script**
+
+```bash
+python3 plugins/loaf/skills/orchestration/scripts/extract-decisions.py \
+  ".agents/sessions/<session-file>.md"
+```
+
+This outputs formatted memory content to stdout and the memory name to stderr.
+
+**Step B: Write to Serena memory**
+
+Use Serena MCP to store the extracted decisions:
+
+```python
+mcp__serena__write_memory(
+    name="session-<slug>-decisions.md",
+    content=<extracted_content>
+)
+```
+
+**Memory naming convention:**
+- Session: `20250123-100000-auth-feature.md`
+- Memory: `session-auth-feature-decisions.md`
+
+**Memory format:**
+
+```markdown
+# Memory: session-auth-feature-decisions.md
+
+## Session Context
+- **Session**: 20250123-100000-auth-feature.md
+- **Title**: Auth Feature Implementation
+- **Archived**: 2025-01-23T14:30:00Z
+- **Linear Issue**: PLT-123
+
+## Key Decisions
+
+### Decision 1: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window
+**Rationale**: Balance between security and user experience
+**Council**: None - backend-dev recommendation accepted
+
+### Decision 2: Refresh Token Storage
+**Decision**: Store in HttpOnly cookies, not localStorage
+**Rationale**: Prevents XSS token theft
+**Council**: Security council (5 agents) - unanimous
+```
+
+**Why store decisions:**
+- Enables `/reference-session` command for cross-session continuity
+- Preserves decision rationale for future work
+- Avoids re-deliberating already-resolved questions
 
 ## Output
 
@@ -134,7 +187,8 @@ Before completing:
 - [ ] `## Resumption Prompt` provides self-contained context
 - [ ] `## Resumption Prompt` includes Transcript Archive instruction
 - [ ] `## Session Log` has timestamped entry
-- [ ] Serena memory written if decisions exist
+- [ ] Decisions extracted and written to Serena memory (if `## Decisions` has content)
+- [ ] Memory name follows convention: `session-<slug>-decisions.md`
 
 ---
 version: 1.11.0

--- a/dist/cursor/agents/qa.md
+++ b/dist/cursor/agents/qa.md
@@ -15,6 +15,7 @@ You are a QA engineer. Your skills tell you how to test and review code.
 - Check for OWASP Top 10 issues
 - Verify type safety and linting passes
 - Audit test coverage
+- Debug failing tests and diagnose flaky tests
 
 ## How You Work
 
@@ -22,6 +23,18 @@ You are a QA engineer. Your skills tell you how to test and review code.
 2. **Match project style** - follow existing test patterns
 3. **Test behavior, not implementation** - tests should survive refactors
 4. **Run full suite** - all tests must pass before completing
+5. **Debug systematically** - use hypothesis-driven debugging for failures
+
+## Debugging Workflow
+
+When investigating test failures or bugs:
+
+1. **Reproduce** - Establish reliable reproduction steps
+2. **Hypothesize** - Generate 3-5 possible causes, rank by likelihood
+3. **Test** - Design minimal experiments to confirm or rule out each hypothesis
+4. **Document** - Track hypotheses and evidence in investigation log
+
+See the `debugging` skill for hypothesis tracking templates and language-specific debugging patterns.
 
 Your skills contain all the patterns and conventions. Reference them.
 

--- a/dist/cursor/commands/architecture.md
+++ b/dist/cursor/commands/architecture.md
@@ -1,0 +1,258 @@
+# Architecture Command
+
+Interview about technical decisions, update ARCHITECTURE.md, create ADRs.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Technical decisions should be:
+1. **Deliberate** - Made consciously, not by accident
+2. **Documented** - Captured in ARCHITECTURE.md and ADRs
+3. **Traceable** - Future readers understand why
+
+---
+
+## CRITICAL: Interview First
+
+**Before making any architectural decision, understand:**
+
+1. What decision needs to be made?
+2. What constraints exist (technical, business, team)?
+3. What options have already been considered?
+4. What would "good enough" look like vs "ideal"?
+5. What's the impact of getting this wrong?
+
+Use `AskUserQuestion` to gather context.
+
+---
+
+## Process
+
+### Step 1: Understand the Decision
+
+Parse `$ARGUMENTS` to understand what decision is needed.
+
+**If unclear:** Ask clarifying questions about:
+- The problem being solved
+- Technical constraints
+- Business constraints
+- Time/resource constraints
+
+### Step 2: Gather Context
+
+1. **Read existing documents:**
+   - `docs/VISION.md` - Strategic direction
+   - `docs/ARCHITECTURE.md` - Current technical design
+   - `docs/decisions/ADR-*.md` - Previous decisions
+
+2. **Check for relevant patterns:**
+   - How similar problems were solved
+   - Established conventions in the codebase
+   - Previous attempts and outcomes
+
+3. **Review session history:**
+   - Implementation learnings
+   - Pain points from previous work
+
+### Step 3: Consider Options
+
+For each viable option:
+
+| Aspect | Evaluate |
+|--------|----------|
+| Alignment | Does it fit VISION and existing ARCHITECTURE? |
+| Complexity | How much does it add to the system? |
+| Reversibility | How hard to change later? |
+| Team capability | Can the team execute this? |
+| Maintenance | Long-term cost? |
+
+### Step 4: Convene Council (If Needed)
+
+For complex or contentious decisions, convene a council:
+
+- **Odd number:** 5 or 7 agents
+- **Diverse expertise:** Mix of perspectives
+- **Structured deliberation:** Each argues a position
+
+See `orchestration/councils` skill for council workflow.
+
+**Council advises, user decides.**
+
+### Step 5: Present Options
+
+Format:
+
+```markdown
+## Decision: [Question]
+
+### Context
+[Why this decision is needed now]
+
+### Options
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Fits when:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Fits when:** ...
+
+### Recommendation
+[Which option and why]
+
+### What do you think?
+```
+
+### Step 6: Await User Decision
+
+**Do NOT proceed without explicit user choice.**
+
+User may:
+- Accept a recommendation
+- Choose a different option
+- Ask for more information
+- Request a council deliberation
+
+### Step 7: Document the Decision
+
+After user decides:
+
+1. **Update ARCHITECTURE.md** with new decision
+2. **Create ADR** in `docs/decisions/`
+
+---
+
+## ADR Format
+
+**Filename:** `ADR-{number}-{slug}.md`
+
+```yaml
+---
+id: ADR-001
+title: "PostgreSQL as Primary Database"
+status: Accepted  # Proposed | Accepted | Deprecated | Superseded
+date: 2026-01-23
+supersedes: null  # ADR-000 if replacing
+superseded_by: null  # ADR-002 if replaced
+---
+
+# ADR-001: PostgreSQL as Primary Database
+
+## Context
+
+[Why this decision was needed. What problem we faced.]
+
+## Decision
+
+[What we decided. Be specific and unambiguous.]
+
+## Consequences
+
+### Positive
+- [Benefit 1]
+- [Benefit 2]
+
+### Negative
+- [Tradeoff 1]
+- [Tradeoff 2]
+
+### Neutral
+- [Implication that's neither good nor bad]
+
+## Alternatives Considered
+
+### [Alternative 1]
+[Why it was rejected]
+
+### [Alternative 2]
+[Why it was rejected]
+```
+
+---
+
+## ADR Numbering
+
+Find next available number:
+
+```bash
+ls docs/decisions/ADR-*.md 2>/dev/null | \
+  grep -oE 'ADR-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+If no ADRs exist, start with `ADR-001`.
+
+---
+
+## ARCHITECTURE.md Updates
+
+When updating ARCHITECTURE.md:
+
+1. **Find relevant section** or create new one
+2. **Add decision** with reference to ADR
+3. **Keep it current** - Remove outdated information
+
+Example addition:
+
+```markdown
+## Data Storage
+
+We use **PostgreSQL** as our primary database (see [ADR-001](decisions/ADR-001-postgresql.md)).
+
+Key decisions:
+- Single database for simplicity
+- Connection pooling via PgBouncer
+- Read replicas for reporting queries
+```
+
+---
+
+## Decision Types
+
+| Type | Scope | ADR Required? |
+|------|-------|---------------|
+| Strategic | System-wide, hard to reverse | Yes |
+| Tactical | Component-level, reversible | Optional |
+| Trivial | No significant impact | No |
+
+**When in doubt, create an ADR.** Future you will thank you.
+
+---
+
+## Guardrails
+
+1. **Interview first** - Understand the full context
+2. **Check existing decisions** - Don't contradict without superseding
+3. **Present options** - User decides, not you
+4. **Document thoroughly** - ADRs explain the "why"
+5. **Keep ARCHITECTURE.md current** - Update, don't just append
+
+---
+
+## Council Trigger Conditions
+
+Consider convening a council when:
+
+- Decision affects multiple domains (backend + frontend + infra)
+- Team has conflicting opinions
+- High cost of reversal
+- Novel problem without established patterns
+- User explicitly requests deliberation
+
+---
+
+## Related Skills
+
+- **orchestration/councils** - Council deliberation workflow
+- **orchestration/product-development** - Where architecture fits in hierarchy
+- **foundations** - Documentation standards for ADRs
+---
+version: 1.11.0

--- a/dist/cursor/commands/prd.md
+++ b/dist/cursor/commands/prd.md
@@ -1,0 +1,289 @@
+# PRD Command
+
+Interview to discover product requirements, update REQUIREMENTS.md.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Requirements capture **what** the product must do, not **how**.
+
+Good requirements are:
+- **User-focused** - Written from user perspective
+- **Testable** - Clear acceptance criteria
+- **Organized** - Grouped by domain
+- **Complete** - Cover edge cases and business rules
+
+---
+
+## CRITICAL: Interview First
+
+**Before writing any requirements, understand:**
+
+1. What feature area are we defining?
+2. Who are the users affected?
+3. What business rules apply?
+4. What edge cases exist?
+5. What's explicitly out of scope?
+
+Use `AskUserQuestion` with non-obvious questions.
+
+---
+
+## Process
+
+### Step 1: Parse Input
+
+`$ARGUMENTS` should indicate the feature area or requirement section.
+
+Examples:
+- "user authentication"
+- "section 2.1"
+- "payment processing"
+
+**If unclear:** Ask what feature area to define.
+
+### Step 2: Gather Context
+
+1. **Read VISION.md** - Strategic direction constrains requirements
+2. **Read ARCHITECTURE.md** - Technical constraints
+3. **Read existing REQUIREMENTS.md** - Don't duplicate
+
+### Step 3: Interview with Non-Obvious Questions
+
+Ask questions the user might not have considered:
+
+| Category | Example Questions |
+|----------|-------------------|
+| Edge cases | "What happens if the user closes the browser mid-flow?" |
+| Business rules | "Are there rate limits? Time-based restrictions?" |
+| Persona conflicts | "How do admin users differ from regular users here?" |
+| Failure modes | "What's the graceful degradation if this fails?" |
+| Compliance | "Any audit logging requirements?" |
+| Scale | "Expected volume? Concurrent users?" |
+
+**Interview structure:**
+```
+1. Start with obvious questions to confirm understanding
+2. Move to edge cases
+3. Explore business rule conflicts
+4. Check compliance/security needs
+5. Confirm scope boundaries
+```
+
+### Step 4: Draft Requirements Section
+
+Format:
+
+```markdown
+## [Number]. [Domain Name]
+
+### [Number].[SubNumber] [Feature Name]
+
+**Business Rules**
+- [Rule 1]
+- [Rule 2]
+
+**User Stories**
+As a [persona], I want to [action] so that [benefit].
+
+**Acceptance Criteria**
+- [ ] Given [context], when [action], then [outcome]
+- [ ] Given [context], when [action], then [outcome]
+
+**Edge Cases**
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| [Edge case] | [How system responds] |
+
+**Out of Scope**
+- [Explicitly excluded item]
+```
+
+### Step 5: Present for Approval
+
+Show the drafted section to the user:
+
+```markdown
+## Proposed Addition to REQUIREMENTS.md
+
+[Draft section]
+
+---
+
+**Questions before adding:**
+1. Are these business rules accurate?
+2. Any missing acceptance criteria?
+3. Should anything be out of scope?
+```
+
+### Step 6: Await Approval
+
+**Do NOT update REQUIREMENTS.md without explicit approval.**
+
+User may:
+- Approve as-is
+- Request changes
+- Add missing requirements
+- Move items to out of scope
+
+### Step 7: Update REQUIREMENTS.md
+
+After approval:
+1. Add new section to REQUIREMENTS.md
+2. Maintain consistent numbering
+3. Update table of contents if exists
+
+---
+
+## Requirements Format
+
+### File Structure
+
+```markdown
+# Requirements
+
+## 1. Core Platform
+
+### 1.1 Feature A
+...
+
+### 1.2 Feature B
+...
+
+## 2. Identity & Access
+
+### 2.1 User Authentication
+...
+
+### 2.2 Authorization
+...
+```
+
+### Section Template
+
+```markdown
+### 2.1 User Authentication
+
+**Business Rules**
+- Users authenticate via OAuth (Google, GitHub)
+- Sessions expire after 24 hours of inactivity
+- Failed login attempts are logged for security audit
+- Users can have at most 5 active sessions
+
+**User Stories**
+
+As a new user, I want to sign in with my existing Google account
+so that I don't need to create another password.
+
+As a returning user, I want my session to persist across browser tabs
+so that I can work in multiple windows.
+
+**Acceptance Criteria**
+- [ ] Given a new user, when they click "Sign in with Google", then they are redirected to Google OAuth
+- [ ] Given valid Google credentials, when OAuth completes, then user is logged in and redirected to dashboard
+- [ ] Given an existing session, when user opens new tab, then they remain logged in
+- [ ] Given 24 hours of inactivity, when user returns, then they must re-authenticate
+- [ ] Given a logged-in user, when they click logout, then all session data is cleared
+
+**Edge Cases**
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| OAuth provider unavailable | Show friendly error, suggest trying later |
+| User revokes OAuth access | Invalidate session on next request |
+| Multiple accounts same email | Prevent duplicate accounts, suggest login |
+| Session cookie deleted | Redirect to login on next request |
+
+**Out of Scope**
+- Password-based authentication (security/maintenance burden)
+- Apple/Microsoft OAuth (future consideration)
+- MFA (separate feature area)
+```
+
+---
+
+## Acceptance Criteria Format
+
+Use Given-When-Then:
+
+```markdown
+Given [precondition/context],
+when [action is performed],
+then [expected outcome].
+```
+
+**Good criteria are:**
+- Specific and testable
+- Single behavior per criterion
+- Observable outcome (not internal state)
+- User-focused language
+
+**Bad criteria:**
+```markdown
+- Login should be fast  # Not measurable
+- Data should be correct  # Too vague
+- System should handle errors  # No specific behavior
+```
+
+**Good criteria:**
+```markdown
+- [ ] Given valid credentials, when login submitted, then dashboard loads within 2 seconds
+- [ ] Given invalid email format, when login attempted, then "Invalid email" error shown
+- [ ] Given network failure during OAuth, when callback fails, then retry prompt displayed
+```
+
+---
+
+## Numbering Convention
+
+```
+[Major].[Minor] [Feature Name]
+
+1. Core Platform
+   1.1 Dashboard
+   1.2 Navigation
+
+2. Identity & Access
+   2.1 User Authentication
+   2.2 Role-Based Access
+```
+
+When adding new sections:
+- Check existing numbers
+- Insert at appropriate position
+- Update subsequent numbers if needed
+
+---
+
+## Guardrails
+
+1. **Interview deeply** - Ask non-obvious questions
+2. **Check constraints** - VISION and ARCHITECTURE bound requirements
+3. **Write testable criteria** - Given-When-Then format
+4. **Document edge cases** - What could go wrong?
+5. **Explicit out of scope** - Prevent scope creep
+6. **Get approval** - Don't update without user confirmation
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Requirements describe HOW | Focus on WHAT, leave HOW to specs |
+| Missing edge cases | Interview for failure modes |
+| Vague criteria | Use Given-When-Then |
+| No out of scope | Explicitly list exclusions |
+| Conflicting rules | Resolve before adding |
+
+---
+
+## Related Skills
+
+- **orchestration/product-development** - Where requirements fit in hierarchy
+- **orchestration/specs** - Breaking requirements into specifications
+- **foundations** - Documentation standards
+---
+version: 1.11.0

--- a/dist/cursor/commands/reference-session.md
+++ b/dist/cursor/commands/reference-session.md
@@ -1,0 +1,233 @@
+# Reference Session
+
+Import context from past sessions into current work. This command helps maintain continuity across sessions without duplicating full context.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` for:
+- **Search term**: Session name fragment, Linear issue ID, or topic keyword
+- **Content type** (optional): `decisions`, `context`, or `all` (default: `decisions`)
+
+```
+/reference-session auth              # Search for "auth" sessions, import decisions
+/reference-session auth decisions    # Explicit: import decisions only
+/reference-session auth context      # Import full context summary
+/reference-session PLT-123           # Search by Linear issue
+```
+
+If no arguments provided, list recent decision memories:
+
+```
+/reference-session                   # List available session decisions
+```
+
+---
+
+## Step 2: Search for Matching Sessions
+
+### Option A: List Serena Memories
+
+Use Serena MCP to list available decision memories:
+
+```
+mcp__serena__list_memories()
+```
+
+Filter for memories matching pattern: `session-*-decisions.md`
+
+### Option B: Search Session Archives
+
+If no matching memories found, search archived sessions:
+
+```
+.agents/sessions/archive/*<search-term>*.md
+```
+
+---
+
+## Step 3: Display Matches
+
+Present matching sessions/memories:
+
+```markdown
+## Matching Session Decisions
+
+| Session | Archived | Linear | Decisions |
+|---------|----------|--------|-----------|
+| 20250115-140000-auth-jwt | 2025-01-15 | PLT-123 | 3 decisions |
+| 20250110-090000-auth-oauth | 2025-01-10 | PLT-100 | 2 decisions |
+
+Select a session number to import, or 'all' for multiple:
+```
+
+If single match, proceed directly to Step 4.
+
+---
+
+## Step 4: Read Decision Memory
+
+For selected session(s), read the decision memory:
+
+```
+mcp__serena__read_memory(name="session-<slug>-decisions.md")
+```
+
+If memory doesn't exist but session file does, run extraction:
+
+```bash
+python3 src/skills/orchestration/scripts/extract-decisions.py \
+  ".agents/sessions/archive/<session-file>.md"
+```
+
+---
+
+## Step 5: Import into Current Session
+
+If an active session exists (`.agents/sessions/` has `in_progress` files):
+
+### Update Session Frontmatter
+
+Add to the active session's frontmatter:
+
+```yaml
+session:
+  # ... existing fields ...
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"
+      imported_at: "2025-01-23T14:30:00Z"
+      content_type: decisions
+      decisions_imported:
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+```
+
+### Add Reference Section
+
+If importing decisions, add to session body:
+
+```markdown
+## Referenced Decisions
+
+### From: 20250115-140000-auth-jwt.md
+
+#### Decision: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window
+**Rationale**: Balance between security and user experience
+**Context**: Authentication service design
+
+#### Decision: Refresh Token Storage
+**Decision**: Store in HttpOnly cookie, not localStorage
+**Rationale**: Prevents XSS token theft
+**Context**: Frontend security consideration
+
+---
+```
+
+---
+
+## Step 6: Report Import
+
+Confirm what was imported:
+
+```markdown
+## Session Reference Complete
+
+**Imported from**: 20250115-140000-auth-jwt.md
+**Content type**: decisions
+**Decisions imported**: 3
+
+### Summary
+
+1. **JWT Token Rotation Strategy** - Rotate every 15 minutes
+2. **Refresh Token Storage** - HttpOnly cookies
+3. **Token Validation Flow** - Validate signature before claims
+
+These decisions are now tracked in the current session's frontmatter
+under `referenced_sessions`.
+
+**Current session updated**: .agents/sessions/20250123-100000-auth-v2.md
+```
+
+---
+
+## No Active Session
+
+If no active session exists, display the decisions without updating any file:
+
+```markdown
+## Decisions from: 20250115-140000-auth-jwt.md
+
+[Display decision content]
+
+**Note**: No active session to update. Start a session first with
+`/start-session` to track this reference.
+```
+
+---
+
+## Content Types
+
+### `decisions` (default)
+
+Imports only the `## Decisions` section formatted as memory:
+- Decision name
+- What was decided
+- Rationale
+- Council outcome (if applicable)
+
+### `context`
+
+Imports session context summary:
+- Problem statement
+- Technical approach
+- Key files involved
+- Final outcome
+
+### `all`
+
+Imports both decisions and context.
+
+---
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Import full session files | Import only decisions/summaries |
+| Import without tracking | Always update `referenced_sessions` |
+| Import from unrelated sessions | Search by topic or Linear issue |
+| Import during exploration | Import when decisions are relevant |
+
+---
+
+## Error Handling
+
+### No matches found
+
+```
+No sessions found matching "auth-v3"
+
+Try:
+- Different search terms
+- Check .agents/sessions/archive/ directly
+- List all: /reference-session
+```
+
+### Memory not found
+
+```
+Decision memory not found for session 20250115-140000-auth-jwt.md
+
+Would you like to extract decisions now? This will:
+1. Read the archived session file
+2. Extract the Decisions section
+3. Create a Serena memory for future use
+
+[y/n]
+```
+---
+version: 1.11.0

--- a/dist/cursor/commands/research.md
+++ b/dist/cursor/commands/research.md
@@ -1,0 +1,262 @@
+# Research Command
+
+Step back from implementation to understand, explore, or brainstorm.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Mode Detection
+
+Parse the input to determine research mode:
+
+| Input Pattern | Mode | Action |
+|---------------|------|--------|
+| "project state" / "catch me up" / empty | State Assessment | Review docs, sessions, recent work |
+| Topic description | Topic Exploration | Structured inquiry |
+| "brainstorm" / "ideas for" | Brainstorming | Generate and refine options |
+| "evolve vision" / "update vision" | Vision Evolution | Propose VISION changes |
+
+---
+
+## CRITICAL: Interview First
+
+**Before any research, interview the user to understand:**
+
+1. What specifically are you trying to understand?
+2. What context do you already have?
+3. What constraints should guide this research?
+4. What decision will this inform?
+
+Use `AskUserQuestion` to gather this context.
+
+---
+
+## Mode 1: Project State Assessment
+
+**Trigger:** Empty input, "project state", "catch me up"
+
+### Steps
+
+1. **Read project documents:**
+   - `docs/VISION.md` (if exists)
+   - `docs/ARCHITECTURE.md` (if exists)
+   - `docs/REQUIREMENTS.md` (if exists)
+
+2. **Check recent sessions:**
+   - List `.agents/sessions/*.md`
+   - Read recent sessions for lessons learned
+   - Note any unresolved issues or blockers
+
+3. **Review recent commits:**
+   ```bash
+   git log --oneline -20
+   ```
+
+4. **Synthesize findings:**
+   - Current position
+   - Recent progress
+   - Lessons learned
+   - Open questions
+   - Recommendations
+
+5. **Present to user** with actionable next steps
+
+---
+
+## Mode 2: Topic Exploration
+
+**Trigger:** Specific topic or question
+
+### Steps
+
+1. **Interview** to understand the question deeply
+
+2. **Check project context first:**
+   - Existing decisions in `docs/decisions/ADR-*.md`
+   - Relevant sections in ARCHITECTURE.md
+   - Previous session discussions
+
+3. **Apply confidence hierarchy:**
+   ```
+   Project context > Context7 > Official docs > Community > Web
+   ```
+
+4. **For library/framework questions:**
+   - Use Context7 MCP to get authoritative documentation
+   - Cross-reference with official sources
+
+5. **Synthesize findings:**
+   - Summary with confidence level
+   - Options with tradeoffs
+   - Recommendation with rationale
+   - Sources cited
+
+6. **Present options** - Don't make the decision for the user
+
+---
+
+## Mode 3: Brainstorming
+
+**Trigger:** "brainstorm", "ideas for", creative exploration
+
+### Steps
+
+1. **Interview to establish bounds:**
+   - What's the ideal outcome?
+   - What constraints exist?
+   - What's been tried/rejected?
+
+2. **Generate diverse options:**
+   - Conventional approaches
+   - Unconventional approaches
+   - What if we had 10x resources?
+   - What if we had 1/10 resources?
+   - Contrarian view
+
+3. **Filter through constraints:**
+   - Technical feasibility
+   - Time/resource budget
+   - Alignment with VISION
+
+4. **Refine promising directions:**
+   - Shape the top 2-3 options
+   - Identify risks and mitigations
+
+5. **Present curated options** with pros/cons for decision
+
+---
+
+## Mode 4: Vision Evolution
+
+**Trigger:** "evolve vision", "update vision", evidence of needed change
+
+### Steps
+
+1. **Gather evidence:**
+   - What changed since last VISION update?
+   - Session learnings that contradict VISION
+   - External factors (market, technology, team)
+
+2. **Read current VISION.md**
+
+3. **Draft change proposal:**
+   ```markdown
+   ## VISION.md Change Proposal
+
+   **Evidence:** [What prompted this]
+
+   ### Current State
+   [Quote relevant section]
+
+   ### Proposed Change
+   [New text]
+
+   ### Rationale
+   [Why this is warranted]
+
+   ### Impact
+   - [Downstream effects]
+   ```
+
+4. **Present proposal to user**
+
+5. **WAIT FOR EXPLICIT APPROVAL**
+   - Do NOT edit VISION.md without approval
+   - User must explicitly confirm changes
+
+6. **If approved:** Edit VISION.md with approved changes
+
+---
+
+## Output Format
+
+### State Assessment
+
+```markdown
+## Project State Assessment
+
+**Date:** [Generated timestamp]
+
+### Current Position
+[Summary]
+
+### Recent Progress
+- [Accomplishment 1]
+- [Accomplishment 2]
+
+### Lessons Learned
+- [Insight 1]
+- [Insight 2]
+
+### Open Questions
+- [Question 1]
+- [Question 2]
+
+### Recommendations
+1. [Next step]
+2. [Next step]
+```
+
+### Research Findings
+
+```markdown
+## Research: [Topic]
+
+**Question:** [What we're investigating]
+
+### Summary
+[Answer with confidence level]
+
+### Options
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+
+### Recommendation
+[Which option and why]
+
+### Sources
+- [Source with confidence]
+```
+
+---
+
+## Guardrails
+
+1. **Always interview first** - Don't assume you understand the question
+2. **Check project context** - Respect existing decisions
+3. **Present options** - Don't make decisions for the user
+4. **Cite sources** - With confidence levels
+5. **Never edit VISION without approval** - Proposals only
+6. **Time-bound research** - Don't go down rabbit holes indefinitely
+
+---
+
+## Context7 Usage
+
+For library/framework questions, use Context7:
+
+```
+1. mcp__plugin_context7_context7__resolve-library-id
+   - Find the library ID
+
+2. mcp__plugin_context7_context7__query-docs
+   - Query specific documentation
+```
+
+This provides authoritative, up-to-date documentation.
+
+---
+
+## Related Skills
+
+- **research** - Full methodology for research modes
+- **orchestration/product-development** - Where research fits in workflow
+---
+version: 1.11.0

--- a/dist/cursor/commands/specs.md
+++ b/dist/cursor/commands/specs.md
@@ -1,0 +1,275 @@
+# Specs Command
+
+Break requirements into shaped, implementable specifications.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Specs define **shaped solutions** - bounded work with clear scope.
+
+A spec is:
+- **Shaped** - Direction, not blueprint
+- **Bounded** - Clear in/out of scope
+- **Testable** - Observable test conditions
+- **Appetite-driven** - Fixed time, variable scope
+
+See `orchestration/specs` reference for full spec methodology.
+
+---
+
+## CRITICAL: Interview First
+
+**Before writing a spec, clarify:**
+
+1. Which requirement section is this for?
+2. What's the appetite (time budget)?
+3. What scope trade-offs are acceptable?
+4. What are the "rabbit holes" to avoid?
+5. What approaches are explicitly forbidden (no-gos)?
+
+Use `AskUserQuestion` to establish boundaries.
+
+---
+
+## Process
+
+### Step 1: Parse Input
+
+`$ARGUMENTS` should reference a requirement section.
+
+Examples:
+- "2.1 User Authentication"
+- "REQUIREMENTS.md section 2.1"
+- "user auth"
+
+**If unclear:** Ask which requirement to specify.
+
+### Step 2: Gather Context
+
+Read in order:
+1. **VISION.md** - Strategic alignment
+2. **ARCHITECTURE.md** - Technical constraints
+3. **REQUIREMENTS.md** - The requirement being specified
+4. **Existing specs** - Avoid duplication
+
+### Step 3: Interview for Shaping
+
+Shape Up methodology - define boundaries, not tasks.
+
+| Question | Purpose |
+|----------|---------|
+| What's definitely in scope? | Core functionality |
+| What's definitely out of scope? | Prevent creep |
+| What seems related but should be avoided? | Rabbit holes |
+| What approaches are forbidden? | No-gos |
+| How do we know it works? | Test conditions |
+| How much time is it worth? | Appetite |
+| What if we run out of time? | Circuit breaker |
+
+### Step 4: Determine Appetite
+
+| Appetite | Size | Suitable For |
+|----------|------|--------------|
+| Small | 1-2 days | Bug fixes, minor enhancements |
+| Medium | 3-5 days | Feature additions, refactors |
+| Large | 1-2 weeks | Major features (rare) |
+
+**If work can't fit the appetite:** Needs more shaping or splitting.
+
+### Step 5: Draft the Spec
+
+Use spec template:
+
+```yaml
+---
+id: SPEC-001
+title: "User Authentication with OAuth"
+requirement: "2.1 User Authentication"
+created: YYYY-MM-DDTHH:MM:SSZ
+status: drafting
+appetite: "1 week"
+---
+
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+[From REQUIREMENTS - why this matters to users and business]
+
+## Proposed Solution
+
+[Shaped solution - high-level approach, not implementation details]
+
+## Scope
+
+### In Scope
+- [Item 1]
+- [Item 2]
+
+### Out of Scope (Rabbit Holes)
+- [Avoid this complexity]
+- [Don't go here]
+
+### No-Gos
+- [Forbidden approach 1]
+- [Forbidden approach 2]
+
+## Test Conditions
+
+- [ ] [Observable outcome 1]
+- [ ] [Observable outcome 2]
+- [ ] [Observable outcome 3]
+
+## Implementation Notes
+
+[Architecture references, technical constraints, relevant ADRs]
+
+## Circuit Breaker
+
+At 50% appetite: [What to do if we're not on track]
+```
+
+### Step 6: Generate Spec ID
+
+Find next available ID:
+
+```bash
+ls docs/specs/SPEC-*.md docs/specs/archive/SPEC-*.md 2>/dev/null | \
+  grep -oE 'SPEC-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+If no specs exist, start with `SPEC-001`.
+
+### Step 7: Present for Approval
+
+```markdown
+## Proposed Specification
+
+[Full spec content]
+
+---
+
+**Before approval, confirm:**
+1. Is the scope correct?
+2. Are the test conditions sufficient?
+3. Is the appetite realistic?
+4. Any missing rabbit holes or no-gos?
+```
+
+### Step 8: Await Approval
+
+**Do NOT create spec file without explicit approval.**
+
+User may:
+- Approve as-is
+- Adjust scope
+- Change appetite
+- Add constraints
+- Request splitting
+
+### Step 9: Create Spec File
+
+After approval:
+
+1. **Generate timestamps:**
+   ```bash
+   date -u +"%Y-%m-%dT%H:%M:%SZ"  # For frontmatter
+   ```
+
+2. **Create file:**
+   - Location: `docs/specs/SPEC-{id}-{slug}.md`
+   - Slug: kebab-case of title
+
+3. **Announce completion:**
+   ```
+   Created: docs/specs/SPEC-001-user-auth-oauth.md
+
+   Next: Use `/tasks SPEC-001` to break into atomic work items.
+   ```
+
+---
+
+## Spec Lifecycle
+
+```
+drafting → approved → implementing → complete
+```
+
+| Status | Meaning |
+|--------|---------|
+| `drafting` | Being refined, not ready |
+| `approved` | Ready for task breakdown |
+| `implementing` | Tasks created, work in progress |
+| `complete` | All tasks done, archive |
+
+---
+
+## Splitting Large Specs
+
+When a spec is too big for its appetite:
+
+```
+SPEC-001-user-auth.md (large, 2 weeks)
+        ↓ split into
+SPEC-001a-oauth-integration.md (medium, 3 days)
+SPEC-001b-session-management.md (small, 2 days)
+SPEC-001c-login-ui.md (medium, 3 days)
+```
+
+Each sub-spec:
+- Has its own appetite
+- Can be worked independently
+- References original requirement
+
+---
+
+## Test Conditions vs Acceptance Criteria
+
+| Test Conditions (Spec) | Acceptance Criteria (Requirement) |
+|------------------------|-----------------------------------|
+| High-level outcomes | Detailed behaviors |
+| For this shaped solution | For the full feature |
+| May be subset of AC | Complete coverage |
+| Implementation-aware | Implementation-agnostic |
+
+Test conditions prove the spec is done.
+Acceptance criteria prove the requirement is met.
+
+---
+
+## Guardrails
+
+1. **Interview to shape** - Boundaries before details
+2. **Respect appetite** - Fixed time, variable scope
+3. **Document rabbit holes** - Prevent scope creep
+4. **Clear test conditions** - Observable outcomes
+5. **Circuit breaker** - Plan for running out of time
+6. **Get approval** - Don't create without confirmation
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Implementation details | Keep high-level, shape not blueprint |
+| No appetite | Always set time budget |
+| Missing no-gos | Explicitly forbid bad approaches |
+| Vague test conditions | Make observable and verifiable |
+| Too ambitious | Split or increase appetite |
+
+---
+
+## Related Skills
+
+- **orchestration/specs** - Full spec methodology
+- **orchestration/product-development** - Where specs fit in hierarchy
+- **orchestration/planning** - Shape Up methodology details
+---
+version: 1.11.0

--- a/dist/cursor/commands/start-session.md
+++ b/dist/cursor/commands/start-session.md
@@ -6,6 +6,36 @@ You are the PM agent. Start by understanding the task:
 
 ---
 
+## Input Detection
+
+Parse `$ARGUMENTS` to determine the session type:
+
+| Input Pattern | Type | Action |
+|---------------|------|--------|
+| `TASK-XXX` | Local task | Load from `.agents/tasks/active/` |
+| `SPEC-XXX` | Spec (no task) | Warn: suggest `/tasks` first |
+| `PLT-123`, `PROJ-123` | Linear issue | Fetch from Linear |
+| Description text | Ad-hoc | Create session, ask about Linear |
+
+### Task-Coupled Sessions
+
+When starting from a task (`TASK-XXX` or Linear issue):
+
+1. **Fetch task details** (local file or Linear API)
+2. **Load parent spec** if task has `spec:` field
+3. **Load linked requirement** if spec has `requirement:` field
+4. **Build traceability chain** in session frontmatter
+
+### Ad-hoc Sessions
+
+When no task exists:
+
+1. **Inform user:** "No parent task found. Proceeding as ad-hoc session."
+2. **Ask:** "Should I create a Linear issue or local task for tracking?"
+3. If yes, create and link; if no, proceed without
+
+---
+
 ## CRITICAL: Strict Delegation Model
 
 **You are the ORCHESTRATOR, not the implementer.**
@@ -126,8 +156,19 @@ session:
   linear_issue: "PLT-XXX"           # If applicable
   linear_url: "https://linear.app/{{your-workspace}}/issue/PLT-XXX"
   branch: "username/plt-xxx-feature"    # Working branch for this session
+  task: "TASK-001"                      # Local task ID (if applicable)
+  spec: "SPEC-001"                      # Parent spec (if applicable)
+
+# Traceability chain (populated when task-coupled)
+traceability:
+  requirement: "2.1 User Authentication"  # From spec's requirement field
+  architecture:
+    - "Session Management"                # Relevant ARCHITECTURE.md sections
+  decisions:
+    - "ADR-001"                           # Related ADRs
 
 plans: []  # List of plan files in .agents/plans/ used by this session
+transcripts: []  # Archived conversation transcripts (.jsonl files)
 
 orchestration:
   current_task: "Initial planning"
@@ -613,5 +654,76 @@ Follow your three-phase workflow (BEFORE → DURING → AFTER):
 Format: `[YYYY-MM-DD HH:MM UTC]`
 
 Generate with: `date -u +"%Y-%m-%d %H:%M UTC"`
+
+---
+
+## Transcript Archival
+
+After `/compact` or `/clear`, archive conversation transcripts for future reference.
+
+### Process
+
+1. **Get transcript path** from Claude Code output after compaction
+2. **Create transcripts directory** if needed:
+   ```bash
+   mkdir -p .agents/transcripts
+   ```
+3. **Copy transcript** with descriptive name:
+   ```bash
+   cp /path/to/transcript.jsonl .agents/transcripts/YYYYMMDD-HHMMSS-description.jsonl
+   ```
+4. **Update session frontmatter**:
+   ```yaml
+   transcripts:
+     - 20260123-143500-pre-compact.jsonl
+   ```
+
+### When to Archive
+
+| Event | Action |
+|-------|--------|
+| Before `/compact` | Archive current transcript |
+| Before `/clear` | Archive current transcript |
+| Session end | Archive final transcript |
+
+### Benefits
+
+- **Audit trail** - Full history of decisions and work
+- **Knowledge extraction** - Mining past sessions for patterns
+- **Debugging** - Understanding how errors occurred
+- **Training** - Learning from past sessions
+
+---
+
+## Task Completion
+
+When a task-coupled session completes:
+
+1. **Update task status** (local file or Linear)
+2. **Check spec progress:**
+   - List all tasks for the spec
+   - If all done → mark spec as `complete`
+   - If tasks remain → spec stays `implementing`
+3. **Archive session** (standard process)
+
+### Spec Completion Check
+
+```bash
+# For local tasks
+grep -l "spec: SPEC-001" .agents/tasks/active/*.md | wc -l
+# If 0, all tasks done
+
+# For Linear
+# Check all issues with spec label
+```
+
+---
+
+## Related Skills
+
+- **orchestration/product-development** - Full workflow hierarchy
+- **orchestration/specs** - Spec format and lifecycle
+- **orchestration/local-tasks** - Local task management
+- **orchestration/sessions** - Session lifecycle details
 ---
 version: 1.11.0

--- a/dist/cursor/commands/start-session.md
+++ b/dist/cursor/commands/start-session.md
@@ -134,13 +134,65 @@ orchestration:
   spawned_agents: []
 ```
 
-### Step 4: Verify Creation
+### Step 4: Create Plan File
 
-Confirm the session file exists and contains valid frontmatter before proceeding.
+**Location:** `.agents/plans/`
+**Filename:** Same timestamp as session: `YYYYMMDD-HHMMSS-<description>.md`
 
-**DO NOT PROCEED WITHOUT A SESSION FILE.**
+Use this Shape Up-inspired template:
 
-### Step 5: Suggest Session Rename
+```markdown
+---
+session: YYYYMMDD-HHMMSS-<description>.md
+created: "YYYY-MM-DDTHH:MM:SSZ"
+status: drafting
+appetite: ""
+---
+
+# Plan: <description>
+
+## Appetite
+
+*Time budget for this work (e.g., "2 hours", "1 day"). Fixed time, variable scope.*
+
+## Problem
+
+*What problem are we solving? Why does it matter?*
+
+## Solution Shape
+
+*High-level approach, not a detailed spec. What's the general shape of the solution?*
+
+## Rabbit Holes
+
+*What NOT to do. Scope boundaries. Things that seem related but should be avoided.*
+
+## No-Gos
+
+*Explicit exclusions. Features or approaches we're deliberately not doing.*
+
+## Circuit Breaker
+
+At 50% of appetite spent: Re-evaluate if we're on track. If not, consider:
+- Simplifying scope
+- Taking a different approach
+- Stopping early and documenting learnings
+```
+
+**Update session frontmatter** to link the plan:
+
+```yaml
+plans:
+  - YYYYMMDD-HHMMSS-<description>.md
+```
+
+### Step 5: Verify Creation
+
+Confirm both session file AND plan file exist with valid frontmatter before proceeding.
+
+**DO NOT PROCEED WITHOUT A SESSION FILE AND PLAN FILE.**
+
+### Step 6: Suggest Session Rename
 
 After creating the session file, suggest renaming the Claude Code session for easy identification:
 
@@ -207,7 +259,7 @@ Is this a code/config/doc change?
 
 ## Startup Checklist
 
-**After creating session file:**
+**After creating session AND plan files:**
 
 1. [ ] Parse the input — is this a Linear issue ID (e.g., PLT-123, PLAT-123) or a description?
 2. [ ] If Linear ID:
@@ -217,10 +269,13 @@ Is this a code/config/doc change?
 3. [ ] If description: ask user if a Linear issue should be created
 4. [ ] **Create dedicated branch for this work** (see Branch Management below)
 5. [ ] **Suggest team** based on task context (see Team Routing below)
-6. [ ] Populate session `## Context` section with background
-7. [ ] Break down the work using TodoWrite
-8. [ ] **Identify which specialized agents will be needed** (use mapping table)
-9. [ ] Update session `## Next Steps` with planned agent spawns
+6. [ ] **Fill in plan file sections** (Appetite, Problem, Solution Shape, Rabbit Holes)
+7. [ ] Populate session `## Context` section with background
+8. [ ] Break down the work using TodoWrite
+9. [ ] **Identify which specialized agents will be needed** (use mapping table)
+10. [ ] **Consider architecture diagrams** (see Diagram Consideration below)
+11. [ ] Update session `## Next Steps` with planned agent spawns
+12. [ ] **Get user approval on plan** before spawning implementation agents
 
 ---
 
@@ -293,6 +348,48 @@ Suggest Security, confirm if new to project
 ```
 
 Use Linear MCP's `list_teams` to get all workspace teams for validation.
+
+---
+
+## Diagram Consideration
+
+For multi-file or multi-service changes, consider adding architecture diagrams to the session file.
+
+### When to Create Diagrams
+
+| Scenario | Diagram Type |
+|----------|--------------|
+| Changes span 3+ services | Component diagram (interaction points) |
+| Data flow modifications | Sequence diagram (trace data path) |
+| Schema/model changes | ERD (table relationships) |
+| New API endpoints | Sequence diagram (request/response) |
+| State machine logic | State diagram (transitions) |
+
+### Quick Check
+
+Ask yourself:
+1. Will this work touch multiple services or layers?
+2. Is there a data flow that needs to be understood?
+3. Would a visual help communicate the approach?
+
+If yes to any, add an `## Architecture Diagrams` section to the session file.
+
+### Diagram Template
+
+```markdown
+## Architecture Diagrams
+
+### [Descriptive Name]
+
+```mermaid
+[Use flowchart, sequenceDiagram, erDiagram, or stateDiagram-v2]
+```
+
+**Purpose**: Why this diagram clarifies the work
+**Files involved**: `path/to/file1.py`, `path/to/file2.py`
+```
+
+See `foundations` skill `reference/diagrams.md` for Mermaid syntax and best practices.
 
 ---
 
@@ -471,7 +568,9 @@ Follow your three-phase workflow (BEFORE → DURING → AFTER):
 
 ### AFTER (Completion)
 
-1. Spawn `backend-dev`/`frontend-dev` for code review (if significant changes)
+1. **Code review pass** (REQUIRED for significant changes):
+   - Run `pr-review-toolkit:code-reviewer` on all modified files
+   - Address any critical issues before proceeding
 2. Spawn `qa` for final testing and security review
 3. Update Linear issue status to Done
 4. Complete session file with outcomes

--- a/dist/cursor/hooks.json
+++ b/dist/cursor/hooks.json
@@ -23,6 +23,11 @@
         "matcher": "Bash"
       },
       {
+        "command": "bash $HOME/.cursor/hooks/pre-tool/foundations-tdd-advisory.sh",
+        "timeout": 5,
+        "matcher": "Edit|Write"
+      },
+      {
         "command": "python3 $HOME/.cursor/hooks/pre-tool/orchestration-validate-commit.py",
         "timeout": 30,
         "matcher": "Bash"

--- a/dist/cursor/hooks/pre-tool/foundations-tdd-advisory.sh
+++ b/dist/cursor/hooks/pre-tool/foundations-tdd-advisory.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Hook: TDD Advisory (INFORMATIONAL)
+# PreToolUse hook - reads JSON from stdin per Claude Code hooks API
+#
+# Triggers on Edit|Write to implementation files
+# Warns when tests don't exist or don't fail first (non-blocking)
+# Inspired by Cursor's TDD best practice
+
+# Read and parse stdin JSON
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))" 2>/dev/null || echo "")
+
+# Exit early if no file path
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Skip if already a test file
+if [[ "$FILE_PATH" == *"test"* ]] || [[ "$FILE_PATH" == *"spec"* ]] || [[ "$FILE_PATH" == *"_test."* ]] || [[ "$FILE_PATH" == *".test."* ]]; then
+  exit 0
+fi
+
+# Skip non-code files
+EXTENSION="${FILE_PATH##*.}"
+case "$EXTENSION" in
+  py|ts|tsx|js|jsx|rb|go|rs)
+    # Continue checking
+    ;;
+  *)
+    # Not a code file, skip
+    exit 0
+    ;;
+esac
+
+# Skip config and generated files
+if [[ "$FILE_PATH" == *"config"* ]] || [[ "$FILE_PATH" == *"generated"* ]] || [[ "$FILE_PATH" == *"__init__"* ]]; then
+  exit 0
+fi
+
+# Get the base name and directory for test file detection
+BASENAME=$(basename "$FILE_PATH")
+DIRNAME=$(dirname "$FILE_PATH")
+FILENAME="${BASENAME%.*}"
+
+# Build potential test file patterns based on language conventions
+POTENTIAL_TESTS=()
+case "$EXTENSION" in
+  py)
+    POTENTIAL_TESTS=(
+      "${DIRNAME}/test_${FILENAME}.py"
+      "${DIRNAME}/${FILENAME}_test.py"
+      "tests/test_${FILENAME}.py"
+      "tests/${FILENAME}_test.py"
+    )
+    ;;
+  ts|tsx|js|jsx)
+    POTENTIAL_TESTS=(
+      "${DIRNAME}/${FILENAME}.test.${EXTENSION}"
+      "${DIRNAME}/${FILENAME}.spec.${EXTENSION}"
+      "${DIRNAME}/__tests__/${FILENAME}.test.${EXTENSION}"
+      "__tests__/${FILENAME}.test.${EXTENSION}"
+    )
+    ;;
+  rb)
+    POTENTIAL_TESTS=(
+      "spec/${FILENAME}_spec.rb"
+      "${DIRNAME}/${FILENAME}_spec.rb"
+      "test/${FILENAME}_test.rb"
+    )
+    ;;
+  go)
+    POTENTIAL_TESTS=(
+      "${DIRNAME}/${FILENAME}_test.go"
+    )
+    ;;
+esac
+
+# Check if any test file exists
+TEST_EXISTS=false
+FOUND_TEST=""
+for TEST_FILE in "${POTENTIAL_TESTS[@]}"; do
+  if [ -f "$TEST_FILE" ]; then
+    TEST_EXISTS=true
+    FOUND_TEST="$TEST_FILE"
+    break
+  fi
+done
+
+# Output advisory (non-blocking)
+if [ "$TEST_EXISTS" = false ]; then
+  cat << EOF
+# TDD Advisory
+
+Editing implementation file: \`$FILE_PATH\`
+
+**No corresponding test file found.** Consider Test-Driven Development:
+
+1. Write a failing test first
+2. Then implement the feature
+3. Run tests until green
+
+**Expected test locations:**
+$(for t in "${POTENTIAL_TESTS[@]}"; do echo "- \`$t\`"; done)
+
+**Why TDD?** Tests document expected behavior and prevent regressions.
+Skip this advisory if you're:
+- Doing a quick fix with existing test coverage
+- Working in an area where tests aren't practical
+
+EOF
+fi
+
+# Always exit 0 (non-blocking advisory)
+exit 0

--- a/dist/cursor/skills/debugging/SKILL.md
+++ b/dist/cursor/skills/debugging/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: debugging
+description: >-
+  Use for systematic bug investigation and diagnosis. Covers hypothesis-driven
+  debugging workflows, multi-hypothesis tracking, language-specific debugging
+  patterns (Python, TypeScript, Ruby), and test debugging (flaky tests,
+  isolation, state pollution). Activate when investigating failures, debugging
+  production issues, or diagnosing test problems.
+version: 1.11.0
+---
+
+# Systematic Debugging
+
+Hypothesis-driven investigation for efficient and traceable bug diagnosis.
+
+## Philosophy
+
+**Eliminate, don't guess.** Debugging is a process of elimination, not random modification. Each change should test a specific hypothesis and provide evidence to rule it out or confirm it.
+
+**Multiple hypotheses, ranked.** Never fixate on one theory. Generate 3-5 plausible hypotheses, rank by likelihood, and test the most likely first. Surprising evidence should trigger hypothesis revision.
+
+**Reproduce before investigating.** A bug you cannot reproduce is a bug you cannot fix with confidence. Establish reliable reproduction steps before diving into code.
+
+**Minimal changes, maximum information.** Each debugging step should change one variable and maximize the information gained. Shotgun debugging wastes time and obscures root causes.
+
+## Quick Reference
+
+| Situation | Approach | Key Technique |
+|-----------|----------|---------------|
+| **Unknown failure** | Generate hypotheses | List 3-5 possible causes, rank by likelihood |
+| **Intermittent bug** | Isolate variables | Binary search through conditions |
+| **Test flakiness** | Check state pollution | Run test in isolation, check fixtures |
+| **Production issue** | Preserve evidence | Capture logs/state before attempting fixes |
+
+## Topics
+
+| Topic | Reference | Use For |
+|-------|-----------|---------|
+| Hypothesis Tracking | `references/hypothesis-tracking.md` | Multi-hypothesis workflow, session templates, investigation logs |
+| Language Debugging | `references/language-debugging.md` | Python, TypeScript, Ruby debug patterns and tools |
+| Test Debugging | `references/test-debugging.md` | Flaky tests, isolation, state pollution, environment differences |
+
+## Critical Rules
+
+### Always
+
+- Generate multiple hypotheses before investigating
+- Document each hypothesis and its current status
+- Establish reproduction steps before attempting fixes
+- Test one variable at a time
+- Preserve evidence (logs, state, stack traces) before changes
+- Update hypothesis status based on evidence
+- Record failed attempts to avoid repeating them
+
+### Never
+
+- Make random changes hoping something works
+- Fix symptoms without understanding root cause
+- Assume the first hypothesis is correct
+- Skip reproduction verification after a "fix"
+- Delete logs or error output before analysis
+- Change multiple variables simultaneously
+- Ignore contradictory evidence
+
+## Debugging Workflow
+
+```
+1. REPRODUCE: Establish reliable reproduction steps
+2. HYPOTHESIZE: Generate 3-5 possible causes, rank by likelihood
+3. TEST: Design experiment to test highest-likelihood hypothesis
+4. EVALUATE: Analyze results, update hypothesis status
+5. ITERATE: Move to next hypothesis or refine based on evidence
+6. VERIFY: Confirm fix addresses root cause, not just symptoms
+```
+
+## Investigation Log Format
+
+Keep a timestamped log of investigation steps:
+
+```
+[HH:MM] Testing H2 (stale cache)
+        Action: Cleared Redis, restarted service
+        Result: Still failing
+        Evidence: Error occurs before cache read in stack trace
+        Status: H2 RULED OUT
+
+[HH:MM] Testing H3 (race condition)
+        Action: Added mutex around shared state
+        Result: SUCCESS - no failures in 100 runs
+        Evidence: Stack trace showed concurrent access
+        Status: H3 CONFIRMED
+```
+
+## Related Skills
+
+- `foundations` - Test patterns, error handling, logging standards
+- `python` - Python-specific debugging tools (pdb, logging)
+- `typescript` - TypeScript debugging (Chrome DevTools, source maps)
+- `ruby` - Ruby debugging (binding.irb, byebug)

--- a/dist/cursor/skills/debugging/references/hypothesis-tracking.md
+++ b/dist/cursor/skills/debugging/references/hypothesis-tracking.md
@@ -1,0 +1,168 @@
+# Hypothesis Tracking
+
+Systematic workflow for generating, testing, and tracking multiple debugging hypotheses.
+
+## Multi-Hypothesis Workflow
+
+### 1. Generate Hypotheses
+
+Before investigating, brainstorm 3-5 possible causes. Consider:
+
+- **Recent changes** - What changed since it last worked?
+- **Common culprits** - Race conditions, caching, state mutation, null references
+- **Environment differences** - Dev vs prod, different data, timing
+- **External dependencies** - API changes, network issues, third-party services
+
+### 2. Rank by Likelihood
+
+Assign likelihood based on:
+
+| Factor | Higher Likelihood | Lower Likelihood |
+|--------|-------------------|------------------|
+| Recency | Code changed recently | Untouched for months |
+| Complexity | Complex logic, many branches | Simple, well-tested |
+| Dependencies | External services involved | Self-contained |
+| Symptoms | Matches known failure pattern | Novel error |
+
+### 3. Test Systematically
+
+For each hypothesis (highest likelihood first):
+
+1. **Design minimal experiment** - What single change would confirm or rule out this hypothesis?
+2. **Predict outcome** - What result do you expect if hypothesis is correct?
+3. **Execute and observe** - Run experiment, capture results
+4. **Update status** - Mark CONFIRMED, RULED OUT, or NEEDS MORE DATA
+
+### 4. Revise Based on Evidence
+
+When evidence contradicts expectations:
+
+- Lower likelihood of current hypothesis
+- Consider what the evidence suggests instead
+- Add new hypotheses if needed
+- Re-rank based on new information
+
+## Session Template
+
+Use this template at the start of debugging sessions:
+
+```markdown
+## Debug Investigation
+
+**Symptom**: [What's failing - exact error message or behavior]
+**First observed**: [When did this start happening]
+**Reproduction**: [Steps to reliably reproduce]
+
+### Environment
+- OS/Platform:
+- Version:
+- Dependencies:
+- Data state:
+
+### Hypothesis Tracker
+
+| # | Hypothesis | Likelihood | Status | Evidence |
+|---|------------|------------|--------|----------|
+| H1 | [Description] | High/Med/Low | TESTING/RULED OUT/CONFIRMED | [What you learned] |
+| H2 | [Description] | High/Med/Low | PENDING | - |
+| H3 | [Description] | High/Med/Low | PENDING | - |
+
+### Investigation Log
+[Timestamped entries below]
+```
+
+## Example Investigation
+
+### Symptom
+API returns 500 error intermittently on `/api/orders` endpoint.
+
+### Reproduction
+1. Create 10+ concurrent requests to `/api/orders`
+2. ~30% return 500 errors
+3. Only happens under load
+
+### Hypothesis Tracker
+
+| # | Hypothesis | Likelihood | Status | Evidence |
+|---|------------|------------|--------|----------|
+| H1 | Database connection pool exhausted | High | RULED OUT | Pool metrics show 50% utilization during failures |
+| H2 | Race condition in order validation | High | TESTING | Errors correlate with concurrent creates |
+| H3 | Memory pressure causing timeouts | Medium | PENDING | - |
+| H4 | Third-party payment API rate limiting | Low | RULED OUT | Payment API logs show no rate limits |
+
+### Investigation Log
+
+```
+[14:32] Testing H1 (connection pool)
+        Action: Monitored pool metrics during load test
+        Result: Pool never exceeded 50% capacity
+        Evidence: Prometheus shows max 5/10 connections used
+        Status: H1 RULED OUT - pool is not the bottleneck
+
+[14:45] Testing H4 (payment API rate limiting)
+        Action: Checked payment provider dashboard
+        Result: No rate limit events in their logs
+        Evidence: All payment API calls successful
+        Status: H4 RULED OUT
+
+[15:01] Testing H2 (race condition)
+        Action: Added logging around order validation
+        Result: Found concurrent access to shared cart state
+        Evidence: Logs show two requests modifying same cart simultaneously
+        Status: H2 LIKELY - need to verify with fix
+
+[15:23] Verifying H2 fix
+        Action: Added mutex around cart validation
+        Result: 0 errors in 1000 concurrent requests
+        Evidence: Lock prevents concurrent modification
+        Status: H2 CONFIRMED - race condition was root cause
+```
+
+## Hypothesis Status Definitions
+
+| Status | Meaning | Next Action |
+|--------|---------|-------------|
+| PENDING | Not yet investigated | Move to TESTING when ready |
+| TESTING | Currently being investigated | Execute experiment, gather evidence |
+| NEEDS MORE DATA | Inconclusive results | Design better experiment |
+| RULED OUT | Evidence contradicts hypothesis | Document and move on |
+| LIKELY | Evidence supports but not conclusive | Verify with fix |
+| CONFIRMED | Root cause identified and verified | Document fix and close |
+
+## Common Hypothesis Categories
+
+### State-Related
+- Stale cache returning old data
+- Database transaction not committed
+- In-memory state mutation
+- Session/cookie corruption
+
+### Timing-Related
+- Race condition between concurrent operations
+- Timeout too short for slow operations
+- Clock skew between services
+- Event ordering assumptions violated
+
+### Environment-Related
+- Missing environment variable
+- Different library versions
+- File permissions
+- Network connectivity/latency
+
+### Data-Related
+- Null/undefined where unexpected
+- Type mismatch (string vs number)
+- Encoding issues (UTF-8, special characters)
+- Data exceeds expected bounds
+
+## Tips for Effective Hypothesis Tracking
+
+1. **Be specific** - "Something wrong with caching" is not a hypothesis. "Redis TTL set to 0 causing immediate expiration" is.
+
+2. **Make them testable** - Every hypothesis should have a clear experiment that could rule it out.
+
+3. **Update in real-time** - Log entries as you go, not from memory later.
+
+4. **Don't delete** - Ruled-out hypotheses are valuable documentation of what was tried.
+
+5. **Share context** - If handing off, the tracker should let someone else continue without starting over.

--- a/dist/cursor/skills/debugging/references/language-debugging.md
+++ b/dist/cursor/skills/debugging/references/language-debugging.md
@@ -1,0 +1,354 @@
+# Language-Specific Debugging
+
+Debug patterns and tools for Python, TypeScript, and Ruby.
+
+## Python Debugging
+
+### Interactive Debugging with pdb
+
+```python
+# Insert breakpoint in code
+import pdb; pdb.set_trace()
+
+# Python 3.7+ built-in
+breakpoint()
+
+# Conditional breakpoint
+if suspicious_condition:
+    breakpoint()
+```
+
+**Common pdb commands:**
+
+| Command | Action |
+|---------|--------|
+| `n` (next) | Execute next line |
+| `s` (step) | Step into function |
+| `c` (continue) | Continue to next breakpoint |
+| `p expr` | Print expression value |
+| `pp expr` | Pretty-print expression |
+| `l` (list) | Show current code context |
+| `w` (where) | Print stack trace |
+| `u` (up) | Move up stack frame |
+| `d` (down) | Move down stack frame |
+| `q` (quit) | Exit debugger |
+
+### Structured Logging
+
+```python
+import structlog
+
+logger = structlog.get_logger()
+
+# Add context that persists across log calls
+logger = logger.bind(request_id=request.id, user_id=user.id)
+
+# Log with structured data
+logger.info("order_created", order_id=order.id, total=order.total)
+logger.error("payment_failed",
+    order_id=order.id,
+    error_code=e.code,
+    error_message=str(e)
+)
+```
+
+### Traceback Analysis
+
+```python
+import traceback
+
+try:
+    risky_operation()
+except Exception as e:
+    # Full traceback as string
+    tb_str = traceback.format_exc()
+    logger.error("operation_failed", traceback=tb_str)
+
+    # Extract specific frame info
+    tb = traceback.extract_tb(e.__traceback__)
+    for frame in tb:
+        logger.debug("frame",
+            filename=frame.filename,
+            line=frame.lineno,
+            function=frame.name
+        )
+```
+
+### pytest Debugging
+
+```bash
+# Drop into debugger on failure
+pytest --pdb
+
+# Drop into debugger on first failure, then exit
+pytest -x --pdb
+
+# Show local variables in tracebacks
+pytest -l
+
+# Verbose output with print statements
+pytest -v -s
+
+# Run specific test
+pytest tests/test_orders.py::test_create_order -v
+```
+
+### Remote Debugging
+
+```python
+# Using debugpy (VS Code compatible)
+import debugpy
+debugpy.listen(5678)
+debugpy.wait_for_client()  # Pause until debugger attaches
+breakpoint()
+```
+
+## TypeScript Debugging
+
+### Console Methods
+
+```typescript
+// Basic logging
+console.log('value:', value);
+console.error('Error:', error);
+console.warn('Warning:', message);
+
+// Structured output
+console.table(arrayOfObjects);
+console.dir(complexObject, { depth: null });
+
+// Timing
+console.time('operation');
+// ... operation ...
+console.timeEnd('operation');
+
+// Grouping related logs
+console.group('Request Processing');
+console.log('Step 1');
+console.log('Step 2');
+console.groupEnd();
+
+// Conditional logging
+console.assert(condition, 'Condition failed:', data);
+
+// Stack trace without error
+console.trace('How did we get here?');
+```
+
+### Debugger Statement
+
+```typescript
+function processOrder(order: Order): void {
+  // Pauses execution when DevTools is open
+  debugger;
+
+  // Conditional debugger
+  if (order.total > 10000) {
+    debugger;
+  }
+}
+```
+
+### Source Maps
+
+Ensure `tsconfig.json` has source maps enabled:
+
+```json
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "inlineSources": true
+  }
+}
+```
+
+For debugging bundled code, verify source maps are generated and served:
+
+```typescript
+// webpack.config.js
+module.exports = {
+  devtool: 'source-map', // Full source maps for debugging
+};
+```
+
+### Node.js Debugging
+
+```bash
+# Start with inspector
+node --inspect dist/server.js
+
+# Break on first line
+node --inspect-brk dist/server.js
+
+# With ts-node
+node --inspect -r ts-node/register src/server.ts
+```
+
+### Chrome DevTools Tips
+
+1. **Breakpoints**: Click line number in Sources panel
+2. **Conditional breakpoints**: Right-click line number, add condition
+3. **Logpoints**: Right-click, add logpoint (logs without pausing)
+4. **Watch expressions**: Add variables to Watch panel
+5. **Call stack**: Navigate up/down the call stack
+6. **Scope**: Inspect local, closure, and global variables
+
+### Async Debugging
+
+```typescript
+// Capture async stack traces
+Error.stackTraceLimit = 50;
+
+// Label promises for debugging
+const result = await Promise.race([
+  fetchData().then(data => ({ source: 'fetch', data })),
+  timeout(5000).then(() => ({ source: 'timeout', data: null }))
+]);
+console.log('Winner:', result.source);
+```
+
+## Ruby Debugging
+
+### binding.irb (Ruby 2.5+)
+
+```ruby
+def process_order(order)
+  # Opens interactive console at this point
+  binding.irb
+
+  order.validate!
+end
+```
+
+**IRB commands in binding.irb:**
+
+| Command | Action |
+|---------|--------|
+| `exit` | Continue execution |
+| `exit!` | Exit program |
+| `whereami` | Show current code context |
+| `show_source method_name` | Show method source |
+
+### byebug
+
+```ruby
+# Gemfile
+gem 'byebug', group: [:development, :test]
+
+# In code
+require 'byebug'
+
+def process_order(order)
+  byebug  # Execution stops here
+  order.validate!
+end
+```
+
+**byebug commands:**
+
+| Command | Action |
+|---------|--------|
+| `n` (next) | Execute next line |
+| `s` (step) | Step into method |
+| `c` (continue) | Continue execution |
+| `f` (finish) | Run until current method returns |
+| `p expr` | Evaluate expression |
+| `info locals` | Show local variables |
+| `bt` (backtrace) | Show call stack |
+| `up` / `down` | Navigate stack frames |
+
+### Rails Console Debugging
+
+```ruby
+# Start console
+rails console
+
+# Reload after code changes
+reload!
+
+# Find and inspect objects
+user = User.find(123)
+user.attributes
+user.orders.to_sql  # See generated SQL
+
+# Test in sandbox (rollback on exit)
+rails console --sandbox
+```
+
+### Rails Logger
+
+```ruby
+# In application code
+Rails.logger.debug "Processing order: #{order.id}"
+Rails.logger.info "Order created", order_id: order.id
+Rails.logger.error "Payment failed", error: e.message
+
+# Tagged logging
+Rails.logger.tagged("OrderService", order.id) do
+  Rails.logger.info "Starting processing"
+end
+
+# Tail logs
+tail -f log/development.log
+```
+
+### pry-rails
+
+```ruby
+# Gemfile
+gem 'pry-rails', group: [:development, :test]
+
+# In code
+binding.pry  # Opens Pry console
+
+# Pry commands
+ls object          # List methods/variables
+cd object          # Change context to object
+show-source method # Show method definition
+show-doc method    # Show documentation
+wtf?               # Show last exception
+```
+
+### Exception Debugging
+
+```ruby
+begin
+  risky_operation
+rescue => e
+  # Full backtrace
+  puts e.backtrace.join("\n")
+
+  # Filtered backtrace (Rails)
+  puts Rails.backtrace_cleaner.clean(e.backtrace).join("\n")
+
+  # Re-raise with context
+  raise "Order processing failed for order #{order.id}: #{e.message}"
+end
+```
+
+## Cross-Language Tips
+
+### Binary Search Debugging
+
+When you have a long sequence of operations and don't know where the failure occurs:
+
+1. Add logging/breakpoint at the midpoint
+2. Determine if failure is before or after
+3. Repeat with the relevant half
+4. Continue until you isolate the exact line
+
+### Minimal Reproduction
+
+1. Remove code until bug disappears
+2. Add back the last removed piece
+3. That piece contains or triggers the bug
+4. Create minimal test case that reproduces
+
+### Rubber Duck Debugging
+
+When stuck:
+
+1. Explain the code line-by-line out loud
+2. Explain what you expect vs. what happens
+3. Explain your hypotheses and why each might be wrong
+4. Often, articulating the problem reveals the solution

--- a/dist/cursor/skills/debugging/references/test-debugging.md
+++ b/dist/cursor/skills/debugging/references/test-debugging.md
@@ -1,0 +1,326 @@
+# Test Debugging
+
+Strategies for diagnosing flaky tests, isolation failures, and environment-related test issues.
+
+## Flaky Test Diagnosis
+
+A flaky test passes sometimes and fails sometimes with the same code. Common causes:
+
+### Timing Dependencies
+
+**Symptoms:**
+- Test passes locally, fails in CI
+- Test fails more often under load
+- Adding `sleep()` makes it pass
+
+**Investigation:**
+```python
+# Bad: Depends on timing
+def test_async_operation():
+    start_async_job()
+    time.sleep(1)  # Hope it's done
+    assert job_completed()
+
+# Good: Wait for condition
+def test_async_operation():
+    start_async_job()
+    wait_for(lambda: job_completed(), timeout=5)
+    assert job_completed()
+```
+
+**Diagnosis steps:**
+1. Run test 100 times in a loop
+2. Monitor CPU/memory during failures
+3. Add timestamps to understand timing
+4. Check for hardcoded timeouts that are too short
+
+### Order Dependencies
+
+**Symptoms:**
+- Test passes when run alone, fails in suite
+- Test fails only when run after specific other test
+- Reordering tests changes results
+
+**Investigation:**
+```bash
+# pytest: Run in random order
+pytest --random-order
+
+# Find the guilty test pair
+pytest tests/test_a.py tests/test_b.py -v  # Passes
+pytest tests/test_b.py tests/test_a.py -v  # Fails?
+```
+
+**Common culprits:**
+- Global state modified by previous test
+- Database records not cleaned up
+- Cached values persisting
+- Module-level side effects
+
+### Non-Deterministic Data
+
+**Symptoms:**
+- Fails occasionally with no pattern
+- Different assertion failures each time
+- Works with specific seed/data
+
+**Investigation:**
+```python
+# Bad: Non-deterministic
+def test_random_selection():
+    items = get_random_items(10)
+    assert len(items) == 10  # What if source has < 10?
+
+# Good: Control randomness
+def test_random_selection():
+    random.seed(42)
+    items = get_random_items(10)
+    assert len(items) == 10
+```
+
+## Test Isolation Patterns
+
+### Database Isolation
+
+```python
+# pytest with transactions
+@pytest.fixture
+def db_session(engine):
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()
+```
+
+```ruby
+# Rails transactional tests
+class OrderTest < ActiveSupport::TestCase
+  # Each test runs in a transaction that rolls back
+  self.use_transactional_tests = true
+
+  test "creates order" do
+    order = Order.create!(total: 100)
+    assert order.persisted?
+  end  # Order is rolled back
+end
+```
+
+### External Service Isolation
+
+```python
+# Mock external services
+@pytest.fixture
+def mock_payment_api(mocker):
+    return mocker.patch(
+        'app.services.payment.PaymentAPI.charge',
+        return_value={'status': 'success', 'id': 'ch_123'}
+    )
+
+def test_order_payment(mock_payment_api):
+    order = create_order(total=100)
+    order.process_payment()
+
+    mock_payment_api.assert_called_once_with(amount=100)
+    assert order.payment_status == 'paid'
+```
+
+### Time Isolation
+
+```python
+# Freeze time for deterministic tests
+from freezegun import freeze_time
+
+@freeze_time("2024-01-15 12:00:00")
+def test_order_expiry():
+    order = create_order()
+    assert not order.expired
+
+    with freeze_time("2024-01-16 12:00:01"):
+        assert order.expired  # 24+ hours later
+```
+
+```typescript
+// Jest fake timers
+jest.useFakeTimers();
+
+test('order expires after 24 hours', () => {
+  const order = createOrder();
+  expect(order.expired).toBe(false);
+
+  jest.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
+  expect(order.expired).toBe(true);
+});
+```
+
+## State Pollution Detection
+
+### Symptoms
+
+- Test A passes alone, fails after test B
+- Test fails only when suite runs in specific order
+- "Works on my machine" syndrome
+
+### Detection Strategy
+
+```bash
+# 1. Run suspect test in isolation
+pytest tests/test_orders.py::test_specific -v
+
+# 2. Run with a known "polluter"
+pytest tests/test_other.py tests/test_orders.py::test_specific -v
+
+# 3. Binary search for the polluter
+pytest tests/test_orders.py::test_specific --last-failed
+```
+
+### Common State Pollution Sources
+
+| Source | Detection | Fix |
+|--------|-----------|-----|
+| Module globals | Check imports for mutations | Use fixtures, reset in teardown |
+| Class variables | Look for `cls.` modifications | Use instance variables |
+| Singletons | Check shared instances | Reset or mock singletons |
+| Environment variables | Print env in failing test | Restore in teardown |
+| File system | Check for temp files | Use tmp directories, clean up |
+| Database | Check for leftover records | Transaction rollback |
+| Caches | Check memoized values | Clear caches in setup |
+
+### Teardown Pattern
+
+```python
+@pytest.fixture(autouse=True)
+def reset_global_state():
+    # Setup: Save original state
+    original_config = app.config.copy()
+
+    yield
+
+    # Teardown: Restore original state
+    app.config = original_config
+    cache.clear()
+```
+
+## Environment Differences
+
+### Local vs CI Failures
+
+| Difference | Detection | Solution |
+|------------|-----------|----------|
+| Timing | CI slower, races more likely | Use proper waits, not sleeps |
+| Resources | CI has less memory/CPU | Check resource usage |
+| Parallelism | CI runs tests in parallel | Ensure isolation |
+| File paths | Different temp directories | Use portable paths |
+| Timezone | CI uses UTC | Freeze time or use UTC |
+| Locale | CI uses different locale | Set locale explicitly |
+
+### Debugging CI-Only Failures
+
+```yaml
+# GitHub Actions: Enable debug logging
+env:
+  ACTIONS_STEP_DEBUG: true
+  ACTIONS_RUNNER_DEBUG: true
+
+# Add verbose output
+steps:
+  - name: Run tests
+    run: |
+      echo "=== Environment ==="
+      env | sort
+      echo "=== Python version ==="
+      python --version
+      echo "=== Running tests ==="
+      pytest -v --tb=long
+```
+
+### Reproducing CI Environment Locally
+
+```bash
+# Docker: Use same image as CI
+docker run -it --rm -v $(pwd):/app -w /app python:3.11 bash
+pip install -r requirements.txt
+pytest
+
+# Act: Run GitHub Actions locally
+act -j test
+
+# Environment parity
+export CI=true
+export TZ=UTC
+pytest
+```
+
+## Test Debugging Workflow
+
+### 1. Isolate the Failure
+
+```bash
+# Run failing test alone
+pytest tests/test_orders.py::test_failing -v
+
+# If it passes alone, find the interaction
+pytest --collect-only | head -20  # See test order
+```
+
+### 2. Add Diagnostic Output
+
+```python
+def test_order_processing(caplog):
+    with caplog.at_level(logging.DEBUG):
+        order = process_order(data)
+
+    print(f"Captured logs: {caplog.text}")
+    print(f"Order state: {order.__dict__}")
+    assert order.status == "completed"
+```
+
+### 3. Minimize the Test
+
+```python
+# Start with failing test
+def test_order_processing():
+    user = create_user()
+    product = create_product()
+    cart = create_cart(user, product)
+    order = create_order(cart)
+    payment = process_payment(order)
+    shipment = create_shipment(order)
+    assert shipment.status == "ready"
+
+# Remove pieces until bug disappears
+def test_order_processing_minimal():
+    order = create_order()  # Minimal setup
+    assert order.status == "pending"  # Bug is here!
+```
+
+### 4. Check Assumptions
+
+```python
+def test_order_total():
+    order = create_order()
+
+    # Verify assumptions
+    print(f"Order items: {order.items}")
+    print(f"Item prices: {[i.price for i in order.items]}")
+    print(f"Expected total: {sum(i.price for i in order.items)}")
+    print(f"Actual total: {order.total}")
+
+    assert order.total == Decimal("100.00")
+```
+
+## Flaky Test Prevention
+
+| Practice | Why It Helps |
+|----------|--------------|
+| Use factories, not fixtures | Fresh data each test |
+| Avoid shared state | Tests can't pollute each other |
+| Mock time and randomness | Deterministic behavior |
+| Use transactions | Auto-cleanup |
+| Run tests in random order | Catch order dependencies |
+| Run tests in parallel | Catch isolation issues |
+| Set explicit timeouts | Fail fast on hangs |

--- a/dist/cursor/skills/foundations/SKILL.md
+++ b/dist/cursor/skills/foundations/SKILL.md
@@ -36,6 +36,7 @@ Engineering foundations for consistent, secure, and well-documented code.
 |-------|-----------|---------|
 | Code Style | `reference/code-style.md` | Python/TypeScript conventions, naming, patterns |
 | Commits | `reference/commits.md` | Commit messages, branches, PRs, Linear integration |
+| Diagrams | `reference/diagrams.md` | Mermaid syntax, when to diagram, storage patterns |
 | Documentation | `reference/documentation.md` | ADRs, API docs, changelogs |
 | Security | `reference/security.md` | Threat modeling, secrets, compliance |
 | Permissions | `reference/permissions.md` | Tool allowlists, sandbox config, agent permissions |

--- a/dist/cursor/skills/foundations/references/diagrams.md
+++ b/dist/cursor/skills/foundations/references/diagrams.md
@@ -1,0 +1,248 @@
+# Architecture Diagrams
+
+Guidelines for creating Mermaid diagrams to visualize system architecture and data flows.
+
+## When to Create Diagrams
+
+Create architecture diagrams when work involves:
+
+| Scenario | Diagram Type | Why |
+|----------|--------------|-----|
+| Multi-service changes | Component/flowchart | Shows interaction points and dependencies |
+| Data flow changes | Sequence/flowchart | Traces data through the system |
+| Schema modifications | ERD | Visualizes table relationships |
+| API design | Sequence | Documents request/response flows |
+| State machine logic | State diagram | Clarifies transitions and conditions |
+| Complex conditionals | Flowchart | Makes branching logic explicit |
+
+### Skip Diagrams When
+
+- Single-file changes with obvious scope
+- Bug fixes with no architectural impact
+- Configuration-only changes
+- Test additions (unless testing complex flows)
+
+## Mermaid Syntax Quick Reference
+
+### Flowchart (Most Common)
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Action 1]
+    B -->|No| D[Action 2]
+    C --> E[End]
+    D --> E
+```
+
+**Direction options:** `TD` (top-down), `LR` (left-right), `BT` (bottom-top), `RL` (right-left)
+
+**Node shapes:**
+- `[Rectangle]` - Process/action
+- `{Diamond}` - Decision
+- `([Stadium])` - Start/end
+- `[(Database)]` - Database
+- `((Circle))` - Connector
+
+### Sequence Diagram (API/Service Interaction)
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as API
+    participant D as Database
+
+    C->>A: POST /auth/login
+    A->>D: Query user
+    D-->>A: User record
+    A-->>C: JWT token
+```
+
+**Arrow types:**
+- `->>` Solid line with arrowhead (sync call)
+- `-->>` Dashed line with arrowhead (response)
+- `--)` Async message
+
+### Entity Relationship Diagram (Schema)
+
+```mermaid
+erDiagram
+    USER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT ||--o{ LINE_ITEM : "ordered in"
+
+    USER {
+        uuid id PK
+        string email
+        timestamp created_at
+    }
+    ORDER {
+        uuid id PK
+        uuid user_id FK
+        decimal total
+    }
+```
+
+**Relationship notation:**
+- `||` One (required)
+- `o|` Zero or one
+- `}|` One or many
+- `}o` Zero or many
+
+### State Diagram (State Machines)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Pending: submit
+    Pending --> Approved: approve
+    Pending --> Rejected: reject
+    Approved --> [*]
+    Rejected --> Draft: revise
+```
+
+### Component Diagram (System Architecture)
+
+```mermaid
+flowchart LR
+    subgraph Frontend
+        UI[Web App]
+    end
+
+    subgraph Backend
+        API[FastAPI]
+        Worker[Celery]
+    end
+
+    subgraph Data
+        DB[(PostgreSQL)]
+        Cache[(Redis)]
+    end
+
+    UI --> API
+    API --> DB
+    API --> Cache
+    API --> Worker
+    Worker --> DB
+```
+
+## Storage Patterns
+
+### Inline in Session File
+
+Best for: Diagrams specific to current work, temporary visualizations
+
+```markdown
+## Architecture Diagrams
+
+### Auth Flow
+```mermaid
+sequenceDiagram
+    User->>API: Login request
+    API->>DB: Validate credentials
+    DB-->>API: User record
+    API-->>User: JWT token
+```
+**Purpose**: Visualize the authentication flow being implemented
+**Files involved**: `backend/auth/`, `backend/models/user.py`
+```
+
+### Stored in `.agents/diagrams/`
+
+Best for: Reusable diagrams, cross-session reference, team documentation
+
+```
+.agents/diagrams/
+├── system-architecture.md
+├── auth-flow.md
+└── data-pipeline.md
+```
+
+**Diagram file format:**
+
+```markdown
+---
+created: 2025-01-23T14:00:00Z
+last_updated: 2025-01-23T14:00:00Z
+tags: [auth, api, security]
+---
+
+# Auth Flow Diagram
+
+## Overview
+
+Documents the authentication and authorization flow for the API.
+
+## Diagram
+
+```mermaid
+[diagram content]
+```
+
+## Related Files
+
+- `backend/auth/jwt.py` - JWT generation
+- `backend/middleware/auth.py` - Auth middleware
+- `backend/models/user.py` - User model
+
+## Notes
+
+Any additional context about this diagram.
+```
+
+### When to Store vs Inline
+
+| Store in `.agents/diagrams/` | Keep Inline in Session |
+|------------------------------|------------------------|
+| Referenced by multiple sessions | One-time visualization |
+| Documents stable architecture | Documents work-in-progress |
+| Shared across team members | Personal understanding aid |
+| Likely to be updated | Disposable after task |
+
+## Best Practices
+
+### Keep Diagrams Focused
+
+```markdown
+# Good: Single concern
+Auth flow diagram showing login -> validate -> token
+
+# Bad: Everything at once
+Entire system with auth, billing, notifications, logging...
+```
+
+### Use Consistent Naming
+
+```markdown
+# In diagrams, use actual names from code
+API[auth-service]  # Matches service name
+DB[(users)]        # Matches table name
+
+# Not generic placeholders
+API[Service A]
+DB[(Database)]
+```
+
+### Add Context
+
+Every diagram needs:
+1. **Purpose** - Why this diagram exists
+2. **Files involved** - What code it represents
+3. **Limitations** - What it does NOT show
+
+### Update When Code Changes
+
+Diagrams are documentation. When the code they represent changes:
+1. Update the diagram
+2. Update `last_updated` timestamp
+3. Note the change in session log
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Diagram everything | Diagram only complex flows |
+| Include implementation details | Show architectural relationships |
+| Create diagrams after code | Create during planning |
+| Leave stale diagrams | Update or delete |
+| Use inconsistent notation | Follow Mermaid conventions |

--- a/dist/cursor/skills/orchestration/SKILL.md
+++ b/dist/cursor/skills/orchestration/SKILL.md
@@ -37,11 +37,18 @@ Every release should be complete, polished, and delightful - no MVPs or quick ha
 | Stuck on task | Check circuit breaker, consider reshaping |
 | Pre-compaction | Spawn context-archiver to preserve state |
 | Low-priority work | Spawn background-runner with run_in_background |
+| New feature workflow | Research → Architecture → PRD → Specs → Tasks |
+| Create specification | Use `/specs` with requirement reference |
+| Break down spec | Use `/tasks` to generate atomic work items |
+| Task-coupled session | Use `/start-session TASK-XXX` for traceability |
 
 ## Topics
 
 | Topic | Reference | Key Content |
 |-------|-----------|-------------|
+| Product Development | [reference/product-development.md](reference/product-development.md) | Full workflow: Research → Vision → Architecture → Requirements → Specs → Tasks |
+| Specifications | [reference/specs.md](reference/specs.md) | Spec format, lifecycle, shaping, test conditions |
+| Local Tasks | [reference/local-tasks.md](reference/local-tasks.md) | Task format, abstraction layer, Linear/local backend |
 | Agent Delegation | [reference/delegation.md](reference/delegation.md) | Agent capabilities, spawn patterns, decision tree |
 | Background Agents | [reference/background-agents.md](reference/background-agents.md) | Non-interactive work, spawn with run_in_background |
 | Council Workflow | [reference/councils.md](reference/councils.md) | Composition, deliberation, synthesis, user approval |

--- a/dist/cursor/skills/orchestration/SKILL.md
+++ b/dist/cursor/skills/orchestration/SKILL.md
@@ -36,12 +36,14 @@ Every release should be complete, polished, and delightful - no MVPs or quick ha
 | Agent selection | Match domain expertise to task |
 | Stuck on task | Check circuit breaker, consider reshaping |
 | Pre-compaction | Spawn context-archiver to preserve state |
+| Low-priority work | Spawn background-runner with run_in_background |
 
 ## Topics
 
 | Topic | Reference | Key Content |
 |-------|-----------|-------------|
 | Agent Delegation | [reference/delegation.md](reference/delegation.md) | Agent capabilities, spawn patterns, decision tree |
+| Background Agents | [reference/background-agents.md](reference/background-agents.md) | Non-interactive work, spawn with run_in_background |
 | Council Workflow | [reference/councils.md](reference/councils.md) | Composition, deliberation, synthesis, user approval |
 | Session Management | [reference/sessions.md](reference/sessions.md) | Lifecycle, file format, handoffs, validation |
 | Session Resume | [reference/session-resume.md](reference/session-resume.md) | CLI flags, checkpoints, context recovery |

--- a/dist/cursor/skills/orchestration/references/background-agents.md
+++ b/dist/cursor/skills/orchestration/references/background-agents.md
@@ -1,0 +1,236 @@
+# Background Agents
+
+Background agents handle low-priority, long-running, or non-interactive work that can run independently while the user continues with other tasks.
+
+## When to Use Background Agents
+
+| Appropriate | Not Appropriate |
+|-------------|-----------------|
+| Security audits | Interactive debugging |
+| Code coverage analysis | User-facing questions |
+| Large-scale refactoring reports | Time-sensitive fixes |
+| Codebase-wide linting reports | Tasks requiring immediate feedback |
+| Documentation audits | Work needing user decisions mid-task |
+| Dependency vulnerability scans | Blocking tasks for current work |
+
+**Good candidates:**
+- Results can be processed later
+- No user interaction required
+- Task is well-defined with clear completion criteria
+- Output is a report or artifact, not a conversation
+
+**Poor candidates:**
+- Needs clarification mid-task
+- Time-sensitive (user waiting for result)
+- Requires real-time coordination with other agents
+
+## Spawning Background Agents
+
+### Claude Code
+
+Use the Task tool with `run_in_background: true`:
+
+```python
+Task(
+    subagent_type="background-runner",
+    prompt="""
+    Run full security audit on backend codebase.
+
+    Scope:
+    - src/api/
+    - src/services/
+
+    Write report to: .agents/reports/YYYYMMDD-HHMMSS-security-audit.md
+
+    Session: .agents/sessions/20260123-143000-auth-feature.md
+    """,
+    run_in_background=True
+)
+```
+
+### Cursor
+
+Background agents are configured via the `is_background: true` YAML property. When spawning:
+
+```
+@background-runner Run security audit on backend codebase.
+Write report to .agents/reports/
+```
+
+## Background Agent Tracking
+
+Track background agents in session frontmatter:
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security-scan"
+    agent: background-runner
+    task: "Full security audit of backend"
+    status: running  # running | completed | failed
+    result_location: null
+  - id: "bg-20260123-144500-coverage"
+    agent: background-runner
+    task: "Test coverage analysis"
+    status: completed
+    result_location: ".agents/reports/20260123-144500-coverage-report.md"
+```
+
+### Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `running` | Agent still executing |
+| `completed` | Work finished, results available |
+| `failed` | Agent encountered error |
+
+### ID Convention
+
+Background agent IDs follow: `bg-YYYYMMDD-HHMMSS-<description>`
+
+Generate with:
+```bash
+echo "bg-$(date -u +"%Y%m%d-%H%M%S")-<description>"
+```
+
+## Result Retrieval
+
+Background agents write results to `.agents/reports/` with standard frontmatter:
+
+```yaml
+---
+report:
+  title: "Security Audit Report"
+  type: background-agent-output
+  status: unprocessed  # unprocessed | processed | archived
+  created: "2026-01-23T14:30:00Z"
+  background_agent_id: "bg-20260123-143000-security-scan"
+  session_reference: "20260123-140000-auth-feature.md"
+---
+```
+
+### Processing Results
+
+1. SessionStart hook alerts user to completed background work
+2. User or PM reviews report in `.agents/reports/`
+3. PM updates session frontmatter:
+   - Change `status` from `running` to `completed`
+   - Set `result_location` to report path
+4. Process findings as needed (spawn agents, create issues)
+5. Set report `status` to `processed`
+
+## Workflow Example
+
+### 1. PM Identifies Low-Priority Work
+
+During auth feature implementation, PM identifies need for security audit but it is not blocking current work.
+
+### 2. PM Spawns Background Agent
+
+```python
+Task(
+    subagent_type="background-runner",
+    prompt="""
+    Run comprehensive security audit on auth implementation.
+
+    Files to audit:
+    - src/auth/endpoints.py
+    - src/auth/token.py
+    - src/auth/middleware.py
+
+    Check for:
+    - OWASP Top 10 vulnerabilities
+    - Secrets in code
+    - SQL injection risks
+    - Authentication bypasses
+
+    Write report to: .agents/reports/20260123-143000-auth-security.md
+
+    Session: .agents/sessions/20260123-140000-auth-feature.md
+    """,
+    run_in_background=True
+)
+```
+
+### 3. PM Updates Session Frontmatter
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-auth-security"
+    agent: background-runner
+    task: "Auth security audit"
+    status: running
+    result_location: null
+```
+
+### 4. Work Continues
+
+PM and other agents continue with main implementation while background agent works.
+
+### 5. Session Resumes Later
+
+SessionStart hook detects completed background work:
+
+```
+# Background Work Completed
+
+The following background agents have completed:
+
+- **bg-20260123-143000-auth-security** (background-runner)
+  - Task: Auth security audit
+  - Result: .agents/reports/20260123-143000-auth-security.md
+
+Review reports and update session frontmatter after processing.
+```
+
+### 6. Results Processed
+
+PM reads report, creates issues for findings, updates session.
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Use for blocking work | Keep blocking work in foreground |
+| Spawn without tracking | Always update session frontmatter |
+| Ignore completed results | Process results when alerted |
+| Use for interactive tasks | Reserve for autonomous work |
+| Spawn many concurrent background agents | Limit to 2-3 to avoid resource contention |
+| Skip result location in prompt | Always specify where to write output |
+
+## Integration Points
+
+### SessionStart Hook
+
+Checks session frontmatter for `background_agents` with `status: completed`. Alerts user to review results.
+
+### PreCompact Hook
+
+Includes background agent state in preservation. Context-archiver captures:
+- Active background agent list
+- Current status of each
+- Result locations for completed agents
+
+### Session Frontmatter
+
+Full template with background agents:
+
+```yaml
+---
+session:
+  title: "Feature implementation"
+  status: in_progress
+  # ... other session fields ...
+
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: completed
+    result_location: ".agents/reports/20260123-143000-security.md"
+  - id: "bg-20260123-150000-coverage"
+    agent: background-runner
+    task: "Coverage analysis"
+    status: running
+    result_location: null
+---
+```

--- a/dist/cursor/skills/orchestration/references/cross-session.md
+++ b/dist/cursor/skills/orchestration/references/cross-session.md
@@ -1,0 +1,200 @@
+# Cross-Session References
+
+Patterns for importing decisions and context from past sessions into current work without duplicating full context.
+
+## When to Reference Past Sessions
+
+### Good Reasons to Reference
+
+- **Continuing related work**: Building on previous feature decisions
+- **Consistency**: Ensuring alignment with prior architectural choices
+- **Avoiding re-deliberation**: Council decisions already made on similar topics
+- **Context recovery**: Picking up work after long gaps
+
+### Skip Referencing When
+
+- Starting genuinely new work unrelated to past sessions
+- Past decisions are documented in ADRs (use ADRs instead)
+- Context would create more noise than value
+- Decisions were superseded or invalidated
+
+## What to Import
+
+### Decisions Only (Default)
+
+Import the distilled outcomes:
+
+```markdown
+## Referenced Decisions
+
+### From: 20250115-140000-auth-jwt.md
+
+#### Decision: Token Rotation Strategy
+**Decision**: Rotate every 15 minutes
+**Rationale**: Security/UX balance
+```
+
+**Why decisions only:**
+- Minimal context footprint
+- Focus on outcomes, not process
+- Easy to scan and validate relevance
+
+### Context Summary (When Needed)
+
+Import broader context when:
+- Problem space is complex and unfamiliar
+- Technical approach was non-obvious
+- Multiple related decisions form a coherent strategy
+
+```markdown
+## Referenced Context
+
+### From: 20250115-140000-auth-jwt.md
+
+**Problem**: Session management for distributed services
+**Approach**: JWT with refresh token rotation
+**Key Files**: `src/auth/`, `src/middleware/auth.py`
+**Outcome**: Implemented, deployed to production 2025-01-20
+```
+
+## Session Frontmatter for Tracking
+
+Track all cross-session references in frontmatter:
+
+```yaml
+---
+session:
+  title: "Auth V2 Implementation"
+  status: in_progress
+  created: "2025-01-23T10:00:00Z"
+  last_updated: "2025-01-23T14:30:00Z"
+  linear_issue: "PLT-200"
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"
+      imported_at: "2025-01-23T14:30:00Z"
+      content_type: decisions
+      decisions_imported:
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+    - session: "20250110-090000-auth-oauth.md"
+      imported_at: "2025-01-23T14:35:00Z"
+      content_type: context
+      summary: "OAuth provider integration patterns"
+
+orchestration:
+  current_task: "Implement token refresh endpoint"
+---
+```
+
+## Decision Memory Format
+
+When sessions are archived, decisions are extracted to Serena memory:
+
+```markdown
+# Memory: session-auth-jwt-decisions.md
+
+## Session Context
+- **Session**: 20250115-140000-auth-jwt.md
+- **Archived**: 2025-01-15T18:00:00Z
+- **Linear Issue**: PLT-123
+
+## Key Decisions
+
+### Decision 1: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window refresh
+**Rationale**: Balances security (limited token lifetime) with UX (seamless refresh)
+**Council**: None - backend-dev recommendation accepted
+
+### Decision 2: Refresh Token Storage
+**Decision**: Store refresh tokens in HttpOnly cookies, not localStorage
+**Rationale**: Prevents XSS-based token theft; aligns with OWASP recommendations
+**Council**: Security council (5 agents) - unanimous
+
+### Decision 3: Token Validation Order
+**Decision**: Validate signature before parsing claims
+**Rationale**: Fail fast on tampered tokens; reduce processing for invalid requests
+**Council**: None - standard security practice
+```
+
+## Workflow
+
+### At Archive Time (context-archiver)
+
+1. Read session file
+2. Check for `## Decisions` section
+3. If present, run `extract-decisions.py`
+4. Write output to Serena memory via MCP
+
+### At Reference Time (/reference-session)
+
+1. Search Serena memories for matching sessions
+2. Read selected decision memory
+3. Import into current session
+4. Track in `referenced_sessions` frontmatter
+
+## Serena MCP Integration
+
+### List Available Decision Memories
+
+```python
+mcp__serena__list_memories()
+# Filter results for: session-*-decisions.md
+```
+
+### Read Decision Memory
+
+```python
+mcp__serena__read_memory(name="session-auth-jwt-decisions.md")
+```
+
+### Write Decision Memory (at archive time)
+
+```python
+mcp__serena__write_memory(
+    name="session-auth-jwt-decisions.md",
+    content=extracted_decisions_markdown
+)
+```
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Import entire session files | Import only decisions/summaries |
+| Import without tracking | Update `referenced_sessions` in frontmatter |
+| Import unrelated sessions | Search by topic, Linear issue, or keyword |
+| Duplicate ADR content | Reference the ADR directly |
+| Import stale decisions | Verify decisions are still relevant |
+| Over-reference | Import only what's needed for current work |
+| Reference without reading | Always review imported content for relevance |
+
+## When Decisions Conflict
+
+If imported decisions conflict with current approach:
+
+1. **Note the conflict** in session file
+2. **Assess if prior decision still applies**
+   - Different context? Proceed with new approach
+   - Same context? Consider why original decision was made
+3. **Document the change** if deviating
+4. **Consider council** if uncertainty remains
+5. **Update ADRs** if architectural decision changes
+
+## Best Practices
+
+1. **Reference early** - Import relevant decisions before planning
+2. **Validate relevance** - Review each decision's applicability
+3. **Track everything** - All imports go in frontmatter
+4. **Summarize in session log** - Note what was imported and why
+5. **Don't over-import** - Less is more for context management
+6. **Update if superseding** - Mark old decisions as superseded when creating new ones
+
+## Example Session Log Entry
+
+```markdown
+### 2025-01-23 14:30 - PM
+Referenced decisions from auth-jwt session (PLT-123):
+- Token rotation strategy (15-min window)
+- Refresh token storage (HttpOnly cookies)
+Relevant to current auth-v2 work; maintaining consistency.
+```

--- a/dist/cursor/skills/orchestration/references/local-tasks.md
+++ b/dist/cursor/skills/orchestration/references/local-tasks.md
@@ -1,0 +1,276 @@
+# Local Task Management
+
+Break specs into atomic tasks using local files when Linear isn't available.
+
+## Task Abstraction Layer
+
+Tasks work identically whether backed by Linear or local files.
+
+### Configuration
+
+```yaml
+# .agents/loaf.yaml
+task_management:
+  backend: linear  # or "local"
+
+  linear:
+    team: ProjectName
+    default_labels: []
+
+  local:
+    archive_completed: true
+    directory: .agents/tasks
+```
+
+### Abstracted Operations
+
+| Operation | Linear | Local |
+|-----------|--------|-------|
+| Create task | Create issue | Write `.agents/tasks/active/TASK-*.md` |
+| Fetch task | Get issue | Read task file |
+| Update status | Update issue | Edit frontmatter |
+| List tasks | List issues | Glob task files |
+| Complete | Move to Done | Move to archive |
+
+## Local Task Format
+
+```yaml
+---
+id: TASK-001
+title: OAuth Provider Integration
+spec: SPEC-001
+status: todo  # todo | in_progress | review | done
+priority: P1  # P0 (urgent) | P1 (high) | P2 (normal) | P3 (low)
+created: 2026-01-23T14:30:00Z
+updated: 2026-01-23T14:30:00Z
+files:
+  - src/auth/oauth.py
+  - tests/auth/test_oauth.py
+verify: pytest tests/auth/test_oauth.py
+done: OAuth flow works for Google and GitHub
+---
+
+# TASK-001: OAuth Provider Integration
+
+## Description
+
+Implement OAuth provider integration for Google and GitHub following
+the approach outlined in SPEC-001.
+
+## Acceptance Criteria
+
+- [ ] Google OAuth flow completes successfully
+- [ ] GitHub OAuth flow completes successfully
+- [ ] Tokens stored securely in session
+- [ ] Error handling for failed auth
+- [ ] Unit tests pass
+
+## Context
+
+See SPEC-001 for full context and constraints.
+Reference ADR-001 for session storage decisions.
+
+## Work Log
+
+<!-- Updated by session as work progresses -->
+```
+
+**Location:** `.agents/tasks/active/TASK-001-oauth-provider.md`
+
+## Task Lifecycle
+
+```
+todo → in_progress → review → done
+  │        │           │        │
+  └────────┴───────────┴────────┘
+           can return to earlier states
+```
+
+| Status | Meaning |
+|--------|---------|
+| `todo` | Ready to work, not started |
+| `in_progress` | Actively being worked |
+| `review` | Implementation complete, needs verification |
+| `done` | Verified complete, ready for archive |
+
+## Creating Tasks from Specs
+
+### Input
+
+- Spec ID (e.g., `SPEC-001`)
+- Optional: priority override
+
+### Task Breakdown Rules
+
+1. **One concern per task** - Don't mix backend + tests + frontend
+2. **Clear done condition** - Observable, verifiable outcome
+3. **Verification command** - How to prove it works
+4. **File hints** - Which files will likely be modified
+
+### Example Breakdown
+
+```
+SPEC-001: User Authentication with OAuth
+        ↓
+TASK-001: OAuth Provider Integration
+  - Google OAuth client setup
+  - GitHub OAuth client setup
+  - Token exchange logic
+  verify: pytest tests/auth/test_oauth.py
+
+TASK-002: Session Management
+  - Session cookie handling
+  - Session storage (Redis/DB)
+  - Session expiry logic
+  verify: pytest tests/auth/test_session.py
+
+TASK-003: Login UI Components
+  - Login page layout
+  - Provider buttons
+  - Error states
+  verify: npm run test:e2e -- auth
+```
+
+## Directory Structure
+
+```
+.agents/tasks/
+├── active/                    # Current work
+│   ├── TASK-001-oauth-provider.md
+│   ├── TASK-002-session-management.md
+│   └── TASK-003-login-ui.md
+└── archive/                   # Completed work
+    └── 2026-01/              # Organized by month
+        └── TASK-000-initial-setup.md
+```
+
+## Task ID Generation
+
+Format: `TASK-{number}-{slug}`
+
+```bash
+# Find next available number
+ls .agents/tasks/active/ .agents/tasks/archive/*/ 2>/dev/null | \
+  grep -oE 'TASK-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+## Archiving Tasks
+
+When a task is done:
+
+1. Update status to `done`
+2. Add completion timestamp
+3. Move to archive:
+
+```bash
+mkdir -p .agents/tasks/archive/$(date +%Y-%m)
+mv .agents/tasks/active/TASK-001-*.md .agents/tasks/archive/$(date +%Y-%m)/
+```
+
+## Session Integration
+
+When `/start-session TASK-001`:
+
+1. Read task file for context
+2. Read linked spec for full picture
+3. Create session with traceability:
+
+```yaml
+session:
+  title: "OAuth Provider Integration"
+  task: TASK-001
+  spec: SPEC-001
+  status: in_progress
+
+traceability:
+  requirement: "2.1 User Authentication"
+  architecture:
+    - "Session Management"
+  decisions:
+    - ADR-001
+```
+
+## Priority Levels
+
+| Priority | Meaning | Response |
+|----------|---------|----------|
+| P0 | Urgent/blocking | Drop everything |
+| P1 | High | Work next |
+| P2 | Normal | Scheduled work |
+| P3 | Low | When time permits |
+
+## Listing Tasks
+
+### All Active Tasks
+
+```bash
+for f in .agents/tasks/active/TASK-*.md; do
+  id=$(grep '^id:' "$f" | cut -d: -f2 | tr -d ' ')
+  title=$(grep '^title:' "$f" | cut -d: -f2-)
+  status=$(grep '^status:' "$f" | cut -d: -f2 | tr -d ' ')
+  echo "$id [$status] $title"
+done
+```
+
+### Tasks for a Spec
+
+```bash
+grep -l "spec: SPEC-001" .agents/tasks/active/*.md
+```
+
+## Work Log Updates
+
+As work progresses, append to the Work Log section:
+
+```markdown
+## Work Log
+
+### 2026-01-23 14:30 UTC
+Started OAuth integration. Set up Google OAuth client credentials.
+
+### 2026-01-23 15:45 UTC
+Google OAuth working. Moving to GitHub integration.
+
+### 2026-01-23 17:00 UTC
+Both providers working. Tests pass. Moving to review.
+```
+
+## Verification
+
+Before marking `done`:
+
+1. Run the `verify` command from frontmatter
+2. Check all acceptance criteria are checked
+3. Ensure no regressions in related tests
+
+```bash
+# Run task verification
+verify_cmd=$(grep '^verify:' TASK-001-*.md | cut -d: -f2-)
+eval "$verify_cmd"
+```
+
+## Local vs Linear Comparison
+
+| Feature | Local | Linear |
+|---------|-------|--------|
+| No external dependency | yes | no |
+| Rich UI | no | yes |
+| Team collaboration | git-based | native |
+| Notifications | none | email/slack |
+| Reporting | manual | built-in |
+| Offline work | yes | limited |
+
+**Use local when:**
+- Solo project
+- No Linear access
+- Offline development
+- Simple task tracking
+
+**Use Linear when:**
+- Team collaboration needed
+- Rich workflow automation
+- Integration with other tools
+- Reporting requirements

--- a/dist/cursor/skills/orchestration/references/product-development.md
+++ b/dist/cursor/skills/orchestration/references/product-development.md
@@ -1,0 +1,234 @@
+# Product Development Workflow
+
+A Research → Vision → Architecture → Requirements → Specs → Tasks → Session workflow for structured product development.
+
+## Core Insight
+
+**Separate permanent project knowledge from ephemeral orchestration.**
+
+```
+docs/                               # Permanent project knowledge
+├── VISION.md                       # Strategic direction (evolves rarely)
+├── ARCHITECTURE.md                 # Technical design (evolves with learnings)
+├── REQUIREMENTS.md                 # Business/product rules (evolves with feedback)
+├── decisions/                      # Architecture Decision Records
+│   └── ADR-001-database-choice.md
+└── specs/                          # Feature specifications (temporary)
+    ├── SPEC-001-user-auth.md
+    └── archive/                    # Completed specs
+
+.agents/                            # Ephemeral orchestration
+├── loaf.yaml                       # Project config (task backend, etc.)
+├── sessions/                       # Active work contexts
+├── plans/                          # Implementation plans
+├── councils/                       # Deliberation records
+├── transcripts/                    # Archived conversation transcripts
+├── tasks/                          # Local tasks (when not using Linear)
+│   ├── active/
+│   │   └── TASK-001-oauth-provider.md
+│   └── archive/
+└── debug/                          # Persistent debug sessions
+```
+
+## The Hierarchy
+
+```
+RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS → SESSION
+    │         │          │              │           │        │        │
+/research  (manual)  /architecture    /prd       /specs   /tasks  /start-session
+    │                    │              │           │        │
+    └─► evolves ─────────┴──────────────┴───────────┴────────┘
+        VISION                                      (feedback loops)
+```
+
+**Each level breaks down the one above:**
+- Research informs/evolves Vision
+- Vision shapes Architecture
+- Architecture constrains Requirements
+- Requirements break into Specs
+- Specs break into Tasks
+- Tasks become Sessions
+
+## Commands Overview
+
+| Command | Input | Output | Purpose |
+|---------|-------|--------|---------|
+| `/research` | Topic or "project state" | Insights, brainstorm | Zoom out, evolve VISION |
+| `/architecture` | Decision question | ARCHITECTURE.md + ADR | Technical decisions |
+| `/prd` | Feature area | REQUIREMENTS.md section | Product/business rules |
+| `/specs` | Requirement reference | SPEC-001-*.md | Feature specifications |
+| `/tasks` | Spec reference | TASK-* files/issues | Atomic work items |
+| `/start-session` | TASK-ID | Session file | Execute a task |
+
+## Document Formats
+
+### VISION.md
+
+Strategic direction that evolves rarely. Contains:
+- Product purpose and target users
+- Core principles and values
+- Long-term direction
+- What makes this product unique
+
+### ARCHITECTURE.md
+
+Technical design that evolves with learnings:
+- System architecture overview
+- Technology choices and rationale
+- Integration patterns
+- Deployment model
+
+### REQUIREMENTS.md
+
+Business and product rules organized by domain:
+
+```markdown
+## 2. Identity & Access
+
+### 2.1 User Authentication
+
+**Business Rules**
+- Users authenticate via OAuth (Google, GitHub)
+- Sessions expire after 24 hours of inactivity
+- Failed login attempts logged for security
+
+**Acceptance Criteria**
+- [ ] User can sign in with Google
+- [ ] User can sign in with GitHub
+- [ ] Session persists across browser refresh
+- [ ] Logout clears session completely
+```
+
+### Architecture Decision Records (ADRs)
+
+```yaml
+---
+id: ADR-001
+title: "PostgreSQL as Required Database"
+status: Accepted  # Proposed | Accepted | Deprecated | Superseded
+date: 2026-01-23
+---
+
+# ADR-001: PostgreSQL as Required Database
+
+## Context
+[Why this decision is needed]
+
+## Decision
+[What was decided]
+
+## Consequences
+[Tradeoffs and implications]
+```
+
+**Location:** `docs/decisions/ADR-001-*.md`
+
+## Configuration
+
+```yaml
+# .agents/loaf.yaml
+project:
+  name: "My Project"
+
+task_management:
+  backend: linear  # or "local"
+
+  linear:
+    team: ProjectName
+
+  local:
+    archive_completed: true
+
+docs:
+  vision: docs/VISION.md
+  architecture: docs/ARCHITECTURE.md
+  requirements: docs/REQUIREMENTS.md
+  decisions: docs/decisions/
+  specs: docs/specs/
+```
+
+## Workflow Examples
+
+### Full Workflow (New Feature)
+
+```bash
+# 1. Zoom out, check project state
+/research "project state"
+# → Lessons learned, ideas for auth improvement
+
+# 2. Make architecture decision
+/architecture "OAuth vs custom auth"
+# → Interview → ADR-001-auth-approach.md
+
+# 3. Capture requirements
+/prd "user authentication"
+# → Interview → REQUIREMENTS.md section 2.1
+
+# 4. Create specification
+/specs "2.1 User Authentication"
+# → Interview → SPEC-001-user-auth.md
+
+# 5. Generate tasks
+/tasks SPEC-001
+# → TASK-001, TASK-002, TASK-003
+
+# 6. Work on tasks
+/start-session TASK-001
+# → Session → Implementation → Done
+```
+
+### Quick Fix (Ad-hoc)
+
+```bash
+# Create task directly (bug report, small fix)
+/start-session TASK-099
+# PM: "No parent spec. Proceed?"
+# User: "Yes, small fix"
+# → Session → Fix → Done
+```
+
+## Feedback Loops
+
+The workflow is not rigid. Each level can feed back to higher levels:
+
+| Discovery | Action |
+|-----------|--------|
+| Implementation reveals design flaw | Update ARCHITECTURE.md |
+| Edge case invalidates requirement | Update REQUIREMENTS.md |
+| Spec too ambitious for appetite | Re-scope or split |
+| Task reveals missing requirement | Add to REQUIREMENTS.md |
+
+## Transcript Archival
+
+After `/compact` or `/clear`, archive conversation transcripts for future reference:
+
+1. **Copy transcript** to `.agents/transcripts/`
+2. **Link from session file** in frontmatter:
+
+```yaml
+session:
+  title: "Feature Implementation"
+  transcripts:
+    - 20260123-143500-pre-compact.jsonl
+    - 20260123-160000-final.jsonl
+```
+
+This preserves full context for debugging, knowledge extraction, and audit trails.
+
+## Flexibility Preserved
+
+1. **Skip steps** - Quick fixes don't need full workflow
+2. **Feedback loops** - Any level can evolve from learnings
+3. **Agents adapt** - Not a rigid harness
+
+## Critical Files
+
+| File | Purpose |
+|------|---------|
+| `docs/VISION.md` | Strategic direction |
+| `docs/ARCHITECTURE.md` | Technical design |
+| `docs/REQUIREMENTS.md` | Product rules |
+| `docs/decisions/ADR-*.md` | Architecture decisions |
+| `docs/specs/SPEC-*.md` | Feature specifications |
+| `.agents/tasks/active/TASK-*.md` | Local tasks |
+| `.agents/loaf.yaml` | Project configuration |

--- a/dist/cursor/skills/orchestration/references/sessions.md
+++ b/dist/cursor/skills/orchestration/references/sessions.md
@@ -68,6 +68,7 @@ session:
   branch: "username/back-123-feature"          # Optional: working branch
   transcripts: []                              # Archived Claude Code transcripts (filenames only)
                                                # Example: ["2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl"]
+  referenced_sessions: []                      # Cross-session references (see below)
 
 plans: []  # List of plan files in .agents/plans/ used by this session
            # Example: ["20251204-143500-api-design.md", "20251204-150000-frontend.md"]
@@ -79,8 +80,42 @@ orchestration:
       task: "Brief task description"
       status: completed                        # pending|in_progress|completed
       summary: "Outcome summary"
+
+background_agents:                             # Background work running independently
+  - id: "bg-20260123-143000-security-scan"     # ID: bg-YYYYMMDD-HHMMSS-description
+    agent: background-runner                   # Agent type
+    task: "Full security audit"                # Brief description
+    status: running                            # running|completed|failed
+    result_location: null                      # Path to report when complete
 ---
 ```
+
+### Cross-Session References
+
+Track decisions imported from past sessions via `/reference-session`:
+
+```yaml
+session:
+  # ... other fields ...
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"     # Source session filename
+      imported_at: "2025-01-23T14:30:00Z"        # When imported
+      content_type: decisions                     # decisions|context|all
+      decisions_imported:                         # List of decision titles
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+    - session: "20250110-090000-auth-oauth.md"
+      imported_at: "2025-01-23T14:35:00Z"
+      content_type: context
+      summary: "OAuth provider integration patterns"
+```
+
+**Why track references:**
+- Audit trail of where context came from
+- Avoids re-importing same decisions
+- Enables tracing decision lineage across sessions
+
+See `references/cross-session.md` for full patterns.
 
 ### Required Sections
 
@@ -160,6 +195,29 @@ Implementation plans for this session (stored in `.agents/plans/`):
 |------|--------|-------------|
 | [api-design](../plans/20251204-143500-api-design.md) | approved | API endpoint structure |
 | [frontend](../plans/20251204-150000-frontend.md) | pending | UI component design |
+
+## Architecture Diagrams
+
+### [Diagram Name]
+
+```mermaid
+[diagram content]
+```
+
+**Purpose**: Why this diagram helps understand the work
+**Files involved**: List of related file paths
+**Created**: When diagram was created (update if modified)
+
+<!--
+When to add diagrams:
+- Multi-service changes: Show interaction points
+- Data flow changes: Trace data through system
+- Schema modifications: Visualize relationships
+- API design: Document request/response flows
+
+For reusable diagrams, store in .agents/diagrams/ instead.
+See foundations skill reference/diagrams.md for Mermaid syntax.
+-->
 
 ## Council Outcomes
 

--- a/dist/cursor/skills/orchestration/references/specs.md
+++ b/dist/cursor/skills/orchestration/references/specs.md
@@ -1,0 +1,255 @@
+# Feature Specifications
+
+Break VISION + ARCHITECTURE + REQUIREMENTS into specific, implementable specs.
+
+## Philosophy
+
+**Specs are shaped solutions, not detailed designs.**
+
+A spec defines:
+- What problem we're solving
+- Boundaries (in/out of scope)
+- High-level approach
+- Test conditions
+
+A spec does NOT define:
+- Implementation details
+- Code structure
+- Exact UI layouts
+
+## Spec Format
+
+```yaml
+---
+id: SPEC-001
+title: "User Authentication with OAuth"
+requirement: "2.1 User Authentication"
+created: 2026-01-23T14:30:00Z
+status: drafting  # drafting | approved | implementing | complete
+appetite: "1 week"
+---
+
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+[From REQUIREMENTS 2.1 - why this matters to users and the business]
+
+## Proposed Solution
+
+[Shaped solution - high-level approach, not implementation details]
+
+## Scope
+
+### In Scope
+- OAuth: Google, GitHub
+- Session management with secure cookies
+- Login/logout UI
+
+### Out of Scope (Rabbit Holes)
+- Custom OAuth providers (avoid this complexity)
+- MFA (future spec if needed)
+- Password-based auth
+
+### No-Gos
+- Passwords in plaintext
+- Tokens in local storage
+- Session data in URLs
+
+## Test Conditions
+
+- [ ] OAuth flow completes for Google
+- [ ] OAuth flow completes for GitHub
+- [ ] Session persists across page refresh
+- [ ] Logout clears session completely
+- [ ] Invalid tokens are rejected
+
+## Implementation Notes
+
+[Architecture references, technical constraints, relevant ADRs]
+
+## Circuit Breaker
+
+At 50% appetite: if OAuth integration is problematic, simplify to single provider (Google only).
+```
+
+**Location:** `docs/specs/SPEC-001-feature-name.md`
+
+## Spec Lifecycle
+
+```
+drafting → approved → implementing → complete
+    │         │           │           │
+    └─────────┴───────────┴───────────┘
+              can return to drafting
+```
+
+| Status | Meaning |
+|--------|---------|
+| `drafting` | Being refined, not ready for work |
+| `approved` | User approved, ready for task breakdown |
+| `implementing` | Tasks created, work in progress |
+| `complete` | All tasks done, spec archived |
+
+## Creating Specs
+
+### Input Required
+
+1. **Requirement reference** - Which section of REQUIREMENTS.md
+2. **Appetite** - How much time is it worth (from Shape Up)
+
+### Interview Questions
+
+Before drafting, clarify:
+
+| Area | Questions |
+|------|-----------|
+| Scope | What's definitely in? What's definitely out? |
+| Rabbit holes | What seems related but should be avoided? |
+| No-gos | What approaches are forbidden? |
+| Test conditions | How do we know it works? |
+| Dependencies | What must exist first? |
+| Edge cases | What could go wrong? |
+
+### Writing the Spec
+
+1. **Start with Problem Statement** - Not "build X" but "solve Y"
+2. **Shape the solution** - Direction, not blueprint
+3. **Define boundaries explicitly** - In/out/no-gos
+4. **Write test conditions** - Observable outcomes
+5. **Set circuit breaker** - When to stop and reassess
+
+## Appetite Levels
+
+| Appetite | Size | Suitable For |
+|----------|------|--------------|
+| Small | 1-2 days | Bug fixes, minor enhancements |
+| Medium | 3-5 days | Feature additions, refactors |
+| Large | 1-2 weeks | Major features (rare) |
+
+If a spec can't fit the appetite, it needs more shaping or should be split.
+
+## Splitting Large Specs
+
+When a spec is too big:
+
+```
+SPEC-001-user-auth.md (large, 2 weeks)
+        ↓ split into
+SPEC-001a-oauth-integration.md (medium, 3 days)
+SPEC-001b-session-management.md (small, 2 days)
+SPEC-001c-login-ui.md (medium, 3 days)
+```
+
+Each sub-spec:
+- Has its own appetite
+- Can be worked independently
+- References the original requirement
+
+## Archiving Specs
+
+When all tasks for a spec are complete:
+
+1. Update status to `complete`
+2. Add completion date to frontmatter
+3. Move to `docs/specs/archive/`
+
+```bash
+mv docs/specs/SPEC-001-user-auth.md docs/specs/archive/
+```
+
+## Spec vs Plan
+
+| Spec | Plan |
+|------|------|
+| **What** to build | **How** to build it |
+| Lives in `docs/specs/` | Lives in `.agents/plans/` |
+| Survives sessions | Tied to session |
+| User-facing | Implementation detail |
+| Shape Up shaped | Tactical steps |
+
+Specs define the target. Plans define the route to get there.
+
+## Validation Checklist
+
+Before approving a spec:
+
+- [ ] Problem statement is clear and user-focused
+- [ ] Scope boundaries are explicit (in/out/no-gos)
+- [ ] Test conditions are observable and testable
+- [ ] Appetite is realistic for the scope
+- [ ] Circuit breaker is defined
+- [ ] Requirement reference is valid
+- [ ] No implementation details (those go in plans)
+
+## Example: Good vs Bad Specs
+
+### Bad Spec
+
+```markdown
+# SPEC-001: Add OAuth
+
+Add OAuth to the app.
+
+## Requirements
+- Add Google OAuth
+- Add session management
+- Add logout
+```
+
+Problems:
+- No problem statement
+- No scope boundaries
+- No test conditions
+- No appetite
+- Too vague to implement
+
+### Good Spec
+
+```markdown
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+Users currently can't access the application. We need a secure,
+frictionless login flow that leverages existing identity providers
+so users don't need to create yet another password.
+
+## Proposed Solution
+
+Implement OAuth 2.0 flow with Google and GitHub as initial providers.
+Store session in secure HTTP-only cookies. Provide clear login/logout UI.
+
+## Scope
+
+### In Scope
+- Google OAuth integration
+- GitHub OAuth integration
+- Session cookie management
+- Login page with provider buttons
+- Logout functionality
+
+### Out of Scope
+- Apple/Microsoft providers (future)
+- MFA (separate spec if needed)
+- Account linking (complex, avoid)
+
+### No-Gos
+- Storing tokens in localStorage
+- Custom password auth
+- Session data in URLs
+
+## Test Conditions
+
+- [ ] New user can sign in with Google
+- [ ] New user can sign in with GitHub
+- [ ] Session persists across browser tabs
+- [ ] Session survives page refresh
+- [ ] Logout clears all session data
+- [ ] Expired sessions redirect to login
+
+## Circuit Breaker
+
+At 50% appetite: if both providers are problematic, ship with Google only.
+GitHub can be a follow-up spec.
+```

--- a/dist/cursor/skills/orchestration/scripts/extract-decisions.py
+++ b/dist/cursor/skills/orchestration/scripts/extract-decisions.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Extract decisions from a session file and format as Serena memory.
+
+Usage: extract-decisions.py <session-file>
+
+Reads a session file, extracts the ## Decisions section, and outputs
+formatted Serena memory content to stdout. The output can be piped to
+Serena MCP's write_memory tool.
+
+Exit codes:
+  0 - Success (decisions extracted)
+  1 - Error (file not found, parse error)
+  2 - No decisions found
+"""
+
+import sys
+import re
+import yaml
+from pathlib import Path
+from datetime import datetime, timezone
+
+
+def parse_frontmatter(content: str) -> tuple[dict, str]:
+    """Extract YAML frontmatter from markdown content."""
+    if not content.startswith('---'):
+        return {}, content
+
+    parts = content.split('---', 2)
+    if len(parts) < 3:
+        return {}, content
+
+    try:
+        frontmatter = yaml.safe_load(parts[1])
+        body = parts[2]
+        return frontmatter or {}, body
+    except yaml.YAMLError as e:
+        print(f"Warning: Could not parse frontmatter: {e}", file=sys.stderr)
+        return {}, content
+
+
+def extract_decisions_section(body: str) -> str | None:
+    """Extract the ## Decisions section from markdown body."""
+    # Match ## Decisions followed by content until next ## or end
+    pattern = r'^## Decisions\s*\n(.*?)(?=^## |\Z)'
+    match = re.search(pattern, body, re.MULTILINE | re.DOTALL)
+
+    if match:
+        content = match.group(1).strip()
+        if content:
+            return content
+    return None
+
+
+def parse_decisions(decisions_text: str) -> list[dict]:
+    """Parse individual decisions from the decisions section."""
+    decisions = []
+
+    # Match ### Decision N: Title or ### Title patterns
+    pattern = r'^###\s+(?:Decision\s+\d+:\s+)?(.+?)\n(.*?)(?=^### |\Z)'
+    matches = re.findall(pattern, decisions_text, re.MULTILINE | re.DOTALL)
+
+    for title, content in matches:
+        decision = {
+            'title': title.strip(),
+            'decision': '',
+            'rationale': '',
+            'council': ''
+        }
+
+        # Extract **Decision**: value
+        decision_match = re.search(
+            r'\*\*Decision\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if decision_match:
+            decision['decision'] = decision_match.group(1).strip()
+
+        # Extract **Rationale**: value
+        rationale_match = re.search(
+            r'\*\*Rationale\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if rationale_match:
+            decision['rationale'] = rationale_match.group(1).strip()
+
+        # Extract **Council**: value (optional)
+        council_match = re.search(
+            r'\*\*Council\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if council_match:
+            decision['council'] = council_match.group(1).strip()
+
+        # Only add if we have at least a title and decision
+        if decision['title'] and decision['decision']:
+            decisions.append(decision)
+
+    return decisions
+
+
+def format_memory(
+    session_file: str,
+    frontmatter: dict,
+    decisions: list[dict]
+) -> str:
+    """Format decisions as Serena memory markdown."""
+    session = frontmatter.get('session', {})
+    title = session.get('title', 'Unknown Session')
+    linear_issue = session.get('linear_issue', 'N/A')
+    archived_at = session.get('archived_at', datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'))
+
+    # Generate slug from filename
+    filename = Path(session_file).stem
+    slug = re.sub(r'^\d{8}-\d{6}-', '', filename)
+
+    lines = [
+        f"# Memory: session-{slug}-decisions.md",
+        "",
+        "## Session Context",
+        f"- **Session**: {Path(session_file).name}",
+        f"- **Title**: {title}",
+        f"- **Archived**: {archived_at}",
+        f"- **Linear Issue**: {linear_issue}",
+        "",
+        "## Key Decisions",
+        ""
+    ]
+
+    for i, d in enumerate(decisions, 1):
+        lines.append(f"### Decision {i}: {d['title']}")
+        lines.append(f"**Decision**: {d['decision']}")
+        if d['rationale']:
+            lines.append(f"**Rationale**: {d['rationale']}")
+        if d['council']:
+            lines.append(f"**Council**: {d['council']}")
+        lines.append("")
+
+    return '\n'.join(lines)
+
+
+def generate_memory_name(session_file: str) -> str:
+    """Generate Serena memory name from session filename."""
+    filename = Path(session_file).stem
+    slug = re.sub(r'^\d{8}-\d{6}-', '', filename)
+    return f"session-{slug}-decisions.md"
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: extract-decisions.py <session-file>", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Extracts decisions from a session file and outputs Serena memory format.", file=sys.stderr)
+        print("The memory name will be: session-<slug>-decisions.md", file=sys.stderr)
+        sys.exit(1)
+
+    session_file = sys.argv[1]
+    filepath = Path(session_file)
+
+    if not filepath.exists():
+        print(f"Error: File not found: {session_file}", file=sys.stderr)
+        sys.exit(1)
+
+    content = filepath.read_text()
+    frontmatter, body = parse_frontmatter(content)
+
+    decisions_text = extract_decisions_section(body)
+    if not decisions_text:
+        print(f"No ## Decisions section found in: {session_file}", file=sys.stderr)
+        sys.exit(2)
+
+    decisions = parse_decisions(decisions_text)
+    if not decisions:
+        print(f"No parseable decisions found in: {session_file}", file=sys.stderr)
+        sys.exit(2)
+
+    # Output memory content to stdout
+    memory_content = format_memory(session_file, frontmatter, decisions)
+    print(memory_content)
+
+    # Output memory name to stderr for scripting
+    memory_name = generate_memory_name(session_file)
+    print(f"\n# Memory name: {memory_name}", file=sys.stderr)
+    print(f"# Decisions extracted: {len(decisions)}", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/dist/cursor/skills/orchestration/scripts/git-context-summary.sh
+++ b/dist/cursor/skills/orchestration/scripts/git-context-summary.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Generate git context summary for sessions
+# Usage: git-context-summary.sh [--brief]
+#
+# Output includes:
+#   - Current branch name
+#   - Uncommitted changes count
+#   - Recent commits (last 3-5)
+#   - Summary of changes from main/master (if on feature branch)
+#
+# Options:
+#   --brief   Output only branch and uncommitted changes (for hooks)
+
+set -e
+
+BRIEF_MODE=false
+if [[ "$1" == "--brief" ]]; then
+    BRIEF_MODE=true
+fi
+
+# Check if we're in a git repository
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+    echo "Not a git repository"
+    exit 0
+fi
+
+# Get current branch
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if [[ -z "$CURRENT_BRANCH" ]]; then
+    # Detached HEAD state
+    CURRENT_BRANCH="(detached HEAD at $(git rev-parse --short HEAD 2>/dev/null || echo 'unknown'))"
+fi
+
+# Count uncommitted changes (staged + unstaged + untracked)
+UNCOMMITTED_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+
+# Brief mode: just branch and changes
+if [[ "$BRIEF_MODE" == "true" ]]; then
+    echo "## Git Context"
+    echo "- **Branch**: $CURRENT_BRANCH"
+    echo "- **Uncommitted changes**: $UNCOMMITTED_COUNT file(s)"
+    exit 0
+fi
+
+# Full output
+echo "## Git Context"
+echo ""
+echo "**Branch**: \`$CURRENT_BRANCH\`"
+echo ""
+echo "**Uncommitted changes**: $UNCOMMITTED_COUNT file(s)"
+
+# Show brief status if there are changes
+if [[ "$UNCOMMITTED_COUNT" -gt 0 ]]; then
+    echo ""
+    echo "**Changed files**:"
+    # Show first 10 files max
+    git status --porcelain 2>/dev/null | head -10 | while read -r line; do
+        STATUS="${line:0:2}"
+        FILE="${line:3}"
+        case "$STATUS" in
+            "M "| " M"|"MM") echo "  - Modified: \`$FILE\`" ;;
+            "A ") echo "  - Added: \`$FILE\`" ;;
+            "D "| " D") echo "  - Deleted: \`$FILE\`" ;;
+            "R ") echo "  - Renamed: \`$FILE\`" ;;
+            "??") echo "  - Untracked: \`$FILE\`" ;;
+            *) echo "  - Changed: \`$FILE\`" ;;
+        esac
+    done
+    TOTAL=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$TOTAL" -gt 10 ]]; then
+        echo "  - ... and $((TOTAL - 10)) more"
+    fi
+fi
+
+# Recent commits (last 5)
+echo ""
+echo "**Recent commits**:"
+git log --oneline -5 2>/dev/null | while read -r line; do
+    echo "  - \`$line\`"
+done
+
+# Detect main branch (main or master)
+MAIN_BRANCH=""
+if git show-ref --verify --quiet refs/heads/main 2>/dev/null; then
+    MAIN_BRANCH="main"
+elif git show-ref --verify --quiet refs/heads/master 2>/dev/null; then
+    MAIN_BRANCH="master"
+fi
+
+# Summary of changes from main (if on feature branch)
+if [[ -n "$MAIN_BRANCH" && "$CURRENT_BRANCH" != "$MAIN_BRANCH" && "$CURRENT_BRANCH" != "(detached"* ]]; then
+    # Count commits ahead of main
+    COMMITS_AHEAD=$(git rev-list --count "$MAIN_BRANCH..$CURRENT_BRANCH" 2>/dev/null || echo "0")
+    COMMITS_BEHIND=$(git rev-list --count "$CURRENT_BRANCH..$MAIN_BRANCH" 2>/dev/null || echo "0")
+
+    echo ""
+    echo "**Relative to \`$MAIN_BRANCH\`**:"
+    echo "  - $COMMITS_AHEAD commit(s) ahead"
+    echo "  - $COMMITS_BEHIND commit(s) behind"
+
+    # Files changed from main
+    if [[ "$COMMITS_AHEAD" -gt 0 ]]; then
+        FILES_CHANGED=$(git diff --name-only "$MAIN_BRANCH...$CURRENT_BRANCH" 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "$FILES_CHANGED" -gt 0 ]]; then
+            echo "  - $FILES_CHANGED file(s) changed from \`$MAIN_BRANCH\`"
+        fi
+    fi
+fi

--- a/dist/cursor/skills/orchestration/scripts/list-session-decisions.sh
+++ b/dist/cursor/skills/orchestration/scripts/list-session-decisions.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# List available session decision memories from Serena.
+#
+# Usage: list-session-decisions.sh
+#
+# This script lists Serena memories matching the pattern session-*-decisions.md
+# and displays session name and metadata.
+#
+# Note: This is a helper script. In practice, agents should use Serena MCP
+# directly via mcp__serena__list_memories() for programmatic access.
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Session Decision Memories${NC}"
+echo "========================="
+echo ""
+
+# Check if .serena directory exists
+if [[ ! -d ".serena" ]]; then
+    echo -e "${YELLOW}No .serena directory found in current project.${NC}"
+    echo "Serena memories are stored per-project. Make sure you're in a Serena-enabled project."
+    exit 0
+fi
+
+# Check for memories directory
+MEMORIES_DIR=".serena/memories"
+if [[ ! -d "$MEMORIES_DIR" ]]; then
+    echo -e "${YELLOW}No memories directory found.${NC}"
+    echo "No session decisions have been extracted yet."
+    echo ""
+    echo "To extract decisions from a session:"
+    echo "  python3 extract-decisions.py <session-file>"
+    echo "  Then use Serena MCP to write the memory."
+    exit 0
+fi
+
+# Find session decision memories
+MEMORIES=$(find "$MEMORIES_DIR" -name "session-*-decisions.md" 2>/dev/null | sort -r)
+
+if [[ -z "$MEMORIES" ]]; then
+    echo -e "${YELLOW}No session decision memories found.${NC}"
+    echo ""
+    echo "Session decision memories are created when sessions are archived."
+    echo "Pattern: session-<slug>-decisions.md"
+    exit 0
+fi
+
+# Display memories
+count=0
+echo -e "${GREEN}Available Decision Memories:${NC}"
+echo ""
+
+for memory in $MEMORIES; do
+    count=$((count + 1))
+    filename=$(basename "$memory")
+
+    # Extract slug from filename
+    slug=$(echo "$filename" | sed 's/^session-//' | sed 's/-decisions\.md$//')
+
+    # Try to read session info from memory content
+    if [[ -f "$memory" ]]; then
+        session_name=$(grep -m1 "^\- \*\*Session\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "Unknown")
+        archived=$(grep -m1 "^\- \*\*Archived\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "Unknown")
+        linear=$(grep -m1 "^\- \*\*Linear Issue\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "N/A")
+        decision_count=$(grep -c "^### Decision" "$memory" 2>/dev/null || echo "0")
+
+        printf "  %2d. %s\n" "$count" "$slug"
+        printf "      Session:  %s\n" "$session_name"
+        printf "      Archived: %s\n" "$archived"
+        printf "      Linear:   %s\n" "$linear"
+        printf "      Decisions: %s\n" "$decision_count"
+        echo ""
+    else
+        printf "  %2d. %s (unreadable)\n" "$count" "$filename"
+    fi
+done
+
+echo "------------------------"
+echo "Total: $count decision memories"
+echo ""
+echo -e "${BLUE}Usage:${NC}"
+echo "  /reference-session <search-term>    # Import decisions to current session"
+echo "  mcp__serena__read_memory(name=...)  # Read memory directly via MCP"

--- a/dist/cursor/skills/orchestration/scripts/validate-session.py
+++ b/dist/cursor/skills/orchestration/scripts/validate-session.py
@@ -60,7 +60,7 @@ def validate_frontmatter(fm: dict) -> list[str]:
             errors.append(f"Empty required field: session.{field}")
 
     # Validate status values
-    valid_statuses = ['in_progress', 'paused', 'completed']
+    valid_statuses = ['in_progress', 'paused', 'completed', 'archived']
     if session.get('status') and session['status'] not in valid_statuses:
         errors.append(f"Invalid session.status: {session['status']} (must be one of: {', '.join(valid_statuses)})")
 
@@ -72,6 +72,20 @@ def validate_frontmatter(fm: dict) -> list[str]:
                 datetime.fromisoformat(value.replace('Z', '+00:00'))
             except ValueError:
                 errors.append(f"Invalid ISO 8601 timestamp in session.{field}: {value}")
+
+    # Validate branch field format if present (optional field)
+    branch = session.get('branch', '')
+    if branch:
+        # Branch names should be non-empty strings without spaces
+        # Common formats: feature/name, username/ticket-desc, bugfix/name, etc.
+        if not isinstance(branch, str):
+            errors.append(f"Invalid session.branch: must be a string, got {type(branch).__name__}")
+        elif ' ' in branch:
+            errors.append(f"Invalid session.branch: '{branch}' contains spaces (branch names cannot have spaces)")
+        elif branch.startswith('/') or branch.endswith('/'):
+            errors.append(f"Invalid session.branch: '{branch}' cannot start or end with '/'")
+        elif '//' in branch:
+            errors.append(f"Invalid session.branch: '{branch}' contains consecutive slashes")
 
     # Check orchestration block
     orch = fm.get('orchestration', {})

--- a/dist/cursor/skills/research/SKILL.md
+++ b/dist/cursor/skills/research/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: research
+description: >-
+  Use for project reflection, brainstorming, and vision evolution. Covers
+  assessing project state, exploring problem spaces, generating ideas, and
+  evolving strategic direction. Activate when stepping back to think,
+  researching topics, or updating VISION.md.
+version: 1.11.0
+---
+
+# Research
+
+Patterns for zooming out, brainstorming, and evolving project direction.
+
+## Philosophy
+
+**Research is about understanding before doing.**
+
+Research activities:
+1. Assess project state and lessons learned
+2. Explore problem spaces with structured inquiry
+3. Generate and refine ideas through brainstorming
+4. Evolve strategic direction when evidence supports it
+
+Research is NOT about:
+- Implementing solutions
+- Making tactical decisions
+- Writing code or specifications
+
+## Quick Reference
+
+| Need | Action |
+|------|--------|
+| Understand project state | Review sessions, docs, recent changes |
+| Explore a topic | Structured inquiry with confidence hierarchy |
+| Generate ideas | Brainstorm with interview and synthesis |
+| Evolve VISION | Propose changes with evidence |
+
+## Research Modes
+
+### Mode 1: Project State Assessment
+
+**Trigger:** "What's the current state?" / "Catch me up"
+
+**Process:**
+1. Read existing docs (VISION, ARCHITECTURE, REQUIREMENTS)
+2. Check recent sessions for lessons learned
+3. Review recent commits for context
+4. Identify gaps, contradictions, or stale information
+5. Summarize current state with recommendations
+
+**Output:** State assessment with actionable insights
+
+### Mode 2: Topic Exploration
+
+**Trigger:** "Research X" / "How should we approach Y?"
+
+**Process:**
+1. Interview user to understand the question deeply
+2. Apply confidence hierarchy for sources
+3. Synthesize findings with tradeoffs
+4. Present options with recommendations
+
+**Output:** Research findings with options and recommendation
+
+### Mode 3: Brainstorming
+
+**Trigger:** "Let's brainstorm" / "Ideas for X"
+
+**Process:**
+1. Interview to understand constraints and goals
+2. Generate diverse options (quantity over quality initially)
+3. Filter through constraints
+4. Refine promising directions
+5. Present shaped options for decision
+
+**Output:** Curated options with pros/cons
+
+### Mode 4: Vision Evolution
+
+**Trigger:** "Should we change direction?" / "Update VISION"
+
+**Process:**
+1. Gather evidence (sessions, feedback, market changes)
+2. Identify what's changed since last VISION update
+3. Propose specific changes with rationale
+4. Get user approval before any edits
+
+**Output:** VISION.md change proposal (not direct edit)
+
+## Confidence Hierarchy
+
+When researching, prioritize sources in this order:
+
+```
+1. Project context (highest confidence)
+   - VISION.md, ARCHITECTURE.md, REQUIREMENTS.md
+   - Session files and lessons learned
+   - Existing codebase patterns
+
+2. Authoritative documentation
+   - Context7 for library docs
+   - Official documentation sites
+   - RFCs and specifications
+
+3. Community knowledge
+   - Stack Overflow (verified answers)
+   - GitHub issues and discussions
+   - Blog posts from recognized experts
+
+4. General web (lowest confidence)
+   - Search results
+   - Forum posts
+   - Unverified sources
+```
+
+**Rule:** Always check project context first. External research should supplement, not replace, understanding of existing decisions.
+
+## Interview Patterns
+
+### Before Any Research
+
+Ask clarifying questions:
+
+| Area | Questions |
+|------|-----------|
+| Scope | What specifically are you trying to understand? |
+| Context | What do you already know? What have you tried? |
+| Constraints | What constraints should guide the research? |
+| Output | What decision will this research inform? |
+
+### For Topic Exploration
+
+```
+1. What problem are we trying to solve?
+2. What constraints exist (technical, time, team)?
+3. What would success look like?
+4. What have we already considered and rejected?
+5. Are there non-obvious angles to explore?
+```
+
+### For Brainstorming
+
+```
+1. What's the ideal outcome if constraints didn't exist?
+2. What's the minimum viable approach?
+3. What approaches have we seen work elsewhere?
+4. What would we do if we had 10x the resources? 1/10?
+5. What's the contrarian view?
+```
+
+## Output Formats
+
+### State Assessment
+
+```markdown
+## Project State Assessment
+
+**Date:** YYYY-MM-DD
+
+### Current Position
+- [Summary of where the project stands]
+
+### Recent Progress
+- [Key accomplishments from recent sessions]
+
+### Lessons Learned
+- [Insights from implementation feedback]
+
+### Open Questions
+- [Unresolved decisions or gaps]
+
+### Recommendations
+1. [Actionable next step]
+2. [Actionable next step]
+```
+
+### Research Findings
+
+```markdown
+## Research: [Topic]
+
+**Question:** [What we're trying to understand]
+
+### Summary
+[One-paragraph answer with confidence level]
+
+### Options Considered
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Best for:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Best for:** ...
+
+### Recommendation
+[Which option and why, with caveats]
+
+### Sources
+- [Source 1 with confidence level]
+- [Source 2 with confidence level]
+```
+
+### Vision Change Proposal
+
+```markdown
+## VISION.md Change Proposal
+
+**Proposed by:** [Session/Date]
+**Evidence:** [What prompted this]
+
+### Current State
+[Quote relevant VISION.md section]
+
+### Proposed Change
+[New text]
+
+### Rationale
+[Why this change is warranted]
+
+### Impact
+- [What this changes downstream]
+- [ADRs that may need updating]
+- [Requirements that may be affected]
+
+### Approval Required
+This proposal requires user approval before implementation.
+```
+
+## Integration with Workflow
+
+Research fits at the top of the product development hierarchy:
+
+```
+RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS
+    │         │
+    └─────────┘
+    evolves
+```
+
+**Research informs Vision changes.** Vision changes cascade down through Architecture, Requirements, and Specs.
+
+## When to Research
+
+| Situation | Research Mode |
+|-----------|---------------|
+| Starting new project | Project state + Topic exploration |
+| Stuck on approach | Topic exploration + Brainstorming |
+| Finishing major work | Project state (capture learnings) |
+| External change | Vision evolution |
+| Quarterly review | Project state + Vision evolution |
+
+## When NOT to Research
+
+- **When action is clear** - Don't research to avoid doing
+- **When already decided** - Check ADRs first
+- **When time-critical** - Act, then document learnings
+- **For trivial questions** - Just answer them
+
+## Critical Rules
+
+### Always
+- Interview before researching
+- Check project context first
+- Cite sources with confidence levels
+- Present options, let user decide
+- Get approval before editing VISION
+
+### Never
+- Edit VISION without explicit approval
+- Research indefinitely (set time bounds)
+- Ignore existing project decisions
+- Present research as implementation plan
+- Skip the interview step
+
+## Scripts
+
+| Script | Usage | Description |
+|--------|-------|-------------|
+| `check-sessions.sh` | Review recent sessions | Find lessons learned |
+| `git-context-summary.sh` | Summarize git history | Understand recent changes |
+
+## Related Skills
+
+- **orchestration** - For acting on research findings
+- **foundations** - For documentation standards

--- a/dist/gemini/skills/debugging/SKILL.md
+++ b/dist/gemini/skills/debugging/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: debugging
+description: >-
+  Use for systematic bug investigation and diagnosis. Covers hypothesis-driven
+  debugging workflows, multi-hypothesis tracking, language-specific debugging
+  patterns (Python, TypeScript, Ruby), and test debugging (flaky tests,
+  isolation, state pollution). Activate when investigating failures, debugging
+  production issues, or diagnosing test problems.
+version: 1.11.0
+---
+
+# Systematic Debugging
+
+Hypothesis-driven investigation for efficient and traceable bug diagnosis.
+
+## Philosophy
+
+**Eliminate, don't guess.** Debugging is a process of elimination, not random modification. Each change should test a specific hypothesis and provide evidence to rule it out or confirm it.
+
+**Multiple hypotheses, ranked.** Never fixate on one theory. Generate 3-5 plausible hypotheses, rank by likelihood, and test the most likely first. Surprising evidence should trigger hypothesis revision.
+
+**Reproduce before investigating.** A bug you cannot reproduce is a bug you cannot fix with confidence. Establish reliable reproduction steps before diving into code.
+
+**Minimal changes, maximum information.** Each debugging step should change one variable and maximize the information gained. Shotgun debugging wastes time and obscures root causes.
+
+## Quick Reference
+
+| Situation | Approach | Key Technique |
+|-----------|----------|---------------|
+| **Unknown failure** | Generate hypotheses | List 3-5 possible causes, rank by likelihood |
+| **Intermittent bug** | Isolate variables | Binary search through conditions |
+| **Test flakiness** | Check state pollution | Run test in isolation, check fixtures |
+| **Production issue** | Preserve evidence | Capture logs/state before attempting fixes |
+
+## Topics
+
+| Topic | Reference | Use For |
+|-------|-----------|---------|
+| Hypothesis Tracking | `references/hypothesis-tracking.md` | Multi-hypothesis workflow, session templates, investigation logs |
+| Language Debugging | `references/language-debugging.md` | Python, TypeScript, Ruby debug patterns and tools |
+| Test Debugging | `references/test-debugging.md` | Flaky tests, isolation, state pollution, environment differences |
+
+## Critical Rules
+
+### Always
+
+- Generate multiple hypotheses before investigating
+- Document each hypothesis and its current status
+- Establish reproduction steps before attempting fixes
+- Test one variable at a time
+- Preserve evidence (logs, state, stack traces) before changes
+- Update hypothesis status based on evidence
+- Record failed attempts to avoid repeating them
+
+### Never
+
+- Make random changes hoping something works
+- Fix symptoms without understanding root cause
+- Assume the first hypothesis is correct
+- Skip reproduction verification after a "fix"
+- Delete logs or error output before analysis
+- Change multiple variables simultaneously
+- Ignore contradictory evidence
+
+## Debugging Workflow
+
+```
+1. REPRODUCE: Establish reliable reproduction steps
+2. HYPOTHESIZE: Generate 3-5 possible causes, rank by likelihood
+3. TEST: Design experiment to test highest-likelihood hypothesis
+4. EVALUATE: Analyze results, update hypothesis status
+5. ITERATE: Move to next hypothesis or refine based on evidence
+6. VERIFY: Confirm fix addresses root cause, not just symptoms
+```
+
+## Investigation Log Format
+
+Keep a timestamped log of investigation steps:
+
+```
+[HH:MM] Testing H2 (stale cache)
+        Action: Cleared Redis, restarted service
+        Result: Still failing
+        Evidence: Error occurs before cache read in stack trace
+        Status: H2 RULED OUT
+
+[HH:MM] Testing H3 (race condition)
+        Action: Added mutex around shared state
+        Result: SUCCESS - no failures in 100 runs
+        Evidence: Stack trace showed concurrent access
+        Status: H3 CONFIRMED
+```
+
+## Related Skills
+
+- `foundations` - Test patterns, error handling, logging standards
+- `python` - Python-specific debugging tools (pdb, logging)
+- `typescript` - TypeScript debugging (Chrome DevTools, source maps)
+- `ruby` - Ruby debugging (binding.irb, byebug)

--- a/dist/gemini/skills/debugging/references/hypothesis-tracking.md
+++ b/dist/gemini/skills/debugging/references/hypothesis-tracking.md
@@ -1,0 +1,168 @@
+# Hypothesis Tracking
+
+Systematic workflow for generating, testing, and tracking multiple debugging hypotheses.
+
+## Multi-Hypothesis Workflow
+
+### 1. Generate Hypotheses
+
+Before investigating, brainstorm 3-5 possible causes. Consider:
+
+- **Recent changes** - What changed since it last worked?
+- **Common culprits** - Race conditions, caching, state mutation, null references
+- **Environment differences** - Dev vs prod, different data, timing
+- **External dependencies** - API changes, network issues, third-party services
+
+### 2. Rank by Likelihood
+
+Assign likelihood based on:
+
+| Factor | Higher Likelihood | Lower Likelihood |
+|--------|-------------------|------------------|
+| Recency | Code changed recently | Untouched for months |
+| Complexity | Complex logic, many branches | Simple, well-tested |
+| Dependencies | External services involved | Self-contained |
+| Symptoms | Matches known failure pattern | Novel error |
+
+### 3. Test Systematically
+
+For each hypothesis (highest likelihood first):
+
+1. **Design minimal experiment** - What single change would confirm or rule out this hypothesis?
+2. **Predict outcome** - What result do you expect if hypothesis is correct?
+3. **Execute and observe** - Run experiment, capture results
+4. **Update status** - Mark CONFIRMED, RULED OUT, or NEEDS MORE DATA
+
+### 4. Revise Based on Evidence
+
+When evidence contradicts expectations:
+
+- Lower likelihood of current hypothesis
+- Consider what the evidence suggests instead
+- Add new hypotheses if needed
+- Re-rank based on new information
+
+## Session Template
+
+Use this template at the start of debugging sessions:
+
+```markdown
+## Debug Investigation
+
+**Symptom**: [What's failing - exact error message or behavior]
+**First observed**: [When did this start happening]
+**Reproduction**: [Steps to reliably reproduce]
+
+### Environment
+- OS/Platform:
+- Version:
+- Dependencies:
+- Data state:
+
+### Hypothesis Tracker
+
+| # | Hypothesis | Likelihood | Status | Evidence |
+|---|------------|------------|--------|----------|
+| H1 | [Description] | High/Med/Low | TESTING/RULED OUT/CONFIRMED | [What you learned] |
+| H2 | [Description] | High/Med/Low | PENDING | - |
+| H3 | [Description] | High/Med/Low | PENDING | - |
+
+### Investigation Log
+[Timestamped entries below]
+```
+
+## Example Investigation
+
+### Symptom
+API returns 500 error intermittently on `/api/orders` endpoint.
+
+### Reproduction
+1. Create 10+ concurrent requests to `/api/orders`
+2. ~30% return 500 errors
+3. Only happens under load
+
+### Hypothesis Tracker
+
+| # | Hypothesis | Likelihood | Status | Evidence |
+|---|------------|------------|--------|----------|
+| H1 | Database connection pool exhausted | High | RULED OUT | Pool metrics show 50% utilization during failures |
+| H2 | Race condition in order validation | High | TESTING | Errors correlate with concurrent creates |
+| H3 | Memory pressure causing timeouts | Medium | PENDING | - |
+| H4 | Third-party payment API rate limiting | Low | RULED OUT | Payment API logs show no rate limits |
+
+### Investigation Log
+
+```
+[14:32] Testing H1 (connection pool)
+        Action: Monitored pool metrics during load test
+        Result: Pool never exceeded 50% capacity
+        Evidence: Prometheus shows max 5/10 connections used
+        Status: H1 RULED OUT - pool is not the bottleneck
+
+[14:45] Testing H4 (payment API rate limiting)
+        Action: Checked payment provider dashboard
+        Result: No rate limit events in their logs
+        Evidence: All payment API calls successful
+        Status: H4 RULED OUT
+
+[15:01] Testing H2 (race condition)
+        Action: Added logging around order validation
+        Result: Found concurrent access to shared cart state
+        Evidence: Logs show two requests modifying same cart simultaneously
+        Status: H2 LIKELY - need to verify with fix
+
+[15:23] Verifying H2 fix
+        Action: Added mutex around cart validation
+        Result: 0 errors in 1000 concurrent requests
+        Evidence: Lock prevents concurrent modification
+        Status: H2 CONFIRMED - race condition was root cause
+```
+
+## Hypothesis Status Definitions
+
+| Status | Meaning | Next Action |
+|--------|---------|-------------|
+| PENDING | Not yet investigated | Move to TESTING when ready |
+| TESTING | Currently being investigated | Execute experiment, gather evidence |
+| NEEDS MORE DATA | Inconclusive results | Design better experiment |
+| RULED OUT | Evidence contradicts hypothesis | Document and move on |
+| LIKELY | Evidence supports but not conclusive | Verify with fix |
+| CONFIRMED | Root cause identified and verified | Document fix and close |
+
+## Common Hypothesis Categories
+
+### State-Related
+- Stale cache returning old data
+- Database transaction not committed
+- In-memory state mutation
+- Session/cookie corruption
+
+### Timing-Related
+- Race condition between concurrent operations
+- Timeout too short for slow operations
+- Clock skew between services
+- Event ordering assumptions violated
+
+### Environment-Related
+- Missing environment variable
+- Different library versions
+- File permissions
+- Network connectivity/latency
+
+### Data-Related
+- Null/undefined where unexpected
+- Type mismatch (string vs number)
+- Encoding issues (UTF-8, special characters)
+- Data exceeds expected bounds
+
+## Tips for Effective Hypothesis Tracking
+
+1. **Be specific** - "Something wrong with caching" is not a hypothesis. "Redis TTL set to 0 causing immediate expiration" is.
+
+2. **Make them testable** - Every hypothesis should have a clear experiment that could rule it out.
+
+3. **Update in real-time** - Log entries as you go, not from memory later.
+
+4. **Don't delete** - Ruled-out hypotheses are valuable documentation of what was tried.
+
+5. **Share context** - If handing off, the tracker should let someone else continue without starting over.

--- a/dist/gemini/skills/debugging/references/language-debugging.md
+++ b/dist/gemini/skills/debugging/references/language-debugging.md
@@ -1,0 +1,354 @@
+# Language-Specific Debugging
+
+Debug patterns and tools for Python, TypeScript, and Ruby.
+
+## Python Debugging
+
+### Interactive Debugging with pdb
+
+```python
+# Insert breakpoint in code
+import pdb; pdb.set_trace()
+
+# Python 3.7+ built-in
+breakpoint()
+
+# Conditional breakpoint
+if suspicious_condition:
+    breakpoint()
+```
+
+**Common pdb commands:**
+
+| Command | Action |
+|---------|--------|
+| `n` (next) | Execute next line |
+| `s` (step) | Step into function |
+| `c` (continue) | Continue to next breakpoint |
+| `p expr` | Print expression value |
+| `pp expr` | Pretty-print expression |
+| `l` (list) | Show current code context |
+| `w` (where) | Print stack trace |
+| `u` (up) | Move up stack frame |
+| `d` (down) | Move down stack frame |
+| `q` (quit) | Exit debugger |
+
+### Structured Logging
+
+```python
+import structlog
+
+logger = structlog.get_logger()
+
+# Add context that persists across log calls
+logger = logger.bind(request_id=request.id, user_id=user.id)
+
+# Log with structured data
+logger.info("order_created", order_id=order.id, total=order.total)
+logger.error("payment_failed",
+    order_id=order.id,
+    error_code=e.code,
+    error_message=str(e)
+)
+```
+
+### Traceback Analysis
+
+```python
+import traceback
+
+try:
+    risky_operation()
+except Exception as e:
+    # Full traceback as string
+    tb_str = traceback.format_exc()
+    logger.error("operation_failed", traceback=tb_str)
+
+    # Extract specific frame info
+    tb = traceback.extract_tb(e.__traceback__)
+    for frame in tb:
+        logger.debug("frame",
+            filename=frame.filename,
+            line=frame.lineno,
+            function=frame.name
+        )
+```
+
+### pytest Debugging
+
+```bash
+# Drop into debugger on failure
+pytest --pdb
+
+# Drop into debugger on first failure, then exit
+pytest -x --pdb
+
+# Show local variables in tracebacks
+pytest -l
+
+# Verbose output with print statements
+pytest -v -s
+
+# Run specific test
+pytest tests/test_orders.py::test_create_order -v
+```
+
+### Remote Debugging
+
+```python
+# Using debugpy (VS Code compatible)
+import debugpy
+debugpy.listen(5678)
+debugpy.wait_for_client()  # Pause until debugger attaches
+breakpoint()
+```
+
+## TypeScript Debugging
+
+### Console Methods
+
+```typescript
+// Basic logging
+console.log('value:', value);
+console.error('Error:', error);
+console.warn('Warning:', message);
+
+// Structured output
+console.table(arrayOfObjects);
+console.dir(complexObject, { depth: null });
+
+// Timing
+console.time('operation');
+// ... operation ...
+console.timeEnd('operation');
+
+// Grouping related logs
+console.group('Request Processing');
+console.log('Step 1');
+console.log('Step 2');
+console.groupEnd();
+
+// Conditional logging
+console.assert(condition, 'Condition failed:', data);
+
+// Stack trace without error
+console.trace('How did we get here?');
+```
+
+### Debugger Statement
+
+```typescript
+function processOrder(order: Order): void {
+  // Pauses execution when DevTools is open
+  debugger;
+
+  // Conditional debugger
+  if (order.total > 10000) {
+    debugger;
+  }
+}
+```
+
+### Source Maps
+
+Ensure `tsconfig.json` has source maps enabled:
+
+```json
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "inlineSources": true
+  }
+}
+```
+
+For debugging bundled code, verify source maps are generated and served:
+
+```typescript
+// webpack.config.js
+module.exports = {
+  devtool: 'source-map', // Full source maps for debugging
+};
+```
+
+### Node.js Debugging
+
+```bash
+# Start with inspector
+node --inspect dist/server.js
+
+# Break on first line
+node --inspect-brk dist/server.js
+
+# With ts-node
+node --inspect -r ts-node/register src/server.ts
+```
+
+### Chrome DevTools Tips
+
+1. **Breakpoints**: Click line number in Sources panel
+2. **Conditional breakpoints**: Right-click line number, add condition
+3. **Logpoints**: Right-click, add logpoint (logs without pausing)
+4. **Watch expressions**: Add variables to Watch panel
+5. **Call stack**: Navigate up/down the call stack
+6. **Scope**: Inspect local, closure, and global variables
+
+### Async Debugging
+
+```typescript
+// Capture async stack traces
+Error.stackTraceLimit = 50;
+
+// Label promises for debugging
+const result = await Promise.race([
+  fetchData().then(data => ({ source: 'fetch', data })),
+  timeout(5000).then(() => ({ source: 'timeout', data: null }))
+]);
+console.log('Winner:', result.source);
+```
+
+## Ruby Debugging
+
+### binding.irb (Ruby 2.5+)
+
+```ruby
+def process_order(order)
+  # Opens interactive console at this point
+  binding.irb
+
+  order.validate!
+end
+```
+
+**IRB commands in binding.irb:**
+
+| Command | Action |
+|---------|--------|
+| `exit` | Continue execution |
+| `exit!` | Exit program |
+| `whereami` | Show current code context |
+| `show_source method_name` | Show method source |
+
+### byebug
+
+```ruby
+# Gemfile
+gem 'byebug', group: [:development, :test]
+
+# In code
+require 'byebug'
+
+def process_order(order)
+  byebug  # Execution stops here
+  order.validate!
+end
+```
+
+**byebug commands:**
+
+| Command | Action |
+|---------|--------|
+| `n` (next) | Execute next line |
+| `s` (step) | Step into method |
+| `c` (continue) | Continue execution |
+| `f` (finish) | Run until current method returns |
+| `p expr` | Evaluate expression |
+| `info locals` | Show local variables |
+| `bt` (backtrace) | Show call stack |
+| `up` / `down` | Navigate stack frames |
+
+### Rails Console Debugging
+
+```ruby
+# Start console
+rails console
+
+# Reload after code changes
+reload!
+
+# Find and inspect objects
+user = User.find(123)
+user.attributes
+user.orders.to_sql  # See generated SQL
+
+# Test in sandbox (rollback on exit)
+rails console --sandbox
+```
+
+### Rails Logger
+
+```ruby
+# In application code
+Rails.logger.debug "Processing order: #{order.id}"
+Rails.logger.info "Order created", order_id: order.id
+Rails.logger.error "Payment failed", error: e.message
+
+# Tagged logging
+Rails.logger.tagged("OrderService", order.id) do
+  Rails.logger.info "Starting processing"
+end
+
+# Tail logs
+tail -f log/development.log
+```
+
+### pry-rails
+
+```ruby
+# Gemfile
+gem 'pry-rails', group: [:development, :test]
+
+# In code
+binding.pry  # Opens Pry console
+
+# Pry commands
+ls object          # List methods/variables
+cd object          # Change context to object
+show-source method # Show method definition
+show-doc method    # Show documentation
+wtf?               # Show last exception
+```
+
+### Exception Debugging
+
+```ruby
+begin
+  risky_operation
+rescue => e
+  # Full backtrace
+  puts e.backtrace.join("\n")
+
+  # Filtered backtrace (Rails)
+  puts Rails.backtrace_cleaner.clean(e.backtrace).join("\n")
+
+  # Re-raise with context
+  raise "Order processing failed for order #{order.id}: #{e.message}"
+end
+```
+
+## Cross-Language Tips
+
+### Binary Search Debugging
+
+When you have a long sequence of operations and don't know where the failure occurs:
+
+1. Add logging/breakpoint at the midpoint
+2. Determine if failure is before or after
+3. Repeat with the relevant half
+4. Continue until you isolate the exact line
+
+### Minimal Reproduction
+
+1. Remove code until bug disappears
+2. Add back the last removed piece
+3. That piece contains or triggers the bug
+4. Create minimal test case that reproduces
+
+### Rubber Duck Debugging
+
+When stuck:
+
+1. Explain the code line-by-line out loud
+2. Explain what you expect vs. what happens
+3. Explain your hypotheses and why each might be wrong
+4. Often, articulating the problem reveals the solution

--- a/dist/gemini/skills/debugging/references/test-debugging.md
+++ b/dist/gemini/skills/debugging/references/test-debugging.md
@@ -1,0 +1,326 @@
+# Test Debugging
+
+Strategies for diagnosing flaky tests, isolation failures, and environment-related test issues.
+
+## Flaky Test Diagnosis
+
+A flaky test passes sometimes and fails sometimes with the same code. Common causes:
+
+### Timing Dependencies
+
+**Symptoms:**
+- Test passes locally, fails in CI
+- Test fails more often under load
+- Adding `sleep()` makes it pass
+
+**Investigation:**
+```python
+# Bad: Depends on timing
+def test_async_operation():
+    start_async_job()
+    time.sleep(1)  # Hope it's done
+    assert job_completed()
+
+# Good: Wait for condition
+def test_async_operation():
+    start_async_job()
+    wait_for(lambda: job_completed(), timeout=5)
+    assert job_completed()
+```
+
+**Diagnosis steps:**
+1. Run test 100 times in a loop
+2. Monitor CPU/memory during failures
+3. Add timestamps to understand timing
+4. Check for hardcoded timeouts that are too short
+
+### Order Dependencies
+
+**Symptoms:**
+- Test passes when run alone, fails in suite
+- Test fails only when run after specific other test
+- Reordering tests changes results
+
+**Investigation:**
+```bash
+# pytest: Run in random order
+pytest --random-order
+
+# Find the guilty test pair
+pytest tests/test_a.py tests/test_b.py -v  # Passes
+pytest tests/test_b.py tests/test_a.py -v  # Fails?
+```
+
+**Common culprits:**
+- Global state modified by previous test
+- Database records not cleaned up
+- Cached values persisting
+- Module-level side effects
+
+### Non-Deterministic Data
+
+**Symptoms:**
+- Fails occasionally with no pattern
+- Different assertion failures each time
+- Works with specific seed/data
+
+**Investigation:**
+```python
+# Bad: Non-deterministic
+def test_random_selection():
+    items = get_random_items(10)
+    assert len(items) == 10  # What if source has < 10?
+
+# Good: Control randomness
+def test_random_selection():
+    random.seed(42)
+    items = get_random_items(10)
+    assert len(items) == 10
+```
+
+## Test Isolation Patterns
+
+### Database Isolation
+
+```python
+# pytest with transactions
+@pytest.fixture
+def db_session(engine):
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()
+```
+
+```ruby
+# Rails transactional tests
+class OrderTest < ActiveSupport::TestCase
+  # Each test runs in a transaction that rolls back
+  self.use_transactional_tests = true
+
+  test "creates order" do
+    order = Order.create!(total: 100)
+    assert order.persisted?
+  end  # Order is rolled back
+end
+```
+
+### External Service Isolation
+
+```python
+# Mock external services
+@pytest.fixture
+def mock_payment_api(mocker):
+    return mocker.patch(
+        'app.services.payment.PaymentAPI.charge',
+        return_value={'status': 'success', 'id': 'ch_123'}
+    )
+
+def test_order_payment(mock_payment_api):
+    order = create_order(total=100)
+    order.process_payment()
+
+    mock_payment_api.assert_called_once_with(amount=100)
+    assert order.payment_status == 'paid'
+```
+
+### Time Isolation
+
+```python
+# Freeze time for deterministic tests
+from freezegun import freeze_time
+
+@freeze_time("2024-01-15 12:00:00")
+def test_order_expiry():
+    order = create_order()
+    assert not order.expired
+
+    with freeze_time("2024-01-16 12:00:01"):
+        assert order.expired  # 24+ hours later
+```
+
+```typescript
+// Jest fake timers
+jest.useFakeTimers();
+
+test('order expires after 24 hours', () => {
+  const order = createOrder();
+  expect(order.expired).toBe(false);
+
+  jest.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
+  expect(order.expired).toBe(true);
+});
+```
+
+## State Pollution Detection
+
+### Symptoms
+
+- Test A passes alone, fails after test B
+- Test fails only when suite runs in specific order
+- "Works on my machine" syndrome
+
+### Detection Strategy
+
+```bash
+# 1. Run suspect test in isolation
+pytest tests/test_orders.py::test_specific -v
+
+# 2. Run with a known "polluter"
+pytest tests/test_other.py tests/test_orders.py::test_specific -v
+
+# 3. Binary search for the polluter
+pytest tests/test_orders.py::test_specific --last-failed
+```
+
+### Common State Pollution Sources
+
+| Source | Detection | Fix |
+|--------|-----------|-----|
+| Module globals | Check imports for mutations | Use fixtures, reset in teardown |
+| Class variables | Look for `cls.` modifications | Use instance variables |
+| Singletons | Check shared instances | Reset or mock singletons |
+| Environment variables | Print env in failing test | Restore in teardown |
+| File system | Check for temp files | Use tmp directories, clean up |
+| Database | Check for leftover records | Transaction rollback |
+| Caches | Check memoized values | Clear caches in setup |
+
+### Teardown Pattern
+
+```python
+@pytest.fixture(autouse=True)
+def reset_global_state():
+    # Setup: Save original state
+    original_config = app.config.copy()
+
+    yield
+
+    # Teardown: Restore original state
+    app.config = original_config
+    cache.clear()
+```
+
+## Environment Differences
+
+### Local vs CI Failures
+
+| Difference | Detection | Solution |
+|------------|-----------|----------|
+| Timing | CI slower, races more likely | Use proper waits, not sleeps |
+| Resources | CI has less memory/CPU | Check resource usage |
+| Parallelism | CI runs tests in parallel | Ensure isolation |
+| File paths | Different temp directories | Use portable paths |
+| Timezone | CI uses UTC | Freeze time or use UTC |
+| Locale | CI uses different locale | Set locale explicitly |
+
+### Debugging CI-Only Failures
+
+```yaml
+# GitHub Actions: Enable debug logging
+env:
+  ACTIONS_STEP_DEBUG: true
+  ACTIONS_RUNNER_DEBUG: true
+
+# Add verbose output
+steps:
+  - name: Run tests
+    run: |
+      echo "=== Environment ==="
+      env | sort
+      echo "=== Python version ==="
+      python --version
+      echo "=== Running tests ==="
+      pytest -v --tb=long
+```
+
+### Reproducing CI Environment Locally
+
+```bash
+# Docker: Use same image as CI
+docker run -it --rm -v $(pwd):/app -w /app python:3.11 bash
+pip install -r requirements.txt
+pytest
+
+# Act: Run GitHub Actions locally
+act -j test
+
+# Environment parity
+export CI=true
+export TZ=UTC
+pytest
+```
+
+## Test Debugging Workflow
+
+### 1. Isolate the Failure
+
+```bash
+# Run failing test alone
+pytest tests/test_orders.py::test_failing -v
+
+# If it passes alone, find the interaction
+pytest --collect-only | head -20  # See test order
+```
+
+### 2. Add Diagnostic Output
+
+```python
+def test_order_processing(caplog):
+    with caplog.at_level(logging.DEBUG):
+        order = process_order(data)
+
+    print(f"Captured logs: {caplog.text}")
+    print(f"Order state: {order.__dict__}")
+    assert order.status == "completed"
+```
+
+### 3. Minimize the Test
+
+```python
+# Start with failing test
+def test_order_processing():
+    user = create_user()
+    product = create_product()
+    cart = create_cart(user, product)
+    order = create_order(cart)
+    payment = process_payment(order)
+    shipment = create_shipment(order)
+    assert shipment.status == "ready"
+
+# Remove pieces until bug disappears
+def test_order_processing_minimal():
+    order = create_order()  # Minimal setup
+    assert order.status == "pending"  # Bug is here!
+```
+
+### 4. Check Assumptions
+
+```python
+def test_order_total():
+    order = create_order()
+
+    # Verify assumptions
+    print(f"Order items: {order.items}")
+    print(f"Item prices: {[i.price for i in order.items]}")
+    print(f"Expected total: {sum(i.price for i in order.items)}")
+    print(f"Actual total: {order.total}")
+
+    assert order.total == Decimal("100.00")
+```
+
+## Flaky Test Prevention
+
+| Practice | Why It Helps |
+|----------|--------------|
+| Use factories, not fixtures | Fresh data each test |
+| Avoid shared state | Tests can't pollute each other |
+| Mock time and randomness | Deterministic behavior |
+| Use transactions | Auto-cleanup |
+| Run tests in random order | Catch order dependencies |
+| Run tests in parallel | Catch isolation issues |
+| Set explicit timeouts | Fail fast on hangs |

--- a/dist/gemini/skills/foundations/SKILL.md
+++ b/dist/gemini/skills/foundations/SKILL.md
@@ -36,6 +36,7 @@ Engineering foundations for consistent, secure, and well-documented code.
 |-------|-----------|---------|
 | Code Style | `reference/code-style.md` | Python/TypeScript conventions, naming, patterns |
 | Commits | `reference/commits.md` | Commit messages, branches, PRs, Linear integration |
+| Diagrams | `reference/diagrams.md` | Mermaid syntax, when to diagram, storage patterns |
 | Documentation | `reference/documentation.md` | ADRs, API docs, changelogs |
 | Security | `reference/security.md` | Threat modeling, secrets, compliance |
 | Permissions | `reference/permissions.md` | Tool allowlists, sandbox config, agent permissions |

--- a/dist/gemini/skills/foundations/references/diagrams.md
+++ b/dist/gemini/skills/foundations/references/diagrams.md
@@ -1,0 +1,248 @@
+# Architecture Diagrams
+
+Guidelines for creating Mermaid diagrams to visualize system architecture and data flows.
+
+## When to Create Diagrams
+
+Create architecture diagrams when work involves:
+
+| Scenario | Diagram Type | Why |
+|----------|--------------|-----|
+| Multi-service changes | Component/flowchart | Shows interaction points and dependencies |
+| Data flow changes | Sequence/flowchart | Traces data through the system |
+| Schema modifications | ERD | Visualizes table relationships |
+| API design | Sequence | Documents request/response flows |
+| State machine logic | State diagram | Clarifies transitions and conditions |
+| Complex conditionals | Flowchart | Makes branching logic explicit |
+
+### Skip Diagrams When
+
+- Single-file changes with obvious scope
+- Bug fixes with no architectural impact
+- Configuration-only changes
+- Test additions (unless testing complex flows)
+
+## Mermaid Syntax Quick Reference
+
+### Flowchart (Most Common)
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Action 1]
+    B -->|No| D[Action 2]
+    C --> E[End]
+    D --> E
+```
+
+**Direction options:** `TD` (top-down), `LR` (left-right), `BT` (bottom-top), `RL` (right-left)
+
+**Node shapes:**
+- `[Rectangle]` - Process/action
+- `{Diamond}` - Decision
+- `([Stadium])` - Start/end
+- `[(Database)]` - Database
+- `((Circle))` - Connector
+
+### Sequence Diagram (API/Service Interaction)
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as API
+    participant D as Database
+
+    C->>A: POST /auth/login
+    A->>D: Query user
+    D-->>A: User record
+    A-->>C: JWT token
+```
+
+**Arrow types:**
+- `->>` Solid line with arrowhead (sync call)
+- `-->>` Dashed line with arrowhead (response)
+- `--)` Async message
+
+### Entity Relationship Diagram (Schema)
+
+```mermaid
+erDiagram
+    USER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT ||--o{ LINE_ITEM : "ordered in"
+
+    USER {
+        uuid id PK
+        string email
+        timestamp created_at
+    }
+    ORDER {
+        uuid id PK
+        uuid user_id FK
+        decimal total
+    }
+```
+
+**Relationship notation:**
+- `||` One (required)
+- `o|` Zero or one
+- `}|` One or many
+- `}o` Zero or many
+
+### State Diagram (State Machines)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Pending: submit
+    Pending --> Approved: approve
+    Pending --> Rejected: reject
+    Approved --> [*]
+    Rejected --> Draft: revise
+```
+
+### Component Diagram (System Architecture)
+
+```mermaid
+flowchart LR
+    subgraph Frontend
+        UI[Web App]
+    end
+
+    subgraph Backend
+        API[FastAPI]
+        Worker[Celery]
+    end
+
+    subgraph Data
+        DB[(PostgreSQL)]
+        Cache[(Redis)]
+    end
+
+    UI --> API
+    API --> DB
+    API --> Cache
+    API --> Worker
+    Worker --> DB
+```
+
+## Storage Patterns
+
+### Inline in Session File
+
+Best for: Diagrams specific to current work, temporary visualizations
+
+```markdown
+## Architecture Diagrams
+
+### Auth Flow
+```mermaid
+sequenceDiagram
+    User->>API: Login request
+    API->>DB: Validate credentials
+    DB-->>API: User record
+    API-->>User: JWT token
+```
+**Purpose**: Visualize the authentication flow being implemented
+**Files involved**: `backend/auth/`, `backend/models/user.py`
+```
+
+### Stored in `.agents/diagrams/`
+
+Best for: Reusable diagrams, cross-session reference, team documentation
+
+```
+.agents/diagrams/
+├── system-architecture.md
+├── auth-flow.md
+└── data-pipeline.md
+```
+
+**Diagram file format:**
+
+```markdown
+---
+created: 2025-01-23T14:00:00Z
+last_updated: 2025-01-23T14:00:00Z
+tags: [auth, api, security]
+---
+
+# Auth Flow Diagram
+
+## Overview
+
+Documents the authentication and authorization flow for the API.
+
+## Diagram
+
+```mermaid
+[diagram content]
+```
+
+## Related Files
+
+- `backend/auth/jwt.py` - JWT generation
+- `backend/middleware/auth.py` - Auth middleware
+- `backend/models/user.py` - User model
+
+## Notes
+
+Any additional context about this diagram.
+```
+
+### When to Store vs Inline
+
+| Store in `.agents/diagrams/` | Keep Inline in Session |
+|------------------------------|------------------------|
+| Referenced by multiple sessions | One-time visualization |
+| Documents stable architecture | Documents work-in-progress |
+| Shared across team members | Personal understanding aid |
+| Likely to be updated | Disposable after task |
+
+## Best Practices
+
+### Keep Diagrams Focused
+
+```markdown
+# Good: Single concern
+Auth flow diagram showing login -> validate -> token
+
+# Bad: Everything at once
+Entire system with auth, billing, notifications, logging...
+```
+
+### Use Consistent Naming
+
+```markdown
+# In diagrams, use actual names from code
+API[auth-service]  # Matches service name
+DB[(users)]        # Matches table name
+
+# Not generic placeholders
+API[Service A]
+DB[(Database)]
+```
+
+### Add Context
+
+Every diagram needs:
+1. **Purpose** - Why this diagram exists
+2. **Files involved** - What code it represents
+3. **Limitations** - What it does NOT show
+
+### Update When Code Changes
+
+Diagrams are documentation. When the code they represent changes:
+1. Update the diagram
+2. Update `last_updated` timestamp
+3. Note the change in session log
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Diagram everything | Diagram only complex flows |
+| Include implementation details | Show architectural relationships |
+| Create diagrams after code | Create during planning |
+| Leave stale diagrams | Update or delete |
+| Use inconsistent notation | Follow Mermaid conventions |

--- a/dist/gemini/skills/orchestration/SKILL.md
+++ b/dist/gemini/skills/orchestration/SKILL.md
@@ -37,11 +37,18 @@ Every release should be complete, polished, and delightful - no MVPs or quick ha
 | Stuck on task | Check circuit breaker, consider reshaping |
 | Pre-compaction | Spawn context-archiver to preserve state |
 | Low-priority work | Spawn background-runner with run_in_background |
+| New feature workflow | Research → Architecture → PRD → Specs → Tasks |
+| Create specification | Use `/specs` with requirement reference |
+| Break down spec | Use `/tasks` to generate atomic work items |
+| Task-coupled session | Use `/start-session TASK-XXX` for traceability |
 
 ## Topics
 
 | Topic | Reference | Key Content |
 |-------|-----------|-------------|
+| Product Development | [reference/product-development.md](reference/product-development.md) | Full workflow: Research → Vision → Architecture → Requirements → Specs → Tasks |
+| Specifications | [reference/specs.md](reference/specs.md) | Spec format, lifecycle, shaping, test conditions |
+| Local Tasks | [reference/local-tasks.md](reference/local-tasks.md) | Task format, abstraction layer, Linear/local backend |
 | Agent Delegation | [reference/delegation.md](reference/delegation.md) | Agent capabilities, spawn patterns, decision tree |
 | Background Agents | [reference/background-agents.md](reference/background-agents.md) | Non-interactive work, spawn with run_in_background |
 | Council Workflow | [reference/councils.md](reference/councils.md) | Composition, deliberation, synthesis, user approval |

--- a/dist/gemini/skills/orchestration/SKILL.md
+++ b/dist/gemini/skills/orchestration/SKILL.md
@@ -36,12 +36,14 @@ Every release should be complete, polished, and delightful - no MVPs or quick ha
 | Agent selection | Match domain expertise to task |
 | Stuck on task | Check circuit breaker, consider reshaping |
 | Pre-compaction | Spawn context-archiver to preserve state |
+| Low-priority work | Spawn background-runner with run_in_background |
 
 ## Topics
 
 | Topic | Reference | Key Content |
 |-------|-----------|-------------|
 | Agent Delegation | [reference/delegation.md](reference/delegation.md) | Agent capabilities, spawn patterns, decision tree |
+| Background Agents | [reference/background-agents.md](reference/background-agents.md) | Non-interactive work, spawn with run_in_background |
 | Council Workflow | [reference/councils.md](reference/councils.md) | Composition, deliberation, synthesis, user approval |
 | Session Management | [reference/sessions.md](reference/sessions.md) | Lifecycle, file format, handoffs, validation |
 | Session Resume | [reference/session-resume.md](reference/session-resume.md) | CLI flags, checkpoints, context recovery |

--- a/dist/gemini/skills/orchestration/references/background-agents.md
+++ b/dist/gemini/skills/orchestration/references/background-agents.md
@@ -1,0 +1,236 @@
+# Background Agents
+
+Background agents handle low-priority, long-running, or non-interactive work that can run independently while the user continues with other tasks.
+
+## When to Use Background Agents
+
+| Appropriate | Not Appropriate |
+|-------------|-----------------|
+| Security audits | Interactive debugging |
+| Code coverage analysis | User-facing questions |
+| Large-scale refactoring reports | Time-sensitive fixes |
+| Codebase-wide linting reports | Tasks requiring immediate feedback |
+| Documentation audits | Work needing user decisions mid-task |
+| Dependency vulnerability scans | Blocking tasks for current work |
+
+**Good candidates:**
+- Results can be processed later
+- No user interaction required
+- Task is well-defined with clear completion criteria
+- Output is a report or artifact, not a conversation
+
+**Poor candidates:**
+- Needs clarification mid-task
+- Time-sensitive (user waiting for result)
+- Requires real-time coordination with other agents
+
+## Spawning Background Agents
+
+### Claude Code
+
+Use the Task tool with `run_in_background: true`:
+
+```python
+Task(
+    subagent_type="background-runner",
+    prompt="""
+    Run full security audit on backend codebase.
+
+    Scope:
+    - src/api/
+    - src/services/
+
+    Write report to: .agents/reports/YYYYMMDD-HHMMSS-security-audit.md
+
+    Session: .agents/sessions/20260123-143000-auth-feature.md
+    """,
+    run_in_background=True
+)
+```
+
+### Cursor
+
+Background agents are configured via the `is_background: true` YAML property. When spawning:
+
+```
+@background-runner Run security audit on backend codebase.
+Write report to .agents/reports/
+```
+
+## Background Agent Tracking
+
+Track background agents in session frontmatter:
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security-scan"
+    agent: background-runner
+    task: "Full security audit of backend"
+    status: running  # running | completed | failed
+    result_location: null
+  - id: "bg-20260123-144500-coverage"
+    agent: background-runner
+    task: "Test coverage analysis"
+    status: completed
+    result_location: ".agents/reports/20260123-144500-coverage-report.md"
+```
+
+### Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `running` | Agent still executing |
+| `completed` | Work finished, results available |
+| `failed` | Agent encountered error |
+
+### ID Convention
+
+Background agent IDs follow: `bg-YYYYMMDD-HHMMSS-<description>`
+
+Generate with:
+```bash
+echo "bg-$(date -u +"%Y%m%d-%H%M%S")-<description>"
+```
+
+## Result Retrieval
+
+Background agents write results to `.agents/reports/` with standard frontmatter:
+
+```yaml
+---
+report:
+  title: "Security Audit Report"
+  type: background-agent-output
+  status: unprocessed  # unprocessed | processed | archived
+  created: "2026-01-23T14:30:00Z"
+  background_agent_id: "bg-20260123-143000-security-scan"
+  session_reference: "20260123-140000-auth-feature.md"
+---
+```
+
+### Processing Results
+
+1. SessionStart hook alerts user to completed background work
+2. User or PM reviews report in `.agents/reports/`
+3. PM updates session frontmatter:
+   - Change `status` from `running` to `completed`
+   - Set `result_location` to report path
+4. Process findings as needed (spawn agents, create issues)
+5. Set report `status` to `processed`
+
+## Workflow Example
+
+### 1. PM Identifies Low-Priority Work
+
+During auth feature implementation, PM identifies need for security audit but it is not blocking current work.
+
+### 2. PM Spawns Background Agent
+
+```python
+Task(
+    subagent_type="background-runner",
+    prompt="""
+    Run comprehensive security audit on auth implementation.
+
+    Files to audit:
+    - src/auth/endpoints.py
+    - src/auth/token.py
+    - src/auth/middleware.py
+
+    Check for:
+    - OWASP Top 10 vulnerabilities
+    - Secrets in code
+    - SQL injection risks
+    - Authentication bypasses
+
+    Write report to: .agents/reports/20260123-143000-auth-security.md
+
+    Session: .agents/sessions/20260123-140000-auth-feature.md
+    """,
+    run_in_background=True
+)
+```
+
+### 3. PM Updates Session Frontmatter
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-auth-security"
+    agent: background-runner
+    task: "Auth security audit"
+    status: running
+    result_location: null
+```
+
+### 4. Work Continues
+
+PM and other agents continue with main implementation while background agent works.
+
+### 5. Session Resumes Later
+
+SessionStart hook detects completed background work:
+
+```
+# Background Work Completed
+
+The following background agents have completed:
+
+- **bg-20260123-143000-auth-security** (background-runner)
+  - Task: Auth security audit
+  - Result: .agents/reports/20260123-143000-auth-security.md
+
+Review reports and update session frontmatter after processing.
+```
+
+### 6. Results Processed
+
+PM reads report, creates issues for findings, updates session.
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Use for blocking work | Keep blocking work in foreground |
+| Spawn without tracking | Always update session frontmatter |
+| Ignore completed results | Process results when alerted |
+| Use for interactive tasks | Reserve for autonomous work |
+| Spawn many concurrent background agents | Limit to 2-3 to avoid resource contention |
+| Skip result location in prompt | Always specify where to write output |
+
+## Integration Points
+
+### SessionStart Hook
+
+Checks session frontmatter for `background_agents` with `status: completed`. Alerts user to review results.
+
+### PreCompact Hook
+
+Includes background agent state in preservation. Context-archiver captures:
+- Active background agent list
+- Current status of each
+- Result locations for completed agents
+
+### Session Frontmatter
+
+Full template with background agents:
+
+```yaml
+---
+session:
+  title: "Feature implementation"
+  status: in_progress
+  # ... other session fields ...
+
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: completed
+    result_location: ".agents/reports/20260123-143000-security.md"
+  - id: "bg-20260123-150000-coverage"
+    agent: background-runner
+    task: "Coverage analysis"
+    status: running
+    result_location: null
+---
+```

--- a/dist/gemini/skills/orchestration/references/cross-session.md
+++ b/dist/gemini/skills/orchestration/references/cross-session.md
@@ -1,0 +1,200 @@
+# Cross-Session References
+
+Patterns for importing decisions and context from past sessions into current work without duplicating full context.
+
+## When to Reference Past Sessions
+
+### Good Reasons to Reference
+
+- **Continuing related work**: Building on previous feature decisions
+- **Consistency**: Ensuring alignment with prior architectural choices
+- **Avoiding re-deliberation**: Council decisions already made on similar topics
+- **Context recovery**: Picking up work after long gaps
+
+### Skip Referencing When
+
+- Starting genuinely new work unrelated to past sessions
+- Past decisions are documented in ADRs (use ADRs instead)
+- Context would create more noise than value
+- Decisions were superseded or invalidated
+
+## What to Import
+
+### Decisions Only (Default)
+
+Import the distilled outcomes:
+
+```markdown
+## Referenced Decisions
+
+### From: 20250115-140000-auth-jwt.md
+
+#### Decision: Token Rotation Strategy
+**Decision**: Rotate every 15 minutes
+**Rationale**: Security/UX balance
+```
+
+**Why decisions only:**
+- Minimal context footprint
+- Focus on outcomes, not process
+- Easy to scan and validate relevance
+
+### Context Summary (When Needed)
+
+Import broader context when:
+- Problem space is complex and unfamiliar
+- Technical approach was non-obvious
+- Multiple related decisions form a coherent strategy
+
+```markdown
+## Referenced Context
+
+### From: 20250115-140000-auth-jwt.md
+
+**Problem**: Session management for distributed services
+**Approach**: JWT with refresh token rotation
+**Key Files**: `src/auth/`, `src/middleware/auth.py`
+**Outcome**: Implemented, deployed to production 2025-01-20
+```
+
+## Session Frontmatter for Tracking
+
+Track all cross-session references in frontmatter:
+
+```yaml
+---
+session:
+  title: "Auth V2 Implementation"
+  status: in_progress
+  created: "2025-01-23T10:00:00Z"
+  last_updated: "2025-01-23T14:30:00Z"
+  linear_issue: "PLT-200"
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"
+      imported_at: "2025-01-23T14:30:00Z"
+      content_type: decisions
+      decisions_imported:
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+    - session: "20250110-090000-auth-oauth.md"
+      imported_at: "2025-01-23T14:35:00Z"
+      content_type: context
+      summary: "OAuth provider integration patterns"
+
+orchestration:
+  current_task: "Implement token refresh endpoint"
+---
+```
+
+## Decision Memory Format
+
+When sessions are archived, decisions are extracted to Serena memory:
+
+```markdown
+# Memory: session-auth-jwt-decisions.md
+
+## Session Context
+- **Session**: 20250115-140000-auth-jwt.md
+- **Archived**: 2025-01-15T18:00:00Z
+- **Linear Issue**: PLT-123
+
+## Key Decisions
+
+### Decision 1: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window refresh
+**Rationale**: Balances security (limited token lifetime) with UX (seamless refresh)
+**Council**: None - backend-dev recommendation accepted
+
+### Decision 2: Refresh Token Storage
+**Decision**: Store refresh tokens in HttpOnly cookies, not localStorage
+**Rationale**: Prevents XSS-based token theft; aligns with OWASP recommendations
+**Council**: Security council (5 agents) - unanimous
+
+### Decision 3: Token Validation Order
+**Decision**: Validate signature before parsing claims
+**Rationale**: Fail fast on tampered tokens; reduce processing for invalid requests
+**Council**: None - standard security practice
+```
+
+## Workflow
+
+### At Archive Time (context-archiver)
+
+1. Read session file
+2. Check for `## Decisions` section
+3. If present, run `extract-decisions.py`
+4. Write output to Serena memory via MCP
+
+### At Reference Time (/reference-session)
+
+1. Search Serena memories for matching sessions
+2. Read selected decision memory
+3. Import into current session
+4. Track in `referenced_sessions` frontmatter
+
+## Serena MCP Integration
+
+### List Available Decision Memories
+
+```python
+mcp__serena__list_memories()
+# Filter results for: session-*-decisions.md
+```
+
+### Read Decision Memory
+
+```python
+mcp__serena__read_memory(name="session-auth-jwt-decisions.md")
+```
+
+### Write Decision Memory (at archive time)
+
+```python
+mcp__serena__write_memory(
+    name="session-auth-jwt-decisions.md",
+    content=extracted_decisions_markdown
+)
+```
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Import entire session files | Import only decisions/summaries |
+| Import without tracking | Update `referenced_sessions` in frontmatter |
+| Import unrelated sessions | Search by topic, Linear issue, or keyword |
+| Duplicate ADR content | Reference the ADR directly |
+| Import stale decisions | Verify decisions are still relevant |
+| Over-reference | Import only what's needed for current work |
+| Reference without reading | Always review imported content for relevance |
+
+## When Decisions Conflict
+
+If imported decisions conflict with current approach:
+
+1. **Note the conflict** in session file
+2. **Assess if prior decision still applies**
+   - Different context? Proceed with new approach
+   - Same context? Consider why original decision was made
+3. **Document the change** if deviating
+4. **Consider council** if uncertainty remains
+5. **Update ADRs** if architectural decision changes
+
+## Best Practices
+
+1. **Reference early** - Import relevant decisions before planning
+2. **Validate relevance** - Review each decision's applicability
+3. **Track everything** - All imports go in frontmatter
+4. **Summarize in session log** - Note what was imported and why
+5. **Don't over-import** - Less is more for context management
+6. **Update if superseding** - Mark old decisions as superseded when creating new ones
+
+## Example Session Log Entry
+
+```markdown
+### 2025-01-23 14:30 - PM
+Referenced decisions from auth-jwt session (PLT-123):
+- Token rotation strategy (15-min window)
+- Refresh token storage (HttpOnly cookies)
+Relevant to current auth-v2 work; maintaining consistency.
+```

--- a/dist/gemini/skills/orchestration/references/local-tasks.md
+++ b/dist/gemini/skills/orchestration/references/local-tasks.md
@@ -1,0 +1,276 @@
+# Local Task Management
+
+Break specs into atomic tasks using local files when Linear isn't available.
+
+## Task Abstraction Layer
+
+Tasks work identically whether backed by Linear or local files.
+
+### Configuration
+
+```yaml
+# .agents/loaf.yaml
+task_management:
+  backend: linear  # or "local"
+
+  linear:
+    team: ProjectName
+    default_labels: []
+
+  local:
+    archive_completed: true
+    directory: .agents/tasks
+```
+
+### Abstracted Operations
+
+| Operation | Linear | Local |
+|-----------|--------|-------|
+| Create task | Create issue | Write `.agents/tasks/active/TASK-*.md` |
+| Fetch task | Get issue | Read task file |
+| Update status | Update issue | Edit frontmatter |
+| List tasks | List issues | Glob task files |
+| Complete | Move to Done | Move to archive |
+
+## Local Task Format
+
+```yaml
+---
+id: TASK-001
+title: OAuth Provider Integration
+spec: SPEC-001
+status: todo  # todo | in_progress | review | done
+priority: P1  # P0 (urgent) | P1 (high) | P2 (normal) | P3 (low)
+created: 2026-01-23T14:30:00Z
+updated: 2026-01-23T14:30:00Z
+files:
+  - src/auth/oauth.py
+  - tests/auth/test_oauth.py
+verify: pytest tests/auth/test_oauth.py
+done: OAuth flow works for Google and GitHub
+---
+
+# TASK-001: OAuth Provider Integration
+
+## Description
+
+Implement OAuth provider integration for Google and GitHub following
+the approach outlined in SPEC-001.
+
+## Acceptance Criteria
+
+- [ ] Google OAuth flow completes successfully
+- [ ] GitHub OAuth flow completes successfully
+- [ ] Tokens stored securely in session
+- [ ] Error handling for failed auth
+- [ ] Unit tests pass
+
+## Context
+
+See SPEC-001 for full context and constraints.
+Reference ADR-001 for session storage decisions.
+
+## Work Log
+
+<!-- Updated by session as work progresses -->
+```
+
+**Location:** `.agents/tasks/active/TASK-001-oauth-provider.md`
+
+## Task Lifecycle
+
+```
+todo → in_progress → review → done
+  │        │           │        │
+  └────────┴───────────┴────────┘
+           can return to earlier states
+```
+
+| Status | Meaning |
+|--------|---------|
+| `todo` | Ready to work, not started |
+| `in_progress` | Actively being worked |
+| `review` | Implementation complete, needs verification |
+| `done` | Verified complete, ready for archive |
+
+## Creating Tasks from Specs
+
+### Input
+
+- Spec ID (e.g., `SPEC-001`)
+- Optional: priority override
+
+### Task Breakdown Rules
+
+1. **One concern per task** - Don't mix backend + tests + frontend
+2. **Clear done condition** - Observable, verifiable outcome
+3. **Verification command** - How to prove it works
+4. **File hints** - Which files will likely be modified
+
+### Example Breakdown
+
+```
+SPEC-001: User Authentication with OAuth
+        ↓
+TASK-001: OAuth Provider Integration
+  - Google OAuth client setup
+  - GitHub OAuth client setup
+  - Token exchange logic
+  verify: pytest tests/auth/test_oauth.py
+
+TASK-002: Session Management
+  - Session cookie handling
+  - Session storage (Redis/DB)
+  - Session expiry logic
+  verify: pytest tests/auth/test_session.py
+
+TASK-003: Login UI Components
+  - Login page layout
+  - Provider buttons
+  - Error states
+  verify: npm run test:e2e -- auth
+```
+
+## Directory Structure
+
+```
+.agents/tasks/
+├── active/                    # Current work
+│   ├── TASK-001-oauth-provider.md
+│   ├── TASK-002-session-management.md
+│   └── TASK-003-login-ui.md
+└── archive/                   # Completed work
+    └── 2026-01/              # Organized by month
+        └── TASK-000-initial-setup.md
+```
+
+## Task ID Generation
+
+Format: `TASK-{number}-{slug}`
+
+```bash
+# Find next available number
+ls .agents/tasks/active/ .agents/tasks/archive/*/ 2>/dev/null | \
+  grep -oE 'TASK-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+## Archiving Tasks
+
+When a task is done:
+
+1. Update status to `done`
+2. Add completion timestamp
+3. Move to archive:
+
+```bash
+mkdir -p .agents/tasks/archive/$(date +%Y-%m)
+mv .agents/tasks/active/TASK-001-*.md .agents/tasks/archive/$(date +%Y-%m)/
+```
+
+## Session Integration
+
+When `/start-session TASK-001`:
+
+1. Read task file for context
+2. Read linked spec for full picture
+3. Create session with traceability:
+
+```yaml
+session:
+  title: "OAuth Provider Integration"
+  task: TASK-001
+  spec: SPEC-001
+  status: in_progress
+
+traceability:
+  requirement: "2.1 User Authentication"
+  architecture:
+    - "Session Management"
+  decisions:
+    - ADR-001
+```
+
+## Priority Levels
+
+| Priority | Meaning | Response |
+|----------|---------|----------|
+| P0 | Urgent/blocking | Drop everything |
+| P1 | High | Work next |
+| P2 | Normal | Scheduled work |
+| P3 | Low | When time permits |
+
+## Listing Tasks
+
+### All Active Tasks
+
+```bash
+for f in .agents/tasks/active/TASK-*.md; do
+  id=$(grep '^id:' "$f" | cut -d: -f2 | tr -d ' ')
+  title=$(grep '^title:' "$f" | cut -d: -f2-)
+  status=$(grep '^status:' "$f" | cut -d: -f2 | tr -d ' ')
+  echo "$id [$status] $title"
+done
+```
+
+### Tasks for a Spec
+
+```bash
+grep -l "spec: SPEC-001" .agents/tasks/active/*.md
+```
+
+## Work Log Updates
+
+As work progresses, append to the Work Log section:
+
+```markdown
+## Work Log
+
+### 2026-01-23 14:30 UTC
+Started OAuth integration. Set up Google OAuth client credentials.
+
+### 2026-01-23 15:45 UTC
+Google OAuth working. Moving to GitHub integration.
+
+### 2026-01-23 17:00 UTC
+Both providers working. Tests pass. Moving to review.
+```
+
+## Verification
+
+Before marking `done`:
+
+1. Run the `verify` command from frontmatter
+2. Check all acceptance criteria are checked
+3. Ensure no regressions in related tests
+
+```bash
+# Run task verification
+verify_cmd=$(grep '^verify:' TASK-001-*.md | cut -d: -f2-)
+eval "$verify_cmd"
+```
+
+## Local vs Linear Comparison
+
+| Feature | Local | Linear |
+|---------|-------|--------|
+| No external dependency | yes | no |
+| Rich UI | no | yes |
+| Team collaboration | git-based | native |
+| Notifications | none | email/slack |
+| Reporting | manual | built-in |
+| Offline work | yes | limited |
+
+**Use local when:**
+- Solo project
+- No Linear access
+- Offline development
+- Simple task tracking
+
+**Use Linear when:**
+- Team collaboration needed
+- Rich workflow automation
+- Integration with other tools
+- Reporting requirements

--- a/dist/gemini/skills/orchestration/references/product-development.md
+++ b/dist/gemini/skills/orchestration/references/product-development.md
@@ -1,0 +1,234 @@
+# Product Development Workflow
+
+A Research → Vision → Architecture → Requirements → Specs → Tasks → Session workflow for structured product development.
+
+## Core Insight
+
+**Separate permanent project knowledge from ephemeral orchestration.**
+
+```
+docs/                               # Permanent project knowledge
+├── VISION.md                       # Strategic direction (evolves rarely)
+├── ARCHITECTURE.md                 # Technical design (evolves with learnings)
+├── REQUIREMENTS.md                 # Business/product rules (evolves with feedback)
+├── decisions/                      # Architecture Decision Records
+│   └── ADR-001-database-choice.md
+└── specs/                          # Feature specifications (temporary)
+    ├── SPEC-001-user-auth.md
+    └── archive/                    # Completed specs
+
+.agents/                            # Ephemeral orchestration
+├── loaf.yaml                       # Project config (task backend, etc.)
+├── sessions/                       # Active work contexts
+├── plans/                          # Implementation plans
+├── councils/                       # Deliberation records
+├── transcripts/                    # Archived conversation transcripts
+├── tasks/                          # Local tasks (when not using Linear)
+│   ├── active/
+│   │   └── TASK-001-oauth-provider.md
+│   └── archive/
+└── debug/                          # Persistent debug sessions
+```
+
+## The Hierarchy
+
+```
+RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS → SESSION
+    │         │          │              │           │        │        │
+/research  (manual)  /architecture    /prd       /specs   /tasks  /start-session
+    │                    │              │           │        │
+    └─► evolves ─────────┴──────────────┴───────────┴────────┘
+        VISION                                      (feedback loops)
+```
+
+**Each level breaks down the one above:**
+- Research informs/evolves Vision
+- Vision shapes Architecture
+- Architecture constrains Requirements
+- Requirements break into Specs
+- Specs break into Tasks
+- Tasks become Sessions
+
+## Commands Overview
+
+| Command | Input | Output | Purpose |
+|---------|-------|--------|---------|
+| `/research` | Topic or "project state" | Insights, brainstorm | Zoom out, evolve VISION |
+| `/architecture` | Decision question | ARCHITECTURE.md + ADR | Technical decisions |
+| `/prd` | Feature area | REQUIREMENTS.md section | Product/business rules |
+| `/specs` | Requirement reference | SPEC-001-*.md | Feature specifications |
+| `/tasks` | Spec reference | TASK-* files/issues | Atomic work items |
+| `/start-session` | TASK-ID | Session file | Execute a task |
+
+## Document Formats
+
+### VISION.md
+
+Strategic direction that evolves rarely. Contains:
+- Product purpose and target users
+- Core principles and values
+- Long-term direction
+- What makes this product unique
+
+### ARCHITECTURE.md
+
+Technical design that evolves with learnings:
+- System architecture overview
+- Technology choices and rationale
+- Integration patterns
+- Deployment model
+
+### REQUIREMENTS.md
+
+Business and product rules organized by domain:
+
+```markdown
+## 2. Identity & Access
+
+### 2.1 User Authentication
+
+**Business Rules**
+- Users authenticate via OAuth (Google, GitHub)
+- Sessions expire after 24 hours of inactivity
+- Failed login attempts logged for security
+
+**Acceptance Criteria**
+- [ ] User can sign in with Google
+- [ ] User can sign in with GitHub
+- [ ] Session persists across browser refresh
+- [ ] Logout clears session completely
+```
+
+### Architecture Decision Records (ADRs)
+
+```yaml
+---
+id: ADR-001
+title: "PostgreSQL as Required Database"
+status: Accepted  # Proposed | Accepted | Deprecated | Superseded
+date: 2026-01-23
+---
+
+# ADR-001: PostgreSQL as Required Database
+
+## Context
+[Why this decision is needed]
+
+## Decision
+[What was decided]
+
+## Consequences
+[Tradeoffs and implications]
+```
+
+**Location:** `docs/decisions/ADR-001-*.md`
+
+## Configuration
+
+```yaml
+# .agents/loaf.yaml
+project:
+  name: "My Project"
+
+task_management:
+  backend: linear  # or "local"
+
+  linear:
+    team: ProjectName
+
+  local:
+    archive_completed: true
+
+docs:
+  vision: docs/VISION.md
+  architecture: docs/ARCHITECTURE.md
+  requirements: docs/REQUIREMENTS.md
+  decisions: docs/decisions/
+  specs: docs/specs/
+```
+
+## Workflow Examples
+
+### Full Workflow (New Feature)
+
+```bash
+# 1. Zoom out, check project state
+/research "project state"
+# → Lessons learned, ideas for auth improvement
+
+# 2. Make architecture decision
+/architecture "OAuth vs custom auth"
+# → Interview → ADR-001-auth-approach.md
+
+# 3. Capture requirements
+/prd "user authentication"
+# → Interview → REQUIREMENTS.md section 2.1
+
+# 4. Create specification
+/specs "2.1 User Authentication"
+# → Interview → SPEC-001-user-auth.md
+
+# 5. Generate tasks
+/tasks SPEC-001
+# → TASK-001, TASK-002, TASK-003
+
+# 6. Work on tasks
+/start-session TASK-001
+# → Session → Implementation → Done
+```
+
+### Quick Fix (Ad-hoc)
+
+```bash
+# Create task directly (bug report, small fix)
+/start-session TASK-099
+# PM: "No parent spec. Proceed?"
+# User: "Yes, small fix"
+# → Session → Fix → Done
+```
+
+## Feedback Loops
+
+The workflow is not rigid. Each level can feed back to higher levels:
+
+| Discovery | Action |
+|-----------|--------|
+| Implementation reveals design flaw | Update ARCHITECTURE.md |
+| Edge case invalidates requirement | Update REQUIREMENTS.md |
+| Spec too ambitious for appetite | Re-scope or split |
+| Task reveals missing requirement | Add to REQUIREMENTS.md |
+
+## Transcript Archival
+
+After `/compact` or `/clear`, archive conversation transcripts for future reference:
+
+1. **Copy transcript** to `.agents/transcripts/`
+2. **Link from session file** in frontmatter:
+
+```yaml
+session:
+  title: "Feature Implementation"
+  transcripts:
+    - 20260123-143500-pre-compact.jsonl
+    - 20260123-160000-final.jsonl
+```
+
+This preserves full context for debugging, knowledge extraction, and audit trails.
+
+## Flexibility Preserved
+
+1. **Skip steps** - Quick fixes don't need full workflow
+2. **Feedback loops** - Any level can evolve from learnings
+3. **Agents adapt** - Not a rigid harness
+
+## Critical Files
+
+| File | Purpose |
+|------|---------|
+| `docs/VISION.md` | Strategic direction |
+| `docs/ARCHITECTURE.md` | Technical design |
+| `docs/REQUIREMENTS.md` | Product rules |
+| `docs/decisions/ADR-*.md` | Architecture decisions |
+| `docs/specs/SPEC-*.md` | Feature specifications |
+| `.agents/tasks/active/TASK-*.md` | Local tasks |
+| `.agents/loaf.yaml` | Project configuration |

--- a/dist/gemini/skills/orchestration/references/sessions.md
+++ b/dist/gemini/skills/orchestration/references/sessions.md
@@ -68,6 +68,7 @@ session:
   branch: "username/back-123-feature"          # Optional: working branch
   transcripts: []                              # Archived Claude Code transcripts (filenames only)
                                                # Example: ["2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl"]
+  referenced_sessions: []                      # Cross-session references (see below)
 
 plans: []  # List of plan files in .agents/plans/ used by this session
            # Example: ["20251204-143500-api-design.md", "20251204-150000-frontend.md"]
@@ -79,8 +80,42 @@ orchestration:
       task: "Brief task description"
       status: completed                        # pending|in_progress|completed
       summary: "Outcome summary"
+
+background_agents:                             # Background work running independently
+  - id: "bg-20260123-143000-security-scan"     # ID: bg-YYYYMMDD-HHMMSS-description
+    agent: background-runner                   # Agent type
+    task: "Full security audit"                # Brief description
+    status: running                            # running|completed|failed
+    result_location: null                      # Path to report when complete
 ---
 ```
+
+### Cross-Session References
+
+Track decisions imported from past sessions via `/reference-session`:
+
+```yaml
+session:
+  # ... other fields ...
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"     # Source session filename
+      imported_at: "2025-01-23T14:30:00Z"        # When imported
+      content_type: decisions                     # decisions|context|all
+      decisions_imported:                         # List of decision titles
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+    - session: "20250110-090000-auth-oauth.md"
+      imported_at: "2025-01-23T14:35:00Z"
+      content_type: context
+      summary: "OAuth provider integration patterns"
+```
+
+**Why track references:**
+- Audit trail of where context came from
+- Avoids re-importing same decisions
+- Enables tracing decision lineage across sessions
+
+See `references/cross-session.md` for full patterns.
 
 ### Required Sections
 
@@ -160,6 +195,29 @@ Implementation plans for this session (stored in `.agents/plans/`):
 |------|--------|-------------|
 | [api-design](../plans/20251204-143500-api-design.md) | approved | API endpoint structure |
 | [frontend](../plans/20251204-150000-frontend.md) | pending | UI component design |
+
+## Architecture Diagrams
+
+### [Diagram Name]
+
+```mermaid
+[diagram content]
+```
+
+**Purpose**: Why this diagram helps understand the work
+**Files involved**: List of related file paths
+**Created**: When diagram was created (update if modified)
+
+<!--
+When to add diagrams:
+- Multi-service changes: Show interaction points
+- Data flow changes: Trace data through system
+- Schema modifications: Visualize relationships
+- API design: Document request/response flows
+
+For reusable diagrams, store in .agents/diagrams/ instead.
+See foundations skill reference/diagrams.md for Mermaid syntax.
+-->
 
 ## Council Outcomes
 

--- a/dist/gemini/skills/orchestration/references/specs.md
+++ b/dist/gemini/skills/orchestration/references/specs.md
@@ -1,0 +1,255 @@
+# Feature Specifications
+
+Break VISION + ARCHITECTURE + REQUIREMENTS into specific, implementable specs.
+
+## Philosophy
+
+**Specs are shaped solutions, not detailed designs.**
+
+A spec defines:
+- What problem we're solving
+- Boundaries (in/out of scope)
+- High-level approach
+- Test conditions
+
+A spec does NOT define:
+- Implementation details
+- Code structure
+- Exact UI layouts
+
+## Spec Format
+
+```yaml
+---
+id: SPEC-001
+title: "User Authentication with OAuth"
+requirement: "2.1 User Authentication"
+created: 2026-01-23T14:30:00Z
+status: drafting  # drafting | approved | implementing | complete
+appetite: "1 week"
+---
+
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+[From REQUIREMENTS 2.1 - why this matters to users and the business]
+
+## Proposed Solution
+
+[Shaped solution - high-level approach, not implementation details]
+
+## Scope
+
+### In Scope
+- OAuth: Google, GitHub
+- Session management with secure cookies
+- Login/logout UI
+
+### Out of Scope (Rabbit Holes)
+- Custom OAuth providers (avoid this complexity)
+- MFA (future spec if needed)
+- Password-based auth
+
+### No-Gos
+- Passwords in plaintext
+- Tokens in local storage
+- Session data in URLs
+
+## Test Conditions
+
+- [ ] OAuth flow completes for Google
+- [ ] OAuth flow completes for GitHub
+- [ ] Session persists across page refresh
+- [ ] Logout clears session completely
+- [ ] Invalid tokens are rejected
+
+## Implementation Notes
+
+[Architecture references, technical constraints, relevant ADRs]
+
+## Circuit Breaker
+
+At 50% appetite: if OAuth integration is problematic, simplify to single provider (Google only).
+```
+
+**Location:** `docs/specs/SPEC-001-feature-name.md`
+
+## Spec Lifecycle
+
+```
+drafting → approved → implementing → complete
+    │         │           │           │
+    └─────────┴───────────┴───────────┘
+              can return to drafting
+```
+
+| Status | Meaning |
+|--------|---------|
+| `drafting` | Being refined, not ready for work |
+| `approved` | User approved, ready for task breakdown |
+| `implementing` | Tasks created, work in progress |
+| `complete` | All tasks done, spec archived |
+
+## Creating Specs
+
+### Input Required
+
+1. **Requirement reference** - Which section of REQUIREMENTS.md
+2. **Appetite** - How much time is it worth (from Shape Up)
+
+### Interview Questions
+
+Before drafting, clarify:
+
+| Area | Questions |
+|------|-----------|
+| Scope | What's definitely in? What's definitely out? |
+| Rabbit holes | What seems related but should be avoided? |
+| No-gos | What approaches are forbidden? |
+| Test conditions | How do we know it works? |
+| Dependencies | What must exist first? |
+| Edge cases | What could go wrong? |
+
+### Writing the Spec
+
+1. **Start with Problem Statement** - Not "build X" but "solve Y"
+2. **Shape the solution** - Direction, not blueprint
+3. **Define boundaries explicitly** - In/out/no-gos
+4. **Write test conditions** - Observable outcomes
+5. **Set circuit breaker** - When to stop and reassess
+
+## Appetite Levels
+
+| Appetite | Size | Suitable For |
+|----------|------|--------------|
+| Small | 1-2 days | Bug fixes, minor enhancements |
+| Medium | 3-5 days | Feature additions, refactors |
+| Large | 1-2 weeks | Major features (rare) |
+
+If a spec can't fit the appetite, it needs more shaping or should be split.
+
+## Splitting Large Specs
+
+When a spec is too big:
+
+```
+SPEC-001-user-auth.md (large, 2 weeks)
+        ↓ split into
+SPEC-001a-oauth-integration.md (medium, 3 days)
+SPEC-001b-session-management.md (small, 2 days)
+SPEC-001c-login-ui.md (medium, 3 days)
+```
+
+Each sub-spec:
+- Has its own appetite
+- Can be worked independently
+- References the original requirement
+
+## Archiving Specs
+
+When all tasks for a spec are complete:
+
+1. Update status to `complete`
+2. Add completion date to frontmatter
+3. Move to `docs/specs/archive/`
+
+```bash
+mv docs/specs/SPEC-001-user-auth.md docs/specs/archive/
+```
+
+## Spec vs Plan
+
+| Spec | Plan |
+|------|------|
+| **What** to build | **How** to build it |
+| Lives in `docs/specs/` | Lives in `.agents/plans/` |
+| Survives sessions | Tied to session |
+| User-facing | Implementation detail |
+| Shape Up shaped | Tactical steps |
+
+Specs define the target. Plans define the route to get there.
+
+## Validation Checklist
+
+Before approving a spec:
+
+- [ ] Problem statement is clear and user-focused
+- [ ] Scope boundaries are explicit (in/out/no-gos)
+- [ ] Test conditions are observable and testable
+- [ ] Appetite is realistic for the scope
+- [ ] Circuit breaker is defined
+- [ ] Requirement reference is valid
+- [ ] No implementation details (those go in plans)
+
+## Example: Good vs Bad Specs
+
+### Bad Spec
+
+```markdown
+# SPEC-001: Add OAuth
+
+Add OAuth to the app.
+
+## Requirements
+- Add Google OAuth
+- Add session management
+- Add logout
+```
+
+Problems:
+- No problem statement
+- No scope boundaries
+- No test conditions
+- No appetite
+- Too vague to implement
+
+### Good Spec
+
+```markdown
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+Users currently can't access the application. We need a secure,
+frictionless login flow that leverages existing identity providers
+so users don't need to create yet another password.
+
+## Proposed Solution
+
+Implement OAuth 2.0 flow with Google and GitHub as initial providers.
+Store session in secure HTTP-only cookies. Provide clear login/logout UI.
+
+## Scope
+
+### In Scope
+- Google OAuth integration
+- GitHub OAuth integration
+- Session cookie management
+- Login page with provider buttons
+- Logout functionality
+
+### Out of Scope
+- Apple/Microsoft providers (future)
+- MFA (separate spec if needed)
+- Account linking (complex, avoid)
+
+### No-Gos
+- Storing tokens in localStorage
+- Custom password auth
+- Session data in URLs
+
+## Test Conditions
+
+- [ ] New user can sign in with Google
+- [ ] New user can sign in with GitHub
+- [ ] Session persists across browser tabs
+- [ ] Session survives page refresh
+- [ ] Logout clears all session data
+- [ ] Expired sessions redirect to login
+
+## Circuit Breaker
+
+At 50% appetite: if both providers are problematic, ship with Google only.
+GitHub can be a follow-up spec.
+```

--- a/dist/gemini/skills/orchestration/scripts/extract-decisions.py
+++ b/dist/gemini/skills/orchestration/scripts/extract-decisions.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Extract decisions from a session file and format as Serena memory.
+
+Usage: extract-decisions.py <session-file>
+
+Reads a session file, extracts the ## Decisions section, and outputs
+formatted Serena memory content to stdout. The output can be piped to
+Serena MCP's write_memory tool.
+
+Exit codes:
+  0 - Success (decisions extracted)
+  1 - Error (file not found, parse error)
+  2 - No decisions found
+"""
+
+import sys
+import re
+import yaml
+from pathlib import Path
+from datetime import datetime, timezone
+
+
+def parse_frontmatter(content: str) -> tuple[dict, str]:
+    """Extract YAML frontmatter from markdown content."""
+    if not content.startswith('---'):
+        return {}, content
+
+    parts = content.split('---', 2)
+    if len(parts) < 3:
+        return {}, content
+
+    try:
+        frontmatter = yaml.safe_load(parts[1])
+        body = parts[2]
+        return frontmatter or {}, body
+    except yaml.YAMLError as e:
+        print(f"Warning: Could not parse frontmatter: {e}", file=sys.stderr)
+        return {}, content
+
+
+def extract_decisions_section(body: str) -> str | None:
+    """Extract the ## Decisions section from markdown body."""
+    # Match ## Decisions followed by content until next ## or end
+    pattern = r'^## Decisions\s*\n(.*?)(?=^## |\Z)'
+    match = re.search(pattern, body, re.MULTILINE | re.DOTALL)
+
+    if match:
+        content = match.group(1).strip()
+        if content:
+            return content
+    return None
+
+
+def parse_decisions(decisions_text: str) -> list[dict]:
+    """Parse individual decisions from the decisions section."""
+    decisions = []
+
+    # Match ### Decision N: Title or ### Title patterns
+    pattern = r'^###\s+(?:Decision\s+\d+:\s+)?(.+?)\n(.*?)(?=^### |\Z)'
+    matches = re.findall(pattern, decisions_text, re.MULTILINE | re.DOTALL)
+
+    for title, content in matches:
+        decision = {
+            'title': title.strip(),
+            'decision': '',
+            'rationale': '',
+            'council': ''
+        }
+
+        # Extract **Decision**: value
+        decision_match = re.search(
+            r'\*\*Decision\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if decision_match:
+            decision['decision'] = decision_match.group(1).strip()
+
+        # Extract **Rationale**: value
+        rationale_match = re.search(
+            r'\*\*Rationale\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if rationale_match:
+            decision['rationale'] = rationale_match.group(1).strip()
+
+        # Extract **Council**: value (optional)
+        council_match = re.search(
+            r'\*\*Council\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if council_match:
+            decision['council'] = council_match.group(1).strip()
+
+        # Only add if we have at least a title and decision
+        if decision['title'] and decision['decision']:
+            decisions.append(decision)
+
+    return decisions
+
+
+def format_memory(
+    session_file: str,
+    frontmatter: dict,
+    decisions: list[dict]
+) -> str:
+    """Format decisions as Serena memory markdown."""
+    session = frontmatter.get('session', {})
+    title = session.get('title', 'Unknown Session')
+    linear_issue = session.get('linear_issue', 'N/A')
+    archived_at = session.get('archived_at', datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'))
+
+    # Generate slug from filename
+    filename = Path(session_file).stem
+    slug = re.sub(r'^\d{8}-\d{6}-', '', filename)
+
+    lines = [
+        f"# Memory: session-{slug}-decisions.md",
+        "",
+        "## Session Context",
+        f"- **Session**: {Path(session_file).name}",
+        f"- **Title**: {title}",
+        f"- **Archived**: {archived_at}",
+        f"- **Linear Issue**: {linear_issue}",
+        "",
+        "## Key Decisions",
+        ""
+    ]
+
+    for i, d in enumerate(decisions, 1):
+        lines.append(f"### Decision {i}: {d['title']}")
+        lines.append(f"**Decision**: {d['decision']}")
+        if d['rationale']:
+            lines.append(f"**Rationale**: {d['rationale']}")
+        if d['council']:
+            lines.append(f"**Council**: {d['council']}")
+        lines.append("")
+
+    return '\n'.join(lines)
+
+
+def generate_memory_name(session_file: str) -> str:
+    """Generate Serena memory name from session filename."""
+    filename = Path(session_file).stem
+    slug = re.sub(r'^\d{8}-\d{6}-', '', filename)
+    return f"session-{slug}-decisions.md"
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: extract-decisions.py <session-file>", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Extracts decisions from a session file and outputs Serena memory format.", file=sys.stderr)
+        print("The memory name will be: session-<slug>-decisions.md", file=sys.stderr)
+        sys.exit(1)
+
+    session_file = sys.argv[1]
+    filepath = Path(session_file)
+
+    if not filepath.exists():
+        print(f"Error: File not found: {session_file}", file=sys.stderr)
+        sys.exit(1)
+
+    content = filepath.read_text()
+    frontmatter, body = parse_frontmatter(content)
+
+    decisions_text = extract_decisions_section(body)
+    if not decisions_text:
+        print(f"No ## Decisions section found in: {session_file}", file=sys.stderr)
+        sys.exit(2)
+
+    decisions = parse_decisions(decisions_text)
+    if not decisions:
+        print(f"No parseable decisions found in: {session_file}", file=sys.stderr)
+        sys.exit(2)
+
+    # Output memory content to stdout
+    memory_content = format_memory(session_file, frontmatter, decisions)
+    print(memory_content)
+
+    # Output memory name to stderr for scripting
+    memory_name = generate_memory_name(session_file)
+    print(f"\n# Memory name: {memory_name}", file=sys.stderr)
+    print(f"# Decisions extracted: {len(decisions)}", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/dist/gemini/skills/orchestration/scripts/git-context-summary.sh
+++ b/dist/gemini/skills/orchestration/scripts/git-context-summary.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Generate git context summary for sessions
+# Usage: git-context-summary.sh [--brief]
+#
+# Output includes:
+#   - Current branch name
+#   - Uncommitted changes count
+#   - Recent commits (last 3-5)
+#   - Summary of changes from main/master (if on feature branch)
+#
+# Options:
+#   --brief   Output only branch and uncommitted changes (for hooks)
+
+set -e
+
+BRIEF_MODE=false
+if [[ "$1" == "--brief" ]]; then
+    BRIEF_MODE=true
+fi
+
+# Check if we're in a git repository
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+    echo "Not a git repository"
+    exit 0
+fi
+
+# Get current branch
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if [[ -z "$CURRENT_BRANCH" ]]; then
+    # Detached HEAD state
+    CURRENT_BRANCH="(detached HEAD at $(git rev-parse --short HEAD 2>/dev/null || echo 'unknown'))"
+fi
+
+# Count uncommitted changes (staged + unstaged + untracked)
+UNCOMMITTED_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+
+# Brief mode: just branch and changes
+if [[ "$BRIEF_MODE" == "true" ]]; then
+    echo "## Git Context"
+    echo "- **Branch**: $CURRENT_BRANCH"
+    echo "- **Uncommitted changes**: $UNCOMMITTED_COUNT file(s)"
+    exit 0
+fi
+
+# Full output
+echo "## Git Context"
+echo ""
+echo "**Branch**: \`$CURRENT_BRANCH\`"
+echo ""
+echo "**Uncommitted changes**: $UNCOMMITTED_COUNT file(s)"
+
+# Show brief status if there are changes
+if [[ "$UNCOMMITTED_COUNT" -gt 0 ]]; then
+    echo ""
+    echo "**Changed files**:"
+    # Show first 10 files max
+    git status --porcelain 2>/dev/null | head -10 | while read -r line; do
+        STATUS="${line:0:2}"
+        FILE="${line:3}"
+        case "$STATUS" in
+            "M "| " M"|"MM") echo "  - Modified: \`$FILE\`" ;;
+            "A ") echo "  - Added: \`$FILE\`" ;;
+            "D "| " D") echo "  - Deleted: \`$FILE\`" ;;
+            "R ") echo "  - Renamed: \`$FILE\`" ;;
+            "??") echo "  - Untracked: \`$FILE\`" ;;
+            *) echo "  - Changed: \`$FILE\`" ;;
+        esac
+    done
+    TOTAL=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$TOTAL" -gt 10 ]]; then
+        echo "  - ... and $((TOTAL - 10)) more"
+    fi
+fi
+
+# Recent commits (last 5)
+echo ""
+echo "**Recent commits**:"
+git log --oneline -5 2>/dev/null | while read -r line; do
+    echo "  - \`$line\`"
+done
+
+# Detect main branch (main or master)
+MAIN_BRANCH=""
+if git show-ref --verify --quiet refs/heads/main 2>/dev/null; then
+    MAIN_BRANCH="main"
+elif git show-ref --verify --quiet refs/heads/master 2>/dev/null; then
+    MAIN_BRANCH="master"
+fi
+
+# Summary of changes from main (if on feature branch)
+if [[ -n "$MAIN_BRANCH" && "$CURRENT_BRANCH" != "$MAIN_BRANCH" && "$CURRENT_BRANCH" != "(detached"* ]]; then
+    # Count commits ahead of main
+    COMMITS_AHEAD=$(git rev-list --count "$MAIN_BRANCH..$CURRENT_BRANCH" 2>/dev/null || echo "0")
+    COMMITS_BEHIND=$(git rev-list --count "$CURRENT_BRANCH..$MAIN_BRANCH" 2>/dev/null || echo "0")
+
+    echo ""
+    echo "**Relative to \`$MAIN_BRANCH\`**:"
+    echo "  - $COMMITS_AHEAD commit(s) ahead"
+    echo "  - $COMMITS_BEHIND commit(s) behind"
+
+    # Files changed from main
+    if [[ "$COMMITS_AHEAD" -gt 0 ]]; then
+        FILES_CHANGED=$(git diff --name-only "$MAIN_BRANCH...$CURRENT_BRANCH" 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "$FILES_CHANGED" -gt 0 ]]; then
+            echo "  - $FILES_CHANGED file(s) changed from \`$MAIN_BRANCH\`"
+        fi
+    fi
+fi

--- a/dist/gemini/skills/orchestration/scripts/list-session-decisions.sh
+++ b/dist/gemini/skills/orchestration/scripts/list-session-decisions.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# List available session decision memories from Serena.
+#
+# Usage: list-session-decisions.sh
+#
+# This script lists Serena memories matching the pattern session-*-decisions.md
+# and displays session name and metadata.
+#
+# Note: This is a helper script. In practice, agents should use Serena MCP
+# directly via mcp__serena__list_memories() for programmatic access.
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Session Decision Memories${NC}"
+echo "========================="
+echo ""
+
+# Check if .serena directory exists
+if [[ ! -d ".serena" ]]; then
+    echo -e "${YELLOW}No .serena directory found in current project.${NC}"
+    echo "Serena memories are stored per-project. Make sure you're in a Serena-enabled project."
+    exit 0
+fi
+
+# Check for memories directory
+MEMORIES_DIR=".serena/memories"
+if [[ ! -d "$MEMORIES_DIR" ]]; then
+    echo -e "${YELLOW}No memories directory found.${NC}"
+    echo "No session decisions have been extracted yet."
+    echo ""
+    echo "To extract decisions from a session:"
+    echo "  python3 extract-decisions.py <session-file>"
+    echo "  Then use Serena MCP to write the memory."
+    exit 0
+fi
+
+# Find session decision memories
+MEMORIES=$(find "$MEMORIES_DIR" -name "session-*-decisions.md" 2>/dev/null | sort -r)
+
+if [[ -z "$MEMORIES" ]]; then
+    echo -e "${YELLOW}No session decision memories found.${NC}"
+    echo ""
+    echo "Session decision memories are created when sessions are archived."
+    echo "Pattern: session-<slug>-decisions.md"
+    exit 0
+fi
+
+# Display memories
+count=0
+echo -e "${GREEN}Available Decision Memories:${NC}"
+echo ""
+
+for memory in $MEMORIES; do
+    count=$((count + 1))
+    filename=$(basename "$memory")
+
+    # Extract slug from filename
+    slug=$(echo "$filename" | sed 's/^session-//' | sed 's/-decisions\.md$//')
+
+    # Try to read session info from memory content
+    if [[ -f "$memory" ]]; then
+        session_name=$(grep -m1 "^\- \*\*Session\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "Unknown")
+        archived=$(grep -m1 "^\- \*\*Archived\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "Unknown")
+        linear=$(grep -m1 "^\- \*\*Linear Issue\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "N/A")
+        decision_count=$(grep -c "^### Decision" "$memory" 2>/dev/null || echo "0")
+
+        printf "  %2d. %s\n" "$count" "$slug"
+        printf "      Session:  %s\n" "$session_name"
+        printf "      Archived: %s\n" "$archived"
+        printf "      Linear:   %s\n" "$linear"
+        printf "      Decisions: %s\n" "$decision_count"
+        echo ""
+    else
+        printf "  %2d. %s (unreadable)\n" "$count" "$filename"
+    fi
+done
+
+echo "------------------------"
+echo "Total: $count decision memories"
+echo ""
+echo -e "${BLUE}Usage:${NC}"
+echo "  /reference-session <search-term>    # Import decisions to current session"
+echo "  mcp__serena__read_memory(name=...)  # Read memory directly via MCP"

--- a/dist/gemini/skills/orchestration/scripts/validate-session.py
+++ b/dist/gemini/skills/orchestration/scripts/validate-session.py
@@ -60,7 +60,7 @@ def validate_frontmatter(fm: dict) -> list[str]:
             errors.append(f"Empty required field: session.{field}")
 
     # Validate status values
-    valid_statuses = ['in_progress', 'paused', 'completed']
+    valid_statuses = ['in_progress', 'paused', 'completed', 'archived']
     if session.get('status') and session['status'] not in valid_statuses:
         errors.append(f"Invalid session.status: {session['status']} (must be one of: {', '.join(valid_statuses)})")
 
@@ -72,6 +72,20 @@ def validate_frontmatter(fm: dict) -> list[str]:
                 datetime.fromisoformat(value.replace('Z', '+00:00'))
             except ValueError:
                 errors.append(f"Invalid ISO 8601 timestamp in session.{field}: {value}")
+
+    # Validate branch field format if present (optional field)
+    branch = session.get('branch', '')
+    if branch:
+        # Branch names should be non-empty strings without spaces
+        # Common formats: feature/name, username/ticket-desc, bugfix/name, etc.
+        if not isinstance(branch, str):
+            errors.append(f"Invalid session.branch: must be a string, got {type(branch).__name__}")
+        elif ' ' in branch:
+            errors.append(f"Invalid session.branch: '{branch}' contains spaces (branch names cannot have spaces)")
+        elif branch.startswith('/') or branch.endswith('/'):
+            errors.append(f"Invalid session.branch: '{branch}' cannot start or end with '/'")
+        elif '//' in branch:
+            errors.append(f"Invalid session.branch: '{branch}' contains consecutive slashes")
 
     # Check orchestration block
     orch = fm.get('orchestration', {})

--- a/dist/gemini/skills/research/SKILL.md
+++ b/dist/gemini/skills/research/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: research
+description: >-
+  Use for project reflection, brainstorming, and vision evolution. Covers
+  assessing project state, exploring problem spaces, generating ideas, and
+  evolving strategic direction. Activate when stepping back to think,
+  researching topics, or updating VISION.md.
+version: 1.11.0
+---
+
+# Research
+
+Patterns for zooming out, brainstorming, and evolving project direction.
+
+## Philosophy
+
+**Research is about understanding before doing.**
+
+Research activities:
+1. Assess project state and lessons learned
+2. Explore problem spaces with structured inquiry
+3. Generate and refine ideas through brainstorming
+4. Evolve strategic direction when evidence supports it
+
+Research is NOT about:
+- Implementing solutions
+- Making tactical decisions
+- Writing code or specifications
+
+## Quick Reference
+
+| Need | Action |
+|------|--------|
+| Understand project state | Review sessions, docs, recent changes |
+| Explore a topic | Structured inquiry with confidence hierarchy |
+| Generate ideas | Brainstorm with interview and synthesis |
+| Evolve VISION | Propose changes with evidence |
+
+## Research Modes
+
+### Mode 1: Project State Assessment
+
+**Trigger:** "What's the current state?" / "Catch me up"
+
+**Process:**
+1. Read existing docs (VISION, ARCHITECTURE, REQUIREMENTS)
+2. Check recent sessions for lessons learned
+3. Review recent commits for context
+4. Identify gaps, contradictions, or stale information
+5. Summarize current state with recommendations
+
+**Output:** State assessment with actionable insights
+
+### Mode 2: Topic Exploration
+
+**Trigger:** "Research X" / "How should we approach Y?"
+
+**Process:**
+1. Interview user to understand the question deeply
+2. Apply confidence hierarchy for sources
+3. Synthesize findings with tradeoffs
+4. Present options with recommendations
+
+**Output:** Research findings with options and recommendation
+
+### Mode 3: Brainstorming
+
+**Trigger:** "Let's brainstorm" / "Ideas for X"
+
+**Process:**
+1. Interview to understand constraints and goals
+2. Generate diverse options (quantity over quality initially)
+3. Filter through constraints
+4. Refine promising directions
+5. Present shaped options for decision
+
+**Output:** Curated options with pros/cons
+
+### Mode 4: Vision Evolution
+
+**Trigger:** "Should we change direction?" / "Update VISION"
+
+**Process:**
+1. Gather evidence (sessions, feedback, market changes)
+2. Identify what's changed since last VISION update
+3. Propose specific changes with rationale
+4. Get user approval before any edits
+
+**Output:** VISION.md change proposal (not direct edit)
+
+## Confidence Hierarchy
+
+When researching, prioritize sources in this order:
+
+```
+1. Project context (highest confidence)
+   - VISION.md, ARCHITECTURE.md, REQUIREMENTS.md
+   - Session files and lessons learned
+   - Existing codebase patterns
+
+2. Authoritative documentation
+   - Context7 for library docs
+   - Official documentation sites
+   - RFCs and specifications
+
+3. Community knowledge
+   - Stack Overflow (verified answers)
+   - GitHub issues and discussions
+   - Blog posts from recognized experts
+
+4. General web (lowest confidence)
+   - Search results
+   - Forum posts
+   - Unverified sources
+```
+
+**Rule:** Always check project context first. External research should supplement, not replace, understanding of existing decisions.
+
+## Interview Patterns
+
+### Before Any Research
+
+Ask clarifying questions:
+
+| Area | Questions |
+|------|-----------|
+| Scope | What specifically are you trying to understand? |
+| Context | What do you already know? What have you tried? |
+| Constraints | What constraints should guide the research? |
+| Output | What decision will this research inform? |
+
+### For Topic Exploration
+
+```
+1. What problem are we trying to solve?
+2. What constraints exist (technical, time, team)?
+3. What would success look like?
+4. What have we already considered and rejected?
+5. Are there non-obvious angles to explore?
+```
+
+### For Brainstorming
+
+```
+1. What's the ideal outcome if constraints didn't exist?
+2. What's the minimum viable approach?
+3. What approaches have we seen work elsewhere?
+4. What would we do if we had 10x the resources? 1/10?
+5. What's the contrarian view?
+```
+
+## Output Formats
+
+### State Assessment
+
+```markdown
+## Project State Assessment
+
+**Date:** YYYY-MM-DD
+
+### Current Position
+- [Summary of where the project stands]
+
+### Recent Progress
+- [Key accomplishments from recent sessions]
+
+### Lessons Learned
+- [Insights from implementation feedback]
+
+### Open Questions
+- [Unresolved decisions or gaps]
+
+### Recommendations
+1. [Actionable next step]
+2. [Actionable next step]
+```
+
+### Research Findings
+
+```markdown
+## Research: [Topic]
+
+**Question:** [What we're trying to understand]
+
+### Summary
+[One-paragraph answer with confidence level]
+
+### Options Considered
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Best for:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Best for:** ...
+
+### Recommendation
+[Which option and why, with caveats]
+
+### Sources
+- [Source 1 with confidence level]
+- [Source 2 with confidence level]
+```
+
+### Vision Change Proposal
+
+```markdown
+## VISION.md Change Proposal
+
+**Proposed by:** [Session/Date]
+**Evidence:** [What prompted this]
+
+### Current State
+[Quote relevant VISION.md section]
+
+### Proposed Change
+[New text]
+
+### Rationale
+[Why this change is warranted]
+
+### Impact
+- [What this changes downstream]
+- [ADRs that may need updating]
+- [Requirements that may be affected]
+
+### Approval Required
+This proposal requires user approval before implementation.
+```
+
+## Integration with Workflow
+
+Research fits at the top of the product development hierarchy:
+
+```
+RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS
+    │         │
+    └─────────┘
+    evolves
+```
+
+**Research informs Vision changes.** Vision changes cascade down through Architecture, Requirements, and Specs.
+
+## When to Research
+
+| Situation | Research Mode |
+|-----------|---------------|
+| Starting new project | Project state + Topic exploration |
+| Stuck on approach | Topic exploration + Brainstorming |
+| Finishing major work | Project state (capture learnings) |
+| External change | Vision evolution |
+| Quarterly review | Project state + Vision evolution |
+
+## When NOT to Research
+
+- **When action is clear** - Don't research to avoid doing
+- **When already decided** - Check ADRs first
+- **When time-critical** - Act, then document learnings
+- **For trivial questions** - Just answer them
+
+## Critical Rules
+
+### Always
+- Interview before researching
+- Check project context first
+- Cite sources with confidence levels
+- Present options, let user decide
+- Get approval before editing VISION
+
+### Never
+- Edit VISION without explicit approval
+- Research indefinitely (set time bounds)
+- Ignore existing project decisions
+- Present research as implementation plan
+- Skip the interview step
+
+## Scripts
+
+| Script | Usage | Description |
+|--------|-------|-------------|
+| `check-sessions.sh` | Review recent sessions | Find lessons learned |
+| `git-context-summary.sh` | Summarize git history | Understand recent changes |
+
+## Related Skills
+
+- **orchestration** - For acting on research findings
+- **foundations** - For documentation standards

--- a/dist/opencode/agent/background-runner.md
+++ b/dist/opencode/agent/background-runner.md
@@ -1,0 +1,168 @@
+---
+name: background-runner
+description: >-
+  Lightweight background agent for non-interactive tasks. Use for security
+  audits, coverage analysis, code reviews, and other low-priority work that can
+  run independently.
+mode: subagent
+skills:
+  - foundations
+tools:
+  Read: true
+  Edit: true
+  Glob: true
+  Grep: true
+---
+# Background Runner
+
+You execute specific tasks in the background, writing results to a specified location without user interaction.
+
+## When You Run
+
+- Spawned by PM/orchestrator with `run_in_background: true`
+- For low-priority, non-interactive work
+- Results expected later, not immediately
+
+## What You Do
+
+1. **Execute assigned task** - Security audits, coverage analysis, code reviews, etc.
+2. **Write results** - Output to specified `.agents/reports/` location
+3. **Update session** - Mark your background agent entry as complete
+
+## Input You Receive
+
+The spawning agent provides:
+- Specific task to execute
+- Files or scope to analyze
+- Output location (`.agents/reports/YYYYMMDD-HHMMSS-<name>.md`)
+- Session reference
+
+## Execution Process
+
+### 1. Parse Task
+
+Extract from prompt:
+- What to do (audit, analyze, review)
+- Scope (files, directories)
+- Output location
+- Session file path
+
+### 2. Execute Work
+
+Perform the assigned task:
+- Read specified files
+- Run analysis
+- Generate findings
+- Compile report
+
+### 3. Write Report
+
+Create report at specified location:
+
+```yaml
+---
+report:
+  title: "Task Description"
+  type: background-agent-output
+  status: unprocessed
+  created: "2026-01-23T14:30:00Z"
+  background_agent_id: "bg-YYYYMMDD-HHMMSS-description"
+  session_reference: "YYYYMMDD-HHMMSS-session-name.md"
+---
+
+# Report Title
+
+## Summary
+
+Brief overview of findings.
+
+## Findings
+
+### Finding 1: Title
+**Severity**: High | Medium | Low | Info
+**Location**: `path/to/file.py:123`
+**Description**: What was found
+**Recommendation**: What to do
+
+## Recommendations
+
+Prioritized list of actions.
+
+## Files Analyzed
+
+- `path/to/file1.py`
+- `path/to/file2.py`
+```
+
+### 4. Update Session Frontmatter
+
+Read session file and update your background agent entry:
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: completed  # Changed from running
+    result_location: ".agents/reports/20260123-143000-security.md"  # Set path
+```
+
+## Constraints
+
+- **No user interaction** - You cannot ask questions or request clarification
+- **No blocking work** - Complete task with available information
+- **No spawning agents** - Work independently
+- **Write to specified location** - Do not create files elsewhere
+
+## Quality Checklist
+
+Before completing:
+
+- [ ] Task executed per prompt instructions
+- [ ] Report written to specified location
+- [ ] Report has valid frontmatter with `background_agent_id`
+- [ ] Session frontmatter updated with `status: completed`
+- [ ] Session frontmatter updated with `result_location`
+- [ ] No user interaction attempted
+
+## Error Handling
+
+If task cannot be completed:
+
+1. Write partial report with what was accomplished
+2. Document blockers in report
+3. Update session frontmatter with `status: failed`
+4. Include error details in report
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: failed
+    result_location: ".agents/reports/20260123-143000-security-partial.md"
+```
+
+## Example Task
+
+**Prompt received:**
+```
+Run security audit on auth module.
+
+Files:
+- src/auth/endpoints.py
+- src/auth/token.py
+
+Check for OWASP Top 10 vulnerabilities.
+
+Write report to: .agents/reports/20260123-143000-auth-security.md
+
+Session: .agents/sessions/20260123-140000-auth-feature.md
+Background Agent ID: bg-20260123-143000-auth-security
+```
+
+**Actions:**
+1. Read `src/auth/endpoints.py` and `src/auth/token.py`
+2. Analyze for OWASP vulnerabilities
+3. Write findings to `.agents/reports/20260123-143000-auth-security.md`
+4. Update `.agents/sessions/20260123-140000-auth-feature.md` frontmatter

--- a/dist/opencode/agent/context-archiver.md
+++ b/dist/opencode/agent/context-archiver.md
@@ -107,13 +107,66 @@ The agent resuming work should:
 Pre-compaction archive. Preserved: [brief summary of what was captured].
 ```
 
-## Serena Memory (Optional)
+## Serena Memory for Decisions
 
-Write memory ONLY when session has significant decisions:
+Write decision memory when session has significant decisions for cross-session reference.
 
-- Check if `## Decisions` section has content
-- If yes, write to `session-{session-slug}-decisions.md`
-- Include decision rationale and context
+### 5. Extract and Store Decisions
+
+Check if `## Decisions` section has content. If yes:
+
+**Step A: Extract decisions using the extraction script**
+
+```bash
+python3 plugins/loaf/skills/orchestration/scripts/extract-decisions.py \
+  ".agents/sessions/<session-file>.md"
+```
+
+This outputs formatted memory content to stdout and the memory name to stderr.
+
+**Step B: Write to Serena memory**
+
+Use Serena MCP to store the extracted decisions:
+
+```python
+mcp__serena__write_memory(
+    name="session-<slug>-decisions.md",
+    content=<extracted_content>
+)
+```
+
+**Memory naming convention:**
+- Session: `20250123-100000-auth-feature.md`
+- Memory: `session-auth-feature-decisions.md`
+
+**Memory format:**
+
+```markdown
+# Memory: session-auth-feature-decisions.md
+
+## Session Context
+- **Session**: 20250123-100000-auth-feature.md
+- **Title**: Auth Feature Implementation
+- **Archived**: 2025-01-23T14:30:00Z
+- **Linear Issue**: PLT-123
+
+## Key Decisions
+
+### Decision 1: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window
+**Rationale**: Balance between security and user experience
+**Council**: None - backend-dev recommendation accepted
+
+### Decision 2: Refresh Token Storage
+**Decision**: Store in HttpOnly cookies, not localStorage
+**Rationale**: Prevents XSS token theft
+**Council**: Security council (5 agents) - unanimous
+```
+
+**Why store decisions:**
+- Enables `/reference-session` command for cross-session continuity
+- Preserves decision rationale for future work
+- Avoids re-deliberating already-resolved questions
 
 ## Output
 
@@ -142,4 +195,5 @@ Before completing:
 - [ ] `## Resumption Prompt` provides self-contained context
 - [ ] `## Resumption Prompt` includes Transcript Archive instruction
 - [ ] `## Session Log` has timestamped entry
-- [ ] Serena memory written if decisions exist
+- [ ] Decisions extracted and written to Serena memory (if `## Decisions` has content)
+- [ ] Memory name follows convention: `session-<slug>-decisions.md`

--- a/dist/opencode/agent/qa.md
+++ b/dist/opencode/agent/qa.md
@@ -24,6 +24,7 @@ You are a QA engineer. Your skills tell you how to test and review code.
 - Check for OWASP Top 10 issues
 - Verify type safety and linting passes
 - Audit test coverage
+- Debug failing tests and diagnose flaky tests
 
 ## How You Work
 
@@ -31,5 +32,17 @@ You are a QA engineer. Your skills tell you how to test and review code.
 2. **Match project style** - follow existing test patterns
 3. **Test behavior, not implementation** - tests should survive refactors
 4. **Run full suite** - all tests must pass before completing
+5. **Debug systematically** - use hypothesis-driven debugging for failures
+
+## Debugging Workflow
+
+When investigating test failures or bugs:
+
+1. **Reproduce** - Establish reliable reproduction steps
+2. **Hypothesize** - Generate 3-5 possible causes, rank by likelihood
+3. **Test** - Design minimal experiments to confirm or rule out each hypothesis
+4. **Document** - Track hypotheses and evidence in investigation log
+
+See the `debugging` skill for hypothesis tracking templates and language-specific debugging patterns.
 
 Your skills contain all the patterns and conventions. Reference them.

--- a/dist/opencode/command/architecture.md
+++ b/dist/opencode/command/architecture.md
@@ -1,0 +1,261 @@
+---
+description: Make technical decisions and create Architecture Decision Records
+version: 1.11.0
+---
+
+# Architecture Command
+
+Interview about technical decisions, update ARCHITECTURE.md, create ADRs.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Technical decisions should be:
+1. **Deliberate** - Made consciously, not by accident
+2. **Documented** - Captured in ARCHITECTURE.md and ADRs
+3. **Traceable** - Future readers understand why
+
+---
+
+## CRITICAL: Interview First
+
+**Before making any architectural decision, understand:**
+
+1. What decision needs to be made?
+2. What constraints exist (technical, business, team)?
+3. What options have already been considered?
+4. What would "good enough" look like vs "ideal"?
+5. What's the impact of getting this wrong?
+
+Use `AskUserQuestion` to gather context.
+
+---
+
+## Process
+
+### Step 1: Understand the Decision
+
+Parse `$ARGUMENTS` to understand what decision is needed.
+
+**If unclear:** Ask clarifying questions about:
+- The problem being solved
+- Technical constraints
+- Business constraints
+- Time/resource constraints
+
+### Step 2: Gather Context
+
+1. **Read existing documents:**
+   - `docs/VISION.md` - Strategic direction
+   - `docs/ARCHITECTURE.md` - Current technical design
+   - `docs/decisions/ADR-*.md` - Previous decisions
+
+2. **Check for relevant patterns:**
+   - How similar problems were solved
+   - Established conventions in the codebase
+   - Previous attempts and outcomes
+
+3. **Review session history:**
+   - Implementation learnings
+   - Pain points from previous work
+
+### Step 3: Consider Options
+
+For each viable option:
+
+| Aspect | Evaluate |
+|--------|----------|
+| Alignment | Does it fit VISION and existing ARCHITECTURE? |
+| Complexity | How much does it add to the system? |
+| Reversibility | How hard to change later? |
+| Team capability | Can the team execute this? |
+| Maintenance | Long-term cost? |
+
+### Step 4: Convene Council (If Needed)
+
+For complex or contentious decisions, convene a council:
+
+- **Odd number:** 5 or 7 agents
+- **Diverse expertise:** Mix of perspectives
+- **Structured deliberation:** Each argues a position
+
+See `orchestration/councils` skill for council workflow.
+
+**Council advises, user decides.**
+
+### Step 5: Present Options
+
+Format:
+
+```markdown
+## Decision: [Question]
+
+### Context
+[Why this decision is needed now]
+
+### Options
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Fits when:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Fits when:** ...
+
+### Recommendation
+[Which option and why]
+
+### What do you think?
+```
+
+### Step 6: Await User Decision
+
+**Do NOT proceed without explicit user choice.**
+
+User may:
+- Accept a recommendation
+- Choose a different option
+- Ask for more information
+- Request a council deliberation
+
+### Step 7: Document the Decision
+
+After user decides:
+
+1. **Update ARCHITECTURE.md** with new decision
+2. **Create ADR** in `docs/decisions/`
+
+---
+
+## ADR Format
+
+**Filename:** `ADR-{number}-{slug}.md`
+
+```yaml
+---
+id: ADR-001
+title: "PostgreSQL as Primary Database"
+status: Accepted  # Proposed | Accepted | Deprecated | Superseded
+date: 2026-01-23
+supersedes: null  # ADR-000 if replacing
+superseded_by: null  # ADR-002 if replaced
+---
+
+# ADR-001: PostgreSQL as Primary Database
+
+## Context
+
+[Why this decision was needed. What problem we faced.]
+
+## Decision
+
+[What we decided. Be specific and unambiguous.]
+
+## Consequences
+
+### Positive
+- [Benefit 1]
+- [Benefit 2]
+
+### Negative
+- [Tradeoff 1]
+- [Tradeoff 2]
+
+### Neutral
+- [Implication that's neither good nor bad]
+
+## Alternatives Considered
+
+### [Alternative 1]
+[Why it was rejected]
+
+### [Alternative 2]
+[Why it was rejected]
+```
+
+---
+
+## ADR Numbering
+
+Find next available number:
+
+```bash
+ls docs/decisions/ADR-*.md 2>/dev/null | \
+  grep -oE 'ADR-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+If no ADRs exist, start with `ADR-001`.
+
+---
+
+## ARCHITECTURE.md Updates
+
+When updating ARCHITECTURE.md:
+
+1. **Find relevant section** or create new one
+2. **Add decision** with reference to ADR
+3. **Keep it current** - Remove outdated information
+
+Example addition:
+
+```markdown
+## Data Storage
+
+We use **PostgreSQL** as our primary database (see [ADR-001](decisions/ADR-001-postgresql.md)).
+
+Key decisions:
+- Single database for simplicity
+- Connection pooling via PgBouncer
+- Read replicas for reporting queries
+```
+
+---
+
+## Decision Types
+
+| Type | Scope | ADR Required? |
+|------|-------|---------------|
+| Strategic | System-wide, hard to reverse | Yes |
+| Tactical | Component-level, reversible | Optional |
+| Trivial | No significant impact | No |
+
+**When in doubt, create an ADR.** Future you will thank you.
+
+---
+
+## Guardrails
+
+1. **Interview first** - Understand the full context
+2. **Check existing decisions** - Don't contradict without superseding
+3. **Present options** - User decides, not you
+4. **Document thoroughly** - ADRs explain the "why"
+5. **Keep ARCHITECTURE.md current** - Update, don't just append
+
+---
+
+## Council Trigger Conditions
+
+Consider convening a council when:
+
+- Decision affects multiple domains (backend + frontend + infra)
+- Team has conflicting opinions
+- High cost of reversal
+- Novel problem without established patterns
+- User explicitly requests deliberation
+
+---
+
+## Related Skills
+
+- **orchestration/councils** - Council deliberation workflow
+- **orchestration/product-development** - Where architecture fits in hierarchy
+- **foundations** - Documentation standards for ADRs

--- a/dist/opencode/command/prd.md
+++ b/dist/opencode/command/prd.md
@@ -1,0 +1,292 @@
+---
+description: Discover product requirements and update REQUIREMENTS.md
+version: 1.11.0
+---
+
+# PRD Command
+
+Interview to discover product requirements, update REQUIREMENTS.md.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Requirements capture **what** the product must do, not **how**.
+
+Good requirements are:
+- **User-focused** - Written from user perspective
+- **Testable** - Clear acceptance criteria
+- **Organized** - Grouped by domain
+- **Complete** - Cover edge cases and business rules
+
+---
+
+## CRITICAL: Interview First
+
+**Before writing any requirements, understand:**
+
+1. What feature area are we defining?
+2. Who are the users affected?
+3. What business rules apply?
+4. What edge cases exist?
+5. What's explicitly out of scope?
+
+Use `AskUserQuestion` with non-obvious questions.
+
+---
+
+## Process
+
+### Step 1: Parse Input
+
+`$ARGUMENTS` should indicate the feature area or requirement section.
+
+Examples:
+- "user authentication"
+- "section 2.1"
+- "payment processing"
+
+**If unclear:** Ask what feature area to define.
+
+### Step 2: Gather Context
+
+1. **Read VISION.md** - Strategic direction constrains requirements
+2. **Read ARCHITECTURE.md** - Technical constraints
+3. **Read existing REQUIREMENTS.md** - Don't duplicate
+
+### Step 3: Interview with Non-Obvious Questions
+
+Ask questions the user might not have considered:
+
+| Category | Example Questions |
+|----------|-------------------|
+| Edge cases | "What happens if the user closes the browser mid-flow?" |
+| Business rules | "Are there rate limits? Time-based restrictions?" |
+| Persona conflicts | "How do admin users differ from regular users here?" |
+| Failure modes | "What's the graceful degradation if this fails?" |
+| Compliance | "Any audit logging requirements?" |
+| Scale | "Expected volume? Concurrent users?" |
+
+**Interview structure:**
+```
+1. Start with obvious questions to confirm understanding
+2. Move to edge cases
+3. Explore business rule conflicts
+4. Check compliance/security needs
+5. Confirm scope boundaries
+```
+
+### Step 4: Draft Requirements Section
+
+Format:
+
+```markdown
+## [Number]. [Domain Name]
+
+### [Number].[SubNumber] [Feature Name]
+
+**Business Rules**
+- [Rule 1]
+- [Rule 2]
+
+**User Stories**
+As a [persona], I want to [action] so that [benefit].
+
+**Acceptance Criteria**
+- [ ] Given [context], when [action], then [outcome]
+- [ ] Given [context], when [action], then [outcome]
+
+**Edge Cases**
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| [Edge case] | [How system responds] |
+
+**Out of Scope**
+- [Explicitly excluded item]
+```
+
+### Step 5: Present for Approval
+
+Show the drafted section to the user:
+
+```markdown
+## Proposed Addition to REQUIREMENTS.md
+
+[Draft section]
+
+---
+
+**Questions before adding:**
+1. Are these business rules accurate?
+2. Any missing acceptance criteria?
+3. Should anything be out of scope?
+```
+
+### Step 6: Await Approval
+
+**Do NOT update REQUIREMENTS.md without explicit approval.**
+
+User may:
+- Approve as-is
+- Request changes
+- Add missing requirements
+- Move items to out of scope
+
+### Step 7: Update REQUIREMENTS.md
+
+After approval:
+1. Add new section to REQUIREMENTS.md
+2. Maintain consistent numbering
+3. Update table of contents if exists
+
+---
+
+## Requirements Format
+
+### File Structure
+
+```markdown
+# Requirements
+
+## 1. Core Platform
+
+### 1.1 Feature A
+...
+
+### 1.2 Feature B
+...
+
+## 2. Identity & Access
+
+### 2.1 User Authentication
+...
+
+### 2.2 Authorization
+...
+```
+
+### Section Template
+
+```markdown
+### 2.1 User Authentication
+
+**Business Rules**
+- Users authenticate via OAuth (Google, GitHub)
+- Sessions expire after 24 hours of inactivity
+- Failed login attempts are logged for security audit
+- Users can have at most 5 active sessions
+
+**User Stories**
+
+As a new user, I want to sign in with my existing Google account
+so that I don't need to create another password.
+
+As a returning user, I want my session to persist across browser tabs
+so that I can work in multiple windows.
+
+**Acceptance Criteria**
+- [ ] Given a new user, when they click "Sign in with Google", then they are redirected to Google OAuth
+- [ ] Given valid Google credentials, when OAuth completes, then user is logged in and redirected to dashboard
+- [ ] Given an existing session, when user opens new tab, then they remain logged in
+- [ ] Given 24 hours of inactivity, when user returns, then they must re-authenticate
+- [ ] Given a logged-in user, when they click logout, then all session data is cleared
+
+**Edge Cases**
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| OAuth provider unavailable | Show friendly error, suggest trying later |
+| User revokes OAuth access | Invalidate session on next request |
+| Multiple accounts same email | Prevent duplicate accounts, suggest login |
+| Session cookie deleted | Redirect to login on next request |
+
+**Out of Scope**
+- Password-based authentication (security/maintenance burden)
+- Apple/Microsoft OAuth (future consideration)
+- MFA (separate feature area)
+```
+
+---
+
+## Acceptance Criteria Format
+
+Use Given-When-Then:
+
+```markdown
+Given [precondition/context],
+when [action is performed],
+then [expected outcome].
+```
+
+**Good criteria are:**
+- Specific and testable
+- Single behavior per criterion
+- Observable outcome (not internal state)
+- User-focused language
+
+**Bad criteria:**
+```markdown
+- Login should be fast  # Not measurable
+- Data should be correct  # Too vague
+- System should handle errors  # No specific behavior
+```
+
+**Good criteria:**
+```markdown
+- [ ] Given valid credentials, when login submitted, then dashboard loads within 2 seconds
+- [ ] Given invalid email format, when login attempted, then "Invalid email" error shown
+- [ ] Given network failure during OAuth, when callback fails, then retry prompt displayed
+```
+
+---
+
+## Numbering Convention
+
+```
+[Major].[Minor] [Feature Name]
+
+1. Core Platform
+   1.1 Dashboard
+   1.2 Navigation
+
+2. Identity & Access
+   2.1 User Authentication
+   2.2 Role-Based Access
+```
+
+When adding new sections:
+- Check existing numbers
+- Insert at appropriate position
+- Update subsequent numbers if needed
+
+---
+
+## Guardrails
+
+1. **Interview deeply** - Ask non-obvious questions
+2. **Check constraints** - VISION and ARCHITECTURE bound requirements
+3. **Write testable criteria** - Given-When-Then format
+4. **Document edge cases** - What could go wrong?
+5. **Explicit out of scope** - Prevent scope creep
+6. **Get approval** - Don't update without user confirmation
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Requirements describe HOW | Focus on WHAT, leave HOW to specs |
+| Missing edge cases | Interview for failure modes |
+| Vague criteria | Use Given-When-Then |
+| No out of scope | Explicitly list exclusions |
+| Conflicting rules | Resolve before adding |
+
+---
+
+## Related Skills
+
+- **orchestration/product-development** - Where requirements fit in hierarchy
+- **orchestration/specs** - Breaking requirements into specifications
+- **foundations** - Documentation standards

--- a/dist/opencode/command/reference-session.md
+++ b/dist/opencode/command/reference-session.md
@@ -1,0 +1,236 @@
+---
+description: Import decisions from past sessions without full context duplication
+version: 1.11.0
+---
+
+# Reference Session
+
+Import context from past sessions into current work. This command helps maintain continuity across sessions without duplicating full context.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` for:
+- **Search term**: Session name fragment, Linear issue ID, or topic keyword
+- **Content type** (optional): `decisions`, `context`, or `all` (default: `decisions`)
+
+```
+/reference-session auth              # Search for "auth" sessions, import decisions
+/reference-session auth decisions    # Explicit: import decisions only
+/reference-session auth context      # Import full context summary
+/reference-session PLT-123           # Search by Linear issue
+```
+
+If no arguments provided, list recent decision memories:
+
+```
+/reference-session                   # List available session decisions
+```
+
+---
+
+## Step 2: Search for Matching Sessions
+
+### Option A: List Serena Memories
+
+Use Serena MCP to list available decision memories:
+
+```
+mcp__serena__list_memories()
+```
+
+Filter for memories matching pattern: `session-*-decisions.md`
+
+### Option B: Search Session Archives
+
+If no matching memories found, search archived sessions:
+
+```
+.agents/sessions/archive/*<search-term>*.md
+```
+
+---
+
+## Step 3: Display Matches
+
+Present matching sessions/memories:
+
+```markdown
+## Matching Session Decisions
+
+| Session | Archived | Linear | Decisions |
+|---------|----------|--------|-----------|
+| 20250115-140000-auth-jwt | 2025-01-15 | PLT-123 | 3 decisions |
+| 20250110-090000-auth-oauth | 2025-01-10 | PLT-100 | 2 decisions |
+
+Select a session number to import, or 'all' for multiple:
+```
+
+If single match, proceed directly to Step 4.
+
+---
+
+## Step 4: Read Decision Memory
+
+For selected session(s), read the decision memory:
+
+```
+mcp__serena__read_memory(name="session-<slug>-decisions.md")
+```
+
+If memory doesn't exist but session file does, run extraction:
+
+```bash
+python3 src/skills/orchestration/scripts/extract-decisions.py \
+  ".agents/sessions/archive/<session-file>.md"
+```
+
+---
+
+## Step 5: Import into Current Session
+
+If an active session exists (`.agents/sessions/` has `in_progress` files):
+
+### Update Session Frontmatter
+
+Add to the active session's frontmatter:
+
+```yaml
+session:
+  # ... existing fields ...
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"
+      imported_at: "2025-01-23T14:30:00Z"
+      content_type: decisions
+      decisions_imported:
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+```
+
+### Add Reference Section
+
+If importing decisions, add to session body:
+
+```markdown
+## Referenced Decisions
+
+### From: 20250115-140000-auth-jwt.md
+
+#### Decision: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window
+**Rationale**: Balance between security and user experience
+**Context**: Authentication service design
+
+#### Decision: Refresh Token Storage
+**Decision**: Store in HttpOnly cookie, not localStorage
+**Rationale**: Prevents XSS token theft
+**Context**: Frontend security consideration
+
+---
+```
+
+---
+
+## Step 6: Report Import
+
+Confirm what was imported:
+
+```markdown
+## Session Reference Complete
+
+**Imported from**: 20250115-140000-auth-jwt.md
+**Content type**: decisions
+**Decisions imported**: 3
+
+### Summary
+
+1. **JWT Token Rotation Strategy** - Rotate every 15 minutes
+2. **Refresh Token Storage** - HttpOnly cookies
+3. **Token Validation Flow** - Validate signature before claims
+
+These decisions are now tracked in the current session's frontmatter
+under `referenced_sessions`.
+
+**Current session updated**: .agents/sessions/20250123-100000-auth-v2.md
+```
+
+---
+
+## No Active Session
+
+If no active session exists, display the decisions without updating any file:
+
+```markdown
+## Decisions from: 20250115-140000-auth-jwt.md
+
+[Display decision content]
+
+**Note**: No active session to update. Start a session first with
+`/start-session` to track this reference.
+```
+
+---
+
+## Content Types
+
+### `decisions` (default)
+
+Imports only the `## Decisions` section formatted as memory:
+- Decision name
+- What was decided
+- Rationale
+- Council outcome (if applicable)
+
+### `context`
+
+Imports session context summary:
+- Problem statement
+- Technical approach
+- Key files involved
+- Final outcome
+
+### `all`
+
+Imports both decisions and context.
+
+---
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Import full session files | Import only decisions/summaries |
+| Import without tracking | Always update `referenced_sessions` |
+| Import from unrelated sessions | Search by topic or Linear issue |
+| Import during exploration | Import when decisions are relevant |
+
+---
+
+## Error Handling
+
+### No matches found
+
+```
+No sessions found matching "auth-v3"
+
+Try:
+- Different search terms
+- Check .agents/sessions/archive/ directly
+- List all: /reference-session
+```
+
+### Memory not found
+
+```
+Decision memory not found for session 20250115-140000-auth-jwt.md
+
+Would you like to extract decisions now? This will:
+1. Read the archived session file
+2. Extract the Decisions section
+3. Create a Serena memory for future use
+
+[y/n]
+```

--- a/dist/opencode/command/research.md
+++ b/dist/opencode/command/research.md
@@ -1,0 +1,265 @@
+---
+description: 'Zoom out, brainstorm, assess project state, or evolve VISION'
+version: 1.11.0
+---
+
+# Research Command
+
+Step back from implementation to understand, explore, or brainstorm.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Mode Detection
+
+Parse the input to determine research mode:
+
+| Input Pattern | Mode | Action |
+|---------------|------|--------|
+| "project state" / "catch me up" / empty | State Assessment | Review docs, sessions, recent work |
+| Topic description | Topic Exploration | Structured inquiry |
+| "brainstorm" / "ideas for" | Brainstorming | Generate and refine options |
+| "evolve vision" / "update vision" | Vision Evolution | Propose VISION changes |
+
+---
+
+## CRITICAL: Interview First
+
+**Before any research, interview the user to understand:**
+
+1. What specifically are you trying to understand?
+2. What context do you already have?
+3. What constraints should guide this research?
+4. What decision will this inform?
+
+Use `AskUserQuestion` to gather this context.
+
+---
+
+## Mode 1: Project State Assessment
+
+**Trigger:** Empty input, "project state", "catch me up"
+
+### Steps
+
+1. **Read project documents:**
+   - `docs/VISION.md` (if exists)
+   - `docs/ARCHITECTURE.md` (if exists)
+   - `docs/REQUIREMENTS.md` (if exists)
+
+2. **Check recent sessions:**
+   - List `.agents/sessions/*.md`
+   - Read recent sessions for lessons learned
+   - Note any unresolved issues or blockers
+
+3. **Review recent commits:**
+   ```bash
+   git log --oneline -20
+   ```
+
+4. **Synthesize findings:**
+   - Current position
+   - Recent progress
+   - Lessons learned
+   - Open questions
+   - Recommendations
+
+5. **Present to user** with actionable next steps
+
+---
+
+## Mode 2: Topic Exploration
+
+**Trigger:** Specific topic or question
+
+### Steps
+
+1. **Interview** to understand the question deeply
+
+2. **Check project context first:**
+   - Existing decisions in `docs/decisions/ADR-*.md`
+   - Relevant sections in ARCHITECTURE.md
+   - Previous session discussions
+
+3. **Apply confidence hierarchy:**
+   ```
+   Project context > Context7 > Official docs > Community > Web
+   ```
+
+4. **For library/framework questions:**
+   - Use Context7 MCP to get authoritative documentation
+   - Cross-reference with official sources
+
+5. **Synthesize findings:**
+   - Summary with confidence level
+   - Options with tradeoffs
+   - Recommendation with rationale
+   - Sources cited
+
+6. **Present options** - Don't make the decision for the user
+
+---
+
+## Mode 3: Brainstorming
+
+**Trigger:** "brainstorm", "ideas for", creative exploration
+
+### Steps
+
+1. **Interview to establish bounds:**
+   - What's the ideal outcome?
+   - What constraints exist?
+   - What's been tried/rejected?
+
+2. **Generate diverse options:**
+   - Conventional approaches
+   - Unconventional approaches
+   - What if we had 10x resources?
+   - What if we had 1/10 resources?
+   - Contrarian view
+
+3. **Filter through constraints:**
+   - Technical feasibility
+   - Time/resource budget
+   - Alignment with VISION
+
+4. **Refine promising directions:**
+   - Shape the top 2-3 options
+   - Identify risks and mitigations
+
+5. **Present curated options** with pros/cons for decision
+
+---
+
+## Mode 4: Vision Evolution
+
+**Trigger:** "evolve vision", "update vision", evidence of needed change
+
+### Steps
+
+1. **Gather evidence:**
+   - What changed since last VISION update?
+   - Session learnings that contradict VISION
+   - External factors (market, technology, team)
+
+2. **Read current VISION.md**
+
+3. **Draft change proposal:**
+   ```markdown
+   ## VISION.md Change Proposal
+
+   **Evidence:** [What prompted this]
+
+   ### Current State
+   [Quote relevant section]
+
+   ### Proposed Change
+   [New text]
+
+   ### Rationale
+   [Why this is warranted]
+
+   ### Impact
+   - [Downstream effects]
+   ```
+
+4. **Present proposal to user**
+
+5. **WAIT FOR EXPLICIT APPROVAL**
+   - Do NOT edit VISION.md without approval
+   - User must explicitly confirm changes
+
+6. **If approved:** Edit VISION.md with approved changes
+
+---
+
+## Output Format
+
+### State Assessment
+
+```markdown
+## Project State Assessment
+
+**Date:** [Generated timestamp]
+
+### Current Position
+[Summary]
+
+### Recent Progress
+- [Accomplishment 1]
+- [Accomplishment 2]
+
+### Lessons Learned
+- [Insight 1]
+- [Insight 2]
+
+### Open Questions
+- [Question 1]
+- [Question 2]
+
+### Recommendations
+1. [Next step]
+2. [Next step]
+```
+
+### Research Findings
+
+```markdown
+## Research: [Topic]
+
+**Question:** [What we're investigating]
+
+### Summary
+[Answer with confidence level]
+
+### Options
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+
+### Recommendation
+[Which option and why]
+
+### Sources
+- [Source with confidence]
+```
+
+---
+
+## Guardrails
+
+1. **Always interview first** - Don't assume you understand the question
+2. **Check project context** - Respect existing decisions
+3. **Present options** - Don't make decisions for the user
+4. **Cite sources** - With confidence levels
+5. **Never edit VISION without approval** - Proposals only
+6. **Time-bound research** - Don't go down rabbit holes indefinitely
+
+---
+
+## Context7 Usage
+
+For library/framework questions, use Context7:
+
+```
+1. mcp__plugin_context7_context7__resolve-library-id
+   - Find the library ID
+
+2. mcp__plugin_context7_context7__query-docs
+   - Query specific documentation
+```
+
+This provides authoritative, up-to-date documentation.
+
+---
+
+## Related Skills
+
+- **research** - Full methodology for research modes
+- **orchestration/product-development** - Where research fits in workflow

--- a/dist/opencode/command/specs.md
+++ b/dist/opencode/command/specs.md
@@ -1,0 +1,278 @@
+---
+description: Create feature specifications from requirements
+version: 1.11.0
+---
+
+# Specs Command
+
+Break requirements into shaped, implementable specifications.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Specs define **shaped solutions** - bounded work with clear scope.
+
+A spec is:
+- **Shaped** - Direction, not blueprint
+- **Bounded** - Clear in/out of scope
+- **Testable** - Observable test conditions
+- **Appetite-driven** - Fixed time, variable scope
+
+See `orchestration/specs` reference for full spec methodology.
+
+---
+
+## CRITICAL: Interview First
+
+**Before writing a spec, clarify:**
+
+1. Which requirement section is this for?
+2. What's the appetite (time budget)?
+3. What scope trade-offs are acceptable?
+4. What are the "rabbit holes" to avoid?
+5. What approaches are explicitly forbidden (no-gos)?
+
+Use `AskUserQuestion` to establish boundaries.
+
+---
+
+## Process
+
+### Step 1: Parse Input
+
+`$ARGUMENTS` should reference a requirement section.
+
+Examples:
+- "2.1 User Authentication"
+- "REQUIREMENTS.md section 2.1"
+- "user auth"
+
+**If unclear:** Ask which requirement to specify.
+
+### Step 2: Gather Context
+
+Read in order:
+1. **VISION.md** - Strategic alignment
+2. **ARCHITECTURE.md** - Technical constraints
+3. **REQUIREMENTS.md** - The requirement being specified
+4. **Existing specs** - Avoid duplication
+
+### Step 3: Interview for Shaping
+
+Shape Up methodology - define boundaries, not tasks.
+
+| Question | Purpose |
+|----------|---------|
+| What's definitely in scope? | Core functionality |
+| What's definitely out of scope? | Prevent creep |
+| What seems related but should be avoided? | Rabbit holes |
+| What approaches are forbidden? | No-gos |
+| How do we know it works? | Test conditions |
+| How much time is it worth? | Appetite |
+| What if we run out of time? | Circuit breaker |
+
+### Step 4: Determine Appetite
+
+| Appetite | Size | Suitable For |
+|----------|------|--------------|
+| Small | 1-2 days | Bug fixes, minor enhancements |
+| Medium | 3-5 days | Feature additions, refactors |
+| Large | 1-2 weeks | Major features (rare) |
+
+**If work can't fit the appetite:** Needs more shaping or splitting.
+
+### Step 5: Draft the Spec
+
+Use spec template:
+
+```yaml
+---
+id: SPEC-001
+title: "User Authentication with OAuth"
+requirement: "2.1 User Authentication"
+created: YYYY-MM-DDTHH:MM:SSZ
+status: drafting
+appetite: "1 week"
+---
+
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+[From REQUIREMENTS - why this matters to users and business]
+
+## Proposed Solution
+
+[Shaped solution - high-level approach, not implementation details]
+
+## Scope
+
+### In Scope
+- [Item 1]
+- [Item 2]
+
+### Out of Scope (Rabbit Holes)
+- [Avoid this complexity]
+- [Don't go here]
+
+### No-Gos
+- [Forbidden approach 1]
+- [Forbidden approach 2]
+
+## Test Conditions
+
+- [ ] [Observable outcome 1]
+- [ ] [Observable outcome 2]
+- [ ] [Observable outcome 3]
+
+## Implementation Notes
+
+[Architecture references, technical constraints, relevant ADRs]
+
+## Circuit Breaker
+
+At 50% appetite: [What to do if we're not on track]
+```
+
+### Step 6: Generate Spec ID
+
+Find next available ID:
+
+```bash
+ls docs/specs/SPEC-*.md docs/specs/archive/SPEC-*.md 2>/dev/null | \
+  grep -oE 'SPEC-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+If no specs exist, start with `SPEC-001`.
+
+### Step 7: Present for Approval
+
+```markdown
+## Proposed Specification
+
+[Full spec content]
+
+---
+
+**Before approval, confirm:**
+1. Is the scope correct?
+2. Are the test conditions sufficient?
+3. Is the appetite realistic?
+4. Any missing rabbit holes or no-gos?
+```
+
+### Step 8: Await Approval
+
+**Do NOT create spec file without explicit approval.**
+
+User may:
+- Approve as-is
+- Adjust scope
+- Change appetite
+- Add constraints
+- Request splitting
+
+### Step 9: Create Spec File
+
+After approval:
+
+1. **Generate timestamps:**
+   ```bash
+   date -u +"%Y-%m-%dT%H:%M:%SZ"  # For frontmatter
+   ```
+
+2. **Create file:**
+   - Location: `docs/specs/SPEC-{id}-{slug}.md`
+   - Slug: kebab-case of title
+
+3. **Announce completion:**
+   ```
+   Created: docs/specs/SPEC-001-user-auth-oauth.md
+
+   Next: Use `/tasks SPEC-001` to break into atomic work items.
+   ```
+
+---
+
+## Spec Lifecycle
+
+```
+drafting → approved → implementing → complete
+```
+
+| Status | Meaning |
+|--------|---------|
+| `drafting` | Being refined, not ready |
+| `approved` | Ready for task breakdown |
+| `implementing` | Tasks created, work in progress |
+| `complete` | All tasks done, archive |
+
+---
+
+## Splitting Large Specs
+
+When a spec is too big for its appetite:
+
+```
+SPEC-001-user-auth.md (large, 2 weeks)
+        ↓ split into
+SPEC-001a-oauth-integration.md (medium, 3 days)
+SPEC-001b-session-management.md (small, 2 days)
+SPEC-001c-login-ui.md (medium, 3 days)
+```
+
+Each sub-spec:
+- Has its own appetite
+- Can be worked independently
+- References original requirement
+
+---
+
+## Test Conditions vs Acceptance Criteria
+
+| Test Conditions (Spec) | Acceptance Criteria (Requirement) |
+|------------------------|-----------------------------------|
+| High-level outcomes | Detailed behaviors |
+| For this shaped solution | For the full feature |
+| May be subset of AC | Complete coverage |
+| Implementation-aware | Implementation-agnostic |
+
+Test conditions prove the spec is done.
+Acceptance criteria prove the requirement is met.
+
+---
+
+## Guardrails
+
+1. **Interview to shape** - Boundaries before details
+2. **Respect appetite** - Fixed time, variable scope
+3. **Document rabbit holes** - Prevent scope creep
+4. **Clear test conditions** - Observable outcomes
+5. **Circuit breaker** - Plan for running out of time
+6. **Get approval** - Don't create without confirmation
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Implementation details | Keep high-level, shape not blueprint |
+| No appetite | Always set time budget |
+| Missing no-gos | Explicitly forbid bad approaches |
+| Vague test conditions | Make observable and verifiable |
+| Too ambitious | Split or increase appetite |
+
+---
+
+## Related Skills
+
+- **orchestration/specs** - Full spec methodology
+- **orchestration/product-development** - Where specs fit in hierarchy
+- **orchestration/planning** - Shape Up methodology details

--- a/dist/opencode/command/start-session.md
+++ b/dist/opencode/command/start-session.md
@@ -13,6 +13,36 @@ You are the PM agent. Start by understanding the task:
 
 ---
 
+## Input Detection
+
+Parse `$ARGUMENTS` to determine the session type:
+
+| Input Pattern | Type | Action |
+|---------------|------|--------|
+| `TASK-XXX` | Local task | Load from `.agents/tasks/active/` |
+| `SPEC-XXX` | Spec (no task) | Warn: suggest `/tasks` first |
+| `PLT-123`, `PROJ-123` | Linear issue | Fetch from Linear |
+| Description text | Ad-hoc | Create session, ask about Linear |
+
+### Task-Coupled Sessions
+
+When starting from a task (`TASK-XXX` or Linear issue):
+
+1. **Fetch task details** (local file or Linear API)
+2. **Load parent spec** if task has `spec:` field
+3. **Load linked requirement** if spec has `requirement:` field
+4. **Build traceability chain** in session frontmatter
+
+### Ad-hoc Sessions
+
+When no task exists:
+
+1. **Inform user:** "No parent task found. Proceeding as ad-hoc session."
+2. **Ask:** "Should I create a Linear issue or local task for tracking?"
+3. If yes, create and link; if no, proceed without
+
+---
+
 ## CRITICAL: Strict Delegation Model
 
 **You are the ORCHESTRATOR, not the implementer.**
@@ -133,8 +163,19 @@ session:
   linear_issue: "PLT-XXX"           # If applicable
   linear_url: "https://linear.app/{{your-workspace}}/issue/PLT-XXX"
   branch: "username/plt-xxx-feature"    # Working branch for this session
+  task: "TASK-001"                      # Local task ID (if applicable)
+  spec: "SPEC-001"                      # Parent spec (if applicable)
+
+# Traceability chain (populated when task-coupled)
+traceability:
+  requirement: "2.1 User Authentication"  # From spec's requirement field
+  architecture:
+    - "Session Management"                # Relevant ARCHITECTURE.md sections
+  decisions:
+    - "ADR-001"                           # Related ADRs
 
 plans: []  # List of plan files in .agents/plans/ used by this session
+transcripts: []  # Archived conversation transcripts (.jsonl files)
 
 orchestration:
   current_task: "Initial planning"
@@ -620,3 +661,74 @@ Follow your three-phase workflow (BEFORE → DURING → AFTER):
 Format: `[YYYY-MM-DD HH:MM UTC]`
 
 Generate with: `date -u +"%Y-%m-%d %H:%M UTC"`
+
+---
+
+## Transcript Archival
+
+After `/compact` or `/clear`, archive conversation transcripts for future reference.
+
+### Process
+
+1. **Get transcript path** from Claude Code output after compaction
+2. **Create transcripts directory** if needed:
+   ```bash
+   mkdir -p .agents/transcripts
+   ```
+3. **Copy transcript** with descriptive name:
+   ```bash
+   cp /path/to/transcript.jsonl .agents/transcripts/YYYYMMDD-HHMMSS-description.jsonl
+   ```
+4. **Update session frontmatter**:
+   ```yaml
+   transcripts:
+     - 20260123-143500-pre-compact.jsonl
+   ```
+
+### When to Archive
+
+| Event | Action |
+|-------|--------|
+| Before `/compact` | Archive current transcript |
+| Before `/clear` | Archive current transcript |
+| Session end | Archive final transcript |
+
+### Benefits
+
+- **Audit trail** - Full history of decisions and work
+- **Knowledge extraction** - Mining past sessions for patterns
+- **Debugging** - Understanding how errors occurred
+- **Training** - Learning from past sessions
+
+---
+
+## Task Completion
+
+When a task-coupled session completes:
+
+1. **Update task status** (local file or Linear)
+2. **Check spec progress:**
+   - List all tasks for the spec
+   - If all done → mark spec as `complete`
+   - If tasks remain → spec stays `implementing`
+3. **Archive session** (standard process)
+
+### Spec Completion Check
+
+```bash
+# For local tasks
+grep -l "spec: SPEC-001" .agents/tasks/active/*.md | wc -l
+# If 0, all tasks done
+
+# For Linear
+# Check all issues with spec label
+```
+
+---
+
+## Related Skills
+
+- **orchestration/product-development** - Full workflow hierarchy
+- **orchestration/specs** - Spec format and lifecycle
+- **orchestration/local-tasks** - Local task management
+- **orchestration/sessions** - Session lifecycle details

--- a/dist/opencode/command/start-session.md
+++ b/dist/opencode/command/start-session.md
@@ -141,13 +141,65 @@ orchestration:
   spawned_agents: []
 ```
 
-### Step 4: Verify Creation
+### Step 4: Create Plan File
 
-Confirm the session file exists and contains valid frontmatter before proceeding.
+**Location:** `.agents/plans/`
+**Filename:** Same timestamp as session: `YYYYMMDD-HHMMSS-<description>.md`
 
-**DO NOT PROCEED WITHOUT A SESSION FILE.**
+Use this Shape Up-inspired template:
 
-### Step 5: Suggest Session Rename
+```markdown
+---
+session: YYYYMMDD-HHMMSS-<description>.md
+created: "YYYY-MM-DDTHH:MM:SSZ"
+status: drafting
+appetite: ""
+---
+
+# Plan: <description>
+
+## Appetite
+
+*Time budget for this work (e.g., "2 hours", "1 day"). Fixed time, variable scope.*
+
+## Problem
+
+*What problem are we solving? Why does it matter?*
+
+## Solution Shape
+
+*High-level approach, not a detailed spec. What's the general shape of the solution?*
+
+## Rabbit Holes
+
+*What NOT to do. Scope boundaries. Things that seem related but should be avoided.*
+
+## No-Gos
+
+*Explicit exclusions. Features or approaches we're deliberately not doing.*
+
+## Circuit Breaker
+
+At 50% of appetite spent: Re-evaluate if we're on track. If not, consider:
+- Simplifying scope
+- Taking a different approach
+- Stopping early and documenting learnings
+```
+
+**Update session frontmatter** to link the plan:
+
+```yaml
+plans:
+  - YYYYMMDD-HHMMSS-<description>.md
+```
+
+### Step 5: Verify Creation
+
+Confirm both session file AND plan file exist with valid frontmatter before proceeding.
+
+**DO NOT PROCEED WITHOUT A SESSION FILE AND PLAN FILE.**
+
+### Step 6: Suggest Session Rename
 
 After creating the session file, suggest renaming the Claude Code session for easy identification:
 
@@ -214,7 +266,7 @@ Is this a code/config/doc change?
 
 ## Startup Checklist
 
-**After creating session file:**
+**After creating session AND plan files:**
 
 1. [ ] Parse the input — is this a Linear issue ID (e.g., PLT-123, PLAT-123) or a description?
 2. [ ] If Linear ID:
@@ -224,10 +276,13 @@ Is this a code/config/doc change?
 3. [ ] If description: ask user if a Linear issue should be created
 4. [ ] **Create dedicated branch for this work** (see Branch Management below)
 5. [ ] **Suggest team** based on task context (see Team Routing below)
-6. [ ] Populate session `## Context` section with background
-7. [ ] Break down the work using TodoWrite
-8. [ ] **Identify which specialized agents will be needed** (use mapping table)
-9. [ ] Update session `## Next Steps` with planned agent spawns
+6. [ ] **Fill in plan file sections** (Appetite, Problem, Solution Shape, Rabbit Holes)
+7. [ ] Populate session `## Context` section with background
+8. [ ] Break down the work using TodoWrite
+9. [ ] **Identify which specialized agents will be needed** (use mapping table)
+10. [ ] **Consider architecture diagrams** (see Diagram Consideration below)
+11. [ ] Update session `## Next Steps` with planned agent spawns
+12. [ ] **Get user approval on plan** before spawning implementation agents
 
 ---
 
@@ -300,6 +355,48 @@ Suggest Security, confirm if new to project
 ```
 
 Use Linear MCP's `list_teams` to get all workspace teams for validation.
+
+---
+
+## Diagram Consideration
+
+For multi-file or multi-service changes, consider adding architecture diagrams to the session file.
+
+### When to Create Diagrams
+
+| Scenario | Diagram Type |
+|----------|--------------|
+| Changes span 3+ services | Component diagram (interaction points) |
+| Data flow modifications | Sequence diagram (trace data path) |
+| Schema/model changes | ERD (table relationships) |
+| New API endpoints | Sequence diagram (request/response) |
+| State machine logic | State diagram (transitions) |
+
+### Quick Check
+
+Ask yourself:
+1. Will this work touch multiple services or layers?
+2. Is there a data flow that needs to be understood?
+3. Would a visual help communicate the approach?
+
+If yes to any, add an `## Architecture Diagrams` section to the session file.
+
+### Diagram Template
+
+```markdown
+## Architecture Diagrams
+
+### [Descriptive Name]
+
+```mermaid
+[Use flowchart, sequenceDiagram, erDiagram, or stateDiagram-v2]
+```
+
+**Purpose**: Why this diagram clarifies the work
+**Files involved**: `path/to/file1.py`, `path/to/file2.py`
+```
+
+See `foundations` skill `reference/diagrams.md` for Mermaid syntax and best practices.
 
 ---
 
@@ -478,7 +575,9 @@ Follow your three-phase workflow (BEFORE → DURING → AFTER):
 
 ### AFTER (Completion)
 
-1. Spawn `backend-dev`/`frontend-dev` for code review (if significant changes)
+1. **Code review pass** (REQUIRED for significant changes):
+   - Run `pr-review-toolkit:code-reviewer` on all modified files
+   - Address any critical issues before proceeding
 2. Spawn `qa` for final testing and security review
 3. Update Linear issue status to Done
 4. Complete session file with outcomes

--- a/dist/opencode/command/tasks.md
+++ b/dist/opencode/command/tasks.md
@@ -1,0 +1,339 @@
+---
+description: Break specs into atomic work items (Linear or local)
+version: 1.11.0
+---
+
+# Tasks Command
+
+Break specifications into atomic, implementable tasks.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Tasks are the smallest unit of work that can be:
+- Assigned to an agent
+- Completed in a single session
+- Verified with a clear done condition
+
+See `orchestration/local-tasks` reference for task format and abstraction layer.
+
+---
+
+## Task Backend Detection
+
+Check `.agents/loaf.yaml` for backend configuration:
+
+```yaml
+task_management:
+  backend: linear  # or "local"
+```
+
+**If no config exists:** Ask user which backend to use.
+
+---
+
+## Process
+
+### Step 1: Parse Input
+
+`$ARGUMENTS` should reference a spec.
+
+Examples:
+- "SPEC-001"
+- "user auth spec"
+- "docs/specs/SPEC-001-user-auth.md"
+
+**If unclear:** List available specs and ask which to break down.
+
+### Step 2: Read the Spec
+
+1. Find spec file in `docs/specs/`
+2. Read full spec content
+3. Extract:
+   - Test conditions (become task acceptance criteria)
+   - Scope (what's in/out)
+   - Implementation notes (technical context)
+   - Appetite (guides task sizing)
+
+### Step 3: Identify Task Boundaries
+
+Break down by concern:
+
+| Concern | Task Type |
+|---------|-----------|
+| Data model changes | DBA task |
+| Backend logic | Backend task |
+| API endpoints | Backend task |
+| UI components | Frontend task |
+| Tests | QA task |
+| Infrastructure | DevOps task |
+
+**Rules:**
+- One concern per task
+- Tasks can run in parallel if independent
+- Tasks have explicit dependencies if sequential
+
+### Step 4: Interview for Priorities
+
+Ask:
+- Which parts are highest priority?
+- Any tasks that must be done first?
+- Preferred order of implementation?
+
+### Step 5: Draft Task List
+
+For each task:
+
+```yaml
+---
+id: TASK-XXX
+title: [Clear action]
+spec: SPEC-001
+status: todo
+priority: P2
+files:
+  - [likely file 1]
+  - [likely file 2]
+verify: [command to verify]
+done: [observable outcome]
+---
+
+## Description
+[What needs to be done]
+
+## Acceptance Criteria
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+
+## Context
+See SPEC-001 for full context.
+```
+
+### Step 6: Present Task Breakdown
+
+```markdown
+## Proposed Tasks for SPEC-001
+
+### TASK-001: [Title]
+- **Priority:** P1
+- **Verify:** [command]
+- **Done:** [outcome]
+- **Files:** [list]
+
+### TASK-002: [Title]
+- **Priority:** P2
+- **Depends on:** TASK-001
+- **Verify:** [command]
+- **Done:** [outcome]
+
+### TASK-003: [Title]
+- **Priority:** P2
+- **Verify:** [command]
+- **Done:** [outcome]
+
+---
+
+**Task dependencies:**
+```
+TASK-001 → TASK-002 (sequential)
+TASK-003 (can run in parallel)
+```
+
+**Approve this breakdown?**
+```
+
+### Step 7: Await Approval
+
+**Do NOT create tasks without explicit approval.**
+
+User may:
+- Approve as-is
+- Adjust priorities
+- Combine/split tasks
+- Add missing tasks
+- Change dependencies
+
+### Step 8: Create Tasks
+
+Based on backend:
+
+#### Linear Backend
+
+```
+For each task:
+1. Create Linear issue with title, description
+2. Set labels from spec
+3. Link to spec (as attachment or in description)
+4. Set priority
+5. Record issue ID
+```
+
+#### Local Backend
+
+```bash
+# Create task directory if needed
+mkdir -p .agents/tasks/active
+
+# Generate task ID
+next_id=$(find_next_task_id)
+
+# Create task file
+# .agents/tasks/active/TASK-{id}-{slug}.md
+```
+
+### Step 9: Update Spec Status
+
+After tasks created:
+
+```yaml
+# In spec frontmatter
+status: implementing
+```
+
+### Step 10: Announce Completion
+
+```markdown
+## Tasks Created for SPEC-001
+
+| ID | Title | Priority | Backend |
+|----|-------|----------|---------|
+| TASK-001 | OAuth Provider Integration | P1 | [Linear/Local] |
+| TASK-002 | Session Management | P2 | [Linear/Local] |
+| TASK-003 | Login UI Components | P2 | [Linear/Local] |
+
+**Spec status:** implementing
+
+**Next:** Use `/start-session TASK-001` to begin work.
+```
+
+---
+
+## Task ID Generation
+
+### Linear
+IDs come from Linear (e.g., `PLT-123`).
+
+### Local
+Sequential numbering:
+
+```bash
+# Find next available number
+find_next_task_id() {
+  local max=$(ls .agents/tasks/active/ .agents/tasks/archive/*/ 2>/dev/null | \
+    grep -oE 'TASK-[0-9]+' | \
+    sort -t- -k2 -n | \
+    tail -1 | \
+    awk -F- '{print $2}')
+  echo $((${max:-0} + 1))
+}
+```
+
+---
+
+## Task Sizing Guide
+
+| Size | Duration | Characteristics |
+|------|----------|-----------------|
+| Small | < 1 day | Single file, clear change |
+| Medium | 1-2 days | Multiple files, one concern |
+| Large | 2-3 days | Complex logic, multiple concerns |
+
+**If task is large:** Consider splitting into smaller tasks.
+
+---
+
+## Priority Levels
+
+| Priority | Meaning | Response |
+|----------|---------|----------|
+| P0 | Urgent/blocking | Drop everything |
+| P1 | High | Work next |
+| P2 | Normal | Scheduled work |
+| P3 | Low | When time permits |
+
+Default: P2 (normal).
+
+---
+
+## Verification Commands
+
+Each task needs a `verify` command:
+
+| Task Type | Example Verification |
+|-----------|---------------------|
+| Backend Python | `pytest tests/auth/test_oauth.py` |
+| Backend Rails | `rails test test/models/session_test.rb` |
+| Frontend React | `npm run test -- auth.test.tsx` |
+| API endpoint | `curl -X POST localhost:3000/auth/login` |
+| Database | `psql -c "SELECT * FROM users LIMIT 1"` |
+
+---
+
+## Done Conditions
+
+Write clear, observable outcomes:
+
+**Good:**
+- "OAuth flow completes for Google and GitHub"
+- "Session persists across page refresh"
+- "All auth tests pass"
+
+**Bad:**
+- "Auth works" (too vague)
+- "Code is clean" (subjective)
+- "Implementation done" (not verifiable)
+
+---
+
+## Guardrails
+
+1. **One concern per task** - Don't mix backend + frontend
+2. **Clear verification** - How to prove it works
+3. **Observable done condition** - Not subjective
+4. **File hints** - Help session know where to look
+5. **Get approval** - Don't create without confirmation
+6. **Update spec status** - Mark as implementing
+
+---
+
+## Common Patterns
+
+### API Feature
+
+```
+TASK-001: Database migration (DBA)
+TASK-002: API endpoint implementation (Backend)
+TASK-003: Unit tests for endpoint (QA)
+TASK-004: API documentation (Backend)
+```
+
+### UI Feature
+
+```
+TASK-001: Component implementation (Frontend)
+TASK-002: State management (Frontend)
+TASK-003: Component tests (QA)
+TASK-004: E2E tests (QA)
+```
+
+### Full Stack Feature
+
+```
+TASK-001: Database schema (DBA)
+TASK-002: API endpoints (Backend)
+TASK-003: Backend tests (QA)
+TASK-004: UI components (Frontend)
+TASK-005: Frontend tests (QA)
+TASK-006: E2E integration (QA)
+```
+
+---
+
+## Related Skills
+
+- **orchestration/local-tasks** - Local task format and management
+- **orchestration/linear** - Linear integration
+- **orchestration/product-development** - Where tasks fit in hierarchy

--- a/dist/opencode/plugin/hooks.js
+++ b/dist/opencode/plugin/hooks.js
@@ -51,6 +51,7 @@ const preToolHooks = {
     { id: 'check-secrets', script: 'pre-tool/foundations-check-secrets.sh', timeout: 30000 },
     { id: 'validate-changelog', script: 'pre-tool/foundations-validate-changelog.sh', timeout: 30000 },
     { id: 'format-check', script: 'pre-tool/foundations-format-check.sh', timeout: 60000 },
+    { id: 'tdd-advisory', script: 'pre-tool/foundations-tdd-advisory.sh', timeout: 5000 },
     { id: 'python-type-check', script: 'pre-tool/python-type-check.sh', timeout: 60000 },
     { id: 'python-pytest-validation', script: 'pre-tool/python-pytest-validation.sh', timeout: 120000 },
     { id: 'python-type-check-progressive', script: 'pre-tool/python-type-check-progressive.sh', timeout: 120000 },

--- a/dist/opencode/plugin/hooks/pre-tool/foundations-tdd-advisory.sh
+++ b/dist/opencode/plugin/hooks/pre-tool/foundations-tdd-advisory.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Hook: TDD Advisory (INFORMATIONAL)
+# PreToolUse hook - reads JSON from stdin per Claude Code hooks API
+#
+# Triggers on Edit|Write to implementation files
+# Warns when tests don't exist or don't fail first (non-blocking)
+# Inspired by Cursor's TDD best practice
+
+# Read and parse stdin JSON
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))" 2>/dev/null || echo "")
+
+# Exit early if no file path
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Skip if already a test file
+if [[ "$FILE_PATH" == *"test"* ]] || [[ "$FILE_PATH" == *"spec"* ]] || [[ "$FILE_PATH" == *"_test."* ]] || [[ "$FILE_PATH" == *".test."* ]]; then
+  exit 0
+fi
+
+# Skip non-code files
+EXTENSION="${FILE_PATH##*.}"
+case "$EXTENSION" in
+  py|ts|tsx|js|jsx|rb|go|rs)
+    # Continue checking
+    ;;
+  *)
+    # Not a code file, skip
+    exit 0
+    ;;
+esac
+
+# Skip config and generated files
+if [[ "$FILE_PATH" == *"config"* ]] || [[ "$FILE_PATH" == *"generated"* ]] || [[ "$FILE_PATH" == *"__init__"* ]]; then
+  exit 0
+fi
+
+# Get the base name and directory for test file detection
+BASENAME=$(basename "$FILE_PATH")
+DIRNAME=$(dirname "$FILE_PATH")
+FILENAME="${BASENAME%.*}"
+
+# Build potential test file patterns based on language conventions
+POTENTIAL_TESTS=()
+case "$EXTENSION" in
+  py)
+    POTENTIAL_TESTS=(
+      "${DIRNAME}/test_${FILENAME}.py"
+      "${DIRNAME}/${FILENAME}_test.py"
+      "tests/test_${FILENAME}.py"
+      "tests/${FILENAME}_test.py"
+    )
+    ;;
+  ts|tsx|js|jsx)
+    POTENTIAL_TESTS=(
+      "${DIRNAME}/${FILENAME}.test.${EXTENSION}"
+      "${DIRNAME}/${FILENAME}.spec.${EXTENSION}"
+      "${DIRNAME}/__tests__/${FILENAME}.test.${EXTENSION}"
+      "__tests__/${FILENAME}.test.${EXTENSION}"
+    )
+    ;;
+  rb)
+    POTENTIAL_TESTS=(
+      "spec/${FILENAME}_spec.rb"
+      "${DIRNAME}/${FILENAME}_spec.rb"
+      "test/${FILENAME}_test.rb"
+    )
+    ;;
+  go)
+    POTENTIAL_TESTS=(
+      "${DIRNAME}/${FILENAME}_test.go"
+    )
+    ;;
+esac
+
+# Check if any test file exists
+TEST_EXISTS=false
+FOUND_TEST=""
+for TEST_FILE in "${POTENTIAL_TESTS[@]}"; do
+  if [ -f "$TEST_FILE" ]; then
+    TEST_EXISTS=true
+    FOUND_TEST="$TEST_FILE"
+    break
+  fi
+done
+
+# Output advisory (non-blocking)
+if [ "$TEST_EXISTS" = false ]; then
+  cat << EOF
+# TDD Advisory
+
+Editing implementation file: \`$FILE_PATH\`
+
+**No corresponding test file found.** Consider Test-Driven Development:
+
+1. Write a failing test first
+2. Then implement the feature
+3. Run tests until green
+
+**Expected test locations:**
+$(for t in "${POTENTIAL_TESTS[@]}"; do echo "- \`$t\`"; done)
+
+**Why TDD?** Tests document expected behavior and prevent regressions.
+Skip this advisory if you're:
+- Doing a quick fix with existing test coverage
+- Working in an area where tests aren't practical
+
+EOF
+fi
+
+# Always exit 0 (non-blocking advisory)
+exit 0

--- a/dist/opencode/plugin/hooks/session/session-end.sh
+++ b/dist/opencode/plugin/hooks/session/session-end.sh
@@ -38,8 +38,16 @@ case "$AGENT_TYPE" in
     echo "- [ ] Linear issues synced with actual progress"
     echo "- [ ] Decisions captured (ADRs if architectural)"
     echo "- [ ] Session file \`## Current State\` is handoff-ready"
+    echo "- [ ] **Code review completed** (run \`pr-review-toolkit:code-reviewer\` if significant changes)"
     echo "- [ ] Completed sessions deleted (knowledge extracted)"
     echo "- [ ] Active sessions have clear next steps"
+    echo ""
+    echo "### Code Review Reminder"
+    echo ""
+    echo "If this session involved significant code changes, consider running:"
+    echo "\`\`\`"
+    echo "Task(subagent_type=\"pr-review-toolkit:code-reviewer\", prompt=\"Review recent changes for this session\")"
+    echo "\`\`\`"
     ;;
 
   backend-dev|frontend-dev|rails-dev|dba|devops)

--- a/dist/opencode/skill/debugging/SKILL.md
+++ b/dist/opencode/skill/debugging/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: debugging
+description: >-
+  Use for systematic bug investigation and diagnosis. Covers hypothesis-driven
+  debugging workflows, multi-hypothesis tracking, language-specific debugging
+  patterns (Python, TypeScript, Ruby), and test debugging (flaky tests,
+  isolation, state pollution). Activate when investigating failures, debugging
+  production issues, or diagnosing test problems.
+---
+
+# Systematic Debugging
+
+Hypothesis-driven investigation for efficient and traceable bug diagnosis.
+
+## Philosophy
+
+**Eliminate, don't guess.** Debugging is a process of elimination, not random modification. Each change should test a specific hypothesis and provide evidence to rule it out or confirm it.
+
+**Multiple hypotheses, ranked.** Never fixate on one theory. Generate 3-5 plausible hypotheses, rank by likelihood, and test the most likely first. Surprising evidence should trigger hypothesis revision.
+
+**Reproduce before investigating.** A bug you cannot reproduce is a bug you cannot fix with confidence. Establish reliable reproduction steps before diving into code.
+
+**Minimal changes, maximum information.** Each debugging step should change one variable and maximize the information gained. Shotgun debugging wastes time and obscures root causes.
+
+## Quick Reference
+
+| Situation | Approach | Key Technique |
+|-----------|----------|---------------|
+| **Unknown failure** | Generate hypotheses | List 3-5 possible causes, rank by likelihood |
+| **Intermittent bug** | Isolate variables | Binary search through conditions |
+| **Test flakiness** | Check state pollution | Run test in isolation, check fixtures |
+| **Production issue** | Preserve evidence | Capture logs/state before attempting fixes |
+
+## Topics
+
+| Topic | Reference | Use For |
+|-------|-----------|---------|
+| Hypothesis Tracking | `references/hypothesis-tracking.md` | Multi-hypothesis workflow, session templates, investigation logs |
+| Language Debugging | `references/language-debugging.md` | Python, TypeScript, Ruby debug patterns and tools |
+| Test Debugging | `references/test-debugging.md` | Flaky tests, isolation, state pollution, environment differences |
+
+## Critical Rules
+
+### Always
+
+- Generate multiple hypotheses before investigating
+- Document each hypothesis and its current status
+- Establish reproduction steps before attempting fixes
+- Test one variable at a time
+- Preserve evidence (logs, state, stack traces) before changes
+- Update hypothesis status based on evidence
+- Record failed attempts to avoid repeating them
+
+### Never
+
+- Make random changes hoping something works
+- Fix symptoms without understanding root cause
+- Assume the first hypothesis is correct
+- Skip reproduction verification after a "fix"
+- Delete logs or error output before analysis
+- Change multiple variables simultaneously
+- Ignore contradictory evidence
+
+## Debugging Workflow
+
+```
+1. REPRODUCE: Establish reliable reproduction steps
+2. HYPOTHESIZE: Generate 3-5 possible causes, rank by likelihood
+3. TEST: Design experiment to test highest-likelihood hypothesis
+4. EVALUATE: Analyze results, update hypothesis status
+5. ITERATE: Move to next hypothesis or refine based on evidence
+6. VERIFY: Confirm fix addresses root cause, not just symptoms
+```
+
+## Investigation Log Format
+
+Keep a timestamped log of investigation steps:
+
+```
+[HH:MM] Testing H2 (stale cache)
+        Action: Cleared Redis, restarted service
+        Result: Still failing
+        Evidence: Error occurs before cache read in stack trace
+        Status: H2 RULED OUT
+
+[HH:MM] Testing H3 (race condition)
+        Action: Added mutex around shared state
+        Result: SUCCESS - no failures in 100 runs
+        Evidence: Stack trace showed concurrent access
+        Status: H3 CONFIRMED
+```
+
+## Related Skills
+
+- `foundations` - Test patterns, error handling, logging standards
+- `python` - Python-specific debugging tools (pdb, logging)
+- `typescript` - TypeScript debugging (Chrome DevTools, source maps)
+- `ruby` - Ruby debugging (binding.irb, byebug)

--- a/dist/opencode/skill/debugging/references/hypothesis-tracking.md
+++ b/dist/opencode/skill/debugging/references/hypothesis-tracking.md
@@ -1,0 +1,168 @@
+# Hypothesis Tracking
+
+Systematic workflow for generating, testing, and tracking multiple debugging hypotheses.
+
+## Multi-Hypothesis Workflow
+
+### 1. Generate Hypotheses
+
+Before investigating, brainstorm 3-5 possible causes. Consider:
+
+- **Recent changes** - What changed since it last worked?
+- **Common culprits** - Race conditions, caching, state mutation, null references
+- **Environment differences** - Dev vs prod, different data, timing
+- **External dependencies** - API changes, network issues, third-party services
+
+### 2. Rank by Likelihood
+
+Assign likelihood based on:
+
+| Factor | Higher Likelihood | Lower Likelihood |
+|--------|-------------------|------------------|
+| Recency | Code changed recently | Untouched for months |
+| Complexity | Complex logic, many branches | Simple, well-tested |
+| Dependencies | External services involved | Self-contained |
+| Symptoms | Matches known failure pattern | Novel error |
+
+### 3. Test Systematically
+
+For each hypothesis (highest likelihood first):
+
+1. **Design minimal experiment** - What single change would confirm or rule out this hypothesis?
+2. **Predict outcome** - What result do you expect if hypothesis is correct?
+3. **Execute and observe** - Run experiment, capture results
+4. **Update status** - Mark CONFIRMED, RULED OUT, or NEEDS MORE DATA
+
+### 4. Revise Based on Evidence
+
+When evidence contradicts expectations:
+
+- Lower likelihood of current hypothesis
+- Consider what the evidence suggests instead
+- Add new hypotheses if needed
+- Re-rank based on new information
+
+## Session Template
+
+Use this template at the start of debugging sessions:
+
+```markdown
+## Debug Investigation
+
+**Symptom**: [What's failing - exact error message or behavior]
+**First observed**: [When did this start happening]
+**Reproduction**: [Steps to reliably reproduce]
+
+### Environment
+- OS/Platform:
+- Version:
+- Dependencies:
+- Data state:
+
+### Hypothesis Tracker
+
+| # | Hypothesis | Likelihood | Status | Evidence |
+|---|------------|------------|--------|----------|
+| H1 | [Description] | High/Med/Low | TESTING/RULED OUT/CONFIRMED | [What you learned] |
+| H2 | [Description] | High/Med/Low | PENDING | - |
+| H3 | [Description] | High/Med/Low | PENDING | - |
+
+### Investigation Log
+[Timestamped entries below]
+```
+
+## Example Investigation
+
+### Symptom
+API returns 500 error intermittently on `/api/orders` endpoint.
+
+### Reproduction
+1. Create 10+ concurrent requests to `/api/orders`
+2. ~30% return 500 errors
+3. Only happens under load
+
+### Hypothesis Tracker
+
+| # | Hypothesis | Likelihood | Status | Evidence |
+|---|------------|------------|--------|----------|
+| H1 | Database connection pool exhausted | High | RULED OUT | Pool metrics show 50% utilization during failures |
+| H2 | Race condition in order validation | High | TESTING | Errors correlate with concurrent creates |
+| H3 | Memory pressure causing timeouts | Medium | PENDING | - |
+| H4 | Third-party payment API rate limiting | Low | RULED OUT | Payment API logs show no rate limits |
+
+### Investigation Log
+
+```
+[14:32] Testing H1 (connection pool)
+        Action: Monitored pool metrics during load test
+        Result: Pool never exceeded 50% capacity
+        Evidence: Prometheus shows max 5/10 connections used
+        Status: H1 RULED OUT - pool is not the bottleneck
+
+[14:45] Testing H4 (payment API rate limiting)
+        Action: Checked payment provider dashboard
+        Result: No rate limit events in their logs
+        Evidence: All payment API calls successful
+        Status: H4 RULED OUT
+
+[15:01] Testing H2 (race condition)
+        Action: Added logging around order validation
+        Result: Found concurrent access to shared cart state
+        Evidence: Logs show two requests modifying same cart simultaneously
+        Status: H2 LIKELY - need to verify with fix
+
+[15:23] Verifying H2 fix
+        Action: Added mutex around cart validation
+        Result: 0 errors in 1000 concurrent requests
+        Evidence: Lock prevents concurrent modification
+        Status: H2 CONFIRMED - race condition was root cause
+```
+
+## Hypothesis Status Definitions
+
+| Status | Meaning | Next Action |
+|--------|---------|-------------|
+| PENDING | Not yet investigated | Move to TESTING when ready |
+| TESTING | Currently being investigated | Execute experiment, gather evidence |
+| NEEDS MORE DATA | Inconclusive results | Design better experiment |
+| RULED OUT | Evidence contradicts hypothesis | Document and move on |
+| LIKELY | Evidence supports but not conclusive | Verify with fix |
+| CONFIRMED | Root cause identified and verified | Document fix and close |
+
+## Common Hypothesis Categories
+
+### State-Related
+- Stale cache returning old data
+- Database transaction not committed
+- In-memory state mutation
+- Session/cookie corruption
+
+### Timing-Related
+- Race condition between concurrent operations
+- Timeout too short for slow operations
+- Clock skew between services
+- Event ordering assumptions violated
+
+### Environment-Related
+- Missing environment variable
+- Different library versions
+- File permissions
+- Network connectivity/latency
+
+### Data-Related
+- Null/undefined where unexpected
+- Type mismatch (string vs number)
+- Encoding issues (UTF-8, special characters)
+- Data exceeds expected bounds
+
+## Tips for Effective Hypothesis Tracking
+
+1. **Be specific** - "Something wrong with caching" is not a hypothesis. "Redis TTL set to 0 causing immediate expiration" is.
+
+2. **Make them testable** - Every hypothesis should have a clear experiment that could rule it out.
+
+3. **Update in real-time** - Log entries as you go, not from memory later.
+
+4. **Don't delete** - Ruled-out hypotheses are valuable documentation of what was tried.
+
+5. **Share context** - If handing off, the tracker should let someone else continue without starting over.

--- a/dist/opencode/skill/debugging/references/language-debugging.md
+++ b/dist/opencode/skill/debugging/references/language-debugging.md
@@ -1,0 +1,354 @@
+# Language-Specific Debugging
+
+Debug patterns and tools for Python, TypeScript, and Ruby.
+
+## Python Debugging
+
+### Interactive Debugging with pdb
+
+```python
+# Insert breakpoint in code
+import pdb; pdb.set_trace()
+
+# Python 3.7+ built-in
+breakpoint()
+
+# Conditional breakpoint
+if suspicious_condition:
+    breakpoint()
+```
+
+**Common pdb commands:**
+
+| Command | Action |
+|---------|--------|
+| `n` (next) | Execute next line |
+| `s` (step) | Step into function |
+| `c` (continue) | Continue to next breakpoint |
+| `p expr` | Print expression value |
+| `pp expr` | Pretty-print expression |
+| `l` (list) | Show current code context |
+| `w` (where) | Print stack trace |
+| `u` (up) | Move up stack frame |
+| `d` (down) | Move down stack frame |
+| `q` (quit) | Exit debugger |
+
+### Structured Logging
+
+```python
+import structlog
+
+logger = structlog.get_logger()
+
+# Add context that persists across log calls
+logger = logger.bind(request_id=request.id, user_id=user.id)
+
+# Log with structured data
+logger.info("order_created", order_id=order.id, total=order.total)
+logger.error("payment_failed",
+    order_id=order.id,
+    error_code=e.code,
+    error_message=str(e)
+)
+```
+
+### Traceback Analysis
+
+```python
+import traceback
+
+try:
+    risky_operation()
+except Exception as e:
+    # Full traceback as string
+    tb_str = traceback.format_exc()
+    logger.error("operation_failed", traceback=tb_str)
+
+    # Extract specific frame info
+    tb = traceback.extract_tb(e.__traceback__)
+    for frame in tb:
+        logger.debug("frame",
+            filename=frame.filename,
+            line=frame.lineno,
+            function=frame.name
+        )
+```
+
+### pytest Debugging
+
+```bash
+# Drop into debugger on failure
+pytest --pdb
+
+# Drop into debugger on first failure, then exit
+pytest -x --pdb
+
+# Show local variables in tracebacks
+pytest -l
+
+# Verbose output with print statements
+pytest -v -s
+
+# Run specific test
+pytest tests/test_orders.py::test_create_order -v
+```
+
+### Remote Debugging
+
+```python
+# Using debugpy (VS Code compatible)
+import debugpy
+debugpy.listen(5678)
+debugpy.wait_for_client()  # Pause until debugger attaches
+breakpoint()
+```
+
+## TypeScript Debugging
+
+### Console Methods
+
+```typescript
+// Basic logging
+console.log('value:', value);
+console.error('Error:', error);
+console.warn('Warning:', message);
+
+// Structured output
+console.table(arrayOfObjects);
+console.dir(complexObject, { depth: null });
+
+// Timing
+console.time('operation');
+// ... operation ...
+console.timeEnd('operation');
+
+// Grouping related logs
+console.group('Request Processing');
+console.log('Step 1');
+console.log('Step 2');
+console.groupEnd();
+
+// Conditional logging
+console.assert(condition, 'Condition failed:', data);
+
+// Stack trace without error
+console.trace('How did we get here?');
+```
+
+### Debugger Statement
+
+```typescript
+function processOrder(order: Order): void {
+  // Pauses execution when DevTools is open
+  debugger;
+
+  // Conditional debugger
+  if (order.total > 10000) {
+    debugger;
+  }
+}
+```
+
+### Source Maps
+
+Ensure `tsconfig.json` has source maps enabled:
+
+```json
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "inlineSources": true
+  }
+}
+```
+
+For debugging bundled code, verify source maps are generated and served:
+
+```typescript
+// webpack.config.js
+module.exports = {
+  devtool: 'source-map', // Full source maps for debugging
+};
+```
+
+### Node.js Debugging
+
+```bash
+# Start with inspector
+node --inspect dist/server.js
+
+# Break on first line
+node --inspect-brk dist/server.js
+
+# With ts-node
+node --inspect -r ts-node/register src/server.ts
+```
+
+### Chrome DevTools Tips
+
+1. **Breakpoints**: Click line number in Sources panel
+2. **Conditional breakpoints**: Right-click line number, add condition
+3. **Logpoints**: Right-click, add logpoint (logs without pausing)
+4. **Watch expressions**: Add variables to Watch panel
+5. **Call stack**: Navigate up/down the call stack
+6. **Scope**: Inspect local, closure, and global variables
+
+### Async Debugging
+
+```typescript
+// Capture async stack traces
+Error.stackTraceLimit = 50;
+
+// Label promises for debugging
+const result = await Promise.race([
+  fetchData().then(data => ({ source: 'fetch', data })),
+  timeout(5000).then(() => ({ source: 'timeout', data: null }))
+]);
+console.log('Winner:', result.source);
+```
+
+## Ruby Debugging
+
+### binding.irb (Ruby 2.5+)
+
+```ruby
+def process_order(order)
+  # Opens interactive console at this point
+  binding.irb
+
+  order.validate!
+end
+```
+
+**IRB commands in binding.irb:**
+
+| Command | Action |
+|---------|--------|
+| `exit` | Continue execution |
+| `exit!` | Exit program |
+| `whereami` | Show current code context |
+| `show_source method_name` | Show method source |
+
+### byebug
+
+```ruby
+# Gemfile
+gem 'byebug', group: [:development, :test]
+
+# In code
+require 'byebug'
+
+def process_order(order)
+  byebug  # Execution stops here
+  order.validate!
+end
+```
+
+**byebug commands:**
+
+| Command | Action |
+|---------|--------|
+| `n` (next) | Execute next line |
+| `s` (step) | Step into method |
+| `c` (continue) | Continue execution |
+| `f` (finish) | Run until current method returns |
+| `p expr` | Evaluate expression |
+| `info locals` | Show local variables |
+| `bt` (backtrace) | Show call stack |
+| `up` / `down` | Navigate stack frames |
+
+### Rails Console Debugging
+
+```ruby
+# Start console
+rails console
+
+# Reload after code changes
+reload!
+
+# Find and inspect objects
+user = User.find(123)
+user.attributes
+user.orders.to_sql  # See generated SQL
+
+# Test in sandbox (rollback on exit)
+rails console --sandbox
+```
+
+### Rails Logger
+
+```ruby
+# In application code
+Rails.logger.debug "Processing order: #{order.id}"
+Rails.logger.info "Order created", order_id: order.id
+Rails.logger.error "Payment failed", error: e.message
+
+# Tagged logging
+Rails.logger.tagged("OrderService", order.id) do
+  Rails.logger.info "Starting processing"
+end
+
+# Tail logs
+tail -f log/development.log
+```
+
+### pry-rails
+
+```ruby
+# Gemfile
+gem 'pry-rails', group: [:development, :test]
+
+# In code
+binding.pry  # Opens Pry console
+
+# Pry commands
+ls object          # List methods/variables
+cd object          # Change context to object
+show-source method # Show method definition
+show-doc method    # Show documentation
+wtf?               # Show last exception
+```
+
+### Exception Debugging
+
+```ruby
+begin
+  risky_operation
+rescue => e
+  # Full backtrace
+  puts e.backtrace.join("\n")
+
+  # Filtered backtrace (Rails)
+  puts Rails.backtrace_cleaner.clean(e.backtrace).join("\n")
+
+  # Re-raise with context
+  raise "Order processing failed for order #{order.id}: #{e.message}"
+end
+```
+
+## Cross-Language Tips
+
+### Binary Search Debugging
+
+When you have a long sequence of operations and don't know where the failure occurs:
+
+1. Add logging/breakpoint at the midpoint
+2. Determine if failure is before or after
+3. Repeat with the relevant half
+4. Continue until you isolate the exact line
+
+### Minimal Reproduction
+
+1. Remove code until bug disappears
+2. Add back the last removed piece
+3. That piece contains or triggers the bug
+4. Create minimal test case that reproduces
+
+### Rubber Duck Debugging
+
+When stuck:
+
+1. Explain the code line-by-line out loud
+2. Explain what you expect vs. what happens
+3. Explain your hypotheses and why each might be wrong
+4. Often, articulating the problem reveals the solution

--- a/dist/opencode/skill/debugging/references/test-debugging.md
+++ b/dist/opencode/skill/debugging/references/test-debugging.md
@@ -1,0 +1,326 @@
+# Test Debugging
+
+Strategies for diagnosing flaky tests, isolation failures, and environment-related test issues.
+
+## Flaky Test Diagnosis
+
+A flaky test passes sometimes and fails sometimes with the same code. Common causes:
+
+### Timing Dependencies
+
+**Symptoms:**
+- Test passes locally, fails in CI
+- Test fails more often under load
+- Adding `sleep()` makes it pass
+
+**Investigation:**
+```python
+# Bad: Depends on timing
+def test_async_operation():
+    start_async_job()
+    time.sleep(1)  # Hope it's done
+    assert job_completed()
+
+# Good: Wait for condition
+def test_async_operation():
+    start_async_job()
+    wait_for(lambda: job_completed(), timeout=5)
+    assert job_completed()
+```
+
+**Diagnosis steps:**
+1. Run test 100 times in a loop
+2. Monitor CPU/memory during failures
+3. Add timestamps to understand timing
+4. Check for hardcoded timeouts that are too short
+
+### Order Dependencies
+
+**Symptoms:**
+- Test passes when run alone, fails in suite
+- Test fails only when run after specific other test
+- Reordering tests changes results
+
+**Investigation:**
+```bash
+# pytest: Run in random order
+pytest --random-order
+
+# Find the guilty test pair
+pytest tests/test_a.py tests/test_b.py -v  # Passes
+pytest tests/test_b.py tests/test_a.py -v  # Fails?
+```
+
+**Common culprits:**
+- Global state modified by previous test
+- Database records not cleaned up
+- Cached values persisting
+- Module-level side effects
+
+### Non-Deterministic Data
+
+**Symptoms:**
+- Fails occasionally with no pattern
+- Different assertion failures each time
+- Works with specific seed/data
+
+**Investigation:**
+```python
+# Bad: Non-deterministic
+def test_random_selection():
+    items = get_random_items(10)
+    assert len(items) == 10  # What if source has < 10?
+
+# Good: Control randomness
+def test_random_selection():
+    random.seed(42)
+    items = get_random_items(10)
+    assert len(items) == 10
+```
+
+## Test Isolation Patterns
+
+### Database Isolation
+
+```python
+# pytest with transactions
+@pytest.fixture
+def db_session(engine):
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()
+```
+
+```ruby
+# Rails transactional tests
+class OrderTest < ActiveSupport::TestCase
+  # Each test runs in a transaction that rolls back
+  self.use_transactional_tests = true
+
+  test "creates order" do
+    order = Order.create!(total: 100)
+    assert order.persisted?
+  end  # Order is rolled back
+end
+```
+
+### External Service Isolation
+
+```python
+# Mock external services
+@pytest.fixture
+def mock_payment_api(mocker):
+    return mocker.patch(
+        'app.services.payment.PaymentAPI.charge',
+        return_value={'status': 'success', 'id': 'ch_123'}
+    )
+
+def test_order_payment(mock_payment_api):
+    order = create_order(total=100)
+    order.process_payment()
+
+    mock_payment_api.assert_called_once_with(amount=100)
+    assert order.payment_status == 'paid'
+```
+
+### Time Isolation
+
+```python
+# Freeze time for deterministic tests
+from freezegun import freeze_time
+
+@freeze_time("2024-01-15 12:00:00")
+def test_order_expiry():
+    order = create_order()
+    assert not order.expired
+
+    with freeze_time("2024-01-16 12:00:01"):
+        assert order.expired  # 24+ hours later
+```
+
+```typescript
+// Jest fake timers
+jest.useFakeTimers();
+
+test('order expires after 24 hours', () => {
+  const order = createOrder();
+  expect(order.expired).toBe(false);
+
+  jest.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
+  expect(order.expired).toBe(true);
+});
+```
+
+## State Pollution Detection
+
+### Symptoms
+
+- Test A passes alone, fails after test B
+- Test fails only when suite runs in specific order
+- "Works on my machine" syndrome
+
+### Detection Strategy
+
+```bash
+# 1. Run suspect test in isolation
+pytest tests/test_orders.py::test_specific -v
+
+# 2. Run with a known "polluter"
+pytest tests/test_other.py tests/test_orders.py::test_specific -v
+
+# 3. Binary search for the polluter
+pytest tests/test_orders.py::test_specific --last-failed
+```
+
+### Common State Pollution Sources
+
+| Source | Detection | Fix |
+|--------|-----------|-----|
+| Module globals | Check imports for mutations | Use fixtures, reset in teardown |
+| Class variables | Look for `cls.` modifications | Use instance variables |
+| Singletons | Check shared instances | Reset or mock singletons |
+| Environment variables | Print env in failing test | Restore in teardown |
+| File system | Check for temp files | Use tmp directories, clean up |
+| Database | Check for leftover records | Transaction rollback |
+| Caches | Check memoized values | Clear caches in setup |
+
+### Teardown Pattern
+
+```python
+@pytest.fixture(autouse=True)
+def reset_global_state():
+    # Setup: Save original state
+    original_config = app.config.copy()
+
+    yield
+
+    # Teardown: Restore original state
+    app.config = original_config
+    cache.clear()
+```
+
+## Environment Differences
+
+### Local vs CI Failures
+
+| Difference | Detection | Solution |
+|------------|-----------|----------|
+| Timing | CI slower, races more likely | Use proper waits, not sleeps |
+| Resources | CI has less memory/CPU | Check resource usage |
+| Parallelism | CI runs tests in parallel | Ensure isolation |
+| File paths | Different temp directories | Use portable paths |
+| Timezone | CI uses UTC | Freeze time or use UTC |
+| Locale | CI uses different locale | Set locale explicitly |
+
+### Debugging CI-Only Failures
+
+```yaml
+# GitHub Actions: Enable debug logging
+env:
+  ACTIONS_STEP_DEBUG: true
+  ACTIONS_RUNNER_DEBUG: true
+
+# Add verbose output
+steps:
+  - name: Run tests
+    run: |
+      echo "=== Environment ==="
+      env | sort
+      echo "=== Python version ==="
+      python --version
+      echo "=== Running tests ==="
+      pytest -v --tb=long
+```
+
+### Reproducing CI Environment Locally
+
+```bash
+# Docker: Use same image as CI
+docker run -it --rm -v $(pwd):/app -w /app python:3.11 bash
+pip install -r requirements.txt
+pytest
+
+# Act: Run GitHub Actions locally
+act -j test
+
+# Environment parity
+export CI=true
+export TZ=UTC
+pytest
+```
+
+## Test Debugging Workflow
+
+### 1. Isolate the Failure
+
+```bash
+# Run failing test alone
+pytest tests/test_orders.py::test_failing -v
+
+# If it passes alone, find the interaction
+pytest --collect-only | head -20  # See test order
+```
+
+### 2. Add Diagnostic Output
+
+```python
+def test_order_processing(caplog):
+    with caplog.at_level(logging.DEBUG):
+        order = process_order(data)
+
+    print(f"Captured logs: {caplog.text}")
+    print(f"Order state: {order.__dict__}")
+    assert order.status == "completed"
+```
+
+### 3. Minimize the Test
+
+```python
+# Start with failing test
+def test_order_processing():
+    user = create_user()
+    product = create_product()
+    cart = create_cart(user, product)
+    order = create_order(cart)
+    payment = process_payment(order)
+    shipment = create_shipment(order)
+    assert shipment.status == "ready"
+
+# Remove pieces until bug disappears
+def test_order_processing_minimal():
+    order = create_order()  # Minimal setup
+    assert order.status == "pending"  # Bug is here!
+```
+
+### 4. Check Assumptions
+
+```python
+def test_order_total():
+    order = create_order()
+
+    # Verify assumptions
+    print(f"Order items: {order.items}")
+    print(f"Item prices: {[i.price for i in order.items]}")
+    print(f"Expected total: {sum(i.price for i in order.items)}")
+    print(f"Actual total: {order.total}")
+
+    assert order.total == Decimal("100.00")
+```
+
+## Flaky Test Prevention
+
+| Practice | Why It Helps |
+|----------|--------------|
+| Use factories, not fixtures | Fresh data each test |
+| Avoid shared state | Tests can't pollute each other |
+| Mock time and randomness | Deterministic behavior |
+| Use transactions | Auto-cleanup |
+| Run tests in random order | Catch order dependencies |
+| Run tests in parallel | Catch isolation issues |
+| Set explicit timeouts | Fail fast on hangs |

--- a/dist/opencode/skill/foundations/SKILL.md
+++ b/dist/opencode/skill/foundations/SKILL.md
@@ -35,6 +35,7 @@ Engineering foundations for consistent, secure, and well-documented code.
 |-------|-----------|---------|
 | Code Style | `reference/code-style.md` | Python/TypeScript conventions, naming, patterns |
 | Commits | `reference/commits.md` | Commit messages, branches, PRs, Linear integration |
+| Diagrams | `reference/diagrams.md` | Mermaid syntax, when to diagram, storage patterns |
 | Documentation | `reference/documentation.md` | ADRs, API docs, changelogs |
 | Security | `reference/security.md` | Threat modeling, secrets, compliance |
 | Permissions | `reference/permissions.md` | Tool allowlists, sandbox config, agent permissions |

--- a/dist/opencode/skill/foundations/references/diagrams.md
+++ b/dist/opencode/skill/foundations/references/diagrams.md
@@ -1,0 +1,248 @@
+# Architecture Diagrams
+
+Guidelines for creating Mermaid diagrams to visualize system architecture and data flows.
+
+## When to Create Diagrams
+
+Create architecture diagrams when work involves:
+
+| Scenario | Diagram Type | Why |
+|----------|--------------|-----|
+| Multi-service changes | Component/flowchart | Shows interaction points and dependencies |
+| Data flow changes | Sequence/flowchart | Traces data through the system |
+| Schema modifications | ERD | Visualizes table relationships |
+| API design | Sequence | Documents request/response flows |
+| State machine logic | State diagram | Clarifies transitions and conditions |
+| Complex conditionals | Flowchart | Makes branching logic explicit |
+
+### Skip Diagrams When
+
+- Single-file changes with obvious scope
+- Bug fixes with no architectural impact
+- Configuration-only changes
+- Test additions (unless testing complex flows)
+
+## Mermaid Syntax Quick Reference
+
+### Flowchart (Most Common)
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Action 1]
+    B -->|No| D[Action 2]
+    C --> E[End]
+    D --> E
+```
+
+**Direction options:** `TD` (top-down), `LR` (left-right), `BT` (bottom-top), `RL` (right-left)
+
+**Node shapes:**
+- `[Rectangle]` - Process/action
+- `{Diamond}` - Decision
+- `([Stadium])` - Start/end
+- `[(Database)]` - Database
+- `((Circle))` - Connector
+
+### Sequence Diagram (API/Service Interaction)
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as API
+    participant D as Database
+
+    C->>A: POST /auth/login
+    A->>D: Query user
+    D-->>A: User record
+    A-->>C: JWT token
+```
+
+**Arrow types:**
+- `->>` Solid line with arrowhead (sync call)
+- `-->>` Dashed line with arrowhead (response)
+- `--)` Async message
+
+### Entity Relationship Diagram (Schema)
+
+```mermaid
+erDiagram
+    USER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT ||--o{ LINE_ITEM : "ordered in"
+
+    USER {
+        uuid id PK
+        string email
+        timestamp created_at
+    }
+    ORDER {
+        uuid id PK
+        uuid user_id FK
+        decimal total
+    }
+```
+
+**Relationship notation:**
+- `||` One (required)
+- `o|` Zero or one
+- `}|` One or many
+- `}o` Zero or many
+
+### State Diagram (State Machines)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Pending: submit
+    Pending --> Approved: approve
+    Pending --> Rejected: reject
+    Approved --> [*]
+    Rejected --> Draft: revise
+```
+
+### Component Diagram (System Architecture)
+
+```mermaid
+flowchart LR
+    subgraph Frontend
+        UI[Web App]
+    end
+
+    subgraph Backend
+        API[FastAPI]
+        Worker[Celery]
+    end
+
+    subgraph Data
+        DB[(PostgreSQL)]
+        Cache[(Redis)]
+    end
+
+    UI --> API
+    API --> DB
+    API --> Cache
+    API --> Worker
+    Worker --> DB
+```
+
+## Storage Patterns
+
+### Inline in Session File
+
+Best for: Diagrams specific to current work, temporary visualizations
+
+```markdown
+## Architecture Diagrams
+
+### Auth Flow
+```mermaid
+sequenceDiagram
+    User->>API: Login request
+    API->>DB: Validate credentials
+    DB-->>API: User record
+    API-->>User: JWT token
+```
+**Purpose**: Visualize the authentication flow being implemented
+**Files involved**: `backend/auth/`, `backend/models/user.py`
+```
+
+### Stored in `.agents/diagrams/`
+
+Best for: Reusable diagrams, cross-session reference, team documentation
+
+```
+.agents/diagrams/
+├── system-architecture.md
+├── auth-flow.md
+└── data-pipeline.md
+```
+
+**Diagram file format:**
+
+```markdown
+---
+created: 2025-01-23T14:00:00Z
+last_updated: 2025-01-23T14:00:00Z
+tags: [auth, api, security]
+---
+
+# Auth Flow Diagram
+
+## Overview
+
+Documents the authentication and authorization flow for the API.
+
+## Diagram
+
+```mermaid
+[diagram content]
+```
+
+## Related Files
+
+- `backend/auth/jwt.py` - JWT generation
+- `backend/middleware/auth.py` - Auth middleware
+- `backend/models/user.py` - User model
+
+## Notes
+
+Any additional context about this diagram.
+```
+
+### When to Store vs Inline
+
+| Store in `.agents/diagrams/` | Keep Inline in Session |
+|------------------------------|------------------------|
+| Referenced by multiple sessions | One-time visualization |
+| Documents stable architecture | Documents work-in-progress |
+| Shared across team members | Personal understanding aid |
+| Likely to be updated | Disposable after task |
+
+## Best Practices
+
+### Keep Diagrams Focused
+
+```markdown
+# Good: Single concern
+Auth flow diagram showing login -> validate -> token
+
+# Bad: Everything at once
+Entire system with auth, billing, notifications, logging...
+```
+
+### Use Consistent Naming
+
+```markdown
+# In diagrams, use actual names from code
+API[auth-service]  # Matches service name
+DB[(users)]        # Matches table name
+
+# Not generic placeholders
+API[Service A]
+DB[(Database)]
+```
+
+### Add Context
+
+Every diagram needs:
+1. **Purpose** - Why this diagram exists
+2. **Files involved** - What code it represents
+3. **Limitations** - What it does NOT show
+
+### Update When Code Changes
+
+Diagrams are documentation. When the code they represent changes:
+1. Update the diagram
+2. Update `last_updated` timestamp
+3. Note the change in session log
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Diagram everything | Diagram only complex flows |
+| Include implementation details | Show architectural relationships |
+| Create diagrams after code | Create during planning |
+| Leave stale diagrams | Update or delete |
+| Use inconsistent notation | Follow Mermaid conventions |

--- a/dist/opencode/skill/orchestration/SKILL.md
+++ b/dist/opencode/skill/orchestration/SKILL.md
@@ -36,11 +36,18 @@ Every release should be complete, polished, and delightful - no MVPs or quick ha
 | Stuck on task | Check circuit breaker, consider reshaping |
 | Pre-compaction | Spawn context-archiver to preserve state |
 | Low-priority work | Spawn background-runner with run_in_background |
+| New feature workflow | Research → Architecture → PRD → Specs → Tasks |
+| Create specification | Use `/specs` with requirement reference |
+| Break down spec | Use `/tasks` to generate atomic work items |
+| Task-coupled session | Use `/start-session TASK-XXX` for traceability |
 
 ## Topics
 
 | Topic | Reference | Key Content |
 |-------|-----------|-------------|
+| Product Development | [reference/product-development.md](reference/product-development.md) | Full workflow: Research → Vision → Architecture → Requirements → Specs → Tasks |
+| Specifications | [reference/specs.md](reference/specs.md) | Spec format, lifecycle, shaping, test conditions |
+| Local Tasks | [reference/local-tasks.md](reference/local-tasks.md) | Task format, abstraction layer, Linear/local backend |
 | Agent Delegation | [reference/delegation.md](reference/delegation.md) | Agent capabilities, spawn patterns, decision tree |
 | Background Agents | [reference/background-agents.md](reference/background-agents.md) | Non-interactive work, spawn with run_in_background |
 | Council Workflow | [reference/councils.md](reference/councils.md) | Composition, deliberation, synthesis, user approval |

--- a/dist/opencode/skill/orchestration/SKILL.md
+++ b/dist/opencode/skill/orchestration/SKILL.md
@@ -35,12 +35,14 @@ Every release should be complete, polished, and delightful - no MVPs or quick ha
 | Agent selection | Match domain expertise to task |
 | Stuck on task | Check circuit breaker, consider reshaping |
 | Pre-compaction | Spawn context-archiver to preserve state |
+| Low-priority work | Spawn background-runner with run_in_background |
 
 ## Topics
 
 | Topic | Reference | Key Content |
 |-------|-----------|-------------|
 | Agent Delegation | [reference/delegation.md](reference/delegation.md) | Agent capabilities, spawn patterns, decision tree |
+| Background Agents | [reference/background-agents.md](reference/background-agents.md) | Non-interactive work, spawn with run_in_background |
 | Council Workflow | [reference/councils.md](reference/councils.md) | Composition, deliberation, synthesis, user approval |
 | Session Management | [reference/sessions.md](reference/sessions.md) | Lifecycle, file format, handoffs, validation |
 | Session Resume | [reference/session-resume.md](reference/session-resume.md) | CLI flags, checkpoints, context recovery |

--- a/dist/opencode/skill/orchestration/references/background-agents.md
+++ b/dist/opencode/skill/orchestration/references/background-agents.md
@@ -1,0 +1,236 @@
+# Background Agents
+
+Background agents handle low-priority, long-running, or non-interactive work that can run independently while the user continues with other tasks.
+
+## When to Use Background Agents
+
+| Appropriate | Not Appropriate |
+|-------------|-----------------|
+| Security audits | Interactive debugging |
+| Code coverage analysis | User-facing questions |
+| Large-scale refactoring reports | Time-sensitive fixes |
+| Codebase-wide linting reports | Tasks requiring immediate feedback |
+| Documentation audits | Work needing user decisions mid-task |
+| Dependency vulnerability scans | Blocking tasks for current work |
+
+**Good candidates:**
+- Results can be processed later
+- No user interaction required
+- Task is well-defined with clear completion criteria
+- Output is a report or artifact, not a conversation
+
+**Poor candidates:**
+- Needs clarification mid-task
+- Time-sensitive (user waiting for result)
+- Requires real-time coordination with other agents
+
+## Spawning Background Agents
+
+### Claude Code
+
+Use the Task tool with `run_in_background: true`:
+
+```python
+Task(
+    subagent_type="background-runner",
+    prompt="""
+    Run full security audit on backend codebase.
+
+    Scope:
+    - src/api/
+    - src/services/
+
+    Write report to: .agents/reports/YYYYMMDD-HHMMSS-security-audit.md
+
+    Session: .agents/sessions/20260123-143000-auth-feature.md
+    """,
+    run_in_background=True
+)
+```
+
+### Cursor
+
+Background agents are configured via the `is_background: true` YAML property. When spawning:
+
+```
+@background-runner Run security audit on backend codebase.
+Write report to .agents/reports/
+```
+
+## Background Agent Tracking
+
+Track background agents in session frontmatter:
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security-scan"
+    agent: background-runner
+    task: "Full security audit of backend"
+    status: running  # running | completed | failed
+    result_location: null
+  - id: "bg-20260123-144500-coverage"
+    agent: background-runner
+    task: "Test coverage analysis"
+    status: completed
+    result_location: ".agents/reports/20260123-144500-coverage-report.md"
+```
+
+### Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `running` | Agent still executing |
+| `completed` | Work finished, results available |
+| `failed` | Agent encountered error |
+
+### ID Convention
+
+Background agent IDs follow: `bg-YYYYMMDD-HHMMSS-<description>`
+
+Generate with:
+```bash
+echo "bg-$(date -u +"%Y%m%d-%H%M%S")-<description>"
+```
+
+## Result Retrieval
+
+Background agents write results to `.agents/reports/` with standard frontmatter:
+
+```yaml
+---
+report:
+  title: "Security Audit Report"
+  type: background-agent-output
+  status: unprocessed  # unprocessed | processed | archived
+  created: "2026-01-23T14:30:00Z"
+  background_agent_id: "bg-20260123-143000-security-scan"
+  session_reference: "20260123-140000-auth-feature.md"
+---
+```
+
+### Processing Results
+
+1. SessionStart hook alerts user to completed background work
+2. User or PM reviews report in `.agents/reports/`
+3. PM updates session frontmatter:
+   - Change `status` from `running` to `completed`
+   - Set `result_location` to report path
+4. Process findings as needed (spawn agents, create issues)
+5. Set report `status` to `processed`
+
+## Workflow Example
+
+### 1. PM Identifies Low-Priority Work
+
+During auth feature implementation, PM identifies need for security audit but it is not blocking current work.
+
+### 2. PM Spawns Background Agent
+
+```python
+Task(
+    subagent_type="background-runner",
+    prompt="""
+    Run comprehensive security audit on auth implementation.
+
+    Files to audit:
+    - src/auth/endpoints.py
+    - src/auth/token.py
+    - src/auth/middleware.py
+
+    Check for:
+    - OWASP Top 10 vulnerabilities
+    - Secrets in code
+    - SQL injection risks
+    - Authentication bypasses
+
+    Write report to: .agents/reports/20260123-143000-auth-security.md
+
+    Session: .agents/sessions/20260123-140000-auth-feature.md
+    """,
+    run_in_background=True
+)
+```
+
+### 3. PM Updates Session Frontmatter
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-auth-security"
+    agent: background-runner
+    task: "Auth security audit"
+    status: running
+    result_location: null
+```
+
+### 4. Work Continues
+
+PM and other agents continue with main implementation while background agent works.
+
+### 5. Session Resumes Later
+
+SessionStart hook detects completed background work:
+
+```
+# Background Work Completed
+
+The following background agents have completed:
+
+- **bg-20260123-143000-auth-security** (background-runner)
+  - Task: Auth security audit
+  - Result: .agents/reports/20260123-143000-auth-security.md
+
+Review reports and update session frontmatter after processing.
+```
+
+### 6. Results Processed
+
+PM reads report, creates issues for findings, updates session.
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Use for blocking work | Keep blocking work in foreground |
+| Spawn without tracking | Always update session frontmatter |
+| Ignore completed results | Process results when alerted |
+| Use for interactive tasks | Reserve for autonomous work |
+| Spawn many concurrent background agents | Limit to 2-3 to avoid resource contention |
+| Skip result location in prompt | Always specify where to write output |
+
+## Integration Points
+
+### SessionStart Hook
+
+Checks session frontmatter for `background_agents` with `status: completed`. Alerts user to review results.
+
+### PreCompact Hook
+
+Includes background agent state in preservation. Context-archiver captures:
+- Active background agent list
+- Current status of each
+- Result locations for completed agents
+
+### Session Frontmatter
+
+Full template with background agents:
+
+```yaml
+---
+session:
+  title: "Feature implementation"
+  status: in_progress
+  # ... other session fields ...
+
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: completed
+    result_location: ".agents/reports/20260123-143000-security.md"
+  - id: "bg-20260123-150000-coverage"
+    agent: background-runner
+    task: "Coverage analysis"
+    status: running
+    result_location: null
+---
+```

--- a/dist/opencode/skill/orchestration/references/cross-session.md
+++ b/dist/opencode/skill/orchestration/references/cross-session.md
@@ -1,0 +1,200 @@
+# Cross-Session References
+
+Patterns for importing decisions and context from past sessions into current work without duplicating full context.
+
+## When to Reference Past Sessions
+
+### Good Reasons to Reference
+
+- **Continuing related work**: Building on previous feature decisions
+- **Consistency**: Ensuring alignment with prior architectural choices
+- **Avoiding re-deliberation**: Council decisions already made on similar topics
+- **Context recovery**: Picking up work after long gaps
+
+### Skip Referencing When
+
+- Starting genuinely new work unrelated to past sessions
+- Past decisions are documented in ADRs (use ADRs instead)
+- Context would create more noise than value
+- Decisions were superseded or invalidated
+
+## What to Import
+
+### Decisions Only (Default)
+
+Import the distilled outcomes:
+
+```markdown
+## Referenced Decisions
+
+### From: 20250115-140000-auth-jwt.md
+
+#### Decision: Token Rotation Strategy
+**Decision**: Rotate every 15 minutes
+**Rationale**: Security/UX balance
+```
+
+**Why decisions only:**
+- Minimal context footprint
+- Focus on outcomes, not process
+- Easy to scan and validate relevance
+
+### Context Summary (When Needed)
+
+Import broader context when:
+- Problem space is complex and unfamiliar
+- Technical approach was non-obvious
+- Multiple related decisions form a coherent strategy
+
+```markdown
+## Referenced Context
+
+### From: 20250115-140000-auth-jwt.md
+
+**Problem**: Session management for distributed services
+**Approach**: JWT with refresh token rotation
+**Key Files**: `src/auth/`, `src/middleware/auth.py`
+**Outcome**: Implemented, deployed to production 2025-01-20
+```
+
+## Session Frontmatter for Tracking
+
+Track all cross-session references in frontmatter:
+
+```yaml
+---
+session:
+  title: "Auth V2 Implementation"
+  status: in_progress
+  created: "2025-01-23T10:00:00Z"
+  last_updated: "2025-01-23T14:30:00Z"
+  linear_issue: "PLT-200"
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"
+      imported_at: "2025-01-23T14:30:00Z"
+      content_type: decisions
+      decisions_imported:
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+    - session: "20250110-090000-auth-oauth.md"
+      imported_at: "2025-01-23T14:35:00Z"
+      content_type: context
+      summary: "OAuth provider integration patterns"
+
+orchestration:
+  current_task: "Implement token refresh endpoint"
+---
+```
+
+## Decision Memory Format
+
+When sessions are archived, decisions are extracted to Serena memory:
+
+```markdown
+# Memory: session-auth-jwt-decisions.md
+
+## Session Context
+- **Session**: 20250115-140000-auth-jwt.md
+- **Archived**: 2025-01-15T18:00:00Z
+- **Linear Issue**: PLT-123
+
+## Key Decisions
+
+### Decision 1: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window refresh
+**Rationale**: Balances security (limited token lifetime) with UX (seamless refresh)
+**Council**: None - backend-dev recommendation accepted
+
+### Decision 2: Refresh Token Storage
+**Decision**: Store refresh tokens in HttpOnly cookies, not localStorage
+**Rationale**: Prevents XSS-based token theft; aligns with OWASP recommendations
+**Council**: Security council (5 agents) - unanimous
+
+### Decision 3: Token Validation Order
+**Decision**: Validate signature before parsing claims
+**Rationale**: Fail fast on tampered tokens; reduce processing for invalid requests
+**Council**: None - standard security practice
+```
+
+## Workflow
+
+### At Archive Time (context-archiver)
+
+1. Read session file
+2. Check for `## Decisions` section
+3. If present, run `extract-decisions.py`
+4. Write output to Serena memory via MCP
+
+### At Reference Time (/reference-session)
+
+1. Search Serena memories for matching sessions
+2. Read selected decision memory
+3. Import into current session
+4. Track in `referenced_sessions` frontmatter
+
+## Serena MCP Integration
+
+### List Available Decision Memories
+
+```python
+mcp__serena__list_memories()
+# Filter results for: session-*-decisions.md
+```
+
+### Read Decision Memory
+
+```python
+mcp__serena__read_memory(name="session-auth-jwt-decisions.md")
+```
+
+### Write Decision Memory (at archive time)
+
+```python
+mcp__serena__write_memory(
+    name="session-auth-jwt-decisions.md",
+    content=extracted_decisions_markdown
+)
+```
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Import entire session files | Import only decisions/summaries |
+| Import without tracking | Update `referenced_sessions` in frontmatter |
+| Import unrelated sessions | Search by topic, Linear issue, or keyword |
+| Duplicate ADR content | Reference the ADR directly |
+| Import stale decisions | Verify decisions are still relevant |
+| Over-reference | Import only what's needed for current work |
+| Reference without reading | Always review imported content for relevance |
+
+## When Decisions Conflict
+
+If imported decisions conflict with current approach:
+
+1. **Note the conflict** in session file
+2. **Assess if prior decision still applies**
+   - Different context? Proceed with new approach
+   - Same context? Consider why original decision was made
+3. **Document the change** if deviating
+4. **Consider council** if uncertainty remains
+5. **Update ADRs** if architectural decision changes
+
+## Best Practices
+
+1. **Reference early** - Import relevant decisions before planning
+2. **Validate relevance** - Review each decision's applicability
+3. **Track everything** - All imports go in frontmatter
+4. **Summarize in session log** - Note what was imported and why
+5. **Don't over-import** - Less is more for context management
+6. **Update if superseding** - Mark old decisions as superseded when creating new ones
+
+## Example Session Log Entry
+
+```markdown
+### 2025-01-23 14:30 - PM
+Referenced decisions from auth-jwt session (PLT-123):
+- Token rotation strategy (15-min window)
+- Refresh token storage (HttpOnly cookies)
+Relevant to current auth-v2 work; maintaining consistency.
+```

--- a/dist/opencode/skill/orchestration/references/local-tasks.md
+++ b/dist/opencode/skill/orchestration/references/local-tasks.md
@@ -1,0 +1,276 @@
+# Local Task Management
+
+Break specs into atomic tasks using local files when Linear isn't available.
+
+## Task Abstraction Layer
+
+Tasks work identically whether backed by Linear or local files.
+
+### Configuration
+
+```yaml
+# .agents/loaf.yaml
+task_management:
+  backend: linear  # or "local"
+
+  linear:
+    team: ProjectName
+    default_labels: []
+
+  local:
+    archive_completed: true
+    directory: .agents/tasks
+```
+
+### Abstracted Operations
+
+| Operation | Linear | Local |
+|-----------|--------|-------|
+| Create task | Create issue | Write `.agents/tasks/active/TASK-*.md` |
+| Fetch task | Get issue | Read task file |
+| Update status | Update issue | Edit frontmatter |
+| List tasks | List issues | Glob task files |
+| Complete | Move to Done | Move to archive |
+
+## Local Task Format
+
+```yaml
+---
+id: TASK-001
+title: OAuth Provider Integration
+spec: SPEC-001
+status: todo  # todo | in_progress | review | done
+priority: P1  # P0 (urgent) | P1 (high) | P2 (normal) | P3 (low)
+created: 2026-01-23T14:30:00Z
+updated: 2026-01-23T14:30:00Z
+files:
+  - src/auth/oauth.py
+  - tests/auth/test_oauth.py
+verify: pytest tests/auth/test_oauth.py
+done: OAuth flow works for Google and GitHub
+---
+
+# TASK-001: OAuth Provider Integration
+
+## Description
+
+Implement OAuth provider integration for Google and GitHub following
+the approach outlined in SPEC-001.
+
+## Acceptance Criteria
+
+- [ ] Google OAuth flow completes successfully
+- [ ] GitHub OAuth flow completes successfully
+- [ ] Tokens stored securely in session
+- [ ] Error handling for failed auth
+- [ ] Unit tests pass
+
+## Context
+
+See SPEC-001 for full context and constraints.
+Reference ADR-001 for session storage decisions.
+
+## Work Log
+
+<!-- Updated by session as work progresses -->
+```
+
+**Location:** `.agents/tasks/active/TASK-001-oauth-provider.md`
+
+## Task Lifecycle
+
+```
+todo → in_progress → review → done
+  │        │           │        │
+  └────────┴───────────┴────────┘
+           can return to earlier states
+```
+
+| Status | Meaning |
+|--------|---------|
+| `todo` | Ready to work, not started |
+| `in_progress` | Actively being worked |
+| `review` | Implementation complete, needs verification |
+| `done` | Verified complete, ready for archive |
+
+## Creating Tasks from Specs
+
+### Input
+
+- Spec ID (e.g., `SPEC-001`)
+- Optional: priority override
+
+### Task Breakdown Rules
+
+1. **One concern per task** - Don't mix backend + tests + frontend
+2. **Clear done condition** - Observable, verifiable outcome
+3. **Verification command** - How to prove it works
+4. **File hints** - Which files will likely be modified
+
+### Example Breakdown
+
+```
+SPEC-001: User Authentication with OAuth
+        ↓
+TASK-001: OAuth Provider Integration
+  - Google OAuth client setup
+  - GitHub OAuth client setup
+  - Token exchange logic
+  verify: pytest tests/auth/test_oauth.py
+
+TASK-002: Session Management
+  - Session cookie handling
+  - Session storage (Redis/DB)
+  - Session expiry logic
+  verify: pytest tests/auth/test_session.py
+
+TASK-003: Login UI Components
+  - Login page layout
+  - Provider buttons
+  - Error states
+  verify: npm run test:e2e -- auth
+```
+
+## Directory Structure
+
+```
+.agents/tasks/
+├── active/                    # Current work
+│   ├── TASK-001-oauth-provider.md
+│   ├── TASK-002-session-management.md
+│   └── TASK-003-login-ui.md
+└── archive/                   # Completed work
+    └── 2026-01/              # Organized by month
+        └── TASK-000-initial-setup.md
+```
+
+## Task ID Generation
+
+Format: `TASK-{number}-{slug}`
+
+```bash
+# Find next available number
+ls .agents/tasks/active/ .agents/tasks/archive/*/ 2>/dev/null | \
+  grep -oE 'TASK-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+## Archiving Tasks
+
+When a task is done:
+
+1. Update status to `done`
+2. Add completion timestamp
+3. Move to archive:
+
+```bash
+mkdir -p .agents/tasks/archive/$(date +%Y-%m)
+mv .agents/tasks/active/TASK-001-*.md .agents/tasks/archive/$(date +%Y-%m)/
+```
+
+## Session Integration
+
+When `/start-session TASK-001`:
+
+1. Read task file for context
+2. Read linked spec for full picture
+3. Create session with traceability:
+
+```yaml
+session:
+  title: "OAuth Provider Integration"
+  task: TASK-001
+  spec: SPEC-001
+  status: in_progress
+
+traceability:
+  requirement: "2.1 User Authentication"
+  architecture:
+    - "Session Management"
+  decisions:
+    - ADR-001
+```
+
+## Priority Levels
+
+| Priority | Meaning | Response |
+|----------|---------|----------|
+| P0 | Urgent/blocking | Drop everything |
+| P1 | High | Work next |
+| P2 | Normal | Scheduled work |
+| P3 | Low | When time permits |
+
+## Listing Tasks
+
+### All Active Tasks
+
+```bash
+for f in .agents/tasks/active/TASK-*.md; do
+  id=$(grep '^id:' "$f" | cut -d: -f2 | tr -d ' ')
+  title=$(grep '^title:' "$f" | cut -d: -f2-)
+  status=$(grep '^status:' "$f" | cut -d: -f2 | tr -d ' ')
+  echo "$id [$status] $title"
+done
+```
+
+### Tasks for a Spec
+
+```bash
+grep -l "spec: SPEC-001" .agents/tasks/active/*.md
+```
+
+## Work Log Updates
+
+As work progresses, append to the Work Log section:
+
+```markdown
+## Work Log
+
+### 2026-01-23 14:30 UTC
+Started OAuth integration. Set up Google OAuth client credentials.
+
+### 2026-01-23 15:45 UTC
+Google OAuth working. Moving to GitHub integration.
+
+### 2026-01-23 17:00 UTC
+Both providers working. Tests pass. Moving to review.
+```
+
+## Verification
+
+Before marking `done`:
+
+1. Run the `verify` command from frontmatter
+2. Check all acceptance criteria are checked
+3. Ensure no regressions in related tests
+
+```bash
+# Run task verification
+verify_cmd=$(grep '^verify:' TASK-001-*.md | cut -d: -f2-)
+eval "$verify_cmd"
+```
+
+## Local vs Linear Comparison
+
+| Feature | Local | Linear |
+|---------|-------|--------|
+| No external dependency | yes | no |
+| Rich UI | no | yes |
+| Team collaboration | git-based | native |
+| Notifications | none | email/slack |
+| Reporting | manual | built-in |
+| Offline work | yes | limited |
+
+**Use local when:**
+- Solo project
+- No Linear access
+- Offline development
+- Simple task tracking
+
+**Use Linear when:**
+- Team collaboration needed
+- Rich workflow automation
+- Integration with other tools
+- Reporting requirements

--- a/dist/opencode/skill/orchestration/references/product-development.md
+++ b/dist/opencode/skill/orchestration/references/product-development.md
@@ -1,0 +1,234 @@
+# Product Development Workflow
+
+A Research → Vision → Architecture → Requirements → Specs → Tasks → Session workflow for structured product development.
+
+## Core Insight
+
+**Separate permanent project knowledge from ephemeral orchestration.**
+
+```
+docs/                               # Permanent project knowledge
+├── VISION.md                       # Strategic direction (evolves rarely)
+├── ARCHITECTURE.md                 # Technical design (evolves with learnings)
+├── REQUIREMENTS.md                 # Business/product rules (evolves with feedback)
+├── decisions/                      # Architecture Decision Records
+│   └── ADR-001-database-choice.md
+└── specs/                          # Feature specifications (temporary)
+    ├── SPEC-001-user-auth.md
+    └── archive/                    # Completed specs
+
+.agents/                            # Ephemeral orchestration
+├── loaf.yaml                       # Project config (task backend, etc.)
+├── sessions/                       # Active work contexts
+├── plans/                          # Implementation plans
+├── councils/                       # Deliberation records
+├── transcripts/                    # Archived conversation transcripts
+├── tasks/                          # Local tasks (when not using Linear)
+│   ├── active/
+│   │   └── TASK-001-oauth-provider.md
+│   └── archive/
+└── debug/                          # Persistent debug sessions
+```
+
+## The Hierarchy
+
+```
+RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS → SESSION
+    │         │          │              │           │        │        │
+/research  (manual)  /architecture    /prd       /specs   /tasks  /start-session
+    │                    │              │           │        │
+    └─► evolves ─────────┴──────────────┴───────────┴────────┘
+        VISION                                      (feedback loops)
+```
+
+**Each level breaks down the one above:**
+- Research informs/evolves Vision
+- Vision shapes Architecture
+- Architecture constrains Requirements
+- Requirements break into Specs
+- Specs break into Tasks
+- Tasks become Sessions
+
+## Commands Overview
+
+| Command | Input | Output | Purpose |
+|---------|-------|--------|---------|
+| `/research` | Topic or "project state" | Insights, brainstorm | Zoom out, evolve VISION |
+| `/architecture` | Decision question | ARCHITECTURE.md + ADR | Technical decisions |
+| `/prd` | Feature area | REQUIREMENTS.md section | Product/business rules |
+| `/specs` | Requirement reference | SPEC-001-*.md | Feature specifications |
+| `/tasks` | Spec reference | TASK-* files/issues | Atomic work items |
+| `/start-session` | TASK-ID | Session file | Execute a task |
+
+## Document Formats
+
+### VISION.md
+
+Strategic direction that evolves rarely. Contains:
+- Product purpose and target users
+- Core principles and values
+- Long-term direction
+- What makes this product unique
+
+### ARCHITECTURE.md
+
+Technical design that evolves with learnings:
+- System architecture overview
+- Technology choices and rationale
+- Integration patterns
+- Deployment model
+
+### REQUIREMENTS.md
+
+Business and product rules organized by domain:
+
+```markdown
+## 2. Identity & Access
+
+### 2.1 User Authentication
+
+**Business Rules**
+- Users authenticate via OAuth (Google, GitHub)
+- Sessions expire after 24 hours of inactivity
+- Failed login attempts logged for security
+
+**Acceptance Criteria**
+- [ ] User can sign in with Google
+- [ ] User can sign in with GitHub
+- [ ] Session persists across browser refresh
+- [ ] Logout clears session completely
+```
+
+### Architecture Decision Records (ADRs)
+
+```yaml
+---
+id: ADR-001
+title: "PostgreSQL as Required Database"
+status: Accepted  # Proposed | Accepted | Deprecated | Superseded
+date: 2026-01-23
+---
+
+# ADR-001: PostgreSQL as Required Database
+
+## Context
+[Why this decision is needed]
+
+## Decision
+[What was decided]
+
+## Consequences
+[Tradeoffs and implications]
+```
+
+**Location:** `docs/decisions/ADR-001-*.md`
+
+## Configuration
+
+```yaml
+# .agents/loaf.yaml
+project:
+  name: "My Project"
+
+task_management:
+  backend: linear  # or "local"
+
+  linear:
+    team: ProjectName
+
+  local:
+    archive_completed: true
+
+docs:
+  vision: docs/VISION.md
+  architecture: docs/ARCHITECTURE.md
+  requirements: docs/REQUIREMENTS.md
+  decisions: docs/decisions/
+  specs: docs/specs/
+```
+
+## Workflow Examples
+
+### Full Workflow (New Feature)
+
+```bash
+# 1. Zoom out, check project state
+/research "project state"
+# → Lessons learned, ideas for auth improvement
+
+# 2. Make architecture decision
+/architecture "OAuth vs custom auth"
+# → Interview → ADR-001-auth-approach.md
+
+# 3. Capture requirements
+/prd "user authentication"
+# → Interview → REQUIREMENTS.md section 2.1
+
+# 4. Create specification
+/specs "2.1 User Authentication"
+# → Interview → SPEC-001-user-auth.md
+
+# 5. Generate tasks
+/tasks SPEC-001
+# → TASK-001, TASK-002, TASK-003
+
+# 6. Work on tasks
+/start-session TASK-001
+# → Session → Implementation → Done
+```
+
+### Quick Fix (Ad-hoc)
+
+```bash
+# Create task directly (bug report, small fix)
+/start-session TASK-099
+# PM: "No parent spec. Proceed?"
+# User: "Yes, small fix"
+# → Session → Fix → Done
+```
+
+## Feedback Loops
+
+The workflow is not rigid. Each level can feed back to higher levels:
+
+| Discovery | Action |
+|-----------|--------|
+| Implementation reveals design flaw | Update ARCHITECTURE.md |
+| Edge case invalidates requirement | Update REQUIREMENTS.md |
+| Spec too ambitious for appetite | Re-scope or split |
+| Task reveals missing requirement | Add to REQUIREMENTS.md |
+
+## Transcript Archival
+
+After `/compact` or `/clear`, archive conversation transcripts for future reference:
+
+1. **Copy transcript** to `.agents/transcripts/`
+2. **Link from session file** in frontmatter:
+
+```yaml
+session:
+  title: "Feature Implementation"
+  transcripts:
+    - 20260123-143500-pre-compact.jsonl
+    - 20260123-160000-final.jsonl
+```
+
+This preserves full context for debugging, knowledge extraction, and audit trails.
+
+## Flexibility Preserved
+
+1. **Skip steps** - Quick fixes don't need full workflow
+2. **Feedback loops** - Any level can evolve from learnings
+3. **Agents adapt** - Not a rigid harness
+
+## Critical Files
+
+| File | Purpose |
+|------|---------|
+| `docs/VISION.md` | Strategic direction |
+| `docs/ARCHITECTURE.md` | Technical design |
+| `docs/REQUIREMENTS.md` | Product rules |
+| `docs/decisions/ADR-*.md` | Architecture decisions |
+| `docs/specs/SPEC-*.md` | Feature specifications |
+| `.agents/tasks/active/TASK-*.md` | Local tasks |
+| `.agents/loaf.yaml` | Project configuration |

--- a/dist/opencode/skill/orchestration/references/sessions.md
+++ b/dist/opencode/skill/orchestration/references/sessions.md
@@ -68,6 +68,7 @@ session:
   branch: "username/back-123-feature"          # Optional: working branch
   transcripts: []                              # Archived Claude Code transcripts (filenames only)
                                                # Example: ["2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl"]
+  referenced_sessions: []                      # Cross-session references (see below)
 
 plans: []  # List of plan files in .agents/plans/ used by this session
            # Example: ["20251204-143500-api-design.md", "20251204-150000-frontend.md"]
@@ -79,8 +80,42 @@ orchestration:
       task: "Brief task description"
       status: completed                        # pending|in_progress|completed
       summary: "Outcome summary"
+
+background_agents:                             # Background work running independently
+  - id: "bg-20260123-143000-security-scan"     # ID: bg-YYYYMMDD-HHMMSS-description
+    agent: background-runner                   # Agent type
+    task: "Full security audit"                # Brief description
+    status: running                            # running|completed|failed
+    result_location: null                      # Path to report when complete
 ---
 ```
+
+### Cross-Session References
+
+Track decisions imported from past sessions via `/reference-session`:
+
+```yaml
+session:
+  # ... other fields ...
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"     # Source session filename
+      imported_at: "2025-01-23T14:30:00Z"        # When imported
+      content_type: decisions                     # decisions|context|all
+      decisions_imported:                         # List of decision titles
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+    - session: "20250110-090000-auth-oauth.md"
+      imported_at: "2025-01-23T14:35:00Z"
+      content_type: context
+      summary: "OAuth provider integration patterns"
+```
+
+**Why track references:**
+- Audit trail of where context came from
+- Avoids re-importing same decisions
+- Enables tracing decision lineage across sessions
+
+See `references/cross-session.md` for full patterns.
 
 ### Required Sections
 
@@ -160,6 +195,29 @@ Implementation plans for this session (stored in `.agents/plans/`):
 |------|--------|-------------|
 | [api-design](../plans/20251204-143500-api-design.md) | approved | API endpoint structure |
 | [frontend](../plans/20251204-150000-frontend.md) | pending | UI component design |
+
+## Architecture Diagrams
+
+### [Diagram Name]
+
+```mermaid
+[diagram content]
+```
+
+**Purpose**: Why this diagram helps understand the work
+**Files involved**: List of related file paths
+**Created**: When diagram was created (update if modified)
+
+<!--
+When to add diagrams:
+- Multi-service changes: Show interaction points
+- Data flow changes: Trace data through system
+- Schema modifications: Visualize relationships
+- API design: Document request/response flows
+
+For reusable diagrams, store in .agents/diagrams/ instead.
+See foundations skill reference/diagrams.md for Mermaid syntax.
+-->
 
 ## Council Outcomes
 

--- a/dist/opencode/skill/orchestration/references/specs.md
+++ b/dist/opencode/skill/orchestration/references/specs.md
@@ -1,0 +1,255 @@
+# Feature Specifications
+
+Break VISION + ARCHITECTURE + REQUIREMENTS into specific, implementable specs.
+
+## Philosophy
+
+**Specs are shaped solutions, not detailed designs.**
+
+A spec defines:
+- What problem we're solving
+- Boundaries (in/out of scope)
+- High-level approach
+- Test conditions
+
+A spec does NOT define:
+- Implementation details
+- Code structure
+- Exact UI layouts
+
+## Spec Format
+
+```yaml
+---
+id: SPEC-001
+title: "User Authentication with OAuth"
+requirement: "2.1 User Authentication"
+created: 2026-01-23T14:30:00Z
+status: drafting  # drafting | approved | implementing | complete
+appetite: "1 week"
+---
+
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+[From REQUIREMENTS 2.1 - why this matters to users and the business]
+
+## Proposed Solution
+
+[Shaped solution - high-level approach, not implementation details]
+
+## Scope
+
+### In Scope
+- OAuth: Google, GitHub
+- Session management with secure cookies
+- Login/logout UI
+
+### Out of Scope (Rabbit Holes)
+- Custom OAuth providers (avoid this complexity)
+- MFA (future spec if needed)
+- Password-based auth
+
+### No-Gos
+- Passwords in plaintext
+- Tokens in local storage
+- Session data in URLs
+
+## Test Conditions
+
+- [ ] OAuth flow completes for Google
+- [ ] OAuth flow completes for GitHub
+- [ ] Session persists across page refresh
+- [ ] Logout clears session completely
+- [ ] Invalid tokens are rejected
+
+## Implementation Notes
+
+[Architecture references, technical constraints, relevant ADRs]
+
+## Circuit Breaker
+
+At 50% appetite: if OAuth integration is problematic, simplify to single provider (Google only).
+```
+
+**Location:** `docs/specs/SPEC-001-feature-name.md`
+
+## Spec Lifecycle
+
+```
+drafting → approved → implementing → complete
+    │         │           │           │
+    └─────────┴───────────┴───────────┘
+              can return to drafting
+```
+
+| Status | Meaning |
+|--------|---------|
+| `drafting` | Being refined, not ready for work |
+| `approved` | User approved, ready for task breakdown |
+| `implementing` | Tasks created, work in progress |
+| `complete` | All tasks done, spec archived |
+
+## Creating Specs
+
+### Input Required
+
+1. **Requirement reference** - Which section of REQUIREMENTS.md
+2. **Appetite** - How much time is it worth (from Shape Up)
+
+### Interview Questions
+
+Before drafting, clarify:
+
+| Area | Questions |
+|------|-----------|
+| Scope | What's definitely in? What's definitely out? |
+| Rabbit holes | What seems related but should be avoided? |
+| No-gos | What approaches are forbidden? |
+| Test conditions | How do we know it works? |
+| Dependencies | What must exist first? |
+| Edge cases | What could go wrong? |
+
+### Writing the Spec
+
+1. **Start with Problem Statement** - Not "build X" but "solve Y"
+2. **Shape the solution** - Direction, not blueprint
+3. **Define boundaries explicitly** - In/out/no-gos
+4. **Write test conditions** - Observable outcomes
+5. **Set circuit breaker** - When to stop and reassess
+
+## Appetite Levels
+
+| Appetite | Size | Suitable For |
+|----------|------|--------------|
+| Small | 1-2 days | Bug fixes, minor enhancements |
+| Medium | 3-5 days | Feature additions, refactors |
+| Large | 1-2 weeks | Major features (rare) |
+
+If a spec can't fit the appetite, it needs more shaping or should be split.
+
+## Splitting Large Specs
+
+When a spec is too big:
+
+```
+SPEC-001-user-auth.md (large, 2 weeks)
+        ↓ split into
+SPEC-001a-oauth-integration.md (medium, 3 days)
+SPEC-001b-session-management.md (small, 2 days)
+SPEC-001c-login-ui.md (medium, 3 days)
+```
+
+Each sub-spec:
+- Has its own appetite
+- Can be worked independently
+- References the original requirement
+
+## Archiving Specs
+
+When all tasks for a spec are complete:
+
+1. Update status to `complete`
+2. Add completion date to frontmatter
+3. Move to `docs/specs/archive/`
+
+```bash
+mv docs/specs/SPEC-001-user-auth.md docs/specs/archive/
+```
+
+## Spec vs Plan
+
+| Spec | Plan |
+|------|------|
+| **What** to build | **How** to build it |
+| Lives in `docs/specs/` | Lives in `.agents/plans/` |
+| Survives sessions | Tied to session |
+| User-facing | Implementation detail |
+| Shape Up shaped | Tactical steps |
+
+Specs define the target. Plans define the route to get there.
+
+## Validation Checklist
+
+Before approving a spec:
+
+- [ ] Problem statement is clear and user-focused
+- [ ] Scope boundaries are explicit (in/out/no-gos)
+- [ ] Test conditions are observable and testable
+- [ ] Appetite is realistic for the scope
+- [ ] Circuit breaker is defined
+- [ ] Requirement reference is valid
+- [ ] No implementation details (those go in plans)
+
+## Example: Good vs Bad Specs
+
+### Bad Spec
+
+```markdown
+# SPEC-001: Add OAuth
+
+Add OAuth to the app.
+
+## Requirements
+- Add Google OAuth
+- Add session management
+- Add logout
+```
+
+Problems:
+- No problem statement
+- No scope boundaries
+- No test conditions
+- No appetite
+- Too vague to implement
+
+### Good Spec
+
+```markdown
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+Users currently can't access the application. We need a secure,
+frictionless login flow that leverages existing identity providers
+so users don't need to create yet another password.
+
+## Proposed Solution
+
+Implement OAuth 2.0 flow with Google and GitHub as initial providers.
+Store session in secure HTTP-only cookies. Provide clear login/logout UI.
+
+## Scope
+
+### In Scope
+- Google OAuth integration
+- GitHub OAuth integration
+- Session cookie management
+- Login page with provider buttons
+- Logout functionality
+
+### Out of Scope
+- Apple/Microsoft providers (future)
+- MFA (separate spec if needed)
+- Account linking (complex, avoid)
+
+### No-Gos
+- Storing tokens in localStorage
+- Custom password auth
+- Session data in URLs
+
+## Test Conditions
+
+- [ ] New user can sign in with Google
+- [ ] New user can sign in with GitHub
+- [ ] Session persists across browser tabs
+- [ ] Session survives page refresh
+- [ ] Logout clears all session data
+- [ ] Expired sessions redirect to login
+
+## Circuit Breaker
+
+At 50% appetite: if both providers are problematic, ship with Google only.
+GitHub can be a follow-up spec.
+```

--- a/dist/opencode/skill/orchestration/scripts/extract-decisions.py
+++ b/dist/opencode/skill/orchestration/scripts/extract-decisions.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Extract decisions from a session file and format as Serena memory.
+
+Usage: extract-decisions.py <session-file>
+
+Reads a session file, extracts the ## Decisions section, and outputs
+formatted Serena memory content to stdout. The output can be piped to
+Serena MCP's write_memory tool.
+
+Exit codes:
+  0 - Success (decisions extracted)
+  1 - Error (file not found, parse error)
+  2 - No decisions found
+"""
+
+import sys
+import re
+import yaml
+from pathlib import Path
+from datetime import datetime, timezone
+
+
+def parse_frontmatter(content: str) -> tuple[dict, str]:
+    """Extract YAML frontmatter from markdown content."""
+    if not content.startswith('---'):
+        return {}, content
+
+    parts = content.split('---', 2)
+    if len(parts) < 3:
+        return {}, content
+
+    try:
+        frontmatter = yaml.safe_load(parts[1])
+        body = parts[2]
+        return frontmatter or {}, body
+    except yaml.YAMLError as e:
+        print(f"Warning: Could not parse frontmatter: {e}", file=sys.stderr)
+        return {}, content
+
+
+def extract_decisions_section(body: str) -> str | None:
+    """Extract the ## Decisions section from markdown body."""
+    # Match ## Decisions followed by content until next ## or end
+    pattern = r'^## Decisions\s*\n(.*?)(?=^## |\Z)'
+    match = re.search(pattern, body, re.MULTILINE | re.DOTALL)
+
+    if match:
+        content = match.group(1).strip()
+        if content:
+            return content
+    return None
+
+
+def parse_decisions(decisions_text: str) -> list[dict]:
+    """Parse individual decisions from the decisions section."""
+    decisions = []
+
+    # Match ### Decision N: Title or ### Title patterns
+    pattern = r'^###\s+(?:Decision\s+\d+:\s+)?(.+?)\n(.*?)(?=^### |\Z)'
+    matches = re.findall(pattern, decisions_text, re.MULTILINE | re.DOTALL)
+
+    for title, content in matches:
+        decision = {
+            'title': title.strip(),
+            'decision': '',
+            'rationale': '',
+            'council': ''
+        }
+
+        # Extract **Decision**: value
+        decision_match = re.search(
+            r'\*\*Decision\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if decision_match:
+            decision['decision'] = decision_match.group(1).strip()
+
+        # Extract **Rationale**: value
+        rationale_match = re.search(
+            r'\*\*Rationale\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if rationale_match:
+            decision['rationale'] = rationale_match.group(1).strip()
+
+        # Extract **Council**: value (optional)
+        council_match = re.search(
+            r'\*\*Council\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if council_match:
+            decision['council'] = council_match.group(1).strip()
+
+        # Only add if we have at least a title and decision
+        if decision['title'] and decision['decision']:
+            decisions.append(decision)
+
+    return decisions
+
+
+def format_memory(
+    session_file: str,
+    frontmatter: dict,
+    decisions: list[dict]
+) -> str:
+    """Format decisions as Serena memory markdown."""
+    session = frontmatter.get('session', {})
+    title = session.get('title', 'Unknown Session')
+    linear_issue = session.get('linear_issue', 'N/A')
+    archived_at = session.get('archived_at', datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'))
+
+    # Generate slug from filename
+    filename = Path(session_file).stem
+    slug = re.sub(r'^\d{8}-\d{6}-', '', filename)
+
+    lines = [
+        f"# Memory: session-{slug}-decisions.md",
+        "",
+        "## Session Context",
+        f"- **Session**: {Path(session_file).name}",
+        f"- **Title**: {title}",
+        f"- **Archived**: {archived_at}",
+        f"- **Linear Issue**: {linear_issue}",
+        "",
+        "## Key Decisions",
+        ""
+    ]
+
+    for i, d in enumerate(decisions, 1):
+        lines.append(f"### Decision {i}: {d['title']}")
+        lines.append(f"**Decision**: {d['decision']}")
+        if d['rationale']:
+            lines.append(f"**Rationale**: {d['rationale']}")
+        if d['council']:
+            lines.append(f"**Council**: {d['council']}")
+        lines.append("")
+
+    return '\n'.join(lines)
+
+
+def generate_memory_name(session_file: str) -> str:
+    """Generate Serena memory name from session filename."""
+    filename = Path(session_file).stem
+    slug = re.sub(r'^\d{8}-\d{6}-', '', filename)
+    return f"session-{slug}-decisions.md"
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: extract-decisions.py <session-file>", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Extracts decisions from a session file and outputs Serena memory format.", file=sys.stderr)
+        print("The memory name will be: session-<slug>-decisions.md", file=sys.stderr)
+        sys.exit(1)
+
+    session_file = sys.argv[1]
+    filepath = Path(session_file)
+
+    if not filepath.exists():
+        print(f"Error: File not found: {session_file}", file=sys.stderr)
+        sys.exit(1)
+
+    content = filepath.read_text()
+    frontmatter, body = parse_frontmatter(content)
+
+    decisions_text = extract_decisions_section(body)
+    if not decisions_text:
+        print(f"No ## Decisions section found in: {session_file}", file=sys.stderr)
+        sys.exit(2)
+
+    decisions = parse_decisions(decisions_text)
+    if not decisions:
+        print(f"No parseable decisions found in: {session_file}", file=sys.stderr)
+        sys.exit(2)
+
+    # Output memory content to stdout
+    memory_content = format_memory(session_file, frontmatter, decisions)
+    print(memory_content)
+
+    # Output memory name to stderr for scripting
+    memory_name = generate_memory_name(session_file)
+    print(f"\n# Memory name: {memory_name}", file=sys.stderr)
+    print(f"# Decisions extracted: {len(decisions)}", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/dist/opencode/skill/orchestration/scripts/git-context-summary.sh
+++ b/dist/opencode/skill/orchestration/scripts/git-context-summary.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Generate git context summary for sessions
+# Usage: git-context-summary.sh [--brief]
+#
+# Output includes:
+#   - Current branch name
+#   - Uncommitted changes count
+#   - Recent commits (last 3-5)
+#   - Summary of changes from main/master (if on feature branch)
+#
+# Options:
+#   --brief   Output only branch and uncommitted changes (for hooks)
+
+set -e
+
+BRIEF_MODE=false
+if [[ "$1" == "--brief" ]]; then
+    BRIEF_MODE=true
+fi
+
+# Check if we're in a git repository
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+    echo "Not a git repository"
+    exit 0
+fi
+
+# Get current branch
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if [[ -z "$CURRENT_BRANCH" ]]; then
+    # Detached HEAD state
+    CURRENT_BRANCH="(detached HEAD at $(git rev-parse --short HEAD 2>/dev/null || echo 'unknown'))"
+fi
+
+# Count uncommitted changes (staged + unstaged + untracked)
+UNCOMMITTED_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+
+# Brief mode: just branch and changes
+if [[ "$BRIEF_MODE" == "true" ]]; then
+    echo "## Git Context"
+    echo "- **Branch**: $CURRENT_BRANCH"
+    echo "- **Uncommitted changes**: $UNCOMMITTED_COUNT file(s)"
+    exit 0
+fi
+
+# Full output
+echo "## Git Context"
+echo ""
+echo "**Branch**: \`$CURRENT_BRANCH\`"
+echo ""
+echo "**Uncommitted changes**: $UNCOMMITTED_COUNT file(s)"
+
+# Show brief status if there are changes
+if [[ "$UNCOMMITTED_COUNT" -gt 0 ]]; then
+    echo ""
+    echo "**Changed files**:"
+    # Show first 10 files max
+    git status --porcelain 2>/dev/null | head -10 | while read -r line; do
+        STATUS="${line:0:2}"
+        FILE="${line:3}"
+        case "$STATUS" in
+            "M "| " M"|"MM") echo "  - Modified: \`$FILE\`" ;;
+            "A ") echo "  - Added: \`$FILE\`" ;;
+            "D "| " D") echo "  - Deleted: \`$FILE\`" ;;
+            "R ") echo "  - Renamed: \`$FILE\`" ;;
+            "??") echo "  - Untracked: \`$FILE\`" ;;
+            *) echo "  - Changed: \`$FILE\`" ;;
+        esac
+    done
+    TOTAL=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$TOTAL" -gt 10 ]]; then
+        echo "  - ... and $((TOTAL - 10)) more"
+    fi
+fi
+
+# Recent commits (last 5)
+echo ""
+echo "**Recent commits**:"
+git log --oneline -5 2>/dev/null | while read -r line; do
+    echo "  - \`$line\`"
+done
+
+# Detect main branch (main or master)
+MAIN_BRANCH=""
+if git show-ref --verify --quiet refs/heads/main 2>/dev/null; then
+    MAIN_BRANCH="main"
+elif git show-ref --verify --quiet refs/heads/master 2>/dev/null; then
+    MAIN_BRANCH="master"
+fi
+
+# Summary of changes from main (if on feature branch)
+if [[ -n "$MAIN_BRANCH" && "$CURRENT_BRANCH" != "$MAIN_BRANCH" && "$CURRENT_BRANCH" != "(detached"* ]]; then
+    # Count commits ahead of main
+    COMMITS_AHEAD=$(git rev-list --count "$MAIN_BRANCH..$CURRENT_BRANCH" 2>/dev/null || echo "0")
+    COMMITS_BEHIND=$(git rev-list --count "$CURRENT_BRANCH..$MAIN_BRANCH" 2>/dev/null || echo "0")
+
+    echo ""
+    echo "**Relative to \`$MAIN_BRANCH\`**:"
+    echo "  - $COMMITS_AHEAD commit(s) ahead"
+    echo "  - $COMMITS_BEHIND commit(s) behind"
+
+    # Files changed from main
+    if [[ "$COMMITS_AHEAD" -gt 0 ]]; then
+        FILES_CHANGED=$(git diff --name-only "$MAIN_BRANCH...$CURRENT_BRANCH" 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "$FILES_CHANGED" -gt 0 ]]; then
+            echo "  - $FILES_CHANGED file(s) changed from \`$MAIN_BRANCH\`"
+        fi
+    fi
+fi

--- a/dist/opencode/skill/orchestration/scripts/list-session-decisions.sh
+++ b/dist/opencode/skill/orchestration/scripts/list-session-decisions.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# List available session decision memories from Serena.
+#
+# Usage: list-session-decisions.sh
+#
+# This script lists Serena memories matching the pattern session-*-decisions.md
+# and displays session name and metadata.
+#
+# Note: This is a helper script. In practice, agents should use Serena MCP
+# directly via mcp__serena__list_memories() for programmatic access.
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Session Decision Memories${NC}"
+echo "========================="
+echo ""
+
+# Check if .serena directory exists
+if [[ ! -d ".serena" ]]; then
+    echo -e "${YELLOW}No .serena directory found in current project.${NC}"
+    echo "Serena memories are stored per-project. Make sure you're in a Serena-enabled project."
+    exit 0
+fi
+
+# Check for memories directory
+MEMORIES_DIR=".serena/memories"
+if [[ ! -d "$MEMORIES_DIR" ]]; then
+    echo -e "${YELLOW}No memories directory found.${NC}"
+    echo "No session decisions have been extracted yet."
+    echo ""
+    echo "To extract decisions from a session:"
+    echo "  python3 extract-decisions.py <session-file>"
+    echo "  Then use Serena MCP to write the memory."
+    exit 0
+fi
+
+# Find session decision memories
+MEMORIES=$(find "$MEMORIES_DIR" -name "session-*-decisions.md" 2>/dev/null | sort -r)
+
+if [[ -z "$MEMORIES" ]]; then
+    echo -e "${YELLOW}No session decision memories found.${NC}"
+    echo ""
+    echo "Session decision memories are created when sessions are archived."
+    echo "Pattern: session-<slug>-decisions.md"
+    exit 0
+fi
+
+# Display memories
+count=0
+echo -e "${GREEN}Available Decision Memories:${NC}"
+echo ""
+
+for memory in $MEMORIES; do
+    count=$((count + 1))
+    filename=$(basename "$memory")
+
+    # Extract slug from filename
+    slug=$(echo "$filename" | sed 's/^session-//' | sed 's/-decisions\.md$//')
+
+    # Try to read session info from memory content
+    if [[ -f "$memory" ]]; then
+        session_name=$(grep -m1 "^\- \*\*Session\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "Unknown")
+        archived=$(grep -m1 "^\- \*\*Archived\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "Unknown")
+        linear=$(grep -m1 "^\- \*\*Linear Issue\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "N/A")
+        decision_count=$(grep -c "^### Decision" "$memory" 2>/dev/null || echo "0")
+
+        printf "  %2d. %s\n" "$count" "$slug"
+        printf "      Session:  %s\n" "$session_name"
+        printf "      Archived: %s\n" "$archived"
+        printf "      Linear:   %s\n" "$linear"
+        printf "      Decisions: %s\n" "$decision_count"
+        echo ""
+    else
+        printf "  %2d. %s (unreadable)\n" "$count" "$filename"
+    fi
+done
+
+echo "------------------------"
+echo "Total: $count decision memories"
+echo ""
+echo -e "${BLUE}Usage:${NC}"
+echo "  /reference-session <search-term>    # Import decisions to current session"
+echo "  mcp__serena__read_memory(name=...)  # Read memory directly via MCP"

--- a/dist/opencode/skill/orchestration/scripts/validate-session.py
+++ b/dist/opencode/skill/orchestration/scripts/validate-session.py
@@ -60,7 +60,7 @@ def validate_frontmatter(fm: dict) -> list[str]:
             errors.append(f"Empty required field: session.{field}")
 
     # Validate status values
-    valid_statuses = ['in_progress', 'paused', 'completed']
+    valid_statuses = ['in_progress', 'paused', 'completed', 'archived']
     if session.get('status') and session['status'] not in valid_statuses:
         errors.append(f"Invalid session.status: {session['status']} (must be one of: {', '.join(valid_statuses)})")
 
@@ -72,6 +72,20 @@ def validate_frontmatter(fm: dict) -> list[str]:
                 datetime.fromisoformat(value.replace('Z', '+00:00'))
             except ValueError:
                 errors.append(f"Invalid ISO 8601 timestamp in session.{field}: {value}")
+
+    # Validate branch field format if present (optional field)
+    branch = session.get('branch', '')
+    if branch:
+        # Branch names should be non-empty strings without spaces
+        # Common formats: feature/name, username/ticket-desc, bugfix/name, etc.
+        if not isinstance(branch, str):
+            errors.append(f"Invalid session.branch: must be a string, got {type(branch).__name__}")
+        elif ' ' in branch:
+            errors.append(f"Invalid session.branch: '{branch}' contains spaces (branch names cannot have spaces)")
+        elif branch.startswith('/') or branch.endswith('/'):
+            errors.append(f"Invalid session.branch: '{branch}' cannot start or end with '/'")
+        elif '//' in branch:
+            errors.append(f"Invalid session.branch: '{branch}' contains consecutive slashes")
 
     # Check orchestration block
     orch = fm.get('orchestration', {})

--- a/dist/opencode/skill/research/SKILL.md
+++ b/dist/opencode/skill/research/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: research
+description: >-
+  Use for project reflection, brainstorming, and vision evolution. Covers
+  assessing project state, exploring problem spaces, generating ideas, and
+  evolving strategic direction. Activate when stepping back to think,
+  researching topics, or updating VISION.md.
+---
+
+# Research
+
+Patterns for zooming out, brainstorming, and evolving project direction.
+
+## Philosophy
+
+**Research is about understanding before doing.**
+
+Research activities:
+1. Assess project state and lessons learned
+2. Explore problem spaces with structured inquiry
+3. Generate and refine ideas through brainstorming
+4. Evolve strategic direction when evidence supports it
+
+Research is NOT about:
+- Implementing solutions
+- Making tactical decisions
+- Writing code or specifications
+
+## Quick Reference
+
+| Need | Action |
+|------|--------|
+| Understand project state | Review sessions, docs, recent changes |
+| Explore a topic | Structured inquiry with confidence hierarchy |
+| Generate ideas | Brainstorm with interview and synthesis |
+| Evolve VISION | Propose changes with evidence |
+
+## Research Modes
+
+### Mode 1: Project State Assessment
+
+**Trigger:** "What's the current state?" / "Catch me up"
+
+**Process:**
+1. Read existing docs (VISION, ARCHITECTURE, REQUIREMENTS)
+2. Check recent sessions for lessons learned
+3. Review recent commits for context
+4. Identify gaps, contradictions, or stale information
+5. Summarize current state with recommendations
+
+**Output:** State assessment with actionable insights
+
+### Mode 2: Topic Exploration
+
+**Trigger:** "Research X" / "How should we approach Y?"
+
+**Process:**
+1. Interview user to understand the question deeply
+2. Apply confidence hierarchy for sources
+3. Synthesize findings with tradeoffs
+4. Present options with recommendations
+
+**Output:** Research findings with options and recommendation
+
+### Mode 3: Brainstorming
+
+**Trigger:** "Let's brainstorm" / "Ideas for X"
+
+**Process:**
+1. Interview to understand constraints and goals
+2. Generate diverse options (quantity over quality initially)
+3. Filter through constraints
+4. Refine promising directions
+5. Present shaped options for decision
+
+**Output:** Curated options with pros/cons
+
+### Mode 4: Vision Evolution
+
+**Trigger:** "Should we change direction?" / "Update VISION"
+
+**Process:**
+1. Gather evidence (sessions, feedback, market changes)
+2. Identify what's changed since last VISION update
+3. Propose specific changes with rationale
+4. Get user approval before any edits
+
+**Output:** VISION.md change proposal (not direct edit)
+
+## Confidence Hierarchy
+
+When researching, prioritize sources in this order:
+
+```
+1. Project context (highest confidence)
+   - VISION.md, ARCHITECTURE.md, REQUIREMENTS.md
+   - Session files and lessons learned
+   - Existing codebase patterns
+
+2. Authoritative documentation
+   - Context7 for library docs
+   - Official documentation sites
+   - RFCs and specifications
+
+3. Community knowledge
+   - Stack Overflow (verified answers)
+   - GitHub issues and discussions
+   - Blog posts from recognized experts
+
+4. General web (lowest confidence)
+   - Search results
+   - Forum posts
+   - Unverified sources
+```
+
+**Rule:** Always check project context first. External research should supplement, not replace, understanding of existing decisions.
+
+## Interview Patterns
+
+### Before Any Research
+
+Ask clarifying questions:
+
+| Area | Questions |
+|------|-----------|
+| Scope | What specifically are you trying to understand? |
+| Context | What do you already know? What have you tried? |
+| Constraints | What constraints should guide the research? |
+| Output | What decision will this research inform? |
+
+### For Topic Exploration
+
+```
+1. What problem are we trying to solve?
+2. What constraints exist (technical, time, team)?
+3. What would success look like?
+4. What have we already considered and rejected?
+5. Are there non-obvious angles to explore?
+```
+
+### For Brainstorming
+
+```
+1. What's the ideal outcome if constraints didn't exist?
+2. What's the minimum viable approach?
+3. What approaches have we seen work elsewhere?
+4. What would we do if we had 10x the resources? 1/10?
+5. What's the contrarian view?
+```
+
+## Output Formats
+
+### State Assessment
+
+```markdown
+## Project State Assessment
+
+**Date:** YYYY-MM-DD
+
+### Current Position
+- [Summary of where the project stands]
+
+### Recent Progress
+- [Key accomplishments from recent sessions]
+
+### Lessons Learned
+- [Insights from implementation feedback]
+
+### Open Questions
+- [Unresolved decisions or gaps]
+
+### Recommendations
+1. [Actionable next step]
+2. [Actionable next step]
+```
+
+### Research Findings
+
+```markdown
+## Research: [Topic]
+
+**Question:** [What we're trying to understand]
+
+### Summary
+[One-paragraph answer with confidence level]
+
+### Options Considered
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Best for:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Best for:** ...
+
+### Recommendation
+[Which option and why, with caveats]
+
+### Sources
+- [Source 1 with confidence level]
+- [Source 2 with confidence level]
+```
+
+### Vision Change Proposal
+
+```markdown
+## VISION.md Change Proposal
+
+**Proposed by:** [Session/Date]
+**Evidence:** [What prompted this]
+
+### Current State
+[Quote relevant VISION.md section]
+
+### Proposed Change
+[New text]
+
+### Rationale
+[Why this change is warranted]
+
+### Impact
+- [What this changes downstream]
+- [ADRs that may need updating]
+- [Requirements that may be affected]
+
+### Approval Required
+This proposal requires user approval before implementation.
+```
+
+## Integration with Workflow
+
+Research fits at the top of the product development hierarchy:
+
+```
+RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS
+    │         │
+    └─────────┘
+    evolves
+```
+
+**Research informs Vision changes.** Vision changes cascade down through Architecture, Requirements, and Specs.
+
+## When to Research
+
+| Situation | Research Mode |
+|-----------|---------------|
+| Starting new project | Project state + Topic exploration |
+| Stuck on approach | Topic exploration + Brainstorming |
+| Finishing major work | Project state (capture learnings) |
+| External change | Vision evolution |
+| Quarterly review | Project state + Vision evolution |
+
+## When NOT to Research
+
+- **When action is clear** - Don't research to avoid doing
+- **When already decided** - Check ADRs first
+- **When time-critical** - Act, then document learnings
+- **For trivial questions** - Just answer them
+
+## Critical Rules
+
+### Always
+- Interview before researching
+- Check project context first
+- Cite sources with confidence levels
+- Present options, let user decide
+- Get approval before editing VISION
+
+### Never
+- Edit VISION without explicit approval
+- Research indefinitely (set time bounds)
+- Ignore existing project decisions
+- Present research as implementation plan
+- Skip the interview step
+
+## Scripts
+
+| Script | Usage | Description |
+|--------|-------|-------------|
+| `check-sessions.sh` | Review recent sessions | Find lessons learned |
+| `git-context-summary.sh` | Summarize git history | Understand recent changes |
+
+## Related Skills
+
+- **orchestration** - For acting on research findings
+- **foundations** - For documentation standards

--- a/plugins/loaf/.claude-plugin/plugin.json
+++ b/plugins/loaf/.claude-plugin/plugin.json
@@ -17,11 +17,16 @@
     "./agents/qa.md"
   ],
   "commands": [
+    "./commands/architecture.md",
     "./commands/council-session.md",
+    "./commands/prd.md",
     "./commands/reference-session.md",
+    "./commands/research.md",
     "./commands/resume-session.md",
     "./commands/review-sessions.md",
-    "./commands/start-session.md"
+    "./commands/specs.md",
+    "./commands/start-session.md",
+    "./commands/tasks.md"
   ],
   "skills": [
     "./skills/database/SKILL.md",
@@ -33,6 +38,7 @@
     "./skills/orchestration/SKILL.md",
     "./skills/power-systems/SKILL.md",
     "./skills/python/SKILL.md",
+    "./skills/research/SKILL.md",
     "./skills/ruby/SKILL.md",
     "./skills/typescript/SKILL.md"
   ],

--- a/plugins/loaf/.claude-plugin/plugin.json
+++ b/plugins/loaf/.claude-plugin/plugin.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "agents": [
     "./agents/backend-dev.md",
+    "./agents/background-runner.md",
     "./agents/context-archiver.md",
     "./agents/dba.md",
     "./agents/design.md",
@@ -17,12 +18,14 @@
   ],
   "commands": [
     "./commands/council-session.md",
+    "./commands/reference-session.md",
     "./commands/resume-session.md",
     "./commands/review-sessions.md",
     "./commands/start-session.md"
   ],
   "skills": [
     "./skills/database/SKILL.md",
+    "./skills/debugging/SKILL.md",
     "./skills/design/SKILL.md",
     "./skills/foundations/SKILL.md",
     "./skills/go/SKILL.md",
@@ -55,6 +58,12 @@
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/foundations-format-check.sh",
             "timeout": 60000,
             "description": "Check code formatting"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/foundations-tdd-advisory.sh",
+            "timeout": 5000,
+            "description": "Advisory warning when editing implementation without tests"
           },
           {
             "type": "command",

--- a/plugins/loaf/agents/background-runner.md
+++ b/plugins/loaf/agents/background-runner.md
@@ -1,0 +1,168 @@
+---
+name: background-runner
+description: >-
+  Lightweight background agent for non-interactive tasks. Use with
+  run_in_background: true for security audits, coverage analysis, code reviews,
+  and other low-priority work.
+model: haiku
+skills:
+  - foundations
+tools:
+  - Read
+  - Edit
+  - Glob
+  - Grep
+---
+# Background Runner
+
+You execute specific tasks in the background, writing results to a specified location without user interaction.
+
+## When You Run
+
+- Spawned by PM/orchestrator with `run_in_background: true`
+- For low-priority, non-interactive work
+- Results expected later, not immediately
+
+## What You Do
+
+1. **Execute assigned task** - Security audits, coverage analysis, code reviews, etc.
+2. **Write results** - Output to specified `.agents/reports/` location
+3. **Update session** - Mark your background agent entry as complete
+
+## Input You Receive
+
+The spawning agent provides:
+- Specific task to execute
+- Files or scope to analyze
+- Output location (`.agents/reports/YYYYMMDD-HHMMSS-<name>.md`)
+- Session reference
+
+## Execution Process
+
+### 1. Parse Task
+
+Extract from prompt:
+- What to do (audit, analyze, review)
+- Scope (files, directories)
+- Output location
+- Session file path
+
+### 2. Execute Work
+
+Perform the assigned task:
+- Read specified files
+- Run analysis
+- Generate findings
+- Compile report
+
+### 3. Write Report
+
+Create report at specified location:
+
+```yaml
+---
+report:
+  title: "Task Description"
+  type: background-agent-output
+  status: unprocessed
+  created: "2026-01-23T14:30:00Z"
+  background_agent_id: "bg-YYYYMMDD-HHMMSS-description"
+  session_reference: "YYYYMMDD-HHMMSS-session-name.md"
+---
+
+# Report Title
+
+## Summary
+
+Brief overview of findings.
+
+## Findings
+
+### Finding 1: Title
+**Severity**: High | Medium | Low | Info
+**Location**: `path/to/file.py:123`
+**Description**: What was found
+**Recommendation**: What to do
+
+## Recommendations
+
+Prioritized list of actions.
+
+## Files Analyzed
+
+- `path/to/file1.py`
+- `path/to/file2.py`
+```
+
+### 4. Update Session Frontmatter
+
+Read session file and update your background agent entry:
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: completed  # Changed from running
+    result_location: ".agents/reports/20260123-143000-security.md"  # Set path
+```
+
+## Constraints
+
+- **No user interaction** - You cannot ask questions or request clarification
+- **No blocking work** - Complete task with available information
+- **No spawning agents** - Work independently
+- **Write to specified location** - Do not create files elsewhere
+
+## Quality Checklist
+
+Before completing:
+
+- [ ] Task executed per prompt instructions
+- [ ] Report written to specified location
+- [ ] Report has valid frontmatter with `background_agent_id`
+- [ ] Session frontmatter updated with `status: completed`
+- [ ] Session frontmatter updated with `result_location`
+- [ ] No user interaction attempted
+
+## Error Handling
+
+If task cannot be completed:
+
+1. Write partial report with what was accomplished
+2. Document blockers in report
+3. Update session frontmatter with `status: failed`
+4. Include error details in report
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: failed
+    result_location: ".agents/reports/20260123-143000-security-partial.md"
+```
+
+## Example Task
+
+**Prompt received:**
+```
+Run security audit on auth module.
+
+Files:
+- src/auth/endpoints.py
+- src/auth/token.py
+
+Check for OWASP Top 10 vulnerabilities.
+
+Write report to: .agents/reports/20260123-143000-auth-security.md
+
+Session: .agents/sessions/20260123-140000-auth-feature.md
+Background Agent ID: bg-20260123-143000-auth-security
+```
+
+**Actions:**
+1. Read `src/auth/endpoints.py` and `src/auth/token.py`
+2. Analyze for OWASP vulnerabilities
+3. Write findings to `.agents/reports/20260123-143000-auth-security.md`
+4. Update `.agents/sessions/20260123-140000-auth-feature.md` frontmatter

--- a/plugins/loaf/agents/context-archiver.md
+++ b/plugins/loaf/agents/context-archiver.md
@@ -109,13 +109,66 @@ The agent resuming work should:
 Pre-compaction archive. Preserved: [brief summary of what was captured].
 ```
 
-## Serena Memory (Optional)
+## Serena Memory for Decisions
 
-Write memory ONLY when session has significant decisions:
+Write decision memory when session has significant decisions for cross-session reference.
 
-- Check if `## Decisions` section has content
-- If yes, write to `session-{session-slug}-decisions.md`
-- Include decision rationale and context
+### 5. Extract and Store Decisions
+
+Check if `## Decisions` section has content. If yes:
+
+**Step A: Extract decisions using the extraction script**
+
+```bash
+python3 plugins/loaf/skills/orchestration/scripts/extract-decisions.py \
+  ".agents/sessions/<session-file>.md"
+```
+
+This outputs formatted memory content to stdout and the memory name to stderr.
+
+**Step B: Write to Serena memory**
+
+Use Serena MCP to store the extracted decisions:
+
+```python
+mcp__serena__write_memory(
+    name="session-<slug>-decisions.md",
+    content=<extracted_content>
+)
+```
+
+**Memory naming convention:**
+- Session: `20250123-100000-auth-feature.md`
+- Memory: `session-auth-feature-decisions.md`
+
+**Memory format:**
+
+```markdown
+# Memory: session-auth-feature-decisions.md
+
+## Session Context
+- **Session**: 20250123-100000-auth-feature.md
+- **Title**: Auth Feature Implementation
+- **Archived**: 2025-01-23T14:30:00Z
+- **Linear Issue**: PLT-123
+
+## Key Decisions
+
+### Decision 1: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window
+**Rationale**: Balance between security and user experience
+**Council**: None - backend-dev recommendation accepted
+
+### Decision 2: Refresh Token Storage
+**Decision**: Store in HttpOnly cookies, not localStorage
+**Rationale**: Prevents XSS token theft
+**Council**: Security council (5 agents) - unanimous
+```
+
+**Why store decisions:**
+- Enables `/reference-session` command for cross-session continuity
+- Preserves decision rationale for future work
+- Avoids re-deliberating already-resolved questions
 
 ## Output
 
@@ -144,4 +197,5 @@ Before completing:
 - [ ] `## Resumption Prompt` provides self-contained context
 - [ ] `## Resumption Prompt` includes Transcript Archive instruction
 - [ ] `## Session Log` has timestamped entry
-- [ ] Serena memory written if decisions exist
+- [ ] Decisions extracted and written to Serena memory (if `## Decisions` has content)
+- [ ] Memory name follows convention: `session-<slug>-decisions.md`

--- a/plugins/loaf/agents/qa.md
+++ b/plugins/loaf/agents/qa.md
@@ -31,6 +31,7 @@ You are a QA engineer. Your skills tell you how to test and review code.
 - Check for OWASP Top 10 issues
 - Verify type safety and linting passes
 - Audit test coverage
+- Debug failing tests and diagnose flaky tests
 
 ## How You Work
 
@@ -38,5 +39,17 @@ You are a QA engineer. Your skills tell you how to test and review code.
 2. **Match project style** - follow existing test patterns
 3. **Test behavior, not implementation** - tests should survive refactors
 4. **Run full suite** - all tests must pass before completing
+5. **Debug systematically** - use hypothesis-driven debugging for failures
+
+## Debugging Workflow
+
+When investigating test failures or bugs:
+
+1. **Reproduce** - Establish reliable reproduction steps
+2. **Hypothesize** - Generate 3-5 possible causes, rank by likelihood
+3. **Test** - Design minimal experiments to confirm or rule out each hypothesis
+4. **Document** - Track hypotheses and evidence in investigation log
+
+See the `debugging` skill for hypothesis tracking templates and language-specific debugging patterns.
 
 Your skills contain all the patterns and conventions. Reference them.

--- a/plugins/loaf/commands/architecture.md
+++ b/plugins/loaf/commands/architecture.md
@@ -1,0 +1,261 @@
+---
+description: Make technical decisions and create Architecture Decision Records
+version: 1.11.0
+---
+
+# Architecture Command
+
+Interview about technical decisions, update ARCHITECTURE.md, create ADRs.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Technical decisions should be:
+1. **Deliberate** - Made consciously, not by accident
+2. **Documented** - Captured in ARCHITECTURE.md and ADRs
+3. **Traceable** - Future readers understand why
+
+---
+
+## CRITICAL: Interview First
+
+**Before making any architectural decision, understand:**
+
+1. What decision needs to be made?
+2. What constraints exist (technical, business, team)?
+3. What options have already been considered?
+4. What would "good enough" look like vs "ideal"?
+5. What's the impact of getting this wrong?
+
+Use `AskUserQuestion` to gather context.
+
+---
+
+## Process
+
+### Step 1: Understand the Decision
+
+Parse `$ARGUMENTS` to understand what decision is needed.
+
+**If unclear:** Ask clarifying questions about:
+- The problem being solved
+- Technical constraints
+- Business constraints
+- Time/resource constraints
+
+### Step 2: Gather Context
+
+1. **Read existing documents:**
+   - `docs/VISION.md` - Strategic direction
+   - `docs/ARCHITECTURE.md` - Current technical design
+   - `docs/decisions/ADR-*.md` - Previous decisions
+
+2. **Check for relevant patterns:**
+   - How similar problems were solved
+   - Established conventions in the codebase
+   - Previous attempts and outcomes
+
+3. **Review session history:**
+   - Implementation learnings
+   - Pain points from previous work
+
+### Step 3: Consider Options
+
+For each viable option:
+
+| Aspect | Evaluate |
+|--------|----------|
+| Alignment | Does it fit VISION and existing ARCHITECTURE? |
+| Complexity | How much does it add to the system? |
+| Reversibility | How hard to change later? |
+| Team capability | Can the team execute this? |
+| Maintenance | Long-term cost? |
+
+### Step 4: Convene Council (If Needed)
+
+For complex or contentious decisions, convene a council:
+
+- **Odd number:** 5 or 7 agents
+- **Diverse expertise:** Mix of perspectives
+- **Structured deliberation:** Each argues a position
+
+See `orchestration/councils` skill for council workflow.
+
+**Council advises, user decides.**
+
+### Step 5: Present Options
+
+Format:
+
+```markdown
+## Decision: [Question]
+
+### Context
+[Why this decision is needed now]
+
+### Options
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Fits when:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Fits when:** ...
+
+### Recommendation
+[Which option and why]
+
+### What do you think?
+```
+
+### Step 6: Await User Decision
+
+**Do NOT proceed without explicit user choice.**
+
+User may:
+- Accept a recommendation
+- Choose a different option
+- Ask for more information
+- Request a council deliberation
+
+### Step 7: Document the Decision
+
+After user decides:
+
+1. **Update ARCHITECTURE.md** with new decision
+2. **Create ADR** in `docs/decisions/`
+
+---
+
+## ADR Format
+
+**Filename:** `ADR-{number}-{slug}.md`
+
+```yaml
+---
+id: ADR-001
+title: "PostgreSQL as Primary Database"
+status: Accepted  # Proposed | Accepted | Deprecated | Superseded
+date: 2026-01-23
+supersedes: null  # ADR-000 if replacing
+superseded_by: null  # ADR-002 if replaced
+---
+
+# ADR-001: PostgreSQL as Primary Database
+
+## Context
+
+[Why this decision was needed. What problem we faced.]
+
+## Decision
+
+[What we decided. Be specific and unambiguous.]
+
+## Consequences
+
+### Positive
+- [Benefit 1]
+- [Benefit 2]
+
+### Negative
+- [Tradeoff 1]
+- [Tradeoff 2]
+
+### Neutral
+- [Implication that's neither good nor bad]
+
+## Alternatives Considered
+
+### [Alternative 1]
+[Why it was rejected]
+
+### [Alternative 2]
+[Why it was rejected]
+```
+
+---
+
+## ADR Numbering
+
+Find next available number:
+
+```bash
+ls docs/decisions/ADR-*.md 2>/dev/null | \
+  grep -oE 'ADR-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+If no ADRs exist, start with `ADR-001`.
+
+---
+
+## ARCHITECTURE.md Updates
+
+When updating ARCHITECTURE.md:
+
+1. **Find relevant section** or create new one
+2. **Add decision** with reference to ADR
+3. **Keep it current** - Remove outdated information
+
+Example addition:
+
+```markdown
+## Data Storage
+
+We use **PostgreSQL** as our primary database (see [ADR-001](decisions/ADR-001-postgresql.md)).
+
+Key decisions:
+- Single database for simplicity
+- Connection pooling via PgBouncer
+- Read replicas for reporting queries
+```
+
+---
+
+## Decision Types
+
+| Type | Scope | ADR Required? |
+|------|-------|---------------|
+| Strategic | System-wide, hard to reverse | Yes |
+| Tactical | Component-level, reversible | Optional |
+| Trivial | No significant impact | No |
+
+**When in doubt, create an ADR.** Future you will thank you.
+
+---
+
+## Guardrails
+
+1. **Interview first** - Understand the full context
+2. **Check existing decisions** - Don't contradict without superseding
+3. **Present options** - User decides, not you
+4. **Document thoroughly** - ADRs explain the "why"
+5. **Keep ARCHITECTURE.md current** - Update, don't just append
+
+---
+
+## Council Trigger Conditions
+
+Consider convening a council when:
+
+- Decision affects multiple domains (backend + frontend + infra)
+- Team has conflicting opinions
+- High cost of reversal
+- Novel problem without established patterns
+- User explicitly requests deliberation
+
+---
+
+## Related Skills
+
+- **orchestration/councils** - Council deliberation workflow
+- **orchestration/product-development** - Where architecture fits in hierarchy
+- **foundations** - Documentation standards for ADRs

--- a/plugins/loaf/commands/prd.md
+++ b/plugins/loaf/commands/prd.md
@@ -1,0 +1,292 @@
+---
+description: Discover product requirements and update REQUIREMENTS.md
+version: 1.11.0
+---
+
+# PRD Command
+
+Interview to discover product requirements, update REQUIREMENTS.md.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Requirements capture **what** the product must do, not **how**.
+
+Good requirements are:
+- **User-focused** - Written from user perspective
+- **Testable** - Clear acceptance criteria
+- **Organized** - Grouped by domain
+- **Complete** - Cover edge cases and business rules
+
+---
+
+## CRITICAL: Interview First
+
+**Before writing any requirements, understand:**
+
+1. What feature area are we defining?
+2. Who are the users affected?
+3. What business rules apply?
+4. What edge cases exist?
+5. What's explicitly out of scope?
+
+Use `AskUserQuestion` with non-obvious questions.
+
+---
+
+## Process
+
+### Step 1: Parse Input
+
+`$ARGUMENTS` should indicate the feature area or requirement section.
+
+Examples:
+- "user authentication"
+- "section 2.1"
+- "payment processing"
+
+**If unclear:** Ask what feature area to define.
+
+### Step 2: Gather Context
+
+1. **Read VISION.md** - Strategic direction constrains requirements
+2. **Read ARCHITECTURE.md** - Technical constraints
+3. **Read existing REQUIREMENTS.md** - Don't duplicate
+
+### Step 3: Interview with Non-Obvious Questions
+
+Ask questions the user might not have considered:
+
+| Category | Example Questions |
+|----------|-------------------|
+| Edge cases | "What happens if the user closes the browser mid-flow?" |
+| Business rules | "Are there rate limits? Time-based restrictions?" |
+| Persona conflicts | "How do admin users differ from regular users here?" |
+| Failure modes | "What's the graceful degradation if this fails?" |
+| Compliance | "Any audit logging requirements?" |
+| Scale | "Expected volume? Concurrent users?" |
+
+**Interview structure:**
+```
+1. Start with obvious questions to confirm understanding
+2. Move to edge cases
+3. Explore business rule conflicts
+4. Check compliance/security needs
+5. Confirm scope boundaries
+```
+
+### Step 4: Draft Requirements Section
+
+Format:
+
+```markdown
+## [Number]. [Domain Name]
+
+### [Number].[SubNumber] [Feature Name]
+
+**Business Rules**
+- [Rule 1]
+- [Rule 2]
+
+**User Stories**
+As a [persona], I want to [action] so that [benefit].
+
+**Acceptance Criteria**
+- [ ] Given [context], when [action], then [outcome]
+- [ ] Given [context], when [action], then [outcome]
+
+**Edge Cases**
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| [Edge case] | [How system responds] |
+
+**Out of Scope**
+- [Explicitly excluded item]
+```
+
+### Step 5: Present for Approval
+
+Show the drafted section to the user:
+
+```markdown
+## Proposed Addition to REQUIREMENTS.md
+
+[Draft section]
+
+---
+
+**Questions before adding:**
+1. Are these business rules accurate?
+2. Any missing acceptance criteria?
+3. Should anything be out of scope?
+```
+
+### Step 6: Await Approval
+
+**Do NOT update REQUIREMENTS.md without explicit approval.**
+
+User may:
+- Approve as-is
+- Request changes
+- Add missing requirements
+- Move items to out of scope
+
+### Step 7: Update REQUIREMENTS.md
+
+After approval:
+1. Add new section to REQUIREMENTS.md
+2. Maintain consistent numbering
+3. Update table of contents if exists
+
+---
+
+## Requirements Format
+
+### File Structure
+
+```markdown
+# Requirements
+
+## 1. Core Platform
+
+### 1.1 Feature A
+...
+
+### 1.2 Feature B
+...
+
+## 2. Identity & Access
+
+### 2.1 User Authentication
+...
+
+### 2.2 Authorization
+...
+```
+
+### Section Template
+
+```markdown
+### 2.1 User Authentication
+
+**Business Rules**
+- Users authenticate via OAuth (Google, GitHub)
+- Sessions expire after 24 hours of inactivity
+- Failed login attempts are logged for security audit
+- Users can have at most 5 active sessions
+
+**User Stories**
+
+As a new user, I want to sign in with my existing Google account
+so that I don't need to create another password.
+
+As a returning user, I want my session to persist across browser tabs
+so that I can work in multiple windows.
+
+**Acceptance Criteria**
+- [ ] Given a new user, when they click "Sign in with Google", then they are redirected to Google OAuth
+- [ ] Given valid Google credentials, when OAuth completes, then user is logged in and redirected to dashboard
+- [ ] Given an existing session, when user opens new tab, then they remain logged in
+- [ ] Given 24 hours of inactivity, when user returns, then they must re-authenticate
+- [ ] Given a logged-in user, when they click logout, then all session data is cleared
+
+**Edge Cases**
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| OAuth provider unavailable | Show friendly error, suggest trying later |
+| User revokes OAuth access | Invalidate session on next request |
+| Multiple accounts same email | Prevent duplicate accounts, suggest login |
+| Session cookie deleted | Redirect to login on next request |
+
+**Out of Scope**
+- Password-based authentication (security/maintenance burden)
+- Apple/Microsoft OAuth (future consideration)
+- MFA (separate feature area)
+```
+
+---
+
+## Acceptance Criteria Format
+
+Use Given-When-Then:
+
+```markdown
+Given [precondition/context],
+when [action is performed],
+then [expected outcome].
+```
+
+**Good criteria are:**
+- Specific and testable
+- Single behavior per criterion
+- Observable outcome (not internal state)
+- User-focused language
+
+**Bad criteria:**
+```markdown
+- Login should be fast  # Not measurable
+- Data should be correct  # Too vague
+- System should handle errors  # No specific behavior
+```
+
+**Good criteria:**
+```markdown
+- [ ] Given valid credentials, when login submitted, then dashboard loads within 2 seconds
+- [ ] Given invalid email format, when login attempted, then "Invalid email" error shown
+- [ ] Given network failure during OAuth, when callback fails, then retry prompt displayed
+```
+
+---
+
+## Numbering Convention
+
+```
+[Major].[Minor] [Feature Name]
+
+1. Core Platform
+   1.1 Dashboard
+   1.2 Navigation
+
+2. Identity & Access
+   2.1 User Authentication
+   2.2 Role-Based Access
+```
+
+When adding new sections:
+- Check existing numbers
+- Insert at appropriate position
+- Update subsequent numbers if needed
+
+---
+
+## Guardrails
+
+1. **Interview deeply** - Ask non-obvious questions
+2. **Check constraints** - VISION and ARCHITECTURE bound requirements
+3. **Write testable criteria** - Given-When-Then format
+4. **Document edge cases** - What could go wrong?
+5. **Explicit out of scope** - Prevent scope creep
+6. **Get approval** - Don't update without user confirmation
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Requirements describe HOW | Focus on WHAT, leave HOW to specs |
+| Missing edge cases | Interview for failure modes |
+| Vague criteria | Use Given-When-Then |
+| No out of scope | Explicitly list exclusions |
+| Conflicting rules | Resolve before adding |
+
+---
+
+## Related Skills
+
+- **orchestration/product-development** - Where requirements fit in hierarchy
+- **orchestration/specs** - Breaking requirements into specifications
+- **foundations** - Documentation standards

--- a/plugins/loaf/commands/reference-session.md
+++ b/plugins/loaf/commands/reference-session.md
@@ -1,0 +1,236 @@
+---
+description: Import decisions from past sessions without full context duplication
+version: 1.11.0
+---
+
+# Reference Session
+
+Import context from past sessions into current work. This command helps maintain continuity across sessions without duplicating full context.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` for:
+- **Search term**: Session name fragment, Linear issue ID, or topic keyword
+- **Content type** (optional): `decisions`, `context`, or `all` (default: `decisions`)
+
+```
+/reference-session auth              # Search for "auth" sessions, import decisions
+/reference-session auth decisions    # Explicit: import decisions only
+/reference-session auth context      # Import full context summary
+/reference-session PLT-123           # Search by Linear issue
+```
+
+If no arguments provided, list recent decision memories:
+
+```
+/reference-session                   # List available session decisions
+```
+
+---
+
+## Step 2: Search for Matching Sessions
+
+### Option A: List Serena Memories
+
+Use Serena MCP to list available decision memories:
+
+```
+mcp__serena__list_memories()
+```
+
+Filter for memories matching pattern: `session-*-decisions.md`
+
+### Option B: Search Session Archives
+
+If no matching memories found, search archived sessions:
+
+```
+.agents/sessions/archive/*<search-term>*.md
+```
+
+---
+
+## Step 3: Display Matches
+
+Present matching sessions/memories:
+
+```markdown
+## Matching Session Decisions
+
+| Session | Archived | Linear | Decisions |
+|---------|----------|--------|-----------|
+| 20250115-140000-auth-jwt | 2025-01-15 | PLT-123 | 3 decisions |
+| 20250110-090000-auth-oauth | 2025-01-10 | PLT-100 | 2 decisions |
+
+Select a session number to import, or 'all' for multiple:
+```
+
+If single match, proceed directly to Step 4.
+
+---
+
+## Step 4: Read Decision Memory
+
+For selected session(s), read the decision memory:
+
+```
+mcp__serena__read_memory(name="session-<slug>-decisions.md")
+```
+
+If memory doesn't exist but session file does, run extraction:
+
+```bash
+python3 src/skills/orchestration/scripts/extract-decisions.py \
+  ".agents/sessions/archive/<session-file>.md"
+```
+
+---
+
+## Step 5: Import into Current Session
+
+If an active session exists (`.agents/sessions/` has `in_progress` files):
+
+### Update Session Frontmatter
+
+Add to the active session's frontmatter:
+
+```yaml
+session:
+  # ... existing fields ...
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"
+      imported_at: "2025-01-23T14:30:00Z"
+      content_type: decisions
+      decisions_imported:
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+```
+
+### Add Reference Section
+
+If importing decisions, add to session body:
+
+```markdown
+## Referenced Decisions
+
+### From: 20250115-140000-auth-jwt.md
+
+#### Decision: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window
+**Rationale**: Balance between security and user experience
+**Context**: Authentication service design
+
+#### Decision: Refresh Token Storage
+**Decision**: Store in HttpOnly cookie, not localStorage
+**Rationale**: Prevents XSS token theft
+**Context**: Frontend security consideration
+
+---
+```
+
+---
+
+## Step 6: Report Import
+
+Confirm what was imported:
+
+```markdown
+## Session Reference Complete
+
+**Imported from**: 20250115-140000-auth-jwt.md
+**Content type**: decisions
+**Decisions imported**: 3
+
+### Summary
+
+1. **JWT Token Rotation Strategy** - Rotate every 15 minutes
+2. **Refresh Token Storage** - HttpOnly cookies
+3. **Token Validation Flow** - Validate signature before claims
+
+These decisions are now tracked in the current session's frontmatter
+under `referenced_sessions`.
+
+**Current session updated**: .agents/sessions/20250123-100000-auth-v2.md
+```
+
+---
+
+## No Active Session
+
+If no active session exists, display the decisions without updating any file:
+
+```markdown
+## Decisions from: 20250115-140000-auth-jwt.md
+
+[Display decision content]
+
+**Note**: No active session to update. Start a session first with
+`/start-session` to track this reference.
+```
+
+---
+
+## Content Types
+
+### `decisions` (default)
+
+Imports only the `## Decisions` section formatted as memory:
+- Decision name
+- What was decided
+- Rationale
+- Council outcome (if applicable)
+
+### `context`
+
+Imports session context summary:
+- Problem statement
+- Technical approach
+- Key files involved
+- Final outcome
+
+### `all`
+
+Imports both decisions and context.
+
+---
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Import full session files | Import only decisions/summaries |
+| Import without tracking | Always update `referenced_sessions` |
+| Import from unrelated sessions | Search by topic or Linear issue |
+| Import during exploration | Import when decisions are relevant |
+
+---
+
+## Error Handling
+
+### No matches found
+
+```
+No sessions found matching "auth-v3"
+
+Try:
+- Different search terms
+- Check .agents/sessions/archive/ directly
+- List all: /reference-session
+```
+
+### Memory not found
+
+```
+Decision memory not found for session 20250115-140000-auth-jwt.md
+
+Would you like to extract decisions now? This will:
+1. Read the archived session file
+2. Extract the Decisions section
+3. Create a Serena memory for future use
+
+[y/n]
+```

--- a/plugins/loaf/commands/research.md
+++ b/plugins/loaf/commands/research.md
@@ -1,0 +1,265 @@
+---
+description: 'Zoom out, brainstorm, assess project state, or evolve VISION'
+version: 1.11.0
+---
+
+# Research Command
+
+Step back from implementation to understand, explore, or brainstorm.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Mode Detection
+
+Parse the input to determine research mode:
+
+| Input Pattern | Mode | Action |
+|---------------|------|--------|
+| "project state" / "catch me up" / empty | State Assessment | Review docs, sessions, recent work |
+| Topic description | Topic Exploration | Structured inquiry |
+| "brainstorm" / "ideas for" | Brainstorming | Generate and refine options |
+| "evolve vision" / "update vision" | Vision Evolution | Propose VISION changes |
+
+---
+
+## CRITICAL: Interview First
+
+**Before any research, interview the user to understand:**
+
+1. What specifically are you trying to understand?
+2. What context do you already have?
+3. What constraints should guide this research?
+4. What decision will this inform?
+
+Use `AskUserQuestion` to gather this context.
+
+---
+
+## Mode 1: Project State Assessment
+
+**Trigger:** Empty input, "project state", "catch me up"
+
+### Steps
+
+1. **Read project documents:**
+   - `docs/VISION.md` (if exists)
+   - `docs/ARCHITECTURE.md` (if exists)
+   - `docs/REQUIREMENTS.md` (if exists)
+
+2. **Check recent sessions:**
+   - List `.agents/sessions/*.md`
+   - Read recent sessions for lessons learned
+   - Note any unresolved issues or blockers
+
+3. **Review recent commits:**
+   ```bash
+   git log --oneline -20
+   ```
+
+4. **Synthesize findings:**
+   - Current position
+   - Recent progress
+   - Lessons learned
+   - Open questions
+   - Recommendations
+
+5. **Present to user** with actionable next steps
+
+---
+
+## Mode 2: Topic Exploration
+
+**Trigger:** Specific topic or question
+
+### Steps
+
+1. **Interview** to understand the question deeply
+
+2. **Check project context first:**
+   - Existing decisions in `docs/decisions/ADR-*.md`
+   - Relevant sections in ARCHITECTURE.md
+   - Previous session discussions
+
+3. **Apply confidence hierarchy:**
+   ```
+   Project context > Context7 > Official docs > Community > Web
+   ```
+
+4. **For library/framework questions:**
+   - Use Context7 MCP to get authoritative documentation
+   - Cross-reference with official sources
+
+5. **Synthesize findings:**
+   - Summary with confidence level
+   - Options with tradeoffs
+   - Recommendation with rationale
+   - Sources cited
+
+6. **Present options** - Don't make the decision for the user
+
+---
+
+## Mode 3: Brainstorming
+
+**Trigger:** "brainstorm", "ideas for", creative exploration
+
+### Steps
+
+1. **Interview to establish bounds:**
+   - What's the ideal outcome?
+   - What constraints exist?
+   - What's been tried/rejected?
+
+2. **Generate diverse options:**
+   - Conventional approaches
+   - Unconventional approaches
+   - What if we had 10x resources?
+   - What if we had 1/10 resources?
+   - Contrarian view
+
+3. **Filter through constraints:**
+   - Technical feasibility
+   - Time/resource budget
+   - Alignment with VISION
+
+4. **Refine promising directions:**
+   - Shape the top 2-3 options
+   - Identify risks and mitigations
+
+5. **Present curated options** with pros/cons for decision
+
+---
+
+## Mode 4: Vision Evolution
+
+**Trigger:** "evolve vision", "update vision", evidence of needed change
+
+### Steps
+
+1. **Gather evidence:**
+   - What changed since last VISION update?
+   - Session learnings that contradict VISION
+   - External factors (market, technology, team)
+
+2. **Read current VISION.md**
+
+3. **Draft change proposal:**
+   ```markdown
+   ## VISION.md Change Proposal
+
+   **Evidence:** [What prompted this]
+
+   ### Current State
+   [Quote relevant section]
+
+   ### Proposed Change
+   [New text]
+
+   ### Rationale
+   [Why this is warranted]
+
+   ### Impact
+   - [Downstream effects]
+   ```
+
+4. **Present proposal to user**
+
+5. **WAIT FOR EXPLICIT APPROVAL**
+   - Do NOT edit VISION.md without approval
+   - User must explicitly confirm changes
+
+6. **If approved:** Edit VISION.md with approved changes
+
+---
+
+## Output Format
+
+### State Assessment
+
+```markdown
+## Project State Assessment
+
+**Date:** [Generated timestamp]
+
+### Current Position
+[Summary]
+
+### Recent Progress
+- [Accomplishment 1]
+- [Accomplishment 2]
+
+### Lessons Learned
+- [Insight 1]
+- [Insight 2]
+
+### Open Questions
+- [Question 1]
+- [Question 2]
+
+### Recommendations
+1. [Next step]
+2. [Next step]
+```
+
+### Research Findings
+
+```markdown
+## Research: [Topic]
+
+**Question:** [What we're investigating]
+
+### Summary
+[Answer with confidence level]
+
+### Options
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+
+### Recommendation
+[Which option and why]
+
+### Sources
+- [Source with confidence]
+```
+
+---
+
+## Guardrails
+
+1. **Always interview first** - Don't assume you understand the question
+2. **Check project context** - Respect existing decisions
+3. **Present options** - Don't make decisions for the user
+4. **Cite sources** - With confidence levels
+5. **Never edit VISION without approval** - Proposals only
+6. **Time-bound research** - Don't go down rabbit holes indefinitely
+
+---
+
+## Context7 Usage
+
+For library/framework questions, use Context7:
+
+```
+1. mcp__plugin_context7_context7__resolve-library-id
+   - Find the library ID
+
+2. mcp__plugin_context7_context7__query-docs
+   - Query specific documentation
+```
+
+This provides authoritative, up-to-date documentation.
+
+---
+
+## Related Skills
+
+- **research** - Full methodology for research modes
+- **orchestration/product-development** - Where research fits in workflow

--- a/plugins/loaf/commands/specs.md
+++ b/plugins/loaf/commands/specs.md
@@ -1,0 +1,278 @@
+---
+description: Create feature specifications from requirements
+version: 1.11.0
+---
+
+# Specs Command
+
+Break requirements into shaped, implementable specifications.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Specs define **shaped solutions** - bounded work with clear scope.
+
+A spec is:
+- **Shaped** - Direction, not blueprint
+- **Bounded** - Clear in/out of scope
+- **Testable** - Observable test conditions
+- **Appetite-driven** - Fixed time, variable scope
+
+See `orchestration/specs` reference for full spec methodology.
+
+---
+
+## CRITICAL: Interview First
+
+**Before writing a spec, clarify:**
+
+1. Which requirement section is this for?
+2. What's the appetite (time budget)?
+3. What scope trade-offs are acceptable?
+4. What are the "rabbit holes" to avoid?
+5. What approaches are explicitly forbidden (no-gos)?
+
+Use `AskUserQuestion` to establish boundaries.
+
+---
+
+## Process
+
+### Step 1: Parse Input
+
+`$ARGUMENTS` should reference a requirement section.
+
+Examples:
+- "2.1 User Authentication"
+- "REQUIREMENTS.md section 2.1"
+- "user auth"
+
+**If unclear:** Ask which requirement to specify.
+
+### Step 2: Gather Context
+
+Read in order:
+1. **VISION.md** - Strategic alignment
+2. **ARCHITECTURE.md** - Technical constraints
+3. **REQUIREMENTS.md** - The requirement being specified
+4. **Existing specs** - Avoid duplication
+
+### Step 3: Interview for Shaping
+
+Shape Up methodology - define boundaries, not tasks.
+
+| Question | Purpose |
+|----------|---------|
+| What's definitely in scope? | Core functionality |
+| What's definitely out of scope? | Prevent creep |
+| What seems related but should be avoided? | Rabbit holes |
+| What approaches are forbidden? | No-gos |
+| How do we know it works? | Test conditions |
+| How much time is it worth? | Appetite |
+| What if we run out of time? | Circuit breaker |
+
+### Step 4: Determine Appetite
+
+| Appetite | Size | Suitable For |
+|----------|------|--------------|
+| Small | 1-2 days | Bug fixes, minor enhancements |
+| Medium | 3-5 days | Feature additions, refactors |
+| Large | 1-2 weeks | Major features (rare) |
+
+**If work can't fit the appetite:** Needs more shaping or splitting.
+
+### Step 5: Draft the Spec
+
+Use spec template:
+
+```yaml
+---
+id: SPEC-001
+title: "User Authentication with OAuth"
+requirement: "2.1 User Authentication"
+created: YYYY-MM-DDTHH:MM:SSZ
+status: drafting
+appetite: "1 week"
+---
+
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+[From REQUIREMENTS - why this matters to users and business]
+
+## Proposed Solution
+
+[Shaped solution - high-level approach, not implementation details]
+
+## Scope
+
+### In Scope
+- [Item 1]
+- [Item 2]
+
+### Out of Scope (Rabbit Holes)
+- [Avoid this complexity]
+- [Don't go here]
+
+### No-Gos
+- [Forbidden approach 1]
+- [Forbidden approach 2]
+
+## Test Conditions
+
+- [ ] [Observable outcome 1]
+- [ ] [Observable outcome 2]
+- [ ] [Observable outcome 3]
+
+## Implementation Notes
+
+[Architecture references, technical constraints, relevant ADRs]
+
+## Circuit Breaker
+
+At 50% appetite: [What to do if we're not on track]
+```
+
+### Step 6: Generate Spec ID
+
+Find next available ID:
+
+```bash
+ls docs/specs/SPEC-*.md docs/specs/archive/SPEC-*.md 2>/dev/null | \
+  grep -oE 'SPEC-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+If no specs exist, start with `SPEC-001`.
+
+### Step 7: Present for Approval
+
+```markdown
+## Proposed Specification
+
+[Full spec content]
+
+---
+
+**Before approval, confirm:**
+1. Is the scope correct?
+2. Are the test conditions sufficient?
+3. Is the appetite realistic?
+4. Any missing rabbit holes or no-gos?
+```
+
+### Step 8: Await Approval
+
+**Do NOT create spec file without explicit approval.**
+
+User may:
+- Approve as-is
+- Adjust scope
+- Change appetite
+- Add constraints
+- Request splitting
+
+### Step 9: Create Spec File
+
+After approval:
+
+1. **Generate timestamps:**
+   ```bash
+   date -u +"%Y-%m-%dT%H:%M:%SZ"  # For frontmatter
+   ```
+
+2. **Create file:**
+   - Location: `docs/specs/SPEC-{id}-{slug}.md`
+   - Slug: kebab-case of title
+
+3. **Announce completion:**
+   ```
+   Created: docs/specs/SPEC-001-user-auth-oauth.md
+
+   Next: Use `/tasks SPEC-001` to break into atomic work items.
+   ```
+
+---
+
+## Spec Lifecycle
+
+```
+drafting → approved → implementing → complete
+```
+
+| Status | Meaning |
+|--------|---------|
+| `drafting` | Being refined, not ready |
+| `approved` | Ready for task breakdown |
+| `implementing` | Tasks created, work in progress |
+| `complete` | All tasks done, archive |
+
+---
+
+## Splitting Large Specs
+
+When a spec is too big for its appetite:
+
+```
+SPEC-001-user-auth.md (large, 2 weeks)
+        ↓ split into
+SPEC-001a-oauth-integration.md (medium, 3 days)
+SPEC-001b-session-management.md (small, 2 days)
+SPEC-001c-login-ui.md (medium, 3 days)
+```
+
+Each sub-spec:
+- Has its own appetite
+- Can be worked independently
+- References original requirement
+
+---
+
+## Test Conditions vs Acceptance Criteria
+
+| Test Conditions (Spec) | Acceptance Criteria (Requirement) |
+|------------------------|-----------------------------------|
+| High-level outcomes | Detailed behaviors |
+| For this shaped solution | For the full feature |
+| May be subset of AC | Complete coverage |
+| Implementation-aware | Implementation-agnostic |
+
+Test conditions prove the spec is done.
+Acceptance criteria prove the requirement is met.
+
+---
+
+## Guardrails
+
+1. **Interview to shape** - Boundaries before details
+2. **Respect appetite** - Fixed time, variable scope
+3. **Document rabbit holes** - Prevent scope creep
+4. **Clear test conditions** - Observable outcomes
+5. **Circuit breaker** - Plan for running out of time
+6. **Get approval** - Don't create without confirmation
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Implementation details | Keep high-level, shape not blueprint |
+| No appetite | Always set time budget |
+| Missing no-gos | Explicitly forbid bad approaches |
+| Vague test conditions | Make observable and verifiable |
+| Too ambitious | Split or increase appetite |
+
+---
+
+## Related Skills
+
+- **orchestration/specs** - Full spec methodology
+- **orchestration/product-development** - Where specs fit in hierarchy
+- **orchestration/planning** - Shape Up methodology details

--- a/plugins/loaf/commands/start-session.md
+++ b/plugins/loaf/commands/start-session.md
@@ -146,13 +146,65 @@ orchestration:
   spawned_agents: []
 ```
 
-### Step 4: Verify Creation
+### Step 4: Create Plan File
 
-Confirm the session file exists and contains valid frontmatter before proceeding.
+**Location:** `.agents/plans/`
+**Filename:** Same timestamp as session: `YYYYMMDD-HHMMSS-<description>.md`
 
-**DO NOT PROCEED WITHOUT A SESSION FILE.**
+Use this Shape Up-inspired template:
 
-### Step 5: Suggest Session Rename
+```markdown
+---
+session: YYYYMMDD-HHMMSS-<description>.md
+created: "YYYY-MM-DDTHH:MM:SSZ"
+status: drafting
+appetite: ""
+---
+
+# Plan: <description>
+
+## Appetite
+
+*Time budget for this work (e.g., "2 hours", "1 day"). Fixed time, variable scope.*
+
+## Problem
+
+*What problem are we solving? Why does it matter?*
+
+## Solution Shape
+
+*High-level approach, not a detailed spec. What's the general shape of the solution?*
+
+## Rabbit Holes
+
+*What NOT to do. Scope boundaries. Things that seem related but should be avoided.*
+
+## No-Gos
+
+*Explicit exclusions. Features or approaches we're deliberately not doing.*
+
+## Circuit Breaker
+
+At 50% of appetite spent: Re-evaluate if we're on track. If not, consider:
+- Simplifying scope
+- Taking a different approach
+- Stopping early and documenting learnings
+```
+
+**Update session frontmatter** to link the plan:
+
+```yaml
+plans:
+  - YYYYMMDD-HHMMSS-<description>.md
+```
+
+### Step 5: Verify Creation
+
+Confirm both session file AND plan file exist with valid frontmatter before proceeding.
+
+**DO NOT PROCEED WITHOUT A SESSION FILE AND PLAN FILE.**
+
+### Step 6: Suggest Session Rename
 
 After creating the session file, suggest renaming the Claude Code session for easy identification:
 
@@ -219,7 +271,7 @@ Is this a code/config/doc change?
 
 ## Startup Checklist
 
-**After creating session file:**
+**After creating session AND plan files:**
 
 1. [ ] Parse the input — is this a Linear issue ID (e.g., PLT-123, PLAT-123) or a description?
 2. [ ] If Linear ID:
@@ -229,10 +281,13 @@ Is this a code/config/doc change?
 3. [ ] If description: ask user if a Linear issue should be created
 4. [ ] **Create dedicated branch for this work** (see Branch Management below)
 5. [ ] **Suggest team** based on task context (see Team Routing below)
-6. [ ] Populate session `## Context` section with background
-7. [ ] Break down the work using TodoWrite
-8. [ ] **Identify which specialized agents will be needed** (use mapping table)
-9. [ ] Update session `## Next Steps` with planned agent spawns
+6. [ ] **Fill in plan file sections** (Appetite, Problem, Solution Shape, Rabbit Holes)
+7. [ ] Populate session `## Context` section with background
+8. [ ] Break down the work using TodoWrite
+9. [ ] **Identify which specialized agents will be needed** (use mapping table)
+10. [ ] **Consider architecture diagrams** (see Diagram Consideration below)
+11. [ ] Update session `## Next Steps` with planned agent spawns
+12. [ ] **Get user approval on plan** before spawning implementation agents
 
 ---
 
@@ -305,6 +360,48 @@ Suggest Security, confirm if new to project
 ```
 
 Use Linear MCP's `list_teams` to get all workspace teams for validation.
+
+---
+
+## Diagram Consideration
+
+For multi-file or multi-service changes, consider adding architecture diagrams to the session file.
+
+### When to Create Diagrams
+
+| Scenario | Diagram Type |
+|----------|--------------|
+| Changes span 3+ services | Component diagram (interaction points) |
+| Data flow modifications | Sequence diagram (trace data path) |
+| Schema/model changes | ERD (table relationships) |
+| New API endpoints | Sequence diagram (request/response) |
+| State machine logic | State diagram (transitions) |
+
+### Quick Check
+
+Ask yourself:
+1. Will this work touch multiple services or layers?
+2. Is there a data flow that needs to be understood?
+3. Would a visual help communicate the approach?
+
+If yes to any, add an `## Architecture Diagrams` section to the session file.
+
+### Diagram Template
+
+```markdown
+## Architecture Diagrams
+
+### [Descriptive Name]
+
+```mermaid
+[Use flowchart, sequenceDiagram, erDiagram, or stateDiagram-v2]
+```
+
+**Purpose**: Why this diagram clarifies the work
+**Files involved**: `path/to/file1.py`, `path/to/file2.py`
+```
+
+See `foundations` skill `reference/diagrams.md` for Mermaid syntax and best practices.
 
 ---
 
@@ -483,7 +580,9 @@ Follow your three-phase workflow (BEFORE → DURING → AFTER):
 
 ### AFTER (Completion)
 
-1. Spawn `backend-dev`/`frontend-dev` for code review (if significant changes)
+1. **Code review pass** (REQUIRED for significant changes):
+   - Run `pr-review-toolkit:code-reviewer` on all modified files
+   - Address any critical issues before proceeding
 2. Spawn `qa` for final testing and security review
 3. Update Linear issue status to Done
 4. Complete session file with outcomes

--- a/plugins/loaf/commands/tasks.md
+++ b/plugins/loaf/commands/tasks.md
@@ -1,0 +1,339 @@
+---
+description: Break specs into atomic work items (Linear or local)
+version: 1.11.0
+---
+
+# Tasks Command
+
+Break specifications into atomic, implementable tasks.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Tasks are the smallest unit of work that can be:
+- Assigned to an agent
+- Completed in a single session
+- Verified with a clear done condition
+
+See `orchestration/local-tasks` reference for task format and abstraction layer.
+
+---
+
+## Task Backend Detection
+
+Check `.agents/loaf.yaml` for backend configuration:
+
+```yaml
+task_management:
+  backend: linear  # or "local"
+```
+
+**If no config exists:** Ask user which backend to use.
+
+---
+
+## Process
+
+### Step 1: Parse Input
+
+`$ARGUMENTS` should reference a spec.
+
+Examples:
+- "SPEC-001"
+- "user auth spec"
+- "docs/specs/SPEC-001-user-auth.md"
+
+**If unclear:** List available specs and ask which to break down.
+
+### Step 2: Read the Spec
+
+1. Find spec file in `docs/specs/`
+2. Read full spec content
+3. Extract:
+   - Test conditions (become task acceptance criteria)
+   - Scope (what's in/out)
+   - Implementation notes (technical context)
+   - Appetite (guides task sizing)
+
+### Step 3: Identify Task Boundaries
+
+Break down by concern:
+
+| Concern | Task Type |
+|---------|-----------|
+| Data model changes | DBA task |
+| Backend logic | Backend task |
+| API endpoints | Backend task |
+| UI components | Frontend task |
+| Tests | QA task |
+| Infrastructure | DevOps task |
+
+**Rules:**
+- One concern per task
+- Tasks can run in parallel if independent
+- Tasks have explicit dependencies if sequential
+
+### Step 4: Interview for Priorities
+
+Ask:
+- Which parts are highest priority?
+- Any tasks that must be done first?
+- Preferred order of implementation?
+
+### Step 5: Draft Task List
+
+For each task:
+
+```yaml
+---
+id: TASK-XXX
+title: [Clear action]
+spec: SPEC-001
+status: todo
+priority: P2
+files:
+  - [likely file 1]
+  - [likely file 2]
+verify: [command to verify]
+done: [observable outcome]
+---
+
+## Description
+[What needs to be done]
+
+## Acceptance Criteria
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+
+## Context
+See SPEC-001 for full context.
+```
+
+### Step 6: Present Task Breakdown
+
+```markdown
+## Proposed Tasks for SPEC-001
+
+### TASK-001: [Title]
+- **Priority:** P1
+- **Verify:** [command]
+- **Done:** [outcome]
+- **Files:** [list]
+
+### TASK-002: [Title]
+- **Priority:** P2
+- **Depends on:** TASK-001
+- **Verify:** [command]
+- **Done:** [outcome]
+
+### TASK-003: [Title]
+- **Priority:** P2
+- **Verify:** [command]
+- **Done:** [outcome]
+
+---
+
+**Task dependencies:**
+```
+TASK-001 → TASK-002 (sequential)
+TASK-003 (can run in parallel)
+```
+
+**Approve this breakdown?**
+```
+
+### Step 7: Await Approval
+
+**Do NOT create tasks without explicit approval.**
+
+User may:
+- Approve as-is
+- Adjust priorities
+- Combine/split tasks
+- Add missing tasks
+- Change dependencies
+
+### Step 8: Create Tasks
+
+Based on backend:
+
+#### Linear Backend
+
+```
+For each task:
+1. Create Linear issue with title, description
+2. Set labels from spec
+3. Link to spec (as attachment or in description)
+4. Set priority
+5. Record issue ID
+```
+
+#### Local Backend
+
+```bash
+# Create task directory if needed
+mkdir -p .agents/tasks/active
+
+# Generate task ID
+next_id=$(find_next_task_id)
+
+# Create task file
+# .agents/tasks/active/TASK-{id}-{slug}.md
+```
+
+### Step 9: Update Spec Status
+
+After tasks created:
+
+```yaml
+# In spec frontmatter
+status: implementing
+```
+
+### Step 10: Announce Completion
+
+```markdown
+## Tasks Created for SPEC-001
+
+| ID | Title | Priority | Backend |
+|----|-------|----------|---------|
+| TASK-001 | OAuth Provider Integration | P1 | [Linear/Local] |
+| TASK-002 | Session Management | P2 | [Linear/Local] |
+| TASK-003 | Login UI Components | P2 | [Linear/Local] |
+
+**Spec status:** implementing
+
+**Next:** Use `/start-session TASK-001` to begin work.
+```
+
+---
+
+## Task ID Generation
+
+### Linear
+IDs come from Linear (e.g., `PLT-123`).
+
+### Local
+Sequential numbering:
+
+```bash
+# Find next available number
+find_next_task_id() {
+  local max=$(ls .agents/tasks/active/ .agents/tasks/archive/*/ 2>/dev/null | \
+    grep -oE 'TASK-[0-9]+' | \
+    sort -t- -k2 -n | \
+    tail -1 | \
+    awk -F- '{print $2}')
+  echo $((${max:-0} + 1))
+}
+```
+
+---
+
+## Task Sizing Guide
+
+| Size | Duration | Characteristics |
+|------|----------|-----------------|
+| Small | < 1 day | Single file, clear change |
+| Medium | 1-2 days | Multiple files, one concern |
+| Large | 2-3 days | Complex logic, multiple concerns |
+
+**If task is large:** Consider splitting into smaller tasks.
+
+---
+
+## Priority Levels
+
+| Priority | Meaning | Response |
+|----------|---------|----------|
+| P0 | Urgent/blocking | Drop everything |
+| P1 | High | Work next |
+| P2 | Normal | Scheduled work |
+| P3 | Low | When time permits |
+
+Default: P2 (normal).
+
+---
+
+## Verification Commands
+
+Each task needs a `verify` command:
+
+| Task Type | Example Verification |
+|-----------|---------------------|
+| Backend Python | `pytest tests/auth/test_oauth.py` |
+| Backend Rails | `rails test test/models/session_test.rb` |
+| Frontend React | `npm run test -- auth.test.tsx` |
+| API endpoint | `curl -X POST localhost:3000/auth/login` |
+| Database | `psql -c "SELECT * FROM users LIMIT 1"` |
+
+---
+
+## Done Conditions
+
+Write clear, observable outcomes:
+
+**Good:**
+- "OAuth flow completes for Google and GitHub"
+- "Session persists across page refresh"
+- "All auth tests pass"
+
+**Bad:**
+- "Auth works" (too vague)
+- "Code is clean" (subjective)
+- "Implementation done" (not verifiable)
+
+---
+
+## Guardrails
+
+1. **One concern per task** - Don't mix backend + frontend
+2. **Clear verification** - How to prove it works
+3. **Observable done condition** - Not subjective
+4. **File hints** - Help session know where to look
+5. **Get approval** - Don't create without confirmation
+6. **Update spec status** - Mark as implementing
+
+---
+
+## Common Patterns
+
+### API Feature
+
+```
+TASK-001: Database migration (DBA)
+TASK-002: API endpoint implementation (Backend)
+TASK-003: Unit tests for endpoint (QA)
+TASK-004: API documentation (Backend)
+```
+
+### UI Feature
+
+```
+TASK-001: Component implementation (Frontend)
+TASK-002: State management (Frontend)
+TASK-003: Component tests (QA)
+TASK-004: E2E tests (QA)
+```
+
+### Full Stack Feature
+
+```
+TASK-001: Database schema (DBA)
+TASK-002: API endpoints (Backend)
+TASK-003: Backend tests (QA)
+TASK-004: UI components (Frontend)
+TASK-005: Frontend tests (QA)
+TASK-006: E2E integration (QA)
+```
+
+---
+
+## Related Skills
+
+- **orchestration/local-tasks** - Local task format and management
+- **orchestration/linear** - Linear integration
+- **orchestration/product-development** - Where tasks fit in hierarchy

--- a/plugins/loaf/hooks/foundations-tdd-advisory.sh
+++ b/plugins/loaf/hooks/foundations-tdd-advisory.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Hook: TDD Advisory (INFORMATIONAL)
+# PreToolUse hook - reads JSON from stdin per Claude Code hooks API
+#
+# Triggers on Edit|Write to implementation files
+# Warns when tests don't exist or don't fail first (non-blocking)
+# Inspired by Cursor's TDD best practice
+
+# Read and parse stdin JSON
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))" 2>/dev/null || echo "")
+
+# Exit early if no file path
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Skip if already a test file
+if [[ "$FILE_PATH" == *"test"* ]] || [[ "$FILE_PATH" == *"spec"* ]] || [[ "$FILE_PATH" == *"_test."* ]] || [[ "$FILE_PATH" == *".test."* ]]; then
+  exit 0
+fi
+
+# Skip non-code files
+EXTENSION="${FILE_PATH##*.}"
+case "$EXTENSION" in
+  py|ts|tsx|js|jsx|rb|go|rs)
+    # Continue checking
+    ;;
+  *)
+    # Not a code file, skip
+    exit 0
+    ;;
+esac
+
+# Skip config and generated files
+if [[ "$FILE_PATH" == *"config"* ]] || [[ "$FILE_PATH" == *"generated"* ]] || [[ "$FILE_PATH" == *"__init__"* ]]; then
+  exit 0
+fi
+
+# Get the base name and directory for test file detection
+BASENAME=$(basename "$FILE_PATH")
+DIRNAME=$(dirname "$FILE_PATH")
+FILENAME="${BASENAME%.*}"
+
+# Build potential test file patterns based on language conventions
+POTENTIAL_TESTS=()
+case "$EXTENSION" in
+  py)
+    POTENTIAL_TESTS=(
+      "${DIRNAME}/test_${FILENAME}.py"
+      "${DIRNAME}/${FILENAME}_test.py"
+      "tests/test_${FILENAME}.py"
+      "tests/${FILENAME}_test.py"
+    )
+    ;;
+  ts|tsx|js|jsx)
+    POTENTIAL_TESTS=(
+      "${DIRNAME}/${FILENAME}.test.${EXTENSION}"
+      "${DIRNAME}/${FILENAME}.spec.${EXTENSION}"
+      "${DIRNAME}/__tests__/${FILENAME}.test.${EXTENSION}"
+      "__tests__/${FILENAME}.test.${EXTENSION}"
+    )
+    ;;
+  rb)
+    POTENTIAL_TESTS=(
+      "spec/${FILENAME}_spec.rb"
+      "${DIRNAME}/${FILENAME}_spec.rb"
+      "test/${FILENAME}_test.rb"
+    )
+    ;;
+  go)
+    POTENTIAL_TESTS=(
+      "${DIRNAME}/${FILENAME}_test.go"
+    )
+    ;;
+esac
+
+# Check if any test file exists
+TEST_EXISTS=false
+FOUND_TEST=""
+for TEST_FILE in "${POTENTIAL_TESTS[@]}"; do
+  if [ -f "$TEST_FILE" ]; then
+    TEST_EXISTS=true
+    FOUND_TEST="$TEST_FILE"
+    break
+  fi
+done
+
+# Output advisory (non-blocking)
+if [ "$TEST_EXISTS" = false ]; then
+  cat << EOF
+# TDD Advisory
+
+Editing implementation file: \`$FILE_PATH\`
+
+**No corresponding test file found.** Consider Test-Driven Development:
+
+1. Write a failing test first
+2. Then implement the feature
+3. Run tests until green
+
+**Expected test locations:**
+$(for t in "${POTENTIAL_TESTS[@]}"; do echo "- \`$t\`"; done)
+
+**Why TDD?** Tests document expected behavior and prevent regressions.
+Skip this advisory if you're:
+- Doing a quick fix with existing test coverage
+- Working in an area where tests aren't practical
+
+EOF
+fi
+
+# Always exit 0 (non-blocking advisory)
+exit 0

--- a/plugins/loaf/hooks/session-end.sh
+++ b/plugins/loaf/hooks/session-end.sh
@@ -38,8 +38,16 @@ case "$AGENT_TYPE" in
     echo "- [ ] Linear issues synced with actual progress"
     echo "- [ ] Decisions captured (ADRs if architectural)"
     echo "- [ ] Session file \`## Current State\` is handoff-ready"
+    echo "- [ ] **Code review completed** (run \`pr-review-toolkit:code-reviewer\` if significant changes)"
     echo "- [ ] Completed sessions deleted (knowledge extracted)"
     echo "- [ ] Active sessions have clear next steps"
+    echo ""
+    echo "### Code Review Reminder"
+    echo ""
+    echo "If this session involved significant code changes, consider running:"
+    echo "\`\`\`"
+    echo "Task(subagent_type=\"pr-review-toolkit:code-reviewer\", prompt=\"Review recent changes for this session\")"
+    echo "\`\`\`"
     ;;
 
   backend-dev|frontend-dev|rails-dev|dba|devops)

--- a/plugins/loaf/skills/debugging/SKILL.md
+++ b/plugins/loaf/skills/debugging/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: debugging
+description: >-
+  Use for systematic bug investigation and diagnosis. Covers hypothesis-driven
+  debugging workflows, multi-hypothesis tracking, language-specific debugging
+  patterns (Python, TypeScript, Ruby), and test debugging (flaky tests,
+  isolation, state pollution). Activate when investigating failures, debugging
+  production issues, or diagnosing test problems.
+---
+
+# Systematic Debugging
+
+Hypothesis-driven investigation for efficient and traceable bug diagnosis.
+
+## Philosophy
+
+**Eliminate, don't guess.** Debugging is a process of elimination, not random modification. Each change should test a specific hypothesis and provide evidence to rule it out or confirm it.
+
+**Multiple hypotheses, ranked.** Never fixate on one theory. Generate 3-5 plausible hypotheses, rank by likelihood, and test the most likely first. Surprising evidence should trigger hypothesis revision.
+
+**Reproduce before investigating.** A bug you cannot reproduce is a bug you cannot fix with confidence. Establish reliable reproduction steps before diving into code.
+
+**Minimal changes, maximum information.** Each debugging step should change one variable and maximize the information gained. Shotgun debugging wastes time and obscures root causes.
+
+## Quick Reference
+
+| Situation | Approach | Key Technique |
+|-----------|----------|---------------|
+| **Unknown failure** | Generate hypotheses | List 3-5 possible causes, rank by likelihood |
+| **Intermittent bug** | Isolate variables | Binary search through conditions |
+| **Test flakiness** | Check state pollution | Run test in isolation, check fixtures |
+| **Production issue** | Preserve evidence | Capture logs/state before attempting fixes |
+
+## Topics
+
+| Topic | Reference | Use For |
+|-------|-----------|---------|
+| Hypothesis Tracking | `references/hypothesis-tracking.md` | Multi-hypothesis workflow, session templates, investigation logs |
+| Language Debugging | `references/language-debugging.md` | Python, TypeScript, Ruby debug patterns and tools |
+| Test Debugging | `references/test-debugging.md` | Flaky tests, isolation, state pollution, environment differences |
+
+## Critical Rules
+
+### Always
+
+- Generate multiple hypotheses before investigating
+- Document each hypothesis and its current status
+- Establish reproduction steps before attempting fixes
+- Test one variable at a time
+- Preserve evidence (logs, state, stack traces) before changes
+- Update hypothesis status based on evidence
+- Record failed attempts to avoid repeating them
+
+### Never
+
+- Make random changes hoping something works
+- Fix symptoms without understanding root cause
+- Assume the first hypothesis is correct
+- Skip reproduction verification after a "fix"
+- Delete logs or error output before analysis
+- Change multiple variables simultaneously
+- Ignore contradictory evidence
+
+## Debugging Workflow
+
+```
+1. REPRODUCE: Establish reliable reproduction steps
+2. HYPOTHESIZE: Generate 3-5 possible causes, rank by likelihood
+3. TEST: Design experiment to test highest-likelihood hypothesis
+4. EVALUATE: Analyze results, update hypothesis status
+5. ITERATE: Move to next hypothesis or refine based on evidence
+6. VERIFY: Confirm fix addresses root cause, not just symptoms
+```
+
+## Investigation Log Format
+
+Keep a timestamped log of investigation steps:
+
+```
+[HH:MM] Testing H2 (stale cache)
+        Action: Cleared Redis, restarted service
+        Result: Still failing
+        Evidence: Error occurs before cache read in stack trace
+        Status: H2 RULED OUT
+
+[HH:MM] Testing H3 (race condition)
+        Action: Added mutex around shared state
+        Result: SUCCESS - no failures in 100 runs
+        Evidence: Stack trace showed concurrent access
+        Status: H3 CONFIRMED
+```
+
+## Related Skills
+
+- `foundations` - Test patterns, error handling, logging standards
+- `python` - Python-specific debugging tools (pdb, logging)
+- `typescript` - TypeScript debugging (Chrome DevTools, source maps)
+- `ruby` - Ruby debugging (binding.irb, byebug)

--- a/plugins/loaf/skills/debugging/references/hypothesis-tracking.md
+++ b/plugins/loaf/skills/debugging/references/hypothesis-tracking.md
@@ -1,0 +1,168 @@
+# Hypothesis Tracking
+
+Systematic workflow for generating, testing, and tracking multiple debugging hypotheses.
+
+## Multi-Hypothesis Workflow
+
+### 1. Generate Hypotheses
+
+Before investigating, brainstorm 3-5 possible causes. Consider:
+
+- **Recent changes** - What changed since it last worked?
+- **Common culprits** - Race conditions, caching, state mutation, null references
+- **Environment differences** - Dev vs prod, different data, timing
+- **External dependencies** - API changes, network issues, third-party services
+
+### 2. Rank by Likelihood
+
+Assign likelihood based on:
+
+| Factor | Higher Likelihood | Lower Likelihood |
+|--------|-------------------|------------------|
+| Recency | Code changed recently | Untouched for months |
+| Complexity | Complex logic, many branches | Simple, well-tested |
+| Dependencies | External services involved | Self-contained |
+| Symptoms | Matches known failure pattern | Novel error |
+
+### 3. Test Systematically
+
+For each hypothesis (highest likelihood first):
+
+1. **Design minimal experiment** - What single change would confirm or rule out this hypothesis?
+2. **Predict outcome** - What result do you expect if hypothesis is correct?
+3. **Execute and observe** - Run experiment, capture results
+4. **Update status** - Mark CONFIRMED, RULED OUT, or NEEDS MORE DATA
+
+### 4. Revise Based on Evidence
+
+When evidence contradicts expectations:
+
+- Lower likelihood of current hypothesis
+- Consider what the evidence suggests instead
+- Add new hypotheses if needed
+- Re-rank based on new information
+
+## Session Template
+
+Use this template at the start of debugging sessions:
+
+```markdown
+## Debug Investigation
+
+**Symptom**: [What's failing - exact error message or behavior]
+**First observed**: [When did this start happening]
+**Reproduction**: [Steps to reliably reproduce]
+
+### Environment
+- OS/Platform:
+- Version:
+- Dependencies:
+- Data state:
+
+### Hypothesis Tracker
+
+| # | Hypothesis | Likelihood | Status | Evidence |
+|---|------------|------------|--------|----------|
+| H1 | [Description] | High/Med/Low | TESTING/RULED OUT/CONFIRMED | [What you learned] |
+| H2 | [Description] | High/Med/Low | PENDING | - |
+| H3 | [Description] | High/Med/Low | PENDING | - |
+
+### Investigation Log
+[Timestamped entries below]
+```
+
+## Example Investigation
+
+### Symptom
+API returns 500 error intermittently on `/api/orders` endpoint.
+
+### Reproduction
+1. Create 10+ concurrent requests to `/api/orders`
+2. ~30% return 500 errors
+3. Only happens under load
+
+### Hypothesis Tracker
+
+| # | Hypothesis | Likelihood | Status | Evidence |
+|---|------------|------------|--------|----------|
+| H1 | Database connection pool exhausted | High | RULED OUT | Pool metrics show 50% utilization during failures |
+| H2 | Race condition in order validation | High | TESTING | Errors correlate with concurrent creates |
+| H3 | Memory pressure causing timeouts | Medium | PENDING | - |
+| H4 | Third-party payment API rate limiting | Low | RULED OUT | Payment API logs show no rate limits |
+
+### Investigation Log
+
+```
+[14:32] Testing H1 (connection pool)
+        Action: Monitored pool metrics during load test
+        Result: Pool never exceeded 50% capacity
+        Evidence: Prometheus shows max 5/10 connections used
+        Status: H1 RULED OUT - pool is not the bottleneck
+
+[14:45] Testing H4 (payment API rate limiting)
+        Action: Checked payment provider dashboard
+        Result: No rate limit events in their logs
+        Evidence: All payment API calls successful
+        Status: H4 RULED OUT
+
+[15:01] Testing H2 (race condition)
+        Action: Added logging around order validation
+        Result: Found concurrent access to shared cart state
+        Evidence: Logs show two requests modifying same cart simultaneously
+        Status: H2 LIKELY - need to verify with fix
+
+[15:23] Verifying H2 fix
+        Action: Added mutex around cart validation
+        Result: 0 errors in 1000 concurrent requests
+        Evidence: Lock prevents concurrent modification
+        Status: H2 CONFIRMED - race condition was root cause
+```
+
+## Hypothesis Status Definitions
+
+| Status | Meaning | Next Action |
+|--------|---------|-------------|
+| PENDING | Not yet investigated | Move to TESTING when ready |
+| TESTING | Currently being investigated | Execute experiment, gather evidence |
+| NEEDS MORE DATA | Inconclusive results | Design better experiment |
+| RULED OUT | Evidence contradicts hypothesis | Document and move on |
+| LIKELY | Evidence supports but not conclusive | Verify with fix |
+| CONFIRMED | Root cause identified and verified | Document fix and close |
+
+## Common Hypothesis Categories
+
+### State-Related
+- Stale cache returning old data
+- Database transaction not committed
+- In-memory state mutation
+- Session/cookie corruption
+
+### Timing-Related
+- Race condition between concurrent operations
+- Timeout too short for slow operations
+- Clock skew between services
+- Event ordering assumptions violated
+
+### Environment-Related
+- Missing environment variable
+- Different library versions
+- File permissions
+- Network connectivity/latency
+
+### Data-Related
+- Null/undefined where unexpected
+- Type mismatch (string vs number)
+- Encoding issues (UTF-8, special characters)
+- Data exceeds expected bounds
+
+## Tips for Effective Hypothesis Tracking
+
+1. **Be specific** - "Something wrong with caching" is not a hypothesis. "Redis TTL set to 0 causing immediate expiration" is.
+
+2. **Make them testable** - Every hypothesis should have a clear experiment that could rule it out.
+
+3. **Update in real-time** - Log entries as you go, not from memory later.
+
+4. **Don't delete** - Ruled-out hypotheses are valuable documentation of what was tried.
+
+5. **Share context** - If handing off, the tracker should let someone else continue without starting over.

--- a/plugins/loaf/skills/debugging/references/language-debugging.md
+++ b/plugins/loaf/skills/debugging/references/language-debugging.md
@@ -1,0 +1,354 @@
+# Language-Specific Debugging
+
+Debug patterns and tools for Python, TypeScript, and Ruby.
+
+## Python Debugging
+
+### Interactive Debugging with pdb
+
+```python
+# Insert breakpoint in code
+import pdb; pdb.set_trace()
+
+# Python 3.7+ built-in
+breakpoint()
+
+# Conditional breakpoint
+if suspicious_condition:
+    breakpoint()
+```
+
+**Common pdb commands:**
+
+| Command | Action |
+|---------|--------|
+| `n` (next) | Execute next line |
+| `s` (step) | Step into function |
+| `c` (continue) | Continue to next breakpoint |
+| `p expr` | Print expression value |
+| `pp expr` | Pretty-print expression |
+| `l` (list) | Show current code context |
+| `w` (where) | Print stack trace |
+| `u` (up) | Move up stack frame |
+| `d` (down) | Move down stack frame |
+| `q` (quit) | Exit debugger |
+
+### Structured Logging
+
+```python
+import structlog
+
+logger = structlog.get_logger()
+
+# Add context that persists across log calls
+logger = logger.bind(request_id=request.id, user_id=user.id)
+
+# Log with structured data
+logger.info("order_created", order_id=order.id, total=order.total)
+logger.error("payment_failed",
+    order_id=order.id,
+    error_code=e.code,
+    error_message=str(e)
+)
+```
+
+### Traceback Analysis
+
+```python
+import traceback
+
+try:
+    risky_operation()
+except Exception as e:
+    # Full traceback as string
+    tb_str = traceback.format_exc()
+    logger.error("operation_failed", traceback=tb_str)
+
+    # Extract specific frame info
+    tb = traceback.extract_tb(e.__traceback__)
+    for frame in tb:
+        logger.debug("frame",
+            filename=frame.filename,
+            line=frame.lineno,
+            function=frame.name
+        )
+```
+
+### pytest Debugging
+
+```bash
+# Drop into debugger on failure
+pytest --pdb
+
+# Drop into debugger on first failure, then exit
+pytest -x --pdb
+
+# Show local variables in tracebacks
+pytest -l
+
+# Verbose output with print statements
+pytest -v -s
+
+# Run specific test
+pytest tests/test_orders.py::test_create_order -v
+```
+
+### Remote Debugging
+
+```python
+# Using debugpy (VS Code compatible)
+import debugpy
+debugpy.listen(5678)
+debugpy.wait_for_client()  # Pause until debugger attaches
+breakpoint()
+```
+
+## TypeScript Debugging
+
+### Console Methods
+
+```typescript
+// Basic logging
+console.log('value:', value);
+console.error('Error:', error);
+console.warn('Warning:', message);
+
+// Structured output
+console.table(arrayOfObjects);
+console.dir(complexObject, { depth: null });
+
+// Timing
+console.time('operation');
+// ... operation ...
+console.timeEnd('operation');
+
+// Grouping related logs
+console.group('Request Processing');
+console.log('Step 1');
+console.log('Step 2');
+console.groupEnd();
+
+// Conditional logging
+console.assert(condition, 'Condition failed:', data);
+
+// Stack trace without error
+console.trace('How did we get here?');
+```
+
+### Debugger Statement
+
+```typescript
+function processOrder(order: Order): void {
+  // Pauses execution when DevTools is open
+  debugger;
+
+  // Conditional debugger
+  if (order.total > 10000) {
+    debugger;
+  }
+}
+```
+
+### Source Maps
+
+Ensure `tsconfig.json` has source maps enabled:
+
+```json
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "inlineSources": true
+  }
+}
+```
+
+For debugging bundled code, verify source maps are generated and served:
+
+```typescript
+// webpack.config.js
+module.exports = {
+  devtool: 'source-map', // Full source maps for debugging
+};
+```
+
+### Node.js Debugging
+
+```bash
+# Start with inspector
+node --inspect dist/server.js
+
+# Break on first line
+node --inspect-brk dist/server.js
+
+# With ts-node
+node --inspect -r ts-node/register src/server.ts
+```
+
+### Chrome DevTools Tips
+
+1. **Breakpoints**: Click line number in Sources panel
+2. **Conditional breakpoints**: Right-click line number, add condition
+3. **Logpoints**: Right-click, add logpoint (logs without pausing)
+4. **Watch expressions**: Add variables to Watch panel
+5. **Call stack**: Navigate up/down the call stack
+6. **Scope**: Inspect local, closure, and global variables
+
+### Async Debugging
+
+```typescript
+// Capture async stack traces
+Error.stackTraceLimit = 50;
+
+// Label promises for debugging
+const result = await Promise.race([
+  fetchData().then(data => ({ source: 'fetch', data })),
+  timeout(5000).then(() => ({ source: 'timeout', data: null }))
+]);
+console.log('Winner:', result.source);
+```
+
+## Ruby Debugging
+
+### binding.irb (Ruby 2.5+)
+
+```ruby
+def process_order(order)
+  # Opens interactive console at this point
+  binding.irb
+
+  order.validate!
+end
+```
+
+**IRB commands in binding.irb:**
+
+| Command | Action |
+|---------|--------|
+| `exit` | Continue execution |
+| `exit!` | Exit program |
+| `whereami` | Show current code context |
+| `show_source method_name` | Show method source |
+
+### byebug
+
+```ruby
+# Gemfile
+gem 'byebug', group: [:development, :test]
+
+# In code
+require 'byebug'
+
+def process_order(order)
+  byebug  # Execution stops here
+  order.validate!
+end
+```
+
+**byebug commands:**
+
+| Command | Action |
+|---------|--------|
+| `n` (next) | Execute next line |
+| `s` (step) | Step into method |
+| `c` (continue) | Continue execution |
+| `f` (finish) | Run until current method returns |
+| `p expr` | Evaluate expression |
+| `info locals` | Show local variables |
+| `bt` (backtrace) | Show call stack |
+| `up` / `down` | Navigate stack frames |
+
+### Rails Console Debugging
+
+```ruby
+# Start console
+rails console
+
+# Reload after code changes
+reload!
+
+# Find and inspect objects
+user = User.find(123)
+user.attributes
+user.orders.to_sql  # See generated SQL
+
+# Test in sandbox (rollback on exit)
+rails console --sandbox
+```
+
+### Rails Logger
+
+```ruby
+# In application code
+Rails.logger.debug "Processing order: #{order.id}"
+Rails.logger.info "Order created", order_id: order.id
+Rails.logger.error "Payment failed", error: e.message
+
+# Tagged logging
+Rails.logger.tagged("OrderService", order.id) do
+  Rails.logger.info "Starting processing"
+end
+
+# Tail logs
+tail -f log/development.log
+```
+
+### pry-rails
+
+```ruby
+# Gemfile
+gem 'pry-rails', group: [:development, :test]
+
+# In code
+binding.pry  # Opens Pry console
+
+# Pry commands
+ls object          # List methods/variables
+cd object          # Change context to object
+show-source method # Show method definition
+show-doc method    # Show documentation
+wtf?               # Show last exception
+```
+
+### Exception Debugging
+
+```ruby
+begin
+  risky_operation
+rescue => e
+  # Full backtrace
+  puts e.backtrace.join("\n")
+
+  # Filtered backtrace (Rails)
+  puts Rails.backtrace_cleaner.clean(e.backtrace).join("\n")
+
+  # Re-raise with context
+  raise "Order processing failed for order #{order.id}: #{e.message}"
+end
+```
+
+## Cross-Language Tips
+
+### Binary Search Debugging
+
+When you have a long sequence of operations and don't know where the failure occurs:
+
+1. Add logging/breakpoint at the midpoint
+2. Determine if failure is before or after
+3. Repeat with the relevant half
+4. Continue until you isolate the exact line
+
+### Minimal Reproduction
+
+1. Remove code until bug disappears
+2. Add back the last removed piece
+3. That piece contains or triggers the bug
+4. Create minimal test case that reproduces
+
+### Rubber Duck Debugging
+
+When stuck:
+
+1. Explain the code line-by-line out loud
+2. Explain what you expect vs. what happens
+3. Explain your hypotheses and why each might be wrong
+4. Often, articulating the problem reveals the solution

--- a/plugins/loaf/skills/debugging/references/test-debugging.md
+++ b/plugins/loaf/skills/debugging/references/test-debugging.md
@@ -1,0 +1,326 @@
+# Test Debugging
+
+Strategies for diagnosing flaky tests, isolation failures, and environment-related test issues.
+
+## Flaky Test Diagnosis
+
+A flaky test passes sometimes and fails sometimes with the same code. Common causes:
+
+### Timing Dependencies
+
+**Symptoms:**
+- Test passes locally, fails in CI
+- Test fails more often under load
+- Adding `sleep()` makes it pass
+
+**Investigation:**
+```python
+# Bad: Depends on timing
+def test_async_operation():
+    start_async_job()
+    time.sleep(1)  # Hope it's done
+    assert job_completed()
+
+# Good: Wait for condition
+def test_async_operation():
+    start_async_job()
+    wait_for(lambda: job_completed(), timeout=5)
+    assert job_completed()
+```
+
+**Diagnosis steps:**
+1. Run test 100 times in a loop
+2. Monitor CPU/memory during failures
+3. Add timestamps to understand timing
+4. Check for hardcoded timeouts that are too short
+
+### Order Dependencies
+
+**Symptoms:**
+- Test passes when run alone, fails in suite
+- Test fails only when run after specific other test
+- Reordering tests changes results
+
+**Investigation:**
+```bash
+# pytest: Run in random order
+pytest --random-order
+
+# Find the guilty test pair
+pytest tests/test_a.py tests/test_b.py -v  # Passes
+pytest tests/test_b.py tests/test_a.py -v  # Fails?
+```
+
+**Common culprits:**
+- Global state modified by previous test
+- Database records not cleaned up
+- Cached values persisting
+- Module-level side effects
+
+### Non-Deterministic Data
+
+**Symptoms:**
+- Fails occasionally with no pattern
+- Different assertion failures each time
+- Works with specific seed/data
+
+**Investigation:**
+```python
+# Bad: Non-deterministic
+def test_random_selection():
+    items = get_random_items(10)
+    assert len(items) == 10  # What if source has < 10?
+
+# Good: Control randomness
+def test_random_selection():
+    random.seed(42)
+    items = get_random_items(10)
+    assert len(items) == 10
+```
+
+## Test Isolation Patterns
+
+### Database Isolation
+
+```python
+# pytest with transactions
+@pytest.fixture
+def db_session(engine):
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()
+```
+
+```ruby
+# Rails transactional tests
+class OrderTest < ActiveSupport::TestCase
+  # Each test runs in a transaction that rolls back
+  self.use_transactional_tests = true
+
+  test "creates order" do
+    order = Order.create!(total: 100)
+    assert order.persisted?
+  end  # Order is rolled back
+end
+```
+
+### External Service Isolation
+
+```python
+# Mock external services
+@pytest.fixture
+def mock_payment_api(mocker):
+    return mocker.patch(
+        'app.services.payment.PaymentAPI.charge',
+        return_value={'status': 'success', 'id': 'ch_123'}
+    )
+
+def test_order_payment(mock_payment_api):
+    order = create_order(total=100)
+    order.process_payment()
+
+    mock_payment_api.assert_called_once_with(amount=100)
+    assert order.payment_status == 'paid'
+```
+
+### Time Isolation
+
+```python
+# Freeze time for deterministic tests
+from freezegun import freeze_time
+
+@freeze_time("2024-01-15 12:00:00")
+def test_order_expiry():
+    order = create_order()
+    assert not order.expired
+
+    with freeze_time("2024-01-16 12:00:01"):
+        assert order.expired  # 24+ hours later
+```
+
+```typescript
+// Jest fake timers
+jest.useFakeTimers();
+
+test('order expires after 24 hours', () => {
+  const order = createOrder();
+  expect(order.expired).toBe(false);
+
+  jest.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
+  expect(order.expired).toBe(true);
+});
+```
+
+## State Pollution Detection
+
+### Symptoms
+
+- Test A passes alone, fails after test B
+- Test fails only when suite runs in specific order
+- "Works on my machine" syndrome
+
+### Detection Strategy
+
+```bash
+# 1. Run suspect test in isolation
+pytest tests/test_orders.py::test_specific -v
+
+# 2. Run with a known "polluter"
+pytest tests/test_other.py tests/test_orders.py::test_specific -v
+
+# 3. Binary search for the polluter
+pytest tests/test_orders.py::test_specific --last-failed
+```
+
+### Common State Pollution Sources
+
+| Source | Detection | Fix |
+|--------|-----------|-----|
+| Module globals | Check imports for mutations | Use fixtures, reset in teardown |
+| Class variables | Look for `cls.` modifications | Use instance variables |
+| Singletons | Check shared instances | Reset or mock singletons |
+| Environment variables | Print env in failing test | Restore in teardown |
+| File system | Check for temp files | Use tmp directories, clean up |
+| Database | Check for leftover records | Transaction rollback |
+| Caches | Check memoized values | Clear caches in setup |
+
+### Teardown Pattern
+
+```python
+@pytest.fixture(autouse=True)
+def reset_global_state():
+    # Setup: Save original state
+    original_config = app.config.copy()
+
+    yield
+
+    # Teardown: Restore original state
+    app.config = original_config
+    cache.clear()
+```
+
+## Environment Differences
+
+### Local vs CI Failures
+
+| Difference | Detection | Solution |
+|------------|-----------|----------|
+| Timing | CI slower, races more likely | Use proper waits, not sleeps |
+| Resources | CI has less memory/CPU | Check resource usage |
+| Parallelism | CI runs tests in parallel | Ensure isolation |
+| File paths | Different temp directories | Use portable paths |
+| Timezone | CI uses UTC | Freeze time or use UTC |
+| Locale | CI uses different locale | Set locale explicitly |
+
+### Debugging CI-Only Failures
+
+```yaml
+# GitHub Actions: Enable debug logging
+env:
+  ACTIONS_STEP_DEBUG: true
+  ACTIONS_RUNNER_DEBUG: true
+
+# Add verbose output
+steps:
+  - name: Run tests
+    run: |
+      echo "=== Environment ==="
+      env | sort
+      echo "=== Python version ==="
+      python --version
+      echo "=== Running tests ==="
+      pytest -v --tb=long
+```
+
+### Reproducing CI Environment Locally
+
+```bash
+# Docker: Use same image as CI
+docker run -it --rm -v $(pwd):/app -w /app python:3.11 bash
+pip install -r requirements.txt
+pytest
+
+# Act: Run GitHub Actions locally
+act -j test
+
+# Environment parity
+export CI=true
+export TZ=UTC
+pytest
+```
+
+## Test Debugging Workflow
+
+### 1. Isolate the Failure
+
+```bash
+# Run failing test alone
+pytest tests/test_orders.py::test_failing -v
+
+# If it passes alone, find the interaction
+pytest --collect-only | head -20  # See test order
+```
+
+### 2. Add Diagnostic Output
+
+```python
+def test_order_processing(caplog):
+    with caplog.at_level(logging.DEBUG):
+        order = process_order(data)
+
+    print(f"Captured logs: {caplog.text}")
+    print(f"Order state: {order.__dict__}")
+    assert order.status == "completed"
+```
+
+### 3. Minimize the Test
+
+```python
+# Start with failing test
+def test_order_processing():
+    user = create_user()
+    product = create_product()
+    cart = create_cart(user, product)
+    order = create_order(cart)
+    payment = process_payment(order)
+    shipment = create_shipment(order)
+    assert shipment.status == "ready"
+
+# Remove pieces until bug disappears
+def test_order_processing_minimal():
+    order = create_order()  # Minimal setup
+    assert order.status == "pending"  # Bug is here!
+```
+
+### 4. Check Assumptions
+
+```python
+def test_order_total():
+    order = create_order()
+
+    # Verify assumptions
+    print(f"Order items: {order.items}")
+    print(f"Item prices: {[i.price for i in order.items]}")
+    print(f"Expected total: {sum(i.price for i in order.items)}")
+    print(f"Actual total: {order.total}")
+
+    assert order.total == Decimal("100.00")
+```
+
+## Flaky Test Prevention
+
+| Practice | Why It Helps |
+|----------|--------------|
+| Use factories, not fixtures | Fresh data each test |
+| Avoid shared state | Tests can't pollute each other |
+| Mock time and randomness | Deterministic behavior |
+| Use transactions | Auto-cleanup |
+| Run tests in random order | Catch order dependencies |
+| Run tests in parallel | Catch isolation issues |
+| Set explicit timeouts | Fail fast on hangs |

--- a/plugins/loaf/skills/foundations/SKILL.md
+++ b/plugins/loaf/skills/foundations/SKILL.md
@@ -36,6 +36,7 @@ Engineering foundations for consistent, secure, and well-documented code.
 |-------|-----------|---------|
 | Code Style | `reference/code-style.md` | Python/TypeScript conventions, naming, patterns |
 | Commits | `reference/commits.md` | Commit messages, branches, PRs, Linear integration |
+| Diagrams | `reference/diagrams.md` | Mermaid syntax, when to diagram, storage patterns |
 | Documentation | `reference/documentation.md` | ADRs, API docs, changelogs |
 | Security | `reference/security.md` | Threat modeling, secrets, compliance |
 | Permissions | `reference/permissions.md` | Tool allowlists, sandbox config, agent permissions |

--- a/plugins/loaf/skills/foundations/references/diagrams.md
+++ b/plugins/loaf/skills/foundations/references/diagrams.md
@@ -1,0 +1,248 @@
+# Architecture Diagrams
+
+Guidelines for creating Mermaid diagrams to visualize system architecture and data flows.
+
+## When to Create Diagrams
+
+Create architecture diagrams when work involves:
+
+| Scenario | Diagram Type | Why |
+|----------|--------------|-----|
+| Multi-service changes | Component/flowchart | Shows interaction points and dependencies |
+| Data flow changes | Sequence/flowchart | Traces data through the system |
+| Schema modifications | ERD | Visualizes table relationships |
+| API design | Sequence | Documents request/response flows |
+| State machine logic | State diagram | Clarifies transitions and conditions |
+| Complex conditionals | Flowchart | Makes branching logic explicit |
+
+### Skip Diagrams When
+
+- Single-file changes with obvious scope
+- Bug fixes with no architectural impact
+- Configuration-only changes
+- Test additions (unless testing complex flows)
+
+## Mermaid Syntax Quick Reference
+
+### Flowchart (Most Common)
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Action 1]
+    B -->|No| D[Action 2]
+    C --> E[End]
+    D --> E
+```
+
+**Direction options:** `TD` (top-down), `LR` (left-right), `BT` (bottom-top), `RL` (right-left)
+
+**Node shapes:**
+- `[Rectangle]` - Process/action
+- `{Diamond}` - Decision
+- `([Stadium])` - Start/end
+- `[(Database)]` - Database
+- `((Circle))` - Connector
+
+### Sequence Diagram (API/Service Interaction)
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as API
+    participant D as Database
+
+    C->>A: POST /auth/login
+    A->>D: Query user
+    D-->>A: User record
+    A-->>C: JWT token
+```
+
+**Arrow types:**
+- `->>` Solid line with arrowhead (sync call)
+- `-->>` Dashed line with arrowhead (response)
+- `--)` Async message
+
+### Entity Relationship Diagram (Schema)
+
+```mermaid
+erDiagram
+    USER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT ||--o{ LINE_ITEM : "ordered in"
+
+    USER {
+        uuid id PK
+        string email
+        timestamp created_at
+    }
+    ORDER {
+        uuid id PK
+        uuid user_id FK
+        decimal total
+    }
+```
+
+**Relationship notation:**
+- `||` One (required)
+- `o|` Zero or one
+- `}|` One or many
+- `}o` Zero or many
+
+### State Diagram (State Machines)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Pending: submit
+    Pending --> Approved: approve
+    Pending --> Rejected: reject
+    Approved --> [*]
+    Rejected --> Draft: revise
+```
+
+### Component Diagram (System Architecture)
+
+```mermaid
+flowchart LR
+    subgraph Frontend
+        UI[Web App]
+    end
+
+    subgraph Backend
+        API[FastAPI]
+        Worker[Celery]
+    end
+
+    subgraph Data
+        DB[(PostgreSQL)]
+        Cache[(Redis)]
+    end
+
+    UI --> API
+    API --> DB
+    API --> Cache
+    API --> Worker
+    Worker --> DB
+```
+
+## Storage Patterns
+
+### Inline in Session File
+
+Best for: Diagrams specific to current work, temporary visualizations
+
+```markdown
+## Architecture Diagrams
+
+### Auth Flow
+```mermaid
+sequenceDiagram
+    User->>API: Login request
+    API->>DB: Validate credentials
+    DB-->>API: User record
+    API-->>User: JWT token
+```
+**Purpose**: Visualize the authentication flow being implemented
+**Files involved**: `backend/auth/`, `backend/models/user.py`
+```
+
+### Stored in `.agents/diagrams/`
+
+Best for: Reusable diagrams, cross-session reference, team documentation
+
+```
+.agents/diagrams/
+├── system-architecture.md
+├── auth-flow.md
+└── data-pipeline.md
+```
+
+**Diagram file format:**
+
+```markdown
+---
+created: 2025-01-23T14:00:00Z
+last_updated: 2025-01-23T14:00:00Z
+tags: [auth, api, security]
+---
+
+# Auth Flow Diagram
+
+## Overview
+
+Documents the authentication and authorization flow for the API.
+
+## Diagram
+
+```mermaid
+[diagram content]
+```
+
+## Related Files
+
+- `backend/auth/jwt.py` - JWT generation
+- `backend/middleware/auth.py` - Auth middleware
+- `backend/models/user.py` - User model
+
+## Notes
+
+Any additional context about this diagram.
+```
+
+### When to Store vs Inline
+
+| Store in `.agents/diagrams/` | Keep Inline in Session |
+|------------------------------|------------------------|
+| Referenced by multiple sessions | One-time visualization |
+| Documents stable architecture | Documents work-in-progress |
+| Shared across team members | Personal understanding aid |
+| Likely to be updated | Disposable after task |
+
+## Best Practices
+
+### Keep Diagrams Focused
+
+```markdown
+# Good: Single concern
+Auth flow diagram showing login -> validate -> token
+
+# Bad: Everything at once
+Entire system with auth, billing, notifications, logging...
+```
+
+### Use Consistent Naming
+
+```markdown
+# In diagrams, use actual names from code
+API[auth-service]  # Matches service name
+DB[(users)]        # Matches table name
+
+# Not generic placeholders
+API[Service A]
+DB[(Database)]
+```
+
+### Add Context
+
+Every diagram needs:
+1. **Purpose** - Why this diagram exists
+2. **Files involved** - What code it represents
+3. **Limitations** - What it does NOT show
+
+### Update When Code Changes
+
+Diagrams are documentation. When the code they represent changes:
+1. Update the diagram
+2. Update `last_updated` timestamp
+3. Note the change in session log
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Diagram everything | Diagram only complex flows |
+| Include implementation details | Show architectural relationships |
+| Create diagrams after code | Create during planning |
+| Leave stale diagrams | Update or delete |
+| Use inconsistent notation | Follow Mermaid conventions |

--- a/plugins/loaf/skills/orchestration/SKILL.md
+++ b/plugins/loaf/skills/orchestration/SKILL.md
@@ -38,11 +38,18 @@ Every release should be complete, polished, and delightful - no MVPs or quick ha
 | Stuck on task | Check circuit breaker, consider reshaping |
 | Pre-compaction | Spawn context-archiver to preserve state |
 | Low-priority work | Spawn background-runner with run_in_background |
+| New feature workflow | Research → Architecture → PRD → Specs → Tasks |
+| Create specification | Use `/specs` with requirement reference |
+| Break down spec | Use `/tasks` to generate atomic work items |
+| Task-coupled session | Use `/start-session TASK-XXX` for traceability |
 
 ## Topics
 
 | Topic | Reference | Key Content |
 |-------|-----------|-------------|
+| Product Development | [reference/product-development.md](reference/product-development.md) | Full workflow: Research → Vision → Architecture → Requirements → Specs → Tasks |
+| Specifications | [reference/specs.md](reference/specs.md) | Spec format, lifecycle, shaping, test conditions |
+| Local Tasks | [reference/local-tasks.md](reference/local-tasks.md) | Task format, abstraction layer, Linear/local backend |
 | Agent Delegation | [reference/delegation.md](reference/delegation.md) | Agent capabilities, spawn patterns, decision tree |
 | Background Agents | [reference/background-agents.md](reference/background-agents.md) | Non-interactive work, spawn with run_in_background |
 | Council Workflow | [reference/councils.md](reference/councils.md) | Composition, deliberation, synthesis, user approval |

--- a/plugins/loaf/skills/orchestration/SKILL.md
+++ b/plugins/loaf/skills/orchestration/SKILL.md
@@ -37,12 +37,14 @@ Every release should be complete, polished, and delightful - no MVPs or quick ha
 | Agent selection | Match domain expertise to task |
 | Stuck on task | Check circuit breaker, consider reshaping |
 | Pre-compaction | Spawn context-archiver to preserve state |
+| Low-priority work | Spawn background-runner with run_in_background |
 
 ## Topics
 
 | Topic | Reference | Key Content |
 |-------|-----------|-------------|
 | Agent Delegation | [reference/delegation.md](reference/delegation.md) | Agent capabilities, spawn patterns, decision tree |
+| Background Agents | [reference/background-agents.md](reference/background-agents.md) | Non-interactive work, spawn with run_in_background |
 | Council Workflow | [reference/councils.md](reference/councils.md) | Composition, deliberation, synthesis, user approval |
 | Session Management | [reference/sessions.md](reference/sessions.md) | Lifecycle, file format, handoffs, validation |
 | Session Resume | [reference/session-resume.md](reference/session-resume.md) | CLI flags, checkpoints, context recovery |

--- a/plugins/loaf/skills/orchestration/references/background-agents.md
+++ b/plugins/loaf/skills/orchestration/references/background-agents.md
@@ -1,0 +1,236 @@
+# Background Agents
+
+Background agents handle low-priority, long-running, or non-interactive work that can run independently while the user continues with other tasks.
+
+## When to Use Background Agents
+
+| Appropriate | Not Appropriate |
+|-------------|-----------------|
+| Security audits | Interactive debugging |
+| Code coverage analysis | User-facing questions |
+| Large-scale refactoring reports | Time-sensitive fixes |
+| Codebase-wide linting reports | Tasks requiring immediate feedback |
+| Documentation audits | Work needing user decisions mid-task |
+| Dependency vulnerability scans | Blocking tasks for current work |
+
+**Good candidates:**
+- Results can be processed later
+- No user interaction required
+- Task is well-defined with clear completion criteria
+- Output is a report or artifact, not a conversation
+
+**Poor candidates:**
+- Needs clarification mid-task
+- Time-sensitive (user waiting for result)
+- Requires real-time coordination with other agents
+
+## Spawning Background Agents
+
+### Claude Code
+
+Use the Task tool with `run_in_background: true`:
+
+```python
+Task(
+    subagent_type="background-runner",
+    prompt="""
+    Run full security audit on backend codebase.
+
+    Scope:
+    - src/api/
+    - src/services/
+
+    Write report to: .agents/reports/YYYYMMDD-HHMMSS-security-audit.md
+
+    Session: .agents/sessions/20260123-143000-auth-feature.md
+    """,
+    run_in_background=True
+)
+```
+
+### Cursor
+
+Background agents are configured via the `is_background: true` YAML property. When spawning:
+
+```
+@background-runner Run security audit on backend codebase.
+Write report to .agents/reports/
+```
+
+## Background Agent Tracking
+
+Track background agents in session frontmatter:
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security-scan"
+    agent: background-runner
+    task: "Full security audit of backend"
+    status: running  # running | completed | failed
+    result_location: null
+  - id: "bg-20260123-144500-coverage"
+    agent: background-runner
+    task: "Test coverage analysis"
+    status: completed
+    result_location: ".agents/reports/20260123-144500-coverage-report.md"
+```
+
+### Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `running` | Agent still executing |
+| `completed` | Work finished, results available |
+| `failed` | Agent encountered error |
+
+### ID Convention
+
+Background agent IDs follow: `bg-YYYYMMDD-HHMMSS-<description>`
+
+Generate with:
+```bash
+echo "bg-$(date -u +"%Y%m%d-%H%M%S")-<description>"
+```
+
+## Result Retrieval
+
+Background agents write results to `.agents/reports/` with standard frontmatter:
+
+```yaml
+---
+report:
+  title: "Security Audit Report"
+  type: background-agent-output
+  status: unprocessed  # unprocessed | processed | archived
+  created: "2026-01-23T14:30:00Z"
+  background_agent_id: "bg-20260123-143000-security-scan"
+  session_reference: "20260123-140000-auth-feature.md"
+---
+```
+
+### Processing Results
+
+1. SessionStart hook alerts user to completed background work
+2. User or PM reviews report in `.agents/reports/`
+3. PM updates session frontmatter:
+   - Change `status` from `running` to `completed`
+   - Set `result_location` to report path
+4. Process findings as needed (spawn agents, create issues)
+5. Set report `status` to `processed`
+
+## Workflow Example
+
+### 1. PM Identifies Low-Priority Work
+
+During auth feature implementation, PM identifies need for security audit but it is not blocking current work.
+
+### 2. PM Spawns Background Agent
+
+```python
+Task(
+    subagent_type="background-runner",
+    prompt="""
+    Run comprehensive security audit on auth implementation.
+
+    Files to audit:
+    - src/auth/endpoints.py
+    - src/auth/token.py
+    - src/auth/middleware.py
+
+    Check for:
+    - OWASP Top 10 vulnerabilities
+    - Secrets in code
+    - SQL injection risks
+    - Authentication bypasses
+
+    Write report to: .agents/reports/20260123-143000-auth-security.md
+
+    Session: .agents/sessions/20260123-140000-auth-feature.md
+    """,
+    run_in_background=True
+)
+```
+
+### 3. PM Updates Session Frontmatter
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-auth-security"
+    agent: background-runner
+    task: "Auth security audit"
+    status: running
+    result_location: null
+```
+
+### 4. Work Continues
+
+PM and other agents continue with main implementation while background agent works.
+
+### 5. Session Resumes Later
+
+SessionStart hook detects completed background work:
+
+```
+# Background Work Completed
+
+The following background agents have completed:
+
+- **bg-20260123-143000-auth-security** (background-runner)
+  - Task: Auth security audit
+  - Result: .agents/reports/20260123-143000-auth-security.md
+
+Review reports and update session frontmatter after processing.
+```
+
+### 6. Results Processed
+
+PM reads report, creates issues for findings, updates session.
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Use for blocking work | Keep blocking work in foreground |
+| Spawn without tracking | Always update session frontmatter |
+| Ignore completed results | Process results when alerted |
+| Use for interactive tasks | Reserve for autonomous work |
+| Spawn many concurrent background agents | Limit to 2-3 to avoid resource contention |
+| Skip result location in prompt | Always specify where to write output |
+
+## Integration Points
+
+### SessionStart Hook
+
+Checks session frontmatter for `background_agents` with `status: completed`. Alerts user to review results.
+
+### PreCompact Hook
+
+Includes background agent state in preservation. Context-archiver captures:
+- Active background agent list
+- Current status of each
+- Result locations for completed agents
+
+### Session Frontmatter
+
+Full template with background agents:
+
+```yaml
+---
+session:
+  title: "Feature implementation"
+  status: in_progress
+  # ... other session fields ...
+
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: completed
+    result_location: ".agents/reports/20260123-143000-security.md"
+  - id: "bg-20260123-150000-coverage"
+    agent: background-runner
+    task: "Coverage analysis"
+    status: running
+    result_location: null
+---
+```

--- a/plugins/loaf/skills/orchestration/references/cross-session.md
+++ b/plugins/loaf/skills/orchestration/references/cross-session.md
@@ -1,0 +1,200 @@
+# Cross-Session References
+
+Patterns for importing decisions and context from past sessions into current work without duplicating full context.
+
+## When to Reference Past Sessions
+
+### Good Reasons to Reference
+
+- **Continuing related work**: Building on previous feature decisions
+- **Consistency**: Ensuring alignment with prior architectural choices
+- **Avoiding re-deliberation**: Council decisions already made on similar topics
+- **Context recovery**: Picking up work after long gaps
+
+### Skip Referencing When
+
+- Starting genuinely new work unrelated to past sessions
+- Past decisions are documented in ADRs (use ADRs instead)
+- Context would create more noise than value
+- Decisions were superseded or invalidated
+
+## What to Import
+
+### Decisions Only (Default)
+
+Import the distilled outcomes:
+
+```markdown
+## Referenced Decisions
+
+### From: 20250115-140000-auth-jwt.md
+
+#### Decision: Token Rotation Strategy
+**Decision**: Rotate every 15 minutes
+**Rationale**: Security/UX balance
+```
+
+**Why decisions only:**
+- Minimal context footprint
+- Focus on outcomes, not process
+- Easy to scan and validate relevance
+
+### Context Summary (When Needed)
+
+Import broader context when:
+- Problem space is complex and unfamiliar
+- Technical approach was non-obvious
+- Multiple related decisions form a coherent strategy
+
+```markdown
+## Referenced Context
+
+### From: 20250115-140000-auth-jwt.md
+
+**Problem**: Session management for distributed services
+**Approach**: JWT with refresh token rotation
+**Key Files**: `src/auth/`, `src/middleware/auth.py`
+**Outcome**: Implemented, deployed to production 2025-01-20
+```
+
+## Session Frontmatter for Tracking
+
+Track all cross-session references in frontmatter:
+
+```yaml
+---
+session:
+  title: "Auth V2 Implementation"
+  status: in_progress
+  created: "2025-01-23T10:00:00Z"
+  last_updated: "2025-01-23T14:30:00Z"
+  linear_issue: "PLT-200"
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"
+      imported_at: "2025-01-23T14:30:00Z"
+      content_type: decisions
+      decisions_imported:
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+    - session: "20250110-090000-auth-oauth.md"
+      imported_at: "2025-01-23T14:35:00Z"
+      content_type: context
+      summary: "OAuth provider integration patterns"
+
+orchestration:
+  current_task: "Implement token refresh endpoint"
+---
+```
+
+## Decision Memory Format
+
+When sessions are archived, decisions are extracted to Serena memory:
+
+```markdown
+# Memory: session-auth-jwt-decisions.md
+
+## Session Context
+- **Session**: 20250115-140000-auth-jwt.md
+- **Archived**: 2025-01-15T18:00:00Z
+- **Linear Issue**: PLT-123
+
+## Key Decisions
+
+### Decision 1: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window refresh
+**Rationale**: Balances security (limited token lifetime) with UX (seamless refresh)
+**Council**: None - backend-dev recommendation accepted
+
+### Decision 2: Refresh Token Storage
+**Decision**: Store refresh tokens in HttpOnly cookies, not localStorage
+**Rationale**: Prevents XSS-based token theft; aligns with OWASP recommendations
+**Council**: Security council (5 agents) - unanimous
+
+### Decision 3: Token Validation Order
+**Decision**: Validate signature before parsing claims
+**Rationale**: Fail fast on tampered tokens; reduce processing for invalid requests
+**Council**: None - standard security practice
+```
+
+## Workflow
+
+### At Archive Time (context-archiver)
+
+1. Read session file
+2. Check for `## Decisions` section
+3. If present, run `extract-decisions.py`
+4. Write output to Serena memory via MCP
+
+### At Reference Time (/reference-session)
+
+1. Search Serena memories for matching sessions
+2. Read selected decision memory
+3. Import into current session
+4. Track in `referenced_sessions` frontmatter
+
+## Serena MCP Integration
+
+### List Available Decision Memories
+
+```python
+mcp__serena__list_memories()
+# Filter results for: session-*-decisions.md
+```
+
+### Read Decision Memory
+
+```python
+mcp__serena__read_memory(name="session-auth-jwt-decisions.md")
+```
+
+### Write Decision Memory (at archive time)
+
+```python
+mcp__serena__write_memory(
+    name="session-auth-jwt-decisions.md",
+    content=extracted_decisions_markdown
+)
+```
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Import entire session files | Import only decisions/summaries |
+| Import without tracking | Update `referenced_sessions` in frontmatter |
+| Import unrelated sessions | Search by topic, Linear issue, or keyword |
+| Duplicate ADR content | Reference the ADR directly |
+| Import stale decisions | Verify decisions are still relevant |
+| Over-reference | Import only what's needed for current work |
+| Reference without reading | Always review imported content for relevance |
+
+## When Decisions Conflict
+
+If imported decisions conflict with current approach:
+
+1. **Note the conflict** in session file
+2. **Assess if prior decision still applies**
+   - Different context? Proceed with new approach
+   - Same context? Consider why original decision was made
+3. **Document the change** if deviating
+4. **Consider council** if uncertainty remains
+5. **Update ADRs** if architectural decision changes
+
+## Best Practices
+
+1. **Reference early** - Import relevant decisions before planning
+2. **Validate relevance** - Review each decision's applicability
+3. **Track everything** - All imports go in frontmatter
+4. **Summarize in session log** - Note what was imported and why
+5. **Don't over-import** - Less is more for context management
+6. **Update if superseding** - Mark old decisions as superseded when creating new ones
+
+## Example Session Log Entry
+
+```markdown
+### 2025-01-23 14:30 - PM
+Referenced decisions from auth-jwt session (PLT-123):
+- Token rotation strategy (15-min window)
+- Refresh token storage (HttpOnly cookies)
+Relevant to current auth-v2 work; maintaining consistency.
+```

--- a/plugins/loaf/skills/orchestration/references/local-tasks.md
+++ b/plugins/loaf/skills/orchestration/references/local-tasks.md
@@ -1,0 +1,276 @@
+# Local Task Management
+
+Break specs into atomic tasks using local files when Linear isn't available.
+
+## Task Abstraction Layer
+
+Tasks work identically whether backed by Linear or local files.
+
+### Configuration
+
+```yaml
+# .agents/loaf.yaml
+task_management:
+  backend: linear  # or "local"
+
+  linear:
+    team: ProjectName
+    default_labels: []
+
+  local:
+    archive_completed: true
+    directory: .agents/tasks
+```
+
+### Abstracted Operations
+
+| Operation | Linear | Local |
+|-----------|--------|-------|
+| Create task | Create issue | Write `.agents/tasks/active/TASK-*.md` |
+| Fetch task | Get issue | Read task file |
+| Update status | Update issue | Edit frontmatter |
+| List tasks | List issues | Glob task files |
+| Complete | Move to Done | Move to archive |
+
+## Local Task Format
+
+```yaml
+---
+id: TASK-001
+title: OAuth Provider Integration
+spec: SPEC-001
+status: todo  # todo | in_progress | review | done
+priority: P1  # P0 (urgent) | P1 (high) | P2 (normal) | P3 (low)
+created: 2026-01-23T14:30:00Z
+updated: 2026-01-23T14:30:00Z
+files:
+  - src/auth/oauth.py
+  - tests/auth/test_oauth.py
+verify: pytest tests/auth/test_oauth.py
+done: OAuth flow works for Google and GitHub
+---
+
+# TASK-001: OAuth Provider Integration
+
+## Description
+
+Implement OAuth provider integration for Google and GitHub following
+the approach outlined in SPEC-001.
+
+## Acceptance Criteria
+
+- [ ] Google OAuth flow completes successfully
+- [ ] GitHub OAuth flow completes successfully
+- [ ] Tokens stored securely in session
+- [ ] Error handling for failed auth
+- [ ] Unit tests pass
+
+## Context
+
+See SPEC-001 for full context and constraints.
+Reference ADR-001 for session storage decisions.
+
+## Work Log
+
+<!-- Updated by session as work progresses -->
+```
+
+**Location:** `.agents/tasks/active/TASK-001-oauth-provider.md`
+
+## Task Lifecycle
+
+```
+todo → in_progress → review → done
+  │        │           │        │
+  └────────┴───────────┴────────┘
+           can return to earlier states
+```
+
+| Status | Meaning |
+|--------|---------|
+| `todo` | Ready to work, not started |
+| `in_progress` | Actively being worked |
+| `review` | Implementation complete, needs verification |
+| `done` | Verified complete, ready for archive |
+
+## Creating Tasks from Specs
+
+### Input
+
+- Spec ID (e.g., `SPEC-001`)
+- Optional: priority override
+
+### Task Breakdown Rules
+
+1. **One concern per task** - Don't mix backend + tests + frontend
+2. **Clear done condition** - Observable, verifiable outcome
+3. **Verification command** - How to prove it works
+4. **File hints** - Which files will likely be modified
+
+### Example Breakdown
+
+```
+SPEC-001: User Authentication with OAuth
+        ↓
+TASK-001: OAuth Provider Integration
+  - Google OAuth client setup
+  - GitHub OAuth client setup
+  - Token exchange logic
+  verify: pytest tests/auth/test_oauth.py
+
+TASK-002: Session Management
+  - Session cookie handling
+  - Session storage (Redis/DB)
+  - Session expiry logic
+  verify: pytest tests/auth/test_session.py
+
+TASK-003: Login UI Components
+  - Login page layout
+  - Provider buttons
+  - Error states
+  verify: npm run test:e2e -- auth
+```
+
+## Directory Structure
+
+```
+.agents/tasks/
+├── active/                    # Current work
+│   ├── TASK-001-oauth-provider.md
+│   ├── TASK-002-session-management.md
+│   └── TASK-003-login-ui.md
+└── archive/                   # Completed work
+    └── 2026-01/              # Organized by month
+        └── TASK-000-initial-setup.md
+```
+
+## Task ID Generation
+
+Format: `TASK-{number}-{slug}`
+
+```bash
+# Find next available number
+ls .agents/tasks/active/ .agents/tasks/archive/*/ 2>/dev/null | \
+  grep -oE 'TASK-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+## Archiving Tasks
+
+When a task is done:
+
+1. Update status to `done`
+2. Add completion timestamp
+3. Move to archive:
+
+```bash
+mkdir -p .agents/tasks/archive/$(date +%Y-%m)
+mv .agents/tasks/active/TASK-001-*.md .agents/tasks/archive/$(date +%Y-%m)/
+```
+
+## Session Integration
+
+When `/start-session TASK-001`:
+
+1. Read task file for context
+2. Read linked spec for full picture
+3. Create session with traceability:
+
+```yaml
+session:
+  title: "OAuth Provider Integration"
+  task: TASK-001
+  spec: SPEC-001
+  status: in_progress
+
+traceability:
+  requirement: "2.1 User Authentication"
+  architecture:
+    - "Session Management"
+  decisions:
+    - ADR-001
+```
+
+## Priority Levels
+
+| Priority | Meaning | Response |
+|----------|---------|----------|
+| P0 | Urgent/blocking | Drop everything |
+| P1 | High | Work next |
+| P2 | Normal | Scheduled work |
+| P3 | Low | When time permits |
+
+## Listing Tasks
+
+### All Active Tasks
+
+```bash
+for f in .agents/tasks/active/TASK-*.md; do
+  id=$(grep '^id:' "$f" | cut -d: -f2 | tr -d ' ')
+  title=$(grep '^title:' "$f" | cut -d: -f2-)
+  status=$(grep '^status:' "$f" | cut -d: -f2 | tr -d ' ')
+  echo "$id [$status] $title"
+done
+```
+
+### Tasks for a Spec
+
+```bash
+grep -l "spec: SPEC-001" .agents/tasks/active/*.md
+```
+
+## Work Log Updates
+
+As work progresses, append to the Work Log section:
+
+```markdown
+## Work Log
+
+### 2026-01-23 14:30 UTC
+Started OAuth integration. Set up Google OAuth client credentials.
+
+### 2026-01-23 15:45 UTC
+Google OAuth working. Moving to GitHub integration.
+
+### 2026-01-23 17:00 UTC
+Both providers working. Tests pass. Moving to review.
+```
+
+## Verification
+
+Before marking `done`:
+
+1. Run the `verify` command from frontmatter
+2. Check all acceptance criteria are checked
+3. Ensure no regressions in related tests
+
+```bash
+# Run task verification
+verify_cmd=$(grep '^verify:' TASK-001-*.md | cut -d: -f2-)
+eval "$verify_cmd"
+```
+
+## Local vs Linear Comparison
+
+| Feature | Local | Linear |
+|---------|-------|--------|
+| No external dependency | yes | no |
+| Rich UI | no | yes |
+| Team collaboration | git-based | native |
+| Notifications | none | email/slack |
+| Reporting | manual | built-in |
+| Offline work | yes | limited |
+
+**Use local when:**
+- Solo project
+- No Linear access
+- Offline development
+- Simple task tracking
+
+**Use Linear when:**
+- Team collaboration needed
+- Rich workflow automation
+- Integration with other tools
+- Reporting requirements

--- a/plugins/loaf/skills/orchestration/references/product-development.md
+++ b/plugins/loaf/skills/orchestration/references/product-development.md
@@ -1,0 +1,234 @@
+# Product Development Workflow
+
+A Research → Vision → Architecture → Requirements → Specs → Tasks → Session workflow for structured product development.
+
+## Core Insight
+
+**Separate permanent project knowledge from ephemeral orchestration.**
+
+```
+docs/                               # Permanent project knowledge
+├── VISION.md                       # Strategic direction (evolves rarely)
+├── ARCHITECTURE.md                 # Technical design (evolves with learnings)
+├── REQUIREMENTS.md                 # Business/product rules (evolves with feedback)
+├── decisions/                      # Architecture Decision Records
+│   └── ADR-001-database-choice.md
+└── specs/                          # Feature specifications (temporary)
+    ├── SPEC-001-user-auth.md
+    └── archive/                    # Completed specs
+
+.agents/                            # Ephemeral orchestration
+├── loaf.yaml                       # Project config (task backend, etc.)
+├── sessions/                       # Active work contexts
+├── plans/                          # Implementation plans
+├── councils/                       # Deliberation records
+├── transcripts/                    # Archived conversation transcripts
+├── tasks/                          # Local tasks (when not using Linear)
+│   ├── active/
+│   │   └── TASK-001-oauth-provider.md
+│   └── archive/
+└── debug/                          # Persistent debug sessions
+```
+
+## The Hierarchy
+
+```
+RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS → SESSION
+    │         │          │              │           │        │        │
+/research  (manual)  /architecture    /prd       /specs   /tasks  /start-session
+    │                    │              │           │        │
+    └─► evolves ─────────┴──────────────┴───────────┴────────┘
+        VISION                                      (feedback loops)
+```
+
+**Each level breaks down the one above:**
+- Research informs/evolves Vision
+- Vision shapes Architecture
+- Architecture constrains Requirements
+- Requirements break into Specs
+- Specs break into Tasks
+- Tasks become Sessions
+
+## Commands Overview
+
+| Command | Input | Output | Purpose |
+|---------|-------|--------|---------|
+| `/research` | Topic or "project state" | Insights, brainstorm | Zoom out, evolve VISION |
+| `/architecture` | Decision question | ARCHITECTURE.md + ADR | Technical decisions |
+| `/prd` | Feature area | REQUIREMENTS.md section | Product/business rules |
+| `/specs` | Requirement reference | SPEC-001-*.md | Feature specifications |
+| `/tasks` | Spec reference | TASK-* files/issues | Atomic work items |
+| `/start-session` | TASK-ID | Session file | Execute a task |
+
+## Document Formats
+
+### VISION.md
+
+Strategic direction that evolves rarely. Contains:
+- Product purpose and target users
+- Core principles and values
+- Long-term direction
+- What makes this product unique
+
+### ARCHITECTURE.md
+
+Technical design that evolves with learnings:
+- System architecture overview
+- Technology choices and rationale
+- Integration patterns
+- Deployment model
+
+### REQUIREMENTS.md
+
+Business and product rules organized by domain:
+
+```markdown
+## 2. Identity & Access
+
+### 2.1 User Authentication
+
+**Business Rules**
+- Users authenticate via OAuth (Google, GitHub)
+- Sessions expire after 24 hours of inactivity
+- Failed login attempts logged for security
+
+**Acceptance Criteria**
+- [ ] User can sign in with Google
+- [ ] User can sign in with GitHub
+- [ ] Session persists across browser refresh
+- [ ] Logout clears session completely
+```
+
+### Architecture Decision Records (ADRs)
+
+```yaml
+---
+id: ADR-001
+title: "PostgreSQL as Required Database"
+status: Accepted  # Proposed | Accepted | Deprecated | Superseded
+date: 2026-01-23
+---
+
+# ADR-001: PostgreSQL as Required Database
+
+## Context
+[Why this decision is needed]
+
+## Decision
+[What was decided]
+
+## Consequences
+[Tradeoffs and implications]
+```
+
+**Location:** `docs/decisions/ADR-001-*.md`
+
+## Configuration
+
+```yaml
+# .agents/loaf.yaml
+project:
+  name: "My Project"
+
+task_management:
+  backend: linear  # or "local"
+
+  linear:
+    team: ProjectName
+
+  local:
+    archive_completed: true
+
+docs:
+  vision: docs/VISION.md
+  architecture: docs/ARCHITECTURE.md
+  requirements: docs/REQUIREMENTS.md
+  decisions: docs/decisions/
+  specs: docs/specs/
+```
+
+## Workflow Examples
+
+### Full Workflow (New Feature)
+
+```bash
+# 1. Zoom out, check project state
+/research "project state"
+# → Lessons learned, ideas for auth improvement
+
+# 2. Make architecture decision
+/architecture "OAuth vs custom auth"
+# → Interview → ADR-001-auth-approach.md
+
+# 3. Capture requirements
+/prd "user authentication"
+# → Interview → REQUIREMENTS.md section 2.1
+
+# 4. Create specification
+/specs "2.1 User Authentication"
+# → Interview → SPEC-001-user-auth.md
+
+# 5. Generate tasks
+/tasks SPEC-001
+# → TASK-001, TASK-002, TASK-003
+
+# 6. Work on tasks
+/start-session TASK-001
+# → Session → Implementation → Done
+```
+
+### Quick Fix (Ad-hoc)
+
+```bash
+# Create task directly (bug report, small fix)
+/start-session TASK-099
+# PM: "No parent spec. Proceed?"
+# User: "Yes, small fix"
+# → Session → Fix → Done
+```
+
+## Feedback Loops
+
+The workflow is not rigid. Each level can feed back to higher levels:
+
+| Discovery | Action |
+|-----------|--------|
+| Implementation reveals design flaw | Update ARCHITECTURE.md |
+| Edge case invalidates requirement | Update REQUIREMENTS.md |
+| Spec too ambitious for appetite | Re-scope or split |
+| Task reveals missing requirement | Add to REQUIREMENTS.md |
+
+## Transcript Archival
+
+After `/compact` or `/clear`, archive conversation transcripts for future reference:
+
+1. **Copy transcript** to `.agents/transcripts/`
+2. **Link from session file** in frontmatter:
+
+```yaml
+session:
+  title: "Feature Implementation"
+  transcripts:
+    - 20260123-143500-pre-compact.jsonl
+    - 20260123-160000-final.jsonl
+```
+
+This preserves full context for debugging, knowledge extraction, and audit trails.
+
+## Flexibility Preserved
+
+1. **Skip steps** - Quick fixes don't need full workflow
+2. **Feedback loops** - Any level can evolve from learnings
+3. **Agents adapt** - Not a rigid harness
+
+## Critical Files
+
+| File | Purpose |
+|------|---------|
+| `docs/VISION.md` | Strategic direction |
+| `docs/ARCHITECTURE.md` | Technical design |
+| `docs/REQUIREMENTS.md` | Product rules |
+| `docs/decisions/ADR-*.md` | Architecture decisions |
+| `docs/specs/SPEC-*.md` | Feature specifications |
+| `.agents/tasks/active/TASK-*.md` | Local tasks |
+| `.agents/loaf.yaml` | Project configuration |

--- a/plugins/loaf/skills/orchestration/references/sessions.md
+++ b/plugins/loaf/skills/orchestration/references/sessions.md
@@ -68,6 +68,7 @@ session:
   branch: "username/back-123-feature"          # Optional: working branch
   transcripts: []                              # Archived Claude Code transcripts (filenames only)
                                                # Example: ["2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl"]
+  referenced_sessions: []                      # Cross-session references (see below)
 
 plans: []  # List of plan files in .agents/plans/ used by this session
            # Example: ["20251204-143500-api-design.md", "20251204-150000-frontend.md"]
@@ -79,8 +80,42 @@ orchestration:
       task: "Brief task description"
       status: completed                        # pending|in_progress|completed
       summary: "Outcome summary"
+
+background_agents:                             # Background work running independently
+  - id: "bg-20260123-143000-security-scan"     # ID: bg-YYYYMMDD-HHMMSS-description
+    agent: background-runner                   # Agent type
+    task: "Full security audit"                # Brief description
+    status: running                            # running|completed|failed
+    result_location: null                      # Path to report when complete
 ---
 ```
+
+### Cross-Session References
+
+Track decisions imported from past sessions via `/reference-session`:
+
+```yaml
+session:
+  # ... other fields ...
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"     # Source session filename
+      imported_at: "2025-01-23T14:30:00Z"        # When imported
+      content_type: decisions                     # decisions|context|all
+      decisions_imported:                         # List of decision titles
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+    - session: "20250110-090000-auth-oauth.md"
+      imported_at: "2025-01-23T14:35:00Z"
+      content_type: context
+      summary: "OAuth provider integration patterns"
+```
+
+**Why track references:**
+- Audit trail of where context came from
+- Avoids re-importing same decisions
+- Enables tracing decision lineage across sessions
+
+See `references/cross-session.md` for full patterns.
 
 ### Required Sections
 
@@ -160,6 +195,29 @@ Implementation plans for this session (stored in `.agents/plans/`):
 |------|--------|-------------|
 | [api-design](../plans/20251204-143500-api-design.md) | approved | API endpoint structure |
 | [frontend](../plans/20251204-150000-frontend.md) | pending | UI component design |
+
+## Architecture Diagrams
+
+### [Diagram Name]
+
+```mermaid
+[diagram content]
+```
+
+**Purpose**: Why this diagram helps understand the work
+**Files involved**: List of related file paths
+**Created**: When diagram was created (update if modified)
+
+<!--
+When to add diagrams:
+- Multi-service changes: Show interaction points
+- Data flow changes: Trace data through system
+- Schema modifications: Visualize relationships
+- API design: Document request/response flows
+
+For reusable diagrams, store in .agents/diagrams/ instead.
+See foundations skill reference/diagrams.md for Mermaid syntax.
+-->
 
 ## Council Outcomes
 

--- a/plugins/loaf/skills/orchestration/references/specs.md
+++ b/plugins/loaf/skills/orchestration/references/specs.md
@@ -1,0 +1,255 @@
+# Feature Specifications
+
+Break VISION + ARCHITECTURE + REQUIREMENTS into specific, implementable specs.
+
+## Philosophy
+
+**Specs are shaped solutions, not detailed designs.**
+
+A spec defines:
+- What problem we're solving
+- Boundaries (in/out of scope)
+- High-level approach
+- Test conditions
+
+A spec does NOT define:
+- Implementation details
+- Code structure
+- Exact UI layouts
+
+## Spec Format
+
+```yaml
+---
+id: SPEC-001
+title: "User Authentication with OAuth"
+requirement: "2.1 User Authentication"
+created: 2026-01-23T14:30:00Z
+status: drafting  # drafting | approved | implementing | complete
+appetite: "1 week"
+---
+
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+[From REQUIREMENTS 2.1 - why this matters to users and the business]
+
+## Proposed Solution
+
+[Shaped solution - high-level approach, not implementation details]
+
+## Scope
+
+### In Scope
+- OAuth: Google, GitHub
+- Session management with secure cookies
+- Login/logout UI
+
+### Out of Scope (Rabbit Holes)
+- Custom OAuth providers (avoid this complexity)
+- MFA (future spec if needed)
+- Password-based auth
+
+### No-Gos
+- Passwords in plaintext
+- Tokens in local storage
+- Session data in URLs
+
+## Test Conditions
+
+- [ ] OAuth flow completes for Google
+- [ ] OAuth flow completes for GitHub
+- [ ] Session persists across page refresh
+- [ ] Logout clears session completely
+- [ ] Invalid tokens are rejected
+
+## Implementation Notes
+
+[Architecture references, technical constraints, relevant ADRs]
+
+## Circuit Breaker
+
+At 50% appetite: if OAuth integration is problematic, simplify to single provider (Google only).
+```
+
+**Location:** `docs/specs/SPEC-001-feature-name.md`
+
+## Spec Lifecycle
+
+```
+drafting → approved → implementing → complete
+    │         │           │           │
+    └─────────┴───────────┴───────────┘
+              can return to drafting
+```
+
+| Status | Meaning |
+|--------|---------|
+| `drafting` | Being refined, not ready for work |
+| `approved` | User approved, ready for task breakdown |
+| `implementing` | Tasks created, work in progress |
+| `complete` | All tasks done, spec archived |
+
+## Creating Specs
+
+### Input Required
+
+1. **Requirement reference** - Which section of REQUIREMENTS.md
+2. **Appetite** - How much time is it worth (from Shape Up)
+
+### Interview Questions
+
+Before drafting, clarify:
+
+| Area | Questions |
+|------|-----------|
+| Scope | What's definitely in? What's definitely out? |
+| Rabbit holes | What seems related but should be avoided? |
+| No-gos | What approaches are forbidden? |
+| Test conditions | How do we know it works? |
+| Dependencies | What must exist first? |
+| Edge cases | What could go wrong? |
+
+### Writing the Spec
+
+1. **Start with Problem Statement** - Not "build X" but "solve Y"
+2. **Shape the solution** - Direction, not blueprint
+3. **Define boundaries explicitly** - In/out/no-gos
+4. **Write test conditions** - Observable outcomes
+5. **Set circuit breaker** - When to stop and reassess
+
+## Appetite Levels
+
+| Appetite | Size | Suitable For |
+|----------|------|--------------|
+| Small | 1-2 days | Bug fixes, minor enhancements |
+| Medium | 3-5 days | Feature additions, refactors |
+| Large | 1-2 weeks | Major features (rare) |
+
+If a spec can't fit the appetite, it needs more shaping or should be split.
+
+## Splitting Large Specs
+
+When a spec is too big:
+
+```
+SPEC-001-user-auth.md (large, 2 weeks)
+        ↓ split into
+SPEC-001a-oauth-integration.md (medium, 3 days)
+SPEC-001b-session-management.md (small, 2 days)
+SPEC-001c-login-ui.md (medium, 3 days)
+```
+
+Each sub-spec:
+- Has its own appetite
+- Can be worked independently
+- References the original requirement
+
+## Archiving Specs
+
+When all tasks for a spec are complete:
+
+1. Update status to `complete`
+2. Add completion date to frontmatter
+3. Move to `docs/specs/archive/`
+
+```bash
+mv docs/specs/SPEC-001-user-auth.md docs/specs/archive/
+```
+
+## Spec vs Plan
+
+| Spec | Plan |
+|------|------|
+| **What** to build | **How** to build it |
+| Lives in `docs/specs/` | Lives in `.agents/plans/` |
+| Survives sessions | Tied to session |
+| User-facing | Implementation detail |
+| Shape Up shaped | Tactical steps |
+
+Specs define the target. Plans define the route to get there.
+
+## Validation Checklist
+
+Before approving a spec:
+
+- [ ] Problem statement is clear and user-focused
+- [ ] Scope boundaries are explicit (in/out/no-gos)
+- [ ] Test conditions are observable and testable
+- [ ] Appetite is realistic for the scope
+- [ ] Circuit breaker is defined
+- [ ] Requirement reference is valid
+- [ ] No implementation details (those go in plans)
+
+## Example: Good vs Bad Specs
+
+### Bad Spec
+
+```markdown
+# SPEC-001: Add OAuth
+
+Add OAuth to the app.
+
+## Requirements
+- Add Google OAuth
+- Add session management
+- Add logout
+```
+
+Problems:
+- No problem statement
+- No scope boundaries
+- No test conditions
+- No appetite
+- Too vague to implement
+
+### Good Spec
+
+```markdown
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+Users currently can't access the application. We need a secure,
+frictionless login flow that leverages existing identity providers
+so users don't need to create yet another password.
+
+## Proposed Solution
+
+Implement OAuth 2.0 flow with Google and GitHub as initial providers.
+Store session in secure HTTP-only cookies. Provide clear login/logout UI.
+
+## Scope
+
+### In Scope
+- Google OAuth integration
+- GitHub OAuth integration
+- Session cookie management
+- Login page with provider buttons
+- Logout functionality
+
+### Out of Scope
+- Apple/Microsoft providers (future)
+- MFA (separate spec if needed)
+- Account linking (complex, avoid)
+
+### No-Gos
+- Storing tokens in localStorage
+- Custom password auth
+- Session data in URLs
+
+## Test Conditions
+
+- [ ] New user can sign in with Google
+- [ ] New user can sign in with GitHub
+- [ ] Session persists across browser tabs
+- [ ] Session survives page refresh
+- [ ] Logout clears all session data
+- [ ] Expired sessions redirect to login
+
+## Circuit Breaker
+
+At 50% appetite: if both providers are problematic, ship with Google only.
+GitHub can be a follow-up spec.
+```

--- a/plugins/loaf/skills/orchestration/scripts/extract-decisions.py
+++ b/plugins/loaf/skills/orchestration/scripts/extract-decisions.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Extract decisions from a session file and format as Serena memory.
+
+Usage: extract-decisions.py <session-file>
+
+Reads a session file, extracts the ## Decisions section, and outputs
+formatted Serena memory content to stdout. The output can be piped to
+Serena MCP's write_memory tool.
+
+Exit codes:
+  0 - Success (decisions extracted)
+  1 - Error (file not found, parse error)
+  2 - No decisions found
+"""
+
+import sys
+import re
+import yaml
+from pathlib import Path
+from datetime import datetime, timezone
+
+
+def parse_frontmatter(content: str) -> tuple[dict, str]:
+    """Extract YAML frontmatter from markdown content."""
+    if not content.startswith('---'):
+        return {}, content
+
+    parts = content.split('---', 2)
+    if len(parts) < 3:
+        return {}, content
+
+    try:
+        frontmatter = yaml.safe_load(parts[1])
+        body = parts[2]
+        return frontmatter or {}, body
+    except yaml.YAMLError as e:
+        print(f"Warning: Could not parse frontmatter: {e}", file=sys.stderr)
+        return {}, content
+
+
+def extract_decisions_section(body: str) -> str | None:
+    """Extract the ## Decisions section from markdown body."""
+    # Match ## Decisions followed by content until next ## or end
+    pattern = r'^## Decisions\s*\n(.*?)(?=^## |\Z)'
+    match = re.search(pattern, body, re.MULTILINE | re.DOTALL)
+
+    if match:
+        content = match.group(1).strip()
+        if content:
+            return content
+    return None
+
+
+def parse_decisions(decisions_text: str) -> list[dict]:
+    """Parse individual decisions from the decisions section."""
+    decisions = []
+
+    # Match ### Decision N: Title or ### Title patterns
+    pattern = r'^###\s+(?:Decision\s+\d+:\s+)?(.+?)\n(.*?)(?=^### |\Z)'
+    matches = re.findall(pattern, decisions_text, re.MULTILINE | re.DOTALL)
+
+    for title, content in matches:
+        decision = {
+            'title': title.strip(),
+            'decision': '',
+            'rationale': '',
+            'council': ''
+        }
+
+        # Extract **Decision**: value
+        decision_match = re.search(
+            r'\*\*Decision\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if decision_match:
+            decision['decision'] = decision_match.group(1).strip()
+
+        # Extract **Rationale**: value
+        rationale_match = re.search(
+            r'\*\*Rationale\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if rationale_match:
+            decision['rationale'] = rationale_match.group(1).strip()
+
+        # Extract **Council**: value (optional)
+        council_match = re.search(
+            r'\*\*Council\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if council_match:
+            decision['council'] = council_match.group(1).strip()
+
+        # Only add if we have at least a title and decision
+        if decision['title'] and decision['decision']:
+            decisions.append(decision)
+
+    return decisions
+
+
+def format_memory(
+    session_file: str,
+    frontmatter: dict,
+    decisions: list[dict]
+) -> str:
+    """Format decisions as Serena memory markdown."""
+    session = frontmatter.get('session', {})
+    title = session.get('title', 'Unknown Session')
+    linear_issue = session.get('linear_issue', 'N/A')
+    archived_at = session.get('archived_at', datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'))
+
+    # Generate slug from filename
+    filename = Path(session_file).stem
+    slug = re.sub(r'^\d{8}-\d{6}-', '', filename)
+
+    lines = [
+        f"# Memory: session-{slug}-decisions.md",
+        "",
+        "## Session Context",
+        f"- **Session**: {Path(session_file).name}",
+        f"- **Title**: {title}",
+        f"- **Archived**: {archived_at}",
+        f"- **Linear Issue**: {linear_issue}",
+        "",
+        "## Key Decisions",
+        ""
+    ]
+
+    for i, d in enumerate(decisions, 1):
+        lines.append(f"### Decision {i}: {d['title']}")
+        lines.append(f"**Decision**: {d['decision']}")
+        if d['rationale']:
+            lines.append(f"**Rationale**: {d['rationale']}")
+        if d['council']:
+            lines.append(f"**Council**: {d['council']}")
+        lines.append("")
+
+    return '\n'.join(lines)
+
+
+def generate_memory_name(session_file: str) -> str:
+    """Generate Serena memory name from session filename."""
+    filename = Path(session_file).stem
+    slug = re.sub(r'^\d{8}-\d{6}-', '', filename)
+    return f"session-{slug}-decisions.md"
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: extract-decisions.py <session-file>", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Extracts decisions from a session file and outputs Serena memory format.", file=sys.stderr)
+        print("The memory name will be: session-<slug>-decisions.md", file=sys.stderr)
+        sys.exit(1)
+
+    session_file = sys.argv[1]
+    filepath = Path(session_file)
+
+    if not filepath.exists():
+        print(f"Error: File not found: {session_file}", file=sys.stderr)
+        sys.exit(1)
+
+    content = filepath.read_text()
+    frontmatter, body = parse_frontmatter(content)
+
+    decisions_text = extract_decisions_section(body)
+    if not decisions_text:
+        print(f"No ## Decisions section found in: {session_file}", file=sys.stderr)
+        sys.exit(2)
+
+    decisions = parse_decisions(decisions_text)
+    if not decisions:
+        print(f"No parseable decisions found in: {session_file}", file=sys.stderr)
+        sys.exit(2)
+
+    # Output memory content to stdout
+    memory_content = format_memory(session_file, frontmatter, decisions)
+    print(memory_content)
+
+    # Output memory name to stderr for scripting
+    memory_name = generate_memory_name(session_file)
+    print(f"\n# Memory name: {memory_name}", file=sys.stderr)
+    print(f"# Decisions extracted: {len(decisions)}", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/loaf/skills/orchestration/scripts/git-context-summary.sh
+++ b/plugins/loaf/skills/orchestration/scripts/git-context-summary.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Generate git context summary for sessions
+# Usage: git-context-summary.sh [--brief]
+#
+# Output includes:
+#   - Current branch name
+#   - Uncommitted changes count
+#   - Recent commits (last 3-5)
+#   - Summary of changes from main/master (if on feature branch)
+#
+# Options:
+#   --brief   Output only branch and uncommitted changes (for hooks)
+
+set -e
+
+BRIEF_MODE=false
+if [[ "$1" == "--brief" ]]; then
+    BRIEF_MODE=true
+fi
+
+# Check if we're in a git repository
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+    echo "Not a git repository"
+    exit 0
+fi
+
+# Get current branch
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if [[ -z "$CURRENT_BRANCH" ]]; then
+    # Detached HEAD state
+    CURRENT_BRANCH="(detached HEAD at $(git rev-parse --short HEAD 2>/dev/null || echo 'unknown'))"
+fi
+
+# Count uncommitted changes (staged + unstaged + untracked)
+UNCOMMITTED_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+
+# Brief mode: just branch and changes
+if [[ "$BRIEF_MODE" == "true" ]]; then
+    echo "## Git Context"
+    echo "- **Branch**: $CURRENT_BRANCH"
+    echo "- **Uncommitted changes**: $UNCOMMITTED_COUNT file(s)"
+    exit 0
+fi
+
+# Full output
+echo "## Git Context"
+echo ""
+echo "**Branch**: \`$CURRENT_BRANCH\`"
+echo ""
+echo "**Uncommitted changes**: $UNCOMMITTED_COUNT file(s)"
+
+# Show brief status if there are changes
+if [[ "$UNCOMMITTED_COUNT" -gt 0 ]]; then
+    echo ""
+    echo "**Changed files**:"
+    # Show first 10 files max
+    git status --porcelain 2>/dev/null | head -10 | while read -r line; do
+        STATUS="${line:0:2}"
+        FILE="${line:3}"
+        case "$STATUS" in
+            "M "| " M"|"MM") echo "  - Modified: \`$FILE\`" ;;
+            "A ") echo "  - Added: \`$FILE\`" ;;
+            "D "| " D") echo "  - Deleted: \`$FILE\`" ;;
+            "R ") echo "  - Renamed: \`$FILE\`" ;;
+            "??") echo "  - Untracked: \`$FILE\`" ;;
+            *) echo "  - Changed: \`$FILE\`" ;;
+        esac
+    done
+    TOTAL=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$TOTAL" -gt 10 ]]; then
+        echo "  - ... and $((TOTAL - 10)) more"
+    fi
+fi
+
+# Recent commits (last 5)
+echo ""
+echo "**Recent commits**:"
+git log --oneline -5 2>/dev/null | while read -r line; do
+    echo "  - \`$line\`"
+done
+
+# Detect main branch (main or master)
+MAIN_BRANCH=""
+if git show-ref --verify --quiet refs/heads/main 2>/dev/null; then
+    MAIN_BRANCH="main"
+elif git show-ref --verify --quiet refs/heads/master 2>/dev/null; then
+    MAIN_BRANCH="master"
+fi
+
+# Summary of changes from main (if on feature branch)
+if [[ -n "$MAIN_BRANCH" && "$CURRENT_BRANCH" != "$MAIN_BRANCH" && "$CURRENT_BRANCH" != "(detached"* ]]; then
+    # Count commits ahead of main
+    COMMITS_AHEAD=$(git rev-list --count "$MAIN_BRANCH..$CURRENT_BRANCH" 2>/dev/null || echo "0")
+    COMMITS_BEHIND=$(git rev-list --count "$CURRENT_BRANCH..$MAIN_BRANCH" 2>/dev/null || echo "0")
+
+    echo ""
+    echo "**Relative to \`$MAIN_BRANCH\`**:"
+    echo "  - $COMMITS_AHEAD commit(s) ahead"
+    echo "  - $COMMITS_BEHIND commit(s) behind"
+
+    # Files changed from main
+    if [[ "$COMMITS_AHEAD" -gt 0 ]]; then
+        FILES_CHANGED=$(git diff --name-only "$MAIN_BRANCH...$CURRENT_BRANCH" 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "$FILES_CHANGED" -gt 0 ]]; then
+            echo "  - $FILES_CHANGED file(s) changed from \`$MAIN_BRANCH\`"
+        fi
+    fi
+fi

--- a/plugins/loaf/skills/orchestration/scripts/list-session-decisions.sh
+++ b/plugins/loaf/skills/orchestration/scripts/list-session-decisions.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# List available session decision memories from Serena.
+#
+# Usage: list-session-decisions.sh
+#
+# This script lists Serena memories matching the pattern session-*-decisions.md
+# and displays session name and metadata.
+#
+# Note: This is a helper script. In practice, agents should use Serena MCP
+# directly via mcp__serena__list_memories() for programmatic access.
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Session Decision Memories${NC}"
+echo "========================="
+echo ""
+
+# Check if .serena directory exists
+if [[ ! -d ".serena" ]]; then
+    echo -e "${YELLOW}No .serena directory found in current project.${NC}"
+    echo "Serena memories are stored per-project. Make sure you're in a Serena-enabled project."
+    exit 0
+fi
+
+# Check for memories directory
+MEMORIES_DIR=".serena/memories"
+if [[ ! -d "$MEMORIES_DIR" ]]; then
+    echo -e "${YELLOW}No memories directory found.${NC}"
+    echo "No session decisions have been extracted yet."
+    echo ""
+    echo "To extract decisions from a session:"
+    echo "  python3 extract-decisions.py <session-file>"
+    echo "  Then use Serena MCP to write the memory."
+    exit 0
+fi
+
+# Find session decision memories
+MEMORIES=$(find "$MEMORIES_DIR" -name "session-*-decisions.md" 2>/dev/null | sort -r)
+
+if [[ -z "$MEMORIES" ]]; then
+    echo -e "${YELLOW}No session decision memories found.${NC}"
+    echo ""
+    echo "Session decision memories are created when sessions are archived."
+    echo "Pattern: session-<slug>-decisions.md"
+    exit 0
+fi
+
+# Display memories
+count=0
+echo -e "${GREEN}Available Decision Memories:${NC}"
+echo ""
+
+for memory in $MEMORIES; do
+    count=$((count + 1))
+    filename=$(basename "$memory")
+
+    # Extract slug from filename
+    slug=$(echo "$filename" | sed 's/^session-//' | sed 's/-decisions\.md$//')
+
+    # Try to read session info from memory content
+    if [[ -f "$memory" ]]; then
+        session_name=$(grep -m1 "^\- \*\*Session\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "Unknown")
+        archived=$(grep -m1 "^\- \*\*Archived\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "Unknown")
+        linear=$(grep -m1 "^\- \*\*Linear Issue\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "N/A")
+        decision_count=$(grep -c "^### Decision" "$memory" 2>/dev/null || echo "0")
+
+        printf "  %2d. %s\n" "$count" "$slug"
+        printf "      Session:  %s\n" "$session_name"
+        printf "      Archived: %s\n" "$archived"
+        printf "      Linear:   %s\n" "$linear"
+        printf "      Decisions: %s\n" "$decision_count"
+        echo ""
+    else
+        printf "  %2d. %s (unreadable)\n" "$count" "$filename"
+    fi
+done
+
+echo "------------------------"
+echo "Total: $count decision memories"
+echo ""
+echo -e "${BLUE}Usage:${NC}"
+echo "  /reference-session <search-term>    # Import decisions to current session"
+echo "  mcp__serena__read_memory(name=...)  # Read memory directly via MCP"

--- a/plugins/loaf/skills/orchestration/scripts/validate-session.py
+++ b/plugins/loaf/skills/orchestration/scripts/validate-session.py
@@ -60,7 +60,7 @@ def validate_frontmatter(fm: dict) -> list[str]:
             errors.append(f"Empty required field: session.{field}")
 
     # Validate status values
-    valid_statuses = ['in_progress', 'paused', 'completed']
+    valid_statuses = ['in_progress', 'paused', 'completed', 'archived']
     if session.get('status') and session['status'] not in valid_statuses:
         errors.append(f"Invalid session.status: {session['status']} (must be one of: {', '.join(valid_statuses)})")
 
@@ -72,6 +72,20 @@ def validate_frontmatter(fm: dict) -> list[str]:
                 datetime.fromisoformat(value.replace('Z', '+00:00'))
             except ValueError:
                 errors.append(f"Invalid ISO 8601 timestamp in session.{field}: {value}")
+
+    # Validate branch field format if present (optional field)
+    branch = session.get('branch', '')
+    if branch:
+        # Branch names should be non-empty strings without spaces
+        # Common formats: feature/name, username/ticket-desc, bugfix/name, etc.
+        if not isinstance(branch, str):
+            errors.append(f"Invalid session.branch: must be a string, got {type(branch).__name__}")
+        elif ' ' in branch:
+            errors.append(f"Invalid session.branch: '{branch}' contains spaces (branch names cannot have spaces)")
+        elif branch.startswith('/') or branch.endswith('/'):
+            errors.append(f"Invalid session.branch: '{branch}' cannot start or end with '/'")
+        elif '//' in branch:
+            errors.append(f"Invalid session.branch: '{branch}' contains consecutive slashes")
 
     # Check orchestration block
     orch = fm.get('orchestration', {})

--- a/plugins/loaf/skills/research/SKILL.md
+++ b/plugins/loaf/skills/research/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: research
+description: >-
+  Use for project reflection, brainstorming, and vision evolution. Covers
+  assessing project state, exploring problem spaces, generating ideas, and
+  evolving strategic direction. Activate when stepping back to think,
+  researching topics, or updating VISION.md.
+---
+
+# Research
+
+Patterns for zooming out, brainstorming, and evolving project direction.
+
+## Philosophy
+
+**Research is about understanding before doing.**
+
+Research activities:
+1. Assess project state and lessons learned
+2. Explore problem spaces with structured inquiry
+3. Generate and refine ideas through brainstorming
+4. Evolve strategic direction when evidence supports it
+
+Research is NOT about:
+- Implementing solutions
+- Making tactical decisions
+- Writing code or specifications
+
+## Quick Reference
+
+| Need | Action |
+|------|--------|
+| Understand project state | Review sessions, docs, recent changes |
+| Explore a topic | Structured inquiry with confidence hierarchy |
+| Generate ideas | Brainstorm with interview and synthesis |
+| Evolve VISION | Propose changes with evidence |
+
+## Research Modes
+
+### Mode 1: Project State Assessment
+
+**Trigger:** "What's the current state?" / "Catch me up"
+
+**Process:**
+1. Read existing docs (VISION, ARCHITECTURE, REQUIREMENTS)
+2. Check recent sessions for lessons learned
+3. Review recent commits for context
+4. Identify gaps, contradictions, or stale information
+5. Summarize current state with recommendations
+
+**Output:** State assessment with actionable insights
+
+### Mode 2: Topic Exploration
+
+**Trigger:** "Research X" / "How should we approach Y?"
+
+**Process:**
+1. Interview user to understand the question deeply
+2. Apply confidence hierarchy for sources
+3. Synthesize findings with tradeoffs
+4. Present options with recommendations
+
+**Output:** Research findings with options and recommendation
+
+### Mode 3: Brainstorming
+
+**Trigger:** "Let's brainstorm" / "Ideas for X"
+
+**Process:**
+1. Interview to understand constraints and goals
+2. Generate diverse options (quantity over quality initially)
+3. Filter through constraints
+4. Refine promising directions
+5. Present shaped options for decision
+
+**Output:** Curated options with pros/cons
+
+### Mode 4: Vision Evolution
+
+**Trigger:** "Should we change direction?" / "Update VISION"
+
+**Process:**
+1. Gather evidence (sessions, feedback, market changes)
+2. Identify what's changed since last VISION update
+3. Propose specific changes with rationale
+4. Get user approval before any edits
+
+**Output:** VISION.md change proposal (not direct edit)
+
+## Confidence Hierarchy
+
+When researching, prioritize sources in this order:
+
+```
+1. Project context (highest confidence)
+   - VISION.md, ARCHITECTURE.md, REQUIREMENTS.md
+   - Session files and lessons learned
+   - Existing codebase patterns
+
+2. Authoritative documentation
+   - Context7 for library docs
+   - Official documentation sites
+   - RFCs and specifications
+
+3. Community knowledge
+   - Stack Overflow (verified answers)
+   - GitHub issues and discussions
+   - Blog posts from recognized experts
+
+4. General web (lowest confidence)
+   - Search results
+   - Forum posts
+   - Unverified sources
+```
+
+**Rule:** Always check project context first. External research should supplement, not replace, understanding of existing decisions.
+
+## Interview Patterns
+
+### Before Any Research
+
+Ask clarifying questions:
+
+| Area | Questions |
+|------|-----------|
+| Scope | What specifically are you trying to understand? |
+| Context | What do you already know? What have you tried? |
+| Constraints | What constraints should guide the research? |
+| Output | What decision will this research inform? |
+
+### For Topic Exploration
+
+```
+1. What problem are we trying to solve?
+2. What constraints exist (technical, time, team)?
+3. What would success look like?
+4. What have we already considered and rejected?
+5. Are there non-obvious angles to explore?
+```
+
+### For Brainstorming
+
+```
+1. What's the ideal outcome if constraints didn't exist?
+2. What's the minimum viable approach?
+3. What approaches have we seen work elsewhere?
+4. What would we do if we had 10x the resources? 1/10?
+5. What's the contrarian view?
+```
+
+## Output Formats
+
+### State Assessment
+
+```markdown
+## Project State Assessment
+
+**Date:** YYYY-MM-DD
+
+### Current Position
+- [Summary of where the project stands]
+
+### Recent Progress
+- [Key accomplishments from recent sessions]
+
+### Lessons Learned
+- [Insights from implementation feedback]
+
+### Open Questions
+- [Unresolved decisions or gaps]
+
+### Recommendations
+1. [Actionable next step]
+2. [Actionable next step]
+```
+
+### Research Findings
+
+```markdown
+## Research: [Topic]
+
+**Question:** [What we're trying to understand]
+
+### Summary
+[One-paragraph answer with confidence level]
+
+### Options Considered
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Best for:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Best for:** ...
+
+### Recommendation
+[Which option and why, with caveats]
+
+### Sources
+- [Source 1 with confidence level]
+- [Source 2 with confidence level]
+```
+
+### Vision Change Proposal
+
+```markdown
+## VISION.md Change Proposal
+
+**Proposed by:** [Session/Date]
+**Evidence:** [What prompted this]
+
+### Current State
+[Quote relevant VISION.md section]
+
+### Proposed Change
+[New text]
+
+### Rationale
+[Why this change is warranted]
+
+### Impact
+- [What this changes downstream]
+- [ADRs that may need updating]
+- [Requirements that may be affected]
+
+### Approval Required
+This proposal requires user approval before implementation.
+```
+
+## Integration with Workflow
+
+Research fits at the top of the product development hierarchy:
+
+```
+RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS
+    │         │
+    └─────────┘
+    evolves
+```
+
+**Research informs Vision changes.** Vision changes cascade down through Architecture, Requirements, and Specs.
+
+## When to Research
+
+| Situation | Research Mode |
+|-----------|---------------|
+| Starting new project | Project state + Topic exploration |
+| Stuck on approach | Topic exploration + Brainstorming |
+| Finishing major work | Project state (capture learnings) |
+| External change | Vision evolution |
+| Quarterly review | Project state + Vision evolution |
+
+## When NOT to Research
+
+- **When action is clear** - Don't research to avoid doing
+- **When already decided** - Check ADRs first
+- **When time-critical** - Act, then document learnings
+- **For trivial questions** - Just answer them
+
+## Critical Rules
+
+### Always
+- Interview before researching
+- Check project context first
+- Cite sources with confidence levels
+- Present options, let user decide
+- Get approval before editing VISION
+
+### Never
+- Edit VISION without explicit approval
+- Research indefinitely (set time bounds)
+- Ignore existing project decisions
+- Present research as implementation plan
+- Skip the interview step
+
+## Scripts
+
+| Script | Usage | Description |
+|--------|-------|-------------|
+| `check-sessions.sh` | Review recent sessions | Find lessons learned |
+| `git-context-summary.sh` | Summarize git history | Understand recent changes |
+
+## Related Skills
+
+- **orchestration** - For acting on research findings
+- **foundations** - For documentation standards

--- a/src/agents/background-runner.claude-code.yaml
+++ b/src/agents/background-runner.claude-code.yaml
@@ -1,0 +1,12 @@
+name: background-runner
+description: >-
+  Lightweight background agent for non-interactive tasks. Use with run_in_background: true
+  for security audits, coverage analysis, code reviews, and other low-priority work.
+model: haiku
+skills:
+  - foundations
+tools:
+  - Read
+  - Edit
+  - Glob
+  - Grep

--- a/src/agents/background-runner.cursor.yaml
+++ b/src/agents/background-runner.cursor.yaml
@@ -1,0 +1,10 @@
+name: background-runner
+description: >-
+  Lightweight background agent for non-interactive tasks. Use for security audits,
+  coverage analysis, code reviews, and other low-priority work that can run independently.
+is_background: true
+tools:
+  Read: true
+  Edit: true
+  Glob: true
+  Grep: true

--- a/src/agents/background-runner.md
+++ b/src/agents/background-runner.md
@@ -1,0 +1,153 @@
+# Background Runner
+
+You execute specific tasks in the background, writing results to a specified location without user interaction.
+
+## When You Run
+
+- Spawned by PM/orchestrator with `run_in_background: true`
+- For low-priority, non-interactive work
+- Results expected later, not immediately
+
+## What You Do
+
+1. **Execute assigned task** - Security audits, coverage analysis, code reviews, etc.
+2. **Write results** - Output to specified `.agents/reports/` location
+3. **Update session** - Mark your background agent entry as complete
+
+## Input You Receive
+
+The spawning agent provides:
+- Specific task to execute
+- Files or scope to analyze
+- Output location (`.agents/reports/YYYYMMDD-HHMMSS-<name>.md`)
+- Session reference
+
+## Execution Process
+
+### 1. Parse Task
+
+Extract from prompt:
+- What to do (audit, analyze, review)
+- Scope (files, directories)
+- Output location
+- Session file path
+
+### 2. Execute Work
+
+Perform the assigned task:
+- Read specified files
+- Run analysis
+- Generate findings
+- Compile report
+
+### 3. Write Report
+
+Create report at specified location:
+
+```yaml
+---
+report:
+  title: "Task Description"
+  type: background-agent-output
+  status: unprocessed
+  created: "2026-01-23T14:30:00Z"
+  background_agent_id: "bg-YYYYMMDD-HHMMSS-description"
+  session_reference: "YYYYMMDD-HHMMSS-session-name.md"
+---
+
+# Report Title
+
+## Summary
+
+Brief overview of findings.
+
+## Findings
+
+### Finding 1: Title
+**Severity**: High | Medium | Low | Info
+**Location**: `path/to/file.py:123`
+**Description**: What was found
+**Recommendation**: What to do
+
+## Recommendations
+
+Prioritized list of actions.
+
+## Files Analyzed
+
+- `path/to/file1.py`
+- `path/to/file2.py`
+```
+
+### 4. Update Session Frontmatter
+
+Read session file and update your background agent entry:
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: completed  # Changed from running
+    result_location: ".agents/reports/20260123-143000-security.md"  # Set path
+```
+
+## Constraints
+
+- **No user interaction** - You cannot ask questions or request clarification
+- **No blocking work** - Complete task with available information
+- **No spawning agents** - Work independently
+- **Write to specified location** - Do not create files elsewhere
+
+## Quality Checklist
+
+Before completing:
+
+- [ ] Task executed per prompt instructions
+- [ ] Report written to specified location
+- [ ] Report has valid frontmatter with `background_agent_id`
+- [ ] Session frontmatter updated with `status: completed`
+- [ ] Session frontmatter updated with `result_location`
+- [ ] No user interaction attempted
+
+## Error Handling
+
+If task cannot be completed:
+
+1. Write partial report with what was accomplished
+2. Document blockers in report
+3. Update session frontmatter with `status: failed`
+4. Include error details in report
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: failed
+    result_location: ".agents/reports/20260123-143000-security-partial.md"
+```
+
+## Example Task
+
+**Prompt received:**
+```
+Run security audit on auth module.
+
+Files:
+- src/auth/endpoints.py
+- src/auth/token.py
+
+Check for OWASP Top 10 vulnerabilities.
+
+Write report to: .agents/reports/20260123-143000-auth-security.md
+
+Session: .agents/sessions/20260123-140000-auth-feature.md
+Background Agent ID: bg-20260123-143000-auth-security
+```
+
+**Actions:**
+1. Read `src/auth/endpoints.py` and `src/auth/token.py`
+2. Analyze for OWASP vulnerabilities
+3. Write findings to `.agents/reports/20260123-143000-auth-security.md`
+4. Update `.agents/sessions/20260123-140000-auth-feature.md` frontmatter

--- a/src/agents/background-runner.opencode.yaml
+++ b/src/agents/background-runner.opencode.yaml
@@ -1,0 +1,12 @@
+name: background-runner
+description: >-
+  Lightweight background agent for non-interactive tasks. Use for security audits,
+  coverage analysis, code reviews, and other low-priority work that can run independently.
+mode: subagent
+skills:
+  - foundations
+tools:
+  Read: true
+  Edit: true
+  Glob: true
+  Grep: true

--- a/src/agents/context-archiver.md
+++ b/src/agents/context-archiver.md
@@ -93,13 +93,66 @@ The agent resuming work should:
 Pre-compaction archive. Preserved: [brief summary of what was captured].
 ```
 
-## Serena Memory (Optional)
+## Serena Memory for Decisions
 
-Write memory ONLY when session has significant decisions:
+Write decision memory when session has significant decisions for cross-session reference.
 
-- Check if `## Decisions` section has content
-- If yes, write to `session-{session-slug}-decisions.md`
-- Include decision rationale and context
+### 5. Extract and Store Decisions
+
+Check if `## Decisions` section has content. If yes:
+
+**Step A: Extract decisions using the extraction script**
+
+```bash
+python3 plugins/loaf/skills/orchestration/scripts/extract-decisions.py \
+  ".agents/sessions/<session-file>.md"
+```
+
+This outputs formatted memory content to stdout and the memory name to stderr.
+
+**Step B: Write to Serena memory**
+
+Use Serena MCP to store the extracted decisions:
+
+```python
+mcp__serena__write_memory(
+    name="session-<slug>-decisions.md",
+    content=<extracted_content>
+)
+```
+
+**Memory naming convention:**
+- Session: `20250123-100000-auth-feature.md`
+- Memory: `session-auth-feature-decisions.md`
+
+**Memory format:**
+
+```markdown
+# Memory: session-auth-feature-decisions.md
+
+## Session Context
+- **Session**: 20250123-100000-auth-feature.md
+- **Title**: Auth Feature Implementation
+- **Archived**: 2025-01-23T14:30:00Z
+- **Linear Issue**: PLT-123
+
+## Key Decisions
+
+### Decision 1: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window
+**Rationale**: Balance between security and user experience
+**Council**: None - backend-dev recommendation accepted
+
+### Decision 2: Refresh Token Storage
+**Decision**: Store in HttpOnly cookies, not localStorage
+**Rationale**: Prevents XSS token theft
+**Council**: Security council (5 agents) - unanimous
+```
+
+**Why store decisions:**
+- Enables `/reference-session` command for cross-session continuity
+- Preserves decision rationale for future work
+- Avoids re-deliberating already-resolved questions
 
 ## Output
 
@@ -128,4 +181,5 @@ Before completing:
 - [ ] `## Resumption Prompt` provides self-contained context
 - [ ] `## Resumption Prompt` includes Transcript Archive instruction
 - [ ] `## Session Log` has timestamped entry
-- [ ] Serena memory written if decisions exist
+- [ ] Decisions extracted and written to Serena memory (if `## Decisions` has content)
+- [ ] Memory name follows convention: `session-<slug>-decisions.md`

--- a/src/agents/qa.md
+++ b/src/agents/qa.md
@@ -9,6 +9,7 @@ You are a QA engineer. Your skills tell you how to test and review code.
 - Check for OWASP Top 10 issues
 - Verify type safety and linting passes
 - Audit test coverage
+- Debug failing tests and diagnose flaky tests
 
 ## How You Work
 
@@ -16,5 +17,17 @@ You are a QA engineer. Your skills tell you how to test and review code.
 2. **Match project style** - follow existing test patterns
 3. **Test behavior, not implementation** - tests should survive refactors
 4. **Run full suite** - all tests must pass before completing
+5. **Debug systematically** - use hypothesis-driven debugging for failures
+
+## Debugging Workflow
+
+When investigating test failures or bugs:
+
+1. **Reproduce** - Establish reliable reproduction steps
+2. **Hypothesize** - Generate 3-5 possible causes, rank by likelihood
+3. **Test** - Design minimal experiments to confirm or rule out each hypothesis
+4. **Document** - Track hypotheses and evidence in investigation log
+
+See the `debugging` skill for hypothesis tracking templates and language-specific debugging patterns.
 
 Your skills contain all the patterns and conventions. Reference them.

--- a/src/commands/architecture.md
+++ b/src/commands/architecture.md
@@ -1,0 +1,260 @@
+---
+description: Make technical decisions and create Architecture Decision Records
+---
+
+# Architecture Command
+
+Interview about technical decisions, update ARCHITECTURE.md, create ADRs.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Technical decisions should be:
+1. **Deliberate** - Made consciously, not by accident
+2. **Documented** - Captured in ARCHITECTURE.md and ADRs
+3. **Traceable** - Future readers understand why
+
+---
+
+## CRITICAL: Interview First
+
+**Before making any architectural decision, understand:**
+
+1. What decision needs to be made?
+2. What constraints exist (technical, business, team)?
+3. What options have already been considered?
+4. What would "good enough" look like vs "ideal"?
+5. What's the impact of getting this wrong?
+
+Use `AskUserQuestion` to gather context.
+
+---
+
+## Process
+
+### Step 1: Understand the Decision
+
+Parse `$ARGUMENTS` to understand what decision is needed.
+
+**If unclear:** Ask clarifying questions about:
+- The problem being solved
+- Technical constraints
+- Business constraints
+- Time/resource constraints
+
+### Step 2: Gather Context
+
+1. **Read existing documents:**
+   - `docs/VISION.md` - Strategic direction
+   - `docs/ARCHITECTURE.md` - Current technical design
+   - `docs/decisions/ADR-*.md` - Previous decisions
+
+2. **Check for relevant patterns:**
+   - How similar problems were solved
+   - Established conventions in the codebase
+   - Previous attempts and outcomes
+
+3. **Review session history:**
+   - Implementation learnings
+   - Pain points from previous work
+
+### Step 3: Consider Options
+
+For each viable option:
+
+| Aspect | Evaluate |
+|--------|----------|
+| Alignment | Does it fit VISION and existing ARCHITECTURE? |
+| Complexity | How much does it add to the system? |
+| Reversibility | How hard to change later? |
+| Team capability | Can the team execute this? |
+| Maintenance | Long-term cost? |
+
+### Step 4: Convene Council (If Needed)
+
+For complex or contentious decisions, convene a council:
+
+- **Odd number:** 5 or 7 agents
+- **Diverse expertise:** Mix of perspectives
+- **Structured deliberation:** Each argues a position
+
+See `orchestration/councils` skill for council workflow.
+
+**Council advises, user decides.**
+
+### Step 5: Present Options
+
+Format:
+
+```markdown
+## Decision: [Question]
+
+### Context
+[Why this decision is needed now]
+
+### Options
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Fits when:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Fits when:** ...
+
+### Recommendation
+[Which option and why]
+
+### What do you think?
+```
+
+### Step 6: Await User Decision
+
+**Do NOT proceed without explicit user choice.**
+
+User may:
+- Accept a recommendation
+- Choose a different option
+- Ask for more information
+- Request a council deliberation
+
+### Step 7: Document the Decision
+
+After user decides:
+
+1. **Update ARCHITECTURE.md** with new decision
+2. **Create ADR** in `docs/decisions/`
+
+---
+
+## ADR Format
+
+**Filename:** `ADR-{number}-{slug}.md`
+
+```yaml
+---
+id: ADR-001
+title: "PostgreSQL as Primary Database"
+status: Accepted  # Proposed | Accepted | Deprecated | Superseded
+date: 2026-01-23
+supersedes: null  # ADR-000 if replacing
+superseded_by: null  # ADR-002 if replaced
+---
+
+# ADR-001: PostgreSQL as Primary Database
+
+## Context
+
+[Why this decision was needed. What problem we faced.]
+
+## Decision
+
+[What we decided. Be specific and unambiguous.]
+
+## Consequences
+
+### Positive
+- [Benefit 1]
+- [Benefit 2]
+
+### Negative
+- [Tradeoff 1]
+- [Tradeoff 2]
+
+### Neutral
+- [Implication that's neither good nor bad]
+
+## Alternatives Considered
+
+### [Alternative 1]
+[Why it was rejected]
+
+### [Alternative 2]
+[Why it was rejected]
+```
+
+---
+
+## ADR Numbering
+
+Find next available number:
+
+```bash
+ls docs/decisions/ADR-*.md 2>/dev/null | \
+  grep -oE 'ADR-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+If no ADRs exist, start with `ADR-001`.
+
+---
+
+## ARCHITECTURE.md Updates
+
+When updating ARCHITECTURE.md:
+
+1. **Find relevant section** or create new one
+2. **Add decision** with reference to ADR
+3. **Keep it current** - Remove outdated information
+
+Example addition:
+
+```markdown
+## Data Storage
+
+We use **PostgreSQL** as our primary database (see [ADR-001](decisions/ADR-001-postgresql.md)).
+
+Key decisions:
+- Single database for simplicity
+- Connection pooling via PgBouncer
+- Read replicas for reporting queries
+```
+
+---
+
+## Decision Types
+
+| Type | Scope | ADR Required? |
+|------|-------|---------------|
+| Strategic | System-wide, hard to reverse | Yes |
+| Tactical | Component-level, reversible | Optional |
+| Trivial | No significant impact | No |
+
+**When in doubt, create an ADR.** Future you will thank you.
+
+---
+
+## Guardrails
+
+1. **Interview first** - Understand the full context
+2. **Check existing decisions** - Don't contradict without superseding
+3. **Present options** - User decides, not you
+4. **Document thoroughly** - ADRs explain the "why"
+5. **Keep ARCHITECTURE.md current** - Update, don't just append
+
+---
+
+## Council Trigger Conditions
+
+Consider convening a council when:
+
+- Decision affects multiple domains (backend + frontend + infra)
+- Team has conflicting opinions
+- High cost of reversal
+- Novel problem without established patterns
+- User explicitly requests deliberation
+
+---
+
+## Related Skills
+
+- **orchestration/councils** - Council deliberation workflow
+- **orchestration/product-development** - Where architecture fits in hierarchy
+- **foundations** - Documentation standards for ADRs

--- a/src/commands/council-session.opencode.yaml
+++ b/src/commands/council-session.opencode.yaml
@@ -1,0 +1,4 @@
+# OpenCode command configuration
+# Execute as PM agent in main context
+agent: pm
+subtask: false

--- a/src/commands/prd.md
+++ b/src/commands/prd.md
@@ -1,0 +1,291 @@
+---
+description: Discover product requirements and update REQUIREMENTS.md
+---
+
+# PRD Command
+
+Interview to discover product requirements, update REQUIREMENTS.md.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Requirements capture **what** the product must do, not **how**.
+
+Good requirements are:
+- **User-focused** - Written from user perspective
+- **Testable** - Clear acceptance criteria
+- **Organized** - Grouped by domain
+- **Complete** - Cover edge cases and business rules
+
+---
+
+## CRITICAL: Interview First
+
+**Before writing any requirements, understand:**
+
+1. What feature area are we defining?
+2. Who are the users affected?
+3. What business rules apply?
+4. What edge cases exist?
+5. What's explicitly out of scope?
+
+Use `AskUserQuestion` with non-obvious questions.
+
+---
+
+## Process
+
+### Step 1: Parse Input
+
+`$ARGUMENTS` should indicate the feature area or requirement section.
+
+Examples:
+- "user authentication"
+- "section 2.1"
+- "payment processing"
+
+**If unclear:** Ask what feature area to define.
+
+### Step 2: Gather Context
+
+1. **Read VISION.md** - Strategic direction constrains requirements
+2. **Read ARCHITECTURE.md** - Technical constraints
+3. **Read existing REQUIREMENTS.md** - Don't duplicate
+
+### Step 3: Interview with Non-Obvious Questions
+
+Ask questions the user might not have considered:
+
+| Category | Example Questions |
+|----------|-------------------|
+| Edge cases | "What happens if the user closes the browser mid-flow?" |
+| Business rules | "Are there rate limits? Time-based restrictions?" |
+| Persona conflicts | "How do admin users differ from regular users here?" |
+| Failure modes | "What's the graceful degradation if this fails?" |
+| Compliance | "Any audit logging requirements?" |
+| Scale | "Expected volume? Concurrent users?" |
+
+**Interview structure:**
+```
+1. Start with obvious questions to confirm understanding
+2. Move to edge cases
+3. Explore business rule conflicts
+4. Check compliance/security needs
+5. Confirm scope boundaries
+```
+
+### Step 4: Draft Requirements Section
+
+Format:
+
+```markdown
+## [Number]. [Domain Name]
+
+### [Number].[SubNumber] [Feature Name]
+
+**Business Rules**
+- [Rule 1]
+- [Rule 2]
+
+**User Stories**
+As a [persona], I want to [action] so that [benefit].
+
+**Acceptance Criteria**
+- [ ] Given [context], when [action], then [outcome]
+- [ ] Given [context], when [action], then [outcome]
+
+**Edge Cases**
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| [Edge case] | [How system responds] |
+
+**Out of Scope**
+- [Explicitly excluded item]
+```
+
+### Step 5: Present for Approval
+
+Show the drafted section to the user:
+
+```markdown
+## Proposed Addition to REQUIREMENTS.md
+
+[Draft section]
+
+---
+
+**Questions before adding:**
+1. Are these business rules accurate?
+2. Any missing acceptance criteria?
+3. Should anything be out of scope?
+```
+
+### Step 6: Await Approval
+
+**Do NOT update REQUIREMENTS.md without explicit approval.**
+
+User may:
+- Approve as-is
+- Request changes
+- Add missing requirements
+- Move items to out of scope
+
+### Step 7: Update REQUIREMENTS.md
+
+After approval:
+1. Add new section to REQUIREMENTS.md
+2. Maintain consistent numbering
+3. Update table of contents if exists
+
+---
+
+## Requirements Format
+
+### File Structure
+
+```markdown
+# Requirements
+
+## 1. Core Platform
+
+### 1.1 Feature A
+...
+
+### 1.2 Feature B
+...
+
+## 2. Identity & Access
+
+### 2.1 User Authentication
+...
+
+### 2.2 Authorization
+...
+```
+
+### Section Template
+
+```markdown
+### 2.1 User Authentication
+
+**Business Rules**
+- Users authenticate via OAuth (Google, GitHub)
+- Sessions expire after 24 hours of inactivity
+- Failed login attempts are logged for security audit
+- Users can have at most 5 active sessions
+
+**User Stories**
+
+As a new user, I want to sign in with my existing Google account
+so that I don't need to create another password.
+
+As a returning user, I want my session to persist across browser tabs
+so that I can work in multiple windows.
+
+**Acceptance Criteria**
+- [ ] Given a new user, when they click "Sign in with Google", then they are redirected to Google OAuth
+- [ ] Given valid Google credentials, when OAuth completes, then user is logged in and redirected to dashboard
+- [ ] Given an existing session, when user opens new tab, then they remain logged in
+- [ ] Given 24 hours of inactivity, when user returns, then they must re-authenticate
+- [ ] Given a logged-in user, when they click logout, then all session data is cleared
+
+**Edge Cases**
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| OAuth provider unavailable | Show friendly error, suggest trying later |
+| User revokes OAuth access | Invalidate session on next request |
+| Multiple accounts same email | Prevent duplicate accounts, suggest login |
+| Session cookie deleted | Redirect to login on next request |
+
+**Out of Scope**
+- Password-based authentication (security/maintenance burden)
+- Apple/Microsoft OAuth (future consideration)
+- MFA (separate feature area)
+```
+
+---
+
+## Acceptance Criteria Format
+
+Use Given-When-Then:
+
+```markdown
+Given [precondition/context],
+when [action is performed],
+then [expected outcome].
+```
+
+**Good criteria are:**
+- Specific and testable
+- Single behavior per criterion
+- Observable outcome (not internal state)
+- User-focused language
+
+**Bad criteria:**
+```markdown
+- Login should be fast  # Not measurable
+- Data should be correct  # Too vague
+- System should handle errors  # No specific behavior
+```
+
+**Good criteria:**
+```markdown
+- [ ] Given valid credentials, when login submitted, then dashboard loads within 2 seconds
+- [ ] Given invalid email format, when login attempted, then "Invalid email" error shown
+- [ ] Given network failure during OAuth, when callback fails, then retry prompt displayed
+```
+
+---
+
+## Numbering Convention
+
+```
+[Major].[Minor] [Feature Name]
+
+1. Core Platform
+   1.1 Dashboard
+   1.2 Navigation
+
+2. Identity & Access
+   2.1 User Authentication
+   2.2 Role-Based Access
+```
+
+When adding new sections:
+- Check existing numbers
+- Insert at appropriate position
+- Update subsequent numbers if needed
+
+---
+
+## Guardrails
+
+1. **Interview deeply** - Ask non-obvious questions
+2. **Check constraints** - VISION and ARCHITECTURE bound requirements
+3. **Write testable criteria** - Given-When-Then format
+4. **Document edge cases** - What could go wrong?
+5. **Explicit out of scope** - Prevent scope creep
+6. **Get approval** - Don't update without user confirmation
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Requirements describe HOW | Focus on WHAT, leave HOW to specs |
+| Missing edge cases | Interview for failure modes |
+| Vague criteria | Use Given-When-Then |
+| No out of scope | Explicitly list exclusions |
+| Conflicting rules | Resolve before adding |
+
+---
+
+## Related Skills
+
+- **orchestration/product-development** - Where requirements fit in hierarchy
+- **orchestration/specs** - Breaking requirements into specifications
+- **foundations** - Documentation standards

--- a/src/commands/reference-session.md
+++ b/src/commands/reference-session.md
@@ -1,0 +1,235 @@
+---
+description: Import decisions from past sessions without full context duplication
+---
+
+# Reference Session
+
+Import context from past sessions into current work. This command helps maintain continuity across sessions without duplicating full context.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` for:
+- **Search term**: Session name fragment, Linear issue ID, or topic keyword
+- **Content type** (optional): `decisions`, `context`, or `all` (default: `decisions`)
+
+```
+/reference-session auth              # Search for "auth" sessions, import decisions
+/reference-session auth decisions    # Explicit: import decisions only
+/reference-session auth context      # Import full context summary
+/reference-session PLT-123           # Search by Linear issue
+```
+
+If no arguments provided, list recent decision memories:
+
+```
+/reference-session                   # List available session decisions
+```
+
+---
+
+## Step 2: Search for Matching Sessions
+
+### Option A: List Serena Memories
+
+Use Serena MCP to list available decision memories:
+
+```
+mcp__serena__list_memories()
+```
+
+Filter for memories matching pattern: `session-*-decisions.md`
+
+### Option B: Search Session Archives
+
+If no matching memories found, search archived sessions:
+
+```
+.agents/sessions/archive/*<search-term>*.md
+```
+
+---
+
+## Step 3: Display Matches
+
+Present matching sessions/memories:
+
+```markdown
+## Matching Session Decisions
+
+| Session | Archived | Linear | Decisions |
+|---------|----------|--------|-----------|
+| 20250115-140000-auth-jwt | 2025-01-15 | PLT-123 | 3 decisions |
+| 20250110-090000-auth-oauth | 2025-01-10 | PLT-100 | 2 decisions |
+
+Select a session number to import, or 'all' for multiple:
+```
+
+If single match, proceed directly to Step 4.
+
+---
+
+## Step 4: Read Decision Memory
+
+For selected session(s), read the decision memory:
+
+```
+mcp__serena__read_memory(name="session-<slug>-decisions.md")
+```
+
+If memory doesn't exist but session file does, run extraction:
+
+```bash
+python3 src/skills/orchestration/scripts/extract-decisions.py \
+  ".agents/sessions/archive/<session-file>.md"
+```
+
+---
+
+## Step 5: Import into Current Session
+
+If an active session exists (`.agents/sessions/` has `in_progress` files):
+
+### Update Session Frontmatter
+
+Add to the active session's frontmatter:
+
+```yaml
+session:
+  # ... existing fields ...
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"
+      imported_at: "2025-01-23T14:30:00Z"
+      content_type: decisions
+      decisions_imported:
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+```
+
+### Add Reference Section
+
+If importing decisions, add to session body:
+
+```markdown
+## Referenced Decisions
+
+### From: 20250115-140000-auth-jwt.md
+
+#### Decision: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window
+**Rationale**: Balance between security and user experience
+**Context**: Authentication service design
+
+#### Decision: Refresh Token Storage
+**Decision**: Store in HttpOnly cookie, not localStorage
+**Rationale**: Prevents XSS token theft
+**Context**: Frontend security consideration
+
+---
+```
+
+---
+
+## Step 6: Report Import
+
+Confirm what was imported:
+
+```markdown
+## Session Reference Complete
+
+**Imported from**: 20250115-140000-auth-jwt.md
+**Content type**: decisions
+**Decisions imported**: 3
+
+### Summary
+
+1. **JWT Token Rotation Strategy** - Rotate every 15 minutes
+2. **Refresh Token Storage** - HttpOnly cookies
+3. **Token Validation Flow** - Validate signature before claims
+
+These decisions are now tracked in the current session's frontmatter
+under `referenced_sessions`.
+
+**Current session updated**: .agents/sessions/20250123-100000-auth-v2.md
+```
+
+---
+
+## No Active Session
+
+If no active session exists, display the decisions without updating any file:
+
+```markdown
+## Decisions from: 20250115-140000-auth-jwt.md
+
+[Display decision content]
+
+**Note**: No active session to update. Start a session first with
+`/start-session` to track this reference.
+```
+
+---
+
+## Content Types
+
+### `decisions` (default)
+
+Imports only the `## Decisions` section formatted as memory:
+- Decision name
+- What was decided
+- Rationale
+- Council outcome (if applicable)
+
+### `context`
+
+Imports session context summary:
+- Problem statement
+- Technical approach
+- Key files involved
+- Final outcome
+
+### `all`
+
+Imports both decisions and context.
+
+---
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Import full session files | Import only decisions/summaries |
+| Import without tracking | Always update `referenced_sessions` |
+| Import from unrelated sessions | Search by topic or Linear issue |
+| Import during exploration | Import when decisions are relevant |
+
+---
+
+## Error Handling
+
+### No matches found
+
+```
+No sessions found matching "auth-v3"
+
+Try:
+- Different search terms
+- Check .agents/sessions/archive/ directly
+- List all: /reference-session
+```
+
+### Memory not found
+
+```
+Decision memory not found for session 20250115-140000-auth-jwt.md
+
+Would you like to extract decisions now? This will:
+1. Read the archived session file
+2. Extract the Decisions section
+3. Create a Serena memory for future use
+
+[y/n]
+```

--- a/src/commands/research.md
+++ b/src/commands/research.md
@@ -1,0 +1,264 @@
+---
+description: Zoom out, brainstorm, assess project state, or evolve VISION
+---
+
+# Research Command
+
+Step back from implementation to understand, explore, or brainstorm.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Mode Detection
+
+Parse the input to determine research mode:
+
+| Input Pattern | Mode | Action |
+|---------------|------|--------|
+| "project state" / "catch me up" / empty | State Assessment | Review docs, sessions, recent work |
+| Topic description | Topic Exploration | Structured inquiry |
+| "brainstorm" / "ideas for" | Brainstorming | Generate and refine options |
+| "evolve vision" / "update vision" | Vision Evolution | Propose VISION changes |
+
+---
+
+## CRITICAL: Interview First
+
+**Before any research, interview the user to understand:**
+
+1. What specifically are you trying to understand?
+2. What context do you already have?
+3. What constraints should guide this research?
+4. What decision will this inform?
+
+Use `AskUserQuestion` to gather this context.
+
+---
+
+## Mode 1: Project State Assessment
+
+**Trigger:** Empty input, "project state", "catch me up"
+
+### Steps
+
+1. **Read project documents:**
+   - `docs/VISION.md` (if exists)
+   - `docs/ARCHITECTURE.md` (if exists)
+   - `docs/REQUIREMENTS.md` (if exists)
+
+2. **Check recent sessions:**
+   - List `.agents/sessions/*.md`
+   - Read recent sessions for lessons learned
+   - Note any unresolved issues or blockers
+
+3. **Review recent commits:**
+   ```bash
+   git log --oneline -20
+   ```
+
+4. **Synthesize findings:**
+   - Current position
+   - Recent progress
+   - Lessons learned
+   - Open questions
+   - Recommendations
+
+5. **Present to user** with actionable next steps
+
+---
+
+## Mode 2: Topic Exploration
+
+**Trigger:** Specific topic or question
+
+### Steps
+
+1. **Interview** to understand the question deeply
+
+2. **Check project context first:**
+   - Existing decisions in `docs/decisions/ADR-*.md`
+   - Relevant sections in ARCHITECTURE.md
+   - Previous session discussions
+
+3. **Apply confidence hierarchy:**
+   ```
+   Project context > Context7 > Official docs > Community > Web
+   ```
+
+4. **For library/framework questions:**
+   - Use Context7 MCP to get authoritative documentation
+   - Cross-reference with official sources
+
+5. **Synthesize findings:**
+   - Summary with confidence level
+   - Options with tradeoffs
+   - Recommendation with rationale
+   - Sources cited
+
+6. **Present options** - Don't make the decision for the user
+
+---
+
+## Mode 3: Brainstorming
+
+**Trigger:** "brainstorm", "ideas for", creative exploration
+
+### Steps
+
+1. **Interview to establish bounds:**
+   - What's the ideal outcome?
+   - What constraints exist?
+   - What's been tried/rejected?
+
+2. **Generate diverse options:**
+   - Conventional approaches
+   - Unconventional approaches
+   - What if we had 10x resources?
+   - What if we had 1/10 resources?
+   - Contrarian view
+
+3. **Filter through constraints:**
+   - Technical feasibility
+   - Time/resource budget
+   - Alignment with VISION
+
+4. **Refine promising directions:**
+   - Shape the top 2-3 options
+   - Identify risks and mitigations
+
+5. **Present curated options** with pros/cons for decision
+
+---
+
+## Mode 4: Vision Evolution
+
+**Trigger:** "evolve vision", "update vision", evidence of needed change
+
+### Steps
+
+1. **Gather evidence:**
+   - What changed since last VISION update?
+   - Session learnings that contradict VISION
+   - External factors (market, technology, team)
+
+2. **Read current VISION.md**
+
+3. **Draft change proposal:**
+   ```markdown
+   ## VISION.md Change Proposal
+
+   **Evidence:** [What prompted this]
+
+   ### Current State
+   [Quote relevant section]
+
+   ### Proposed Change
+   [New text]
+
+   ### Rationale
+   [Why this is warranted]
+
+   ### Impact
+   - [Downstream effects]
+   ```
+
+4. **Present proposal to user**
+
+5. **WAIT FOR EXPLICIT APPROVAL**
+   - Do NOT edit VISION.md without approval
+   - User must explicitly confirm changes
+
+6. **If approved:** Edit VISION.md with approved changes
+
+---
+
+## Output Format
+
+### State Assessment
+
+```markdown
+## Project State Assessment
+
+**Date:** [Generated timestamp]
+
+### Current Position
+[Summary]
+
+### Recent Progress
+- [Accomplishment 1]
+- [Accomplishment 2]
+
+### Lessons Learned
+- [Insight 1]
+- [Insight 2]
+
+### Open Questions
+- [Question 1]
+- [Question 2]
+
+### Recommendations
+1. [Next step]
+2. [Next step]
+```
+
+### Research Findings
+
+```markdown
+## Research: [Topic]
+
+**Question:** [What we're investigating]
+
+### Summary
+[Answer with confidence level]
+
+### Options
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+
+### Recommendation
+[Which option and why]
+
+### Sources
+- [Source with confidence]
+```
+
+---
+
+## Guardrails
+
+1. **Always interview first** - Don't assume you understand the question
+2. **Check project context** - Respect existing decisions
+3. **Present options** - Don't make decisions for the user
+4. **Cite sources** - With confidence levels
+5. **Never edit VISION without approval** - Proposals only
+6. **Time-bound research** - Don't go down rabbit holes indefinitely
+
+---
+
+## Context7 Usage
+
+For library/framework questions, use Context7:
+
+```
+1. mcp__plugin_context7_context7__resolve-library-id
+   - Find the library ID
+
+2. mcp__plugin_context7_context7__query-docs
+   - Query specific documentation
+```
+
+This provides authoritative, up-to-date documentation.
+
+---
+
+## Related Skills
+
+- **research** - Full methodology for research modes
+- **orchestration/product-development** - Where research fits in workflow

--- a/src/commands/resume-session.claude-code.yaml
+++ b/src/commands/resume-session.claude-code.yaml
@@ -1,0 +1,6 @@
+# Claude Code command configuration
+hooks:
+  Stop:
+    - hooks:
+        - type: command
+          command: "bash ${CLAUDE_PLUGIN_ROOT}/hooks/sessions/validate-session-created.sh"

--- a/src/commands/resume-session.opencode.yaml
+++ b/src/commands/resume-session.opencode.yaml
@@ -1,0 +1,4 @@
+# OpenCode command configuration
+# Execute as PM agent in main context
+agent: pm
+subtask: false

--- a/src/commands/review-sessions.claude-code.yaml
+++ b/src/commands/review-sessions.claude-code.yaml
@@ -1,0 +1,6 @@
+# Claude Code command configuration
+hooks:
+  Stop:
+    - hooks:
+        - type: command
+          command: "bash ${CLAUDE_PLUGIN_ROOT}/hooks/sessions/validate-session-created.sh"

--- a/src/commands/review-sessions.opencode.yaml
+++ b/src/commands/review-sessions.opencode.yaml
@@ -1,0 +1,4 @@
+# OpenCode command configuration
+# Execute as PM agent in main context
+agent: pm
+subtask: false

--- a/src/commands/specs.md
+++ b/src/commands/specs.md
@@ -1,0 +1,277 @@
+---
+description: Create feature specifications from requirements
+---
+
+# Specs Command
+
+Break requirements into shaped, implementable specifications.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Specs define **shaped solutions** - bounded work with clear scope.
+
+A spec is:
+- **Shaped** - Direction, not blueprint
+- **Bounded** - Clear in/out of scope
+- **Testable** - Observable test conditions
+- **Appetite-driven** - Fixed time, variable scope
+
+See `orchestration/specs` reference for full spec methodology.
+
+---
+
+## CRITICAL: Interview First
+
+**Before writing a spec, clarify:**
+
+1. Which requirement section is this for?
+2. What's the appetite (time budget)?
+3. What scope trade-offs are acceptable?
+4. What are the "rabbit holes" to avoid?
+5. What approaches are explicitly forbidden (no-gos)?
+
+Use `AskUserQuestion` to establish boundaries.
+
+---
+
+## Process
+
+### Step 1: Parse Input
+
+`$ARGUMENTS` should reference a requirement section.
+
+Examples:
+- "2.1 User Authentication"
+- "REQUIREMENTS.md section 2.1"
+- "user auth"
+
+**If unclear:** Ask which requirement to specify.
+
+### Step 2: Gather Context
+
+Read in order:
+1. **VISION.md** - Strategic alignment
+2. **ARCHITECTURE.md** - Technical constraints
+3. **REQUIREMENTS.md** - The requirement being specified
+4. **Existing specs** - Avoid duplication
+
+### Step 3: Interview for Shaping
+
+Shape Up methodology - define boundaries, not tasks.
+
+| Question | Purpose |
+|----------|---------|
+| What's definitely in scope? | Core functionality |
+| What's definitely out of scope? | Prevent creep |
+| What seems related but should be avoided? | Rabbit holes |
+| What approaches are forbidden? | No-gos |
+| How do we know it works? | Test conditions |
+| How much time is it worth? | Appetite |
+| What if we run out of time? | Circuit breaker |
+
+### Step 4: Determine Appetite
+
+| Appetite | Size | Suitable For |
+|----------|------|--------------|
+| Small | 1-2 days | Bug fixes, minor enhancements |
+| Medium | 3-5 days | Feature additions, refactors |
+| Large | 1-2 weeks | Major features (rare) |
+
+**If work can't fit the appetite:** Needs more shaping or splitting.
+
+### Step 5: Draft the Spec
+
+Use spec template:
+
+```yaml
+---
+id: SPEC-001
+title: "User Authentication with OAuth"
+requirement: "2.1 User Authentication"
+created: YYYY-MM-DDTHH:MM:SSZ
+status: drafting
+appetite: "1 week"
+---
+
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+[From REQUIREMENTS - why this matters to users and business]
+
+## Proposed Solution
+
+[Shaped solution - high-level approach, not implementation details]
+
+## Scope
+
+### In Scope
+- [Item 1]
+- [Item 2]
+
+### Out of Scope (Rabbit Holes)
+- [Avoid this complexity]
+- [Don't go here]
+
+### No-Gos
+- [Forbidden approach 1]
+- [Forbidden approach 2]
+
+## Test Conditions
+
+- [ ] [Observable outcome 1]
+- [ ] [Observable outcome 2]
+- [ ] [Observable outcome 3]
+
+## Implementation Notes
+
+[Architecture references, technical constraints, relevant ADRs]
+
+## Circuit Breaker
+
+At 50% appetite: [What to do if we're not on track]
+```
+
+### Step 6: Generate Spec ID
+
+Find next available ID:
+
+```bash
+ls docs/specs/SPEC-*.md docs/specs/archive/SPEC-*.md 2>/dev/null | \
+  grep -oE 'SPEC-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+If no specs exist, start with `SPEC-001`.
+
+### Step 7: Present for Approval
+
+```markdown
+## Proposed Specification
+
+[Full spec content]
+
+---
+
+**Before approval, confirm:**
+1. Is the scope correct?
+2. Are the test conditions sufficient?
+3. Is the appetite realistic?
+4. Any missing rabbit holes or no-gos?
+```
+
+### Step 8: Await Approval
+
+**Do NOT create spec file without explicit approval.**
+
+User may:
+- Approve as-is
+- Adjust scope
+- Change appetite
+- Add constraints
+- Request splitting
+
+### Step 9: Create Spec File
+
+After approval:
+
+1. **Generate timestamps:**
+   ```bash
+   date -u +"%Y-%m-%dT%H:%M:%SZ"  # For frontmatter
+   ```
+
+2. **Create file:**
+   - Location: `docs/specs/SPEC-{id}-{slug}.md`
+   - Slug: kebab-case of title
+
+3. **Announce completion:**
+   ```
+   Created: docs/specs/SPEC-001-user-auth-oauth.md
+
+   Next: Use `/tasks SPEC-001` to break into atomic work items.
+   ```
+
+---
+
+## Spec Lifecycle
+
+```
+drafting → approved → implementing → complete
+```
+
+| Status | Meaning |
+|--------|---------|
+| `drafting` | Being refined, not ready |
+| `approved` | Ready for task breakdown |
+| `implementing` | Tasks created, work in progress |
+| `complete` | All tasks done, archive |
+
+---
+
+## Splitting Large Specs
+
+When a spec is too big for its appetite:
+
+```
+SPEC-001-user-auth.md (large, 2 weeks)
+        ↓ split into
+SPEC-001a-oauth-integration.md (medium, 3 days)
+SPEC-001b-session-management.md (small, 2 days)
+SPEC-001c-login-ui.md (medium, 3 days)
+```
+
+Each sub-spec:
+- Has its own appetite
+- Can be worked independently
+- References original requirement
+
+---
+
+## Test Conditions vs Acceptance Criteria
+
+| Test Conditions (Spec) | Acceptance Criteria (Requirement) |
+|------------------------|-----------------------------------|
+| High-level outcomes | Detailed behaviors |
+| For this shaped solution | For the full feature |
+| May be subset of AC | Complete coverage |
+| Implementation-aware | Implementation-agnostic |
+
+Test conditions prove the spec is done.
+Acceptance criteria prove the requirement is met.
+
+---
+
+## Guardrails
+
+1. **Interview to shape** - Boundaries before details
+2. **Respect appetite** - Fixed time, variable scope
+3. **Document rabbit holes** - Prevent scope creep
+4. **Clear test conditions** - Observable outcomes
+5. **Circuit breaker** - Plan for running out of time
+6. **Get approval** - Don't create without confirmation
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Implementation details | Keep high-level, shape not blueprint |
+| No appetite | Always set time budget |
+| Missing no-gos | Explicitly forbid bad approaches |
+| Vague test conditions | Make observable and verifiable |
+| Too ambitious | Split or increase appetite |
+
+---
+
+## Related Skills
+
+- **orchestration/specs** - Full spec methodology
+- **orchestration/product-development** - Where specs fit in hierarchy
+- **orchestration/planning** - Shape Up methodology details

--- a/src/commands/start-session.claude-code.yaml
+++ b/src/commands/start-session.claude-code.yaml
@@ -1,0 +1,6 @@
+# Claude Code command configuration
+hooks:
+  Stop:
+    - hooks:
+        - type: command
+          command: "bash ${CLAUDE_PLUGIN_ROOT}/hooks/sessions/validate-session-created.sh"

--- a/src/commands/start-session.md
+++ b/src/commands/start-session.md
@@ -10,6 +10,36 @@ You are the PM agent. Start by understanding the task:
 
 ---
 
+## Input Detection
+
+Parse `$ARGUMENTS` to determine the session type:
+
+| Input Pattern | Type | Action |
+|---------------|------|--------|
+| `TASK-XXX` | Local task | Load from `.agents/tasks/active/` |
+| `SPEC-XXX` | Spec (no task) | Warn: suggest `/tasks` first |
+| `PLT-123`, `PROJ-123` | Linear issue | Fetch from Linear |
+| Description text | Ad-hoc | Create session, ask about Linear |
+
+### Task-Coupled Sessions
+
+When starting from a task (`TASK-XXX` or Linear issue):
+
+1. **Fetch task details** (local file or Linear API)
+2. **Load parent spec** if task has `spec:` field
+3. **Load linked requirement** if spec has `requirement:` field
+4. **Build traceability chain** in session frontmatter
+
+### Ad-hoc Sessions
+
+When no task exists:
+
+1. **Inform user:** "No parent task found. Proceeding as ad-hoc session."
+2. **Ask:** "Should I create a Linear issue or local task for tracking?"
+3. If yes, create and link; if no, proceed without
+
+---
+
 ## CRITICAL: Strict Delegation Model
 
 **You are the ORCHESTRATOR, not the implementer.**
@@ -130,8 +160,19 @@ session:
   linear_issue: "PLT-XXX"           # If applicable
   linear_url: "https://linear.app/{{your-workspace}}/issue/PLT-XXX"
   branch: "username/plt-xxx-feature"    # Working branch for this session
+  task: "TASK-001"                      # Local task ID (if applicable)
+  spec: "SPEC-001"                      # Parent spec (if applicable)
+
+# Traceability chain (populated when task-coupled)
+traceability:
+  requirement: "2.1 User Authentication"  # From spec's requirement field
+  architecture:
+    - "Session Management"                # Relevant ARCHITECTURE.md sections
+  decisions:
+    - "ADR-001"                           # Related ADRs
 
 plans: []  # List of plan files in .agents/plans/ used by this session
+transcripts: []  # Archived conversation transcripts (.jsonl files)
 
 orchestration:
   current_task: "Initial planning"
@@ -617,3 +658,74 @@ Follow your three-phase workflow (BEFORE → DURING → AFTER):
 Format: `[YYYY-MM-DD HH:MM UTC]`
 
 Generate with: `date -u +"%Y-%m-%d %H:%M UTC"`
+
+---
+
+## Transcript Archival
+
+After `/compact` or `/clear`, archive conversation transcripts for future reference.
+
+### Process
+
+1. **Get transcript path** from Claude Code output after compaction
+2. **Create transcripts directory** if needed:
+   ```bash
+   mkdir -p .agents/transcripts
+   ```
+3. **Copy transcript** with descriptive name:
+   ```bash
+   cp /path/to/transcript.jsonl .agents/transcripts/YYYYMMDD-HHMMSS-description.jsonl
+   ```
+4. **Update session frontmatter**:
+   ```yaml
+   transcripts:
+     - 20260123-143500-pre-compact.jsonl
+   ```
+
+### When to Archive
+
+| Event | Action |
+|-------|--------|
+| Before `/compact` | Archive current transcript |
+| Before `/clear` | Archive current transcript |
+| Session end | Archive final transcript |
+
+### Benefits
+
+- **Audit trail** - Full history of decisions and work
+- **Knowledge extraction** - Mining past sessions for patterns
+- **Debugging** - Understanding how errors occurred
+- **Training** - Learning from past sessions
+
+---
+
+## Task Completion
+
+When a task-coupled session completes:
+
+1. **Update task status** (local file or Linear)
+2. **Check spec progress:**
+   - List all tasks for the spec
+   - If all done → mark spec as `complete`
+   - If tasks remain → spec stays `implementing`
+3. **Archive session** (standard process)
+
+### Spec Completion Check
+
+```bash
+# For local tasks
+grep -l "spec: SPEC-001" .agents/tasks/active/*.md | wc -l
+# If 0, all tasks done
+
+# For Linear
+# Check all issues with spec label
+```
+
+---
+
+## Related Skills
+
+- **orchestration/product-development** - Full workflow hierarchy
+- **orchestration/specs** - Spec format and lifecycle
+- **orchestration/local-tasks** - Local task management
+- **orchestration/sessions** - Session lifecycle details

--- a/src/commands/start-session.md
+++ b/src/commands/start-session.md
@@ -138,13 +138,65 @@ orchestration:
   spawned_agents: []
 ```
 
-### Step 4: Verify Creation
+### Step 4: Create Plan File
 
-Confirm the session file exists and contains valid frontmatter before proceeding.
+**Location:** `.agents/plans/`
+**Filename:** Same timestamp as session: `YYYYMMDD-HHMMSS-<description>.md`
 
-**DO NOT PROCEED WITHOUT A SESSION FILE.**
+Use this Shape Up-inspired template:
 
-### Step 5: Suggest Session Rename
+```markdown
+---
+session: YYYYMMDD-HHMMSS-<description>.md
+created: "YYYY-MM-DDTHH:MM:SSZ"
+status: drafting
+appetite: ""
+---
+
+# Plan: <description>
+
+## Appetite
+
+*Time budget for this work (e.g., "2 hours", "1 day"). Fixed time, variable scope.*
+
+## Problem
+
+*What problem are we solving? Why does it matter?*
+
+## Solution Shape
+
+*High-level approach, not a detailed spec. What's the general shape of the solution?*
+
+## Rabbit Holes
+
+*What NOT to do. Scope boundaries. Things that seem related but should be avoided.*
+
+## No-Gos
+
+*Explicit exclusions. Features or approaches we're deliberately not doing.*
+
+## Circuit Breaker
+
+At 50% of appetite spent: Re-evaluate if we're on track. If not, consider:
+- Simplifying scope
+- Taking a different approach
+- Stopping early and documenting learnings
+```
+
+**Update session frontmatter** to link the plan:
+
+```yaml
+plans:
+  - YYYYMMDD-HHMMSS-<description>.md
+```
+
+### Step 5: Verify Creation
+
+Confirm both session file AND plan file exist with valid frontmatter before proceeding.
+
+**DO NOT PROCEED WITHOUT A SESSION FILE AND PLAN FILE.**
+
+### Step 6: Suggest Session Rename
 
 After creating the session file, suggest renaming the Claude Code session for easy identification:
 
@@ -211,7 +263,7 @@ Is this a code/config/doc change?
 
 ## Startup Checklist
 
-**After creating session file:**
+**After creating session AND plan files:**
 
 1. [ ] Parse the input — is this a Linear issue ID (e.g., PLT-123, PLAT-123) or a description?
 2. [ ] If Linear ID:
@@ -221,10 +273,13 @@ Is this a code/config/doc change?
 3. [ ] If description: ask user if a Linear issue should be created
 4. [ ] **Create dedicated branch for this work** (see Branch Management below)
 5. [ ] **Suggest team** based on task context (see Team Routing below)
-6. [ ] Populate session `## Context` section with background
-7. [ ] Break down the work using TodoWrite
-8. [ ] **Identify which specialized agents will be needed** (use mapping table)
-9. [ ] Update session `## Next Steps` with planned agent spawns
+6. [ ] **Fill in plan file sections** (Appetite, Problem, Solution Shape, Rabbit Holes)
+7. [ ] Populate session `## Context` section with background
+8. [ ] Break down the work using TodoWrite
+9. [ ] **Identify which specialized agents will be needed** (use mapping table)
+10. [ ] **Consider architecture diagrams** (see Diagram Consideration below)
+11. [ ] Update session `## Next Steps` with planned agent spawns
+12. [ ] **Get user approval on plan** before spawning implementation agents
 
 ---
 
@@ -297,6 +352,48 @@ Suggest Security, confirm if new to project
 ```
 
 Use Linear MCP's `list_teams` to get all workspace teams for validation.
+
+---
+
+## Diagram Consideration
+
+For multi-file or multi-service changes, consider adding architecture diagrams to the session file.
+
+### When to Create Diagrams
+
+| Scenario | Diagram Type |
+|----------|--------------|
+| Changes span 3+ services | Component diagram (interaction points) |
+| Data flow modifications | Sequence diagram (trace data path) |
+| Schema/model changes | ERD (table relationships) |
+| New API endpoints | Sequence diagram (request/response) |
+| State machine logic | State diagram (transitions) |
+
+### Quick Check
+
+Ask yourself:
+1. Will this work touch multiple services or layers?
+2. Is there a data flow that needs to be understood?
+3. Would a visual help communicate the approach?
+
+If yes to any, add an `## Architecture Diagrams` section to the session file.
+
+### Diagram Template
+
+```markdown
+## Architecture Diagrams
+
+### [Descriptive Name]
+
+```mermaid
+[Use flowchart, sequenceDiagram, erDiagram, or stateDiagram-v2]
+```
+
+**Purpose**: Why this diagram clarifies the work
+**Files involved**: `path/to/file1.py`, `path/to/file2.py`
+```
+
+See `foundations` skill `reference/diagrams.md` for Mermaid syntax and best practices.
 
 ---
 
@@ -475,7 +572,9 @@ Follow your three-phase workflow (BEFORE → DURING → AFTER):
 
 ### AFTER (Completion)
 
-1. Spawn `backend-dev`/`frontend-dev` for code review (if significant changes)
+1. **Code review pass** (REQUIRED for significant changes):
+   - Run `pr-review-toolkit:code-reviewer` on all modified files
+   - Address any critical issues before proceeding
 2. Spawn `qa` for final testing and security review
 3. Update Linear issue status to Done
 4. Complete session file with outcomes

--- a/src/commands/start-session.opencode.yaml
+++ b/src/commands/start-session.opencode.yaml
@@ -1,0 +1,4 @@
+# OpenCode command configuration
+# Execute as PM agent in main context
+agent: pm
+subtask: false

--- a/src/commands/tasks.md
+++ b/src/commands/tasks.md
@@ -1,0 +1,338 @@
+---
+description: Break specs into atomic work items (Linear or local)
+---
+
+# Tasks Command
+
+Break specifications into atomic, implementable tasks.
+
+**Input:** $ARGUMENTS
+
+---
+
+## Purpose
+
+Tasks are the smallest unit of work that can be:
+- Assigned to an agent
+- Completed in a single session
+- Verified with a clear done condition
+
+See `orchestration/local-tasks` reference for task format and abstraction layer.
+
+---
+
+## Task Backend Detection
+
+Check `.agents/loaf.yaml` for backend configuration:
+
+```yaml
+task_management:
+  backend: linear  # or "local"
+```
+
+**If no config exists:** Ask user which backend to use.
+
+---
+
+## Process
+
+### Step 1: Parse Input
+
+`$ARGUMENTS` should reference a spec.
+
+Examples:
+- "SPEC-001"
+- "user auth spec"
+- "docs/specs/SPEC-001-user-auth.md"
+
+**If unclear:** List available specs and ask which to break down.
+
+### Step 2: Read the Spec
+
+1. Find spec file in `docs/specs/`
+2. Read full spec content
+3. Extract:
+   - Test conditions (become task acceptance criteria)
+   - Scope (what's in/out)
+   - Implementation notes (technical context)
+   - Appetite (guides task sizing)
+
+### Step 3: Identify Task Boundaries
+
+Break down by concern:
+
+| Concern | Task Type |
+|---------|-----------|
+| Data model changes | DBA task |
+| Backend logic | Backend task |
+| API endpoints | Backend task |
+| UI components | Frontend task |
+| Tests | QA task |
+| Infrastructure | DevOps task |
+
+**Rules:**
+- One concern per task
+- Tasks can run in parallel if independent
+- Tasks have explicit dependencies if sequential
+
+### Step 4: Interview for Priorities
+
+Ask:
+- Which parts are highest priority?
+- Any tasks that must be done first?
+- Preferred order of implementation?
+
+### Step 5: Draft Task List
+
+For each task:
+
+```yaml
+---
+id: TASK-XXX
+title: [Clear action]
+spec: SPEC-001
+status: todo
+priority: P2
+files:
+  - [likely file 1]
+  - [likely file 2]
+verify: [command to verify]
+done: [observable outcome]
+---
+
+## Description
+[What needs to be done]
+
+## Acceptance Criteria
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+
+## Context
+See SPEC-001 for full context.
+```
+
+### Step 6: Present Task Breakdown
+
+```markdown
+## Proposed Tasks for SPEC-001
+
+### TASK-001: [Title]
+- **Priority:** P1
+- **Verify:** [command]
+- **Done:** [outcome]
+- **Files:** [list]
+
+### TASK-002: [Title]
+- **Priority:** P2
+- **Depends on:** TASK-001
+- **Verify:** [command]
+- **Done:** [outcome]
+
+### TASK-003: [Title]
+- **Priority:** P2
+- **Verify:** [command]
+- **Done:** [outcome]
+
+---
+
+**Task dependencies:**
+```
+TASK-001 → TASK-002 (sequential)
+TASK-003 (can run in parallel)
+```
+
+**Approve this breakdown?**
+```
+
+### Step 7: Await Approval
+
+**Do NOT create tasks without explicit approval.**
+
+User may:
+- Approve as-is
+- Adjust priorities
+- Combine/split tasks
+- Add missing tasks
+- Change dependencies
+
+### Step 8: Create Tasks
+
+Based on backend:
+
+#### Linear Backend
+
+```
+For each task:
+1. Create Linear issue with title, description
+2. Set labels from spec
+3. Link to spec (as attachment or in description)
+4. Set priority
+5. Record issue ID
+```
+
+#### Local Backend
+
+```bash
+# Create task directory if needed
+mkdir -p .agents/tasks/active
+
+# Generate task ID
+next_id=$(find_next_task_id)
+
+# Create task file
+# .agents/tasks/active/TASK-{id}-{slug}.md
+```
+
+### Step 9: Update Spec Status
+
+After tasks created:
+
+```yaml
+# In spec frontmatter
+status: implementing
+```
+
+### Step 10: Announce Completion
+
+```markdown
+## Tasks Created for SPEC-001
+
+| ID | Title | Priority | Backend |
+|----|-------|----------|---------|
+| TASK-001 | OAuth Provider Integration | P1 | [Linear/Local] |
+| TASK-002 | Session Management | P2 | [Linear/Local] |
+| TASK-003 | Login UI Components | P2 | [Linear/Local] |
+
+**Spec status:** implementing
+
+**Next:** Use `/start-session TASK-001` to begin work.
+```
+
+---
+
+## Task ID Generation
+
+### Linear
+IDs come from Linear (e.g., `PLT-123`).
+
+### Local
+Sequential numbering:
+
+```bash
+# Find next available number
+find_next_task_id() {
+  local max=$(ls .agents/tasks/active/ .agents/tasks/archive/*/ 2>/dev/null | \
+    grep -oE 'TASK-[0-9]+' | \
+    sort -t- -k2 -n | \
+    tail -1 | \
+    awk -F- '{print $2}')
+  echo $((${max:-0} + 1))
+}
+```
+
+---
+
+## Task Sizing Guide
+
+| Size | Duration | Characteristics |
+|------|----------|-----------------|
+| Small | < 1 day | Single file, clear change |
+| Medium | 1-2 days | Multiple files, one concern |
+| Large | 2-3 days | Complex logic, multiple concerns |
+
+**If task is large:** Consider splitting into smaller tasks.
+
+---
+
+## Priority Levels
+
+| Priority | Meaning | Response |
+|----------|---------|----------|
+| P0 | Urgent/blocking | Drop everything |
+| P1 | High | Work next |
+| P2 | Normal | Scheduled work |
+| P3 | Low | When time permits |
+
+Default: P2 (normal).
+
+---
+
+## Verification Commands
+
+Each task needs a `verify` command:
+
+| Task Type | Example Verification |
+|-----------|---------------------|
+| Backend Python | `pytest tests/auth/test_oauth.py` |
+| Backend Rails | `rails test test/models/session_test.rb` |
+| Frontend React | `npm run test -- auth.test.tsx` |
+| API endpoint | `curl -X POST localhost:3000/auth/login` |
+| Database | `psql -c "SELECT * FROM users LIMIT 1"` |
+
+---
+
+## Done Conditions
+
+Write clear, observable outcomes:
+
+**Good:**
+- "OAuth flow completes for Google and GitHub"
+- "Session persists across page refresh"
+- "All auth tests pass"
+
+**Bad:**
+- "Auth works" (too vague)
+- "Code is clean" (subjective)
+- "Implementation done" (not verifiable)
+
+---
+
+## Guardrails
+
+1. **One concern per task** - Don't mix backend + frontend
+2. **Clear verification** - How to prove it works
+3. **Observable done condition** - Not subjective
+4. **File hints** - Help session know where to look
+5. **Get approval** - Don't create without confirmation
+6. **Update spec status** - Mark as implementing
+
+---
+
+## Common Patterns
+
+### API Feature
+
+```
+TASK-001: Database migration (DBA)
+TASK-002: API endpoint implementation (Backend)
+TASK-003: Unit tests for endpoint (QA)
+TASK-004: API documentation (Backend)
+```
+
+### UI Feature
+
+```
+TASK-001: Component implementation (Frontend)
+TASK-002: State management (Frontend)
+TASK-003: Component tests (QA)
+TASK-004: E2E tests (QA)
+```
+
+### Full Stack Feature
+
+```
+TASK-001: Database schema (DBA)
+TASK-002: API endpoints (Backend)
+TASK-003: Backend tests (QA)
+TASK-004: UI components (Frontend)
+TASK-005: Frontend tests (QA)
+TASK-006: E2E integration (QA)
+```
+
+---
+
+## Related Skills
+
+- **orchestration/local-tasks** - Local task format and management
+- **orchestration/linear** - Linear integration
+- **orchestration/product-development** - Where tasks fit in hierarchy

--- a/src/config/hooks.yaml
+++ b/src/config/hooks.yaml
@@ -274,11 +274,18 @@ plugin-groups:
   orchestration:
     description: PM orchestration, session management, Linear workflow integration
     agents: [pm]
-    skills: [orchestration]
-    commands: [start-session, resume-session, review-sessions, council-session, reference-session]
+    skills: [orchestration, research]
+    commands: [start-session, resume-session, review-sessions, council-session, reference-session, research, architecture, prd, specs, tasks]
     related-hooks:
       pre-tool: [validate-commit, detect-linear-magic]
       session: [session-start, session-end, pre-compact-archive]
+
+  # Research - Project reflection and brainstorming
+  research:
+    description: Project state assessment, topic exploration, brainstorming, vision evolution
+    agents: []
+    skills: [research]
+    commands: [research]
 
   # Quality - Cross-language fundamentals
   foundations:

--- a/src/config/hooks.yaml
+++ b/src/config/hooks.yaml
@@ -41,6 +41,14 @@ hooks:
       timeout: 600000
       description: Run security audit on bash commands
 
+    - id: tdd-advisory
+      skill: foundations
+      script: hooks/pre-tool/foundations-tdd-advisory.sh
+      matcher: "Edit|Write"
+      blocking: false
+      timeout: 5000
+      description: Advisory warning when editing implementation without tests
+
     # Orchestration - Commit and Linear integration
     - id: validate-commit
       skill: orchestration
@@ -267,7 +275,7 @@ plugin-groups:
     description: PM orchestration, session management, Linear workflow integration
     agents: [pm]
     skills: [orchestration]
-    commands: [start-session, resume-session, review-sessions, council-session]
+    commands: [start-session, resume-session, review-sessions, council-session, reference-session]
     related-hooks:
       pre-tool: [validate-commit, detect-linear-magic]
       session: [session-start, session-end, pre-compact-archive]
@@ -276,9 +284,15 @@ plugin-groups:
   foundations:
     description: Cross-language development fundamentals and quality gates
     agents: [qa]
-    skills: [foundations]
+    skills: [foundations, debugging]
     related-hooks:
-      pre-tool: [check-secrets, validate-changelog, format-check, security-audit]
+      pre-tool: [check-secrets, validate-changelog, format-check, security-audit, tdd-advisory]
+
+  # Debugging - Systematic bug investigation
+  debugging:
+    description: Hypothesis-driven debugging workflows and systematic bug investigation
+    agents: [qa, backend-dev, frontend-dev]
+    skills: [debugging, foundations]
 
   # Language-specific groups
   python:

--- a/src/hooks/pre-tool/foundations-tdd-advisory.sh
+++ b/src/hooks/pre-tool/foundations-tdd-advisory.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Hook: TDD Advisory (INFORMATIONAL)
+# PreToolUse hook - reads JSON from stdin per Claude Code hooks API
+#
+# Triggers on Edit|Write to implementation files
+# Warns when tests don't exist or don't fail first (non-blocking)
+# Inspired by Cursor's TDD best practice
+
+# Read and parse stdin JSON
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))" 2>/dev/null || echo "")
+
+# Exit early if no file path
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Skip if already a test file
+if [[ "$FILE_PATH" == *"test"* ]] || [[ "$FILE_PATH" == *"spec"* ]] || [[ "$FILE_PATH" == *"_test."* ]] || [[ "$FILE_PATH" == *".test."* ]]; then
+  exit 0
+fi
+
+# Skip non-code files
+EXTENSION="${FILE_PATH##*.}"
+case "$EXTENSION" in
+  py|ts|tsx|js|jsx|rb|go|rs)
+    # Continue checking
+    ;;
+  *)
+    # Not a code file, skip
+    exit 0
+    ;;
+esac
+
+# Skip config and generated files
+if [[ "$FILE_PATH" == *"config"* ]] || [[ "$FILE_PATH" == *"generated"* ]] || [[ "$FILE_PATH" == *"__init__"* ]]; then
+  exit 0
+fi
+
+# Get the base name and directory for test file detection
+BASENAME=$(basename "$FILE_PATH")
+DIRNAME=$(dirname "$FILE_PATH")
+FILENAME="${BASENAME%.*}"
+
+# Build potential test file patterns based on language conventions
+POTENTIAL_TESTS=()
+case "$EXTENSION" in
+  py)
+    POTENTIAL_TESTS=(
+      "${DIRNAME}/test_${FILENAME}.py"
+      "${DIRNAME}/${FILENAME}_test.py"
+      "tests/test_${FILENAME}.py"
+      "tests/${FILENAME}_test.py"
+    )
+    ;;
+  ts|tsx|js|jsx)
+    POTENTIAL_TESTS=(
+      "${DIRNAME}/${FILENAME}.test.${EXTENSION}"
+      "${DIRNAME}/${FILENAME}.spec.${EXTENSION}"
+      "${DIRNAME}/__tests__/${FILENAME}.test.${EXTENSION}"
+      "__tests__/${FILENAME}.test.${EXTENSION}"
+    )
+    ;;
+  rb)
+    POTENTIAL_TESTS=(
+      "spec/${FILENAME}_spec.rb"
+      "${DIRNAME}/${FILENAME}_spec.rb"
+      "test/${FILENAME}_test.rb"
+    )
+    ;;
+  go)
+    POTENTIAL_TESTS=(
+      "${DIRNAME}/${FILENAME}_test.go"
+    )
+    ;;
+esac
+
+# Check if any test file exists
+TEST_EXISTS=false
+FOUND_TEST=""
+for TEST_FILE in "${POTENTIAL_TESTS[@]}"; do
+  if [ -f "$TEST_FILE" ]; then
+    TEST_EXISTS=true
+    FOUND_TEST="$TEST_FILE"
+    break
+  fi
+done
+
+# Output advisory (non-blocking)
+if [ "$TEST_EXISTS" = false ]; then
+  cat << EOF
+# TDD Advisory
+
+Editing implementation file: \`$FILE_PATH\`
+
+**No corresponding test file found.** Consider Test-Driven Development:
+
+1. Write a failing test first
+2. Then implement the feature
+3. Run tests until green
+
+**Expected test locations:**
+$(for t in "${POTENTIAL_TESTS[@]}"; do echo "- \`$t\`"; done)
+
+**Why TDD?** Tests document expected behavior and prevent regressions.
+Skip this advisory if you're:
+- Doing a quick fix with existing test coverage
+- Working in an area where tests aren't practical
+
+EOF
+fi
+
+# Always exit 0 (non-blocking advisory)
+exit 0

--- a/src/hooks/session/session-end.sh
+++ b/src/hooks/session/session-end.sh
@@ -38,8 +38,16 @@ case "$AGENT_TYPE" in
     echo "- [ ] Linear issues synced with actual progress"
     echo "- [ ] Decisions captured (ADRs if architectural)"
     echo "- [ ] Session file \`## Current State\` is handoff-ready"
+    echo "- [ ] **Code review completed** (run \`pr-review-toolkit:code-reviewer\` if significant changes)"
     echo "- [ ] Completed sessions deleted (knowledge extracted)"
     echo "- [ ] Active sessions have clear next steps"
+    echo ""
+    echo "### Code Review Reminder"
+    echo ""
+    echo "If this session involved significant code changes, consider running:"
+    echo "\`\`\`"
+    echo "Task(subagent_type=\"pr-review-toolkit:code-reviewer\", prompt=\"Review recent changes for this session\")"
+    echo "\`\`\`"
     ;;
 
   backend-dev|frontend-dev|rails-dev|dba|devops)

--- a/src/skills/debugging/SKILL.md
+++ b/src/skills/debugging/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: debugging
+description: >-
+  Use for systematic bug investigation and diagnosis. Covers hypothesis-driven
+  debugging workflows, multi-hypothesis tracking, language-specific debugging
+  patterns (Python, TypeScript, Ruby), and test debugging (flaky tests, isolation,
+  state pollution). Activate when investigating failures, debugging production
+  issues, or diagnosing test problems.
+---
+
+# Systematic Debugging
+
+Hypothesis-driven investigation for efficient and traceable bug diagnosis.
+
+## Philosophy
+
+**Eliminate, don't guess.** Debugging is a process of elimination, not random modification. Each change should test a specific hypothesis and provide evidence to rule it out or confirm it.
+
+**Multiple hypotheses, ranked.** Never fixate on one theory. Generate 3-5 plausible hypotheses, rank by likelihood, and test the most likely first. Surprising evidence should trigger hypothesis revision.
+
+**Reproduce before investigating.** A bug you cannot reproduce is a bug you cannot fix with confidence. Establish reliable reproduction steps before diving into code.
+
+**Minimal changes, maximum information.** Each debugging step should change one variable and maximize the information gained. Shotgun debugging wastes time and obscures root causes.
+
+## Quick Reference
+
+| Situation | Approach | Key Technique |
+|-----------|----------|---------------|
+| **Unknown failure** | Generate hypotheses | List 3-5 possible causes, rank by likelihood |
+| **Intermittent bug** | Isolate variables | Binary search through conditions |
+| **Test flakiness** | Check state pollution | Run test in isolation, check fixtures |
+| **Production issue** | Preserve evidence | Capture logs/state before attempting fixes |
+
+## Topics
+
+| Topic | Reference | Use For |
+|-------|-----------|---------|
+| Hypothesis Tracking | `references/hypothesis-tracking.md` | Multi-hypothesis workflow, session templates, investigation logs |
+| Language Debugging | `references/language-debugging.md` | Python, TypeScript, Ruby debug patterns and tools |
+| Test Debugging | `references/test-debugging.md` | Flaky tests, isolation, state pollution, environment differences |
+
+## Critical Rules
+
+### Always
+
+- Generate multiple hypotheses before investigating
+- Document each hypothesis and its current status
+- Establish reproduction steps before attempting fixes
+- Test one variable at a time
+- Preserve evidence (logs, state, stack traces) before changes
+- Update hypothesis status based on evidence
+- Record failed attempts to avoid repeating them
+
+### Never
+
+- Make random changes hoping something works
+- Fix symptoms without understanding root cause
+- Assume the first hypothesis is correct
+- Skip reproduction verification after a "fix"
+- Delete logs or error output before analysis
+- Change multiple variables simultaneously
+- Ignore contradictory evidence
+
+## Debugging Workflow
+
+```
+1. REPRODUCE: Establish reliable reproduction steps
+2. HYPOTHESIZE: Generate 3-5 possible causes, rank by likelihood
+3. TEST: Design experiment to test highest-likelihood hypothesis
+4. EVALUATE: Analyze results, update hypothesis status
+5. ITERATE: Move to next hypothesis or refine based on evidence
+6. VERIFY: Confirm fix addresses root cause, not just symptoms
+```
+
+## Investigation Log Format
+
+Keep a timestamped log of investigation steps:
+
+```
+[HH:MM] Testing H2 (stale cache)
+        Action: Cleared Redis, restarted service
+        Result: Still failing
+        Evidence: Error occurs before cache read in stack trace
+        Status: H2 RULED OUT
+
+[HH:MM] Testing H3 (race condition)
+        Action: Added mutex around shared state
+        Result: SUCCESS - no failures in 100 runs
+        Evidence: Stack trace showed concurrent access
+        Status: H3 CONFIRMED
+```
+
+## Related Skills
+
+- `foundations` - Test patterns, error handling, logging standards
+- `python` - Python-specific debugging tools (pdb, logging)
+- `typescript` - TypeScript debugging (Chrome DevTools, source maps)
+- `ruby` - Ruby debugging (binding.irb, byebug)

--- a/src/skills/debugging/references/hypothesis-tracking.md
+++ b/src/skills/debugging/references/hypothesis-tracking.md
@@ -1,0 +1,168 @@
+# Hypothesis Tracking
+
+Systematic workflow for generating, testing, and tracking multiple debugging hypotheses.
+
+## Multi-Hypothesis Workflow
+
+### 1. Generate Hypotheses
+
+Before investigating, brainstorm 3-5 possible causes. Consider:
+
+- **Recent changes** - What changed since it last worked?
+- **Common culprits** - Race conditions, caching, state mutation, null references
+- **Environment differences** - Dev vs prod, different data, timing
+- **External dependencies** - API changes, network issues, third-party services
+
+### 2. Rank by Likelihood
+
+Assign likelihood based on:
+
+| Factor | Higher Likelihood | Lower Likelihood |
+|--------|-------------------|------------------|
+| Recency | Code changed recently | Untouched for months |
+| Complexity | Complex logic, many branches | Simple, well-tested |
+| Dependencies | External services involved | Self-contained |
+| Symptoms | Matches known failure pattern | Novel error |
+
+### 3. Test Systematically
+
+For each hypothesis (highest likelihood first):
+
+1. **Design minimal experiment** - What single change would confirm or rule out this hypothesis?
+2. **Predict outcome** - What result do you expect if hypothesis is correct?
+3. **Execute and observe** - Run experiment, capture results
+4. **Update status** - Mark CONFIRMED, RULED OUT, or NEEDS MORE DATA
+
+### 4. Revise Based on Evidence
+
+When evidence contradicts expectations:
+
+- Lower likelihood of current hypothesis
+- Consider what the evidence suggests instead
+- Add new hypotheses if needed
+- Re-rank based on new information
+
+## Session Template
+
+Use this template at the start of debugging sessions:
+
+```markdown
+## Debug Investigation
+
+**Symptom**: [What's failing - exact error message or behavior]
+**First observed**: [When did this start happening]
+**Reproduction**: [Steps to reliably reproduce]
+
+### Environment
+- OS/Platform:
+- Version:
+- Dependencies:
+- Data state:
+
+### Hypothesis Tracker
+
+| # | Hypothesis | Likelihood | Status | Evidence |
+|---|------------|------------|--------|----------|
+| H1 | [Description] | High/Med/Low | TESTING/RULED OUT/CONFIRMED | [What you learned] |
+| H2 | [Description] | High/Med/Low | PENDING | - |
+| H3 | [Description] | High/Med/Low | PENDING | - |
+
+### Investigation Log
+[Timestamped entries below]
+```
+
+## Example Investigation
+
+### Symptom
+API returns 500 error intermittently on `/api/orders` endpoint.
+
+### Reproduction
+1. Create 10+ concurrent requests to `/api/orders`
+2. ~30% return 500 errors
+3. Only happens under load
+
+### Hypothesis Tracker
+
+| # | Hypothesis | Likelihood | Status | Evidence |
+|---|------------|------------|--------|----------|
+| H1 | Database connection pool exhausted | High | RULED OUT | Pool metrics show 50% utilization during failures |
+| H2 | Race condition in order validation | High | TESTING | Errors correlate with concurrent creates |
+| H3 | Memory pressure causing timeouts | Medium | PENDING | - |
+| H4 | Third-party payment API rate limiting | Low | RULED OUT | Payment API logs show no rate limits |
+
+### Investigation Log
+
+```
+[14:32] Testing H1 (connection pool)
+        Action: Monitored pool metrics during load test
+        Result: Pool never exceeded 50% capacity
+        Evidence: Prometheus shows max 5/10 connections used
+        Status: H1 RULED OUT - pool is not the bottleneck
+
+[14:45] Testing H4 (payment API rate limiting)
+        Action: Checked payment provider dashboard
+        Result: No rate limit events in their logs
+        Evidence: All payment API calls successful
+        Status: H4 RULED OUT
+
+[15:01] Testing H2 (race condition)
+        Action: Added logging around order validation
+        Result: Found concurrent access to shared cart state
+        Evidence: Logs show two requests modifying same cart simultaneously
+        Status: H2 LIKELY - need to verify with fix
+
+[15:23] Verifying H2 fix
+        Action: Added mutex around cart validation
+        Result: 0 errors in 1000 concurrent requests
+        Evidence: Lock prevents concurrent modification
+        Status: H2 CONFIRMED - race condition was root cause
+```
+
+## Hypothesis Status Definitions
+
+| Status | Meaning | Next Action |
+|--------|---------|-------------|
+| PENDING | Not yet investigated | Move to TESTING when ready |
+| TESTING | Currently being investigated | Execute experiment, gather evidence |
+| NEEDS MORE DATA | Inconclusive results | Design better experiment |
+| RULED OUT | Evidence contradicts hypothesis | Document and move on |
+| LIKELY | Evidence supports but not conclusive | Verify with fix |
+| CONFIRMED | Root cause identified and verified | Document fix and close |
+
+## Common Hypothesis Categories
+
+### State-Related
+- Stale cache returning old data
+- Database transaction not committed
+- In-memory state mutation
+- Session/cookie corruption
+
+### Timing-Related
+- Race condition between concurrent operations
+- Timeout too short for slow operations
+- Clock skew between services
+- Event ordering assumptions violated
+
+### Environment-Related
+- Missing environment variable
+- Different library versions
+- File permissions
+- Network connectivity/latency
+
+### Data-Related
+- Null/undefined where unexpected
+- Type mismatch (string vs number)
+- Encoding issues (UTF-8, special characters)
+- Data exceeds expected bounds
+
+## Tips for Effective Hypothesis Tracking
+
+1. **Be specific** - "Something wrong with caching" is not a hypothesis. "Redis TTL set to 0 causing immediate expiration" is.
+
+2. **Make them testable** - Every hypothesis should have a clear experiment that could rule it out.
+
+3. **Update in real-time** - Log entries as you go, not from memory later.
+
+4. **Don't delete** - Ruled-out hypotheses are valuable documentation of what was tried.
+
+5. **Share context** - If handing off, the tracker should let someone else continue without starting over.

--- a/src/skills/debugging/references/language-debugging.md
+++ b/src/skills/debugging/references/language-debugging.md
@@ -1,0 +1,354 @@
+# Language-Specific Debugging
+
+Debug patterns and tools for Python, TypeScript, and Ruby.
+
+## Python Debugging
+
+### Interactive Debugging with pdb
+
+```python
+# Insert breakpoint in code
+import pdb; pdb.set_trace()
+
+# Python 3.7+ built-in
+breakpoint()
+
+# Conditional breakpoint
+if suspicious_condition:
+    breakpoint()
+```
+
+**Common pdb commands:**
+
+| Command | Action |
+|---------|--------|
+| `n` (next) | Execute next line |
+| `s` (step) | Step into function |
+| `c` (continue) | Continue to next breakpoint |
+| `p expr` | Print expression value |
+| `pp expr` | Pretty-print expression |
+| `l` (list) | Show current code context |
+| `w` (where) | Print stack trace |
+| `u` (up) | Move up stack frame |
+| `d` (down) | Move down stack frame |
+| `q` (quit) | Exit debugger |
+
+### Structured Logging
+
+```python
+import structlog
+
+logger = structlog.get_logger()
+
+# Add context that persists across log calls
+logger = logger.bind(request_id=request.id, user_id=user.id)
+
+# Log with structured data
+logger.info("order_created", order_id=order.id, total=order.total)
+logger.error("payment_failed",
+    order_id=order.id,
+    error_code=e.code,
+    error_message=str(e)
+)
+```
+
+### Traceback Analysis
+
+```python
+import traceback
+
+try:
+    risky_operation()
+except Exception as e:
+    # Full traceback as string
+    tb_str = traceback.format_exc()
+    logger.error("operation_failed", traceback=tb_str)
+
+    # Extract specific frame info
+    tb = traceback.extract_tb(e.__traceback__)
+    for frame in tb:
+        logger.debug("frame",
+            filename=frame.filename,
+            line=frame.lineno,
+            function=frame.name
+        )
+```
+
+### pytest Debugging
+
+```bash
+# Drop into debugger on failure
+pytest --pdb
+
+# Drop into debugger on first failure, then exit
+pytest -x --pdb
+
+# Show local variables in tracebacks
+pytest -l
+
+# Verbose output with print statements
+pytest -v -s
+
+# Run specific test
+pytest tests/test_orders.py::test_create_order -v
+```
+
+### Remote Debugging
+
+```python
+# Using debugpy (VS Code compatible)
+import debugpy
+debugpy.listen(5678)
+debugpy.wait_for_client()  # Pause until debugger attaches
+breakpoint()
+```
+
+## TypeScript Debugging
+
+### Console Methods
+
+```typescript
+// Basic logging
+console.log('value:', value);
+console.error('Error:', error);
+console.warn('Warning:', message);
+
+// Structured output
+console.table(arrayOfObjects);
+console.dir(complexObject, { depth: null });
+
+// Timing
+console.time('operation');
+// ... operation ...
+console.timeEnd('operation');
+
+// Grouping related logs
+console.group('Request Processing');
+console.log('Step 1');
+console.log('Step 2');
+console.groupEnd();
+
+// Conditional logging
+console.assert(condition, 'Condition failed:', data);
+
+// Stack trace without error
+console.trace('How did we get here?');
+```
+
+### Debugger Statement
+
+```typescript
+function processOrder(order: Order): void {
+  // Pauses execution when DevTools is open
+  debugger;
+
+  // Conditional debugger
+  if (order.total > 10000) {
+    debugger;
+  }
+}
+```
+
+### Source Maps
+
+Ensure `tsconfig.json` has source maps enabled:
+
+```json
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "inlineSources": true
+  }
+}
+```
+
+For debugging bundled code, verify source maps are generated and served:
+
+```typescript
+// webpack.config.js
+module.exports = {
+  devtool: 'source-map', // Full source maps for debugging
+};
+```
+
+### Node.js Debugging
+
+```bash
+# Start with inspector
+node --inspect dist/server.js
+
+# Break on first line
+node --inspect-brk dist/server.js
+
+# With ts-node
+node --inspect -r ts-node/register src/server.ts
+```
+
+### Chrome DevTools Tips
+
+1. **Breakpoints**: Click line number in Sources panel
+2. **Conditional breakpoints**: Right-click line number, add condition
+3. **Logpoints**: Right-click, add logpoint (logs without pausing)
+4. **Watch expressions**: Add variables to Watch panel
+5. **Call stack**: Navigate up/down the call stack
+6. **Scope**: Inspect local, closure, and global variables
+
+### Async Debugging
+
+```typescript
+// Capture async stack traces
+Error.stackTraceLimit = 50;
+
+// Label promises for debugging
+const result = await Promise.race([
+  fetchData().then(data => ({ source: 'fetch', data })),
+  timeout(5000).then(() => ({ source: 'timeout', data: null }))
+]);
+console.log('Winner:', result.source);
+```
+
+## Ruby Debugging
+
+### binding.irb (Ruby 2.5+)
+
+```ruby
+def process_order(order)
+  # Opens interactive console at this point
+  binding.irb
+
+  order.validate!
+end
+```
+
+**IRB commands in binding.irb:**
+
+| Command | Action |
+|---------|--------|
+| `exit` | Continue execution |
+| `exit!` | Exit program |
+| `whereami` | Show current code context |
+| `show_source method_name` | Show method source |
+
+### byebug
+
+```ruby
+# Gemfile
+gem 'byebug', group: [:development, :test]
+
+# In code
+require 'byebug'
+
+def process_order(order)
+  byebug  # Execution stops here
+  order.validate!
+end
+```
+
+**byebug commands:**
+
+| Command | Action |
+|---------|--------|
+| `n` (next) | Execute next line |
+| `s` (step) | Step into method |
+| `c` (continue) | Continue execution |
+| `f` (finish) | Run until current method returns |
+| `p expr` | Evaluate expression |
+| `info locals` | Show local variables |
+| `bt` (backtrace) | Show call stack |
+| `up` / `down` | Navigate stack frames |
+
+### Rails Console Debugging
+
+```ruby
+# Start console
+rails console
+
+# Reload after code changes
+reload!
+
+# Find and inspect objects
+user = User.find(123)
+user.attributes
+user.orders.to_sql  # See generated SQL
+
+# Test in sandbox (rollback on exit)
+rails console --sandbox
+```
+
+### Rails Logger
+
+```ruby
+# In application code
+Rails.logger.debug "Processing order: #{order.id}"
+Rails.logger.info "Order created", order_id: order.id
+Rails.logger.error "Payment failed", error: e.message
+
+# Tagged logging
+Rails.logger.tagged("OrderService", order.id) do
+  Rails.logger.info "Starting processing"
+end
+
+# Tail logs
+tail -f log/development.log
+```
+
+### pry-rails
+
+```ruby
+# Gemfile
+gem 'pry-rails', group: [:development, :test]
+
+# In code
+binding.pry  # Opens Pry console
+
+# Pry commands
+ls object          # List methods/variables
+cd object          # Change context to object
+show-source method # Show method definition
+show-doc method    # Show documentation
+wtf?               # Show last exception
+```
+
+### Exception Debugging
+
+```ruby
+begin
+  risky_operation
+rescue => e
+  # Full backtrace
+  puts e.backtrace.join("\n")
+
+  # Filtered backtrace (Rails)
+  puts Rails.backtrace_cleaner.clean(e.backtrace).join("\n")
+
+  # Re-raise with context
+  raise "Order processing failed for order #{order.id}: #{e.message}"
+end
+```
+
+## Cross-Language Tips
+
+### Binary Search Debugging
+
+When you have a long sequence of operations and don't know where the failure occurs:
+
+1. Add logging/breakpoint at the midpoint
+2. Determine if failure is before or after
+3. Repeat with the relevant half
+4. Continue until you isolate the exact line
+
+### Minimal Reproduction
+
+1. Remove code until bug disappears
+2. Add back the last removed piece
+3. That piece contains or triggers the bug
+4. Create minimal test case that reproduces
+
+### Rubber Duck Debugging
+
+When stuck:
+
+1. Explain the code line-by-line out loud
+2. Explain what you expect vs. what happens
+3. Explain your hypotheses and why each might be wrong
+4. Often, articulating the problem reveals the solution

--- a/src/skills/debugging/references/test-debugging.md
+++ b/src/skills/debugging/references/test-debugging.md
@@ -1,0 +1,326 @@
+# Test Debugging
+
+Strategies for diagnosing flaky tests, isolation failures, and environment-related test issues.
+
+## Flaky Test Diagnosis
+
+A flaky test passes sometimes and fails sometimes with the same code. Common causes:
+
+### Timing Dependencies
+
+**Symptoms:**
+- Test passes locally, fails in CI
+- Test fails more often under load
+- Adding `sleep()` makes it pass
+
+**Investigation:**
+```python
+# Bad: Depends on timing
+def test_async_operation():
+    start_async_job()
+    time.sleep(1)  # Hope it's done
+    assert job_completed()
+
+# Good: Wait for condition
+def test_async_operation():
+    start_async_job()
+    wait_for(lambda: job_completed(), timeout=5)
+    assert job_completed()
+```
+
+**Diagnosis steps:**
+1. Run test 100 times in a loop
+2. Monitor CPU/memory during failures
+3. Add timestamps to understand timing
+4. Check for hardcoded timeouts that are too short
+
+### Order Dependencies
+
+**Symptoms:**
+- Test passes when run alone, fails in suite
+- Test fails only when run after specific other test
+- Reordering tests changes results
+
+**Investigation:**
+```bash
+# pytest: Run in random order
+pytest --random-order
+
+# Find the guilty test pair
+pytest tests/test_a.py tests/test_b.py -v  # Passes
+pytest tests/test_b.py tests/test_a.py -v  # Fails?
+```
+
+**Common culprits:**
+- Global state modified by previous test
+- Database records not cleaned up
+- Cached values persisting
+- Module-level side effects
+
+### Non-Deterministic Data
+
+**Symptoms:**
+- Fails occasionally with no pattern
+- Different assertion failures each time
+- Works with specific seed/data
+
+**Investigation:**
+```python
+# Bad: Non-deterministic
+def test_random_selection():
+    items = get_random_items(10)
+    assert len(items) == 10  # What if source has < 10?
+
+# Good: Control randomness
+def test_random_selection():
+    random.seed(42)
+    items = get_random_items(10)
+    assert len(items) == 10
+```
+
+## Test Isolation Patterns
+
+### Database Isolation
+
+```python
+# pytest with transactions
+@pytest.fixture
+def db_session(engine):
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()
+```
+
+```ruby
+# Rails transactional tests
+class OrderTest < ActiveSupport::TestCase
+  # Each test runs in a transaction that rolls back
+  self.use_transactional_tests = true
+
+  test "creates order" do
+    order = Order.create!(total: 100)
+    assert order.persisted?
+  end  # Order is rolled back
+end
+```
+
+### External Service Isolation
+
+```python
+# Mock external services
+@pytest.fixture
+def mock_payment_api(mocker):
+    return mocker.patch(
+        'app.services.payment.PaymentAPI.charge',
+        return_value={'status': 'success', 'id': 'ch_123'}
+    )
+
+def test_order_payment(mock_payment_api):
+    order = create_order(total=100)
+    order.process_payment()
+
+    mock_payment_api.assert_called_once_with(amount=100)
+    assert order.payment_status == 'paid'
+```
+
+### Time Isolation
+
+```python
+# Freeze time for deterministic tests
+from freezegun import freeze_time
+
+@freeze_time("2024-01-15 12:00:00")
+def test_order_expiry():
+    order = create_order()
+    assert not order.expired
+
+    with freeze_time("2024-01-16 12:00:01"):
+        assert order.expired  # 24+ hours later
+```
+
+```typescript
+// Jest fake timers
+jest.useFakeTimers();
+
+test('order expires after 24 hours', () => {
+  const order = createOrder();
+  expect(order.expired).toBe(false);
+
+  jest.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
+  expect(order.expired).toBe(true);
+});
+```
+
+## State Pollution Detection
+
+### Symptoms
+
+- Test A passes alone, fails after test B
+- Test fails only when suite runs in specific order
+- "Works on my machine" syndrome
+
+### Detection Strategy
+
+```bash
+# 1. Run suspect test in isolation
+pytest tests/test_orders.py::test_specific -v
+
+# 2. Run with a known "polluter"
+pytest tests/test_other.py tests/test_orders.py::test_specific -v
+
+# 3. Binary search for the polluter
+pytest tests/test_orders.py::test_specific --last-failed
+```
+
+### Common State Pollution Sources
+
+| Source | Detection | Fix |
+|--------|-----------|-----|
+| Module globals | Check imports for mutations | Use fixtures, reset in teardown |
+| Class variables | Look for `cls.` modifications | Use instance variables |
+| Singletons | Check shared instances | Reset or mock singletons |
+| Environment variables | Print env in failing test | Restore in teardown |
+| File system | Check for temp files | Use tmp directories, clean up |
+| Database | Check for leftover records | Transaction rollback |
+| Caches | Check memoized values | Clear caches in setup |
+
+### Teardown Pattern
+
+```python
+@pytest.fixture(autouse=True)
+def reset_global_state():
+    # Setup: Save original state
+    original_config = app.config.copy()
+
+    yield
+
+    # Teardown: Restore original state
+    app.config = original_config
+    cache.clear()
+```
+
+## Environment Differences
+
+### Local vs CI Failures
+
+| Difference | Detection | Solution |
+|------------|-----------|----------|
+| Timing | CI slower, races more likely | Use proper waits, not sleeps |
+| Resources | CI has less memory/CPU | Check resource usage |
+| Parallelism | CI runs tests in parallel | Ensure isolation |
+| File paths | Different temp directories | Use portable paths |
+| Timezone | CI uses UTC | Freeze time or use UTC |
+| Locale | CI uses different locale | Set locale explicitly |
+
+### Debugging CI-Only Failures
+
+```yaml
+# GitHub Actions: Enable debug logging
+env:
+  ACTIONS_STEP_DEBUG: true
+  ACTIONS_RUNNER_DEBUG: true
+
+# Add verbose output
+steps:
+  - name: Run tests
+    run: |
+      echo "=== Environment ==="
+      env | sort
+      echo "=== Python version ==="
+      python --version
+      echo "=== Running tests ==="
+      pytest -v --tb=long
+```
+
+### Reproducing CI Environment Locally
+
+```bash
+# Docker: Use same image as CI
+docker run -it --rm -v $(pwd):/app -w /app python:3.11 bash
+pip install -r requirements.txt
+pytest
+
+# Act: Run GitHub Actions locally
+act -j test
+
+# Environment parity
+export CI=true
+export TZ=UTC
+pytest
+```
+
+## Test Debugging Workflow
+
+### 1. Isolate the Failure
+
+```bash
+# Run failing test alone
+pytest tests/test_orders.py::test_failing -v
+
+# If it passes alone, find the interaction
+pytest --collect-only | head -20  # See test order
+```
+
+### 2. Add Diagnostic Output
+
+```python
+def test_order_processing(caplog):
+    with caplog.at_level(logging.DEBUG):
+        order = process_order(data)
+
+    print(f"Captured logs: {caplog.text}")
+    print(f"Order state: {order.__dict__}")
+    assert order.status == "completed"
+```
+
+### 3. Minimize the Test
+
+```python
+# Start with failing test
+def test_order_processing():
+    user = create_user()
+    product = create_product()
+    cart = create_cart(user, product)
+    order = create_order(cart)
+    payment = process_payment(order)
+    shipment = create_shipment(order)
+    assert shipment.status == "ready"
+
+# Remove pieces until bug disappears
+def test_order_processing_minimal():
+    order = create_order()  # Minimal setup
+    assert order.status == "pending"  # Bug is here!
+```
+
+### 4. Check Assumptions
+
+```python
+def test_order_total():
+    order = create_order()
+
+    # Verify assumptions
+    print(f"Order items: {order.items}")
+    print(f"Item prices: {[i.price for i in order.items]}")
+    print(f"Expected total: {sum(i.price for i in order.items)}")
+    print(f"Actual total: {order.total}")
+
+    assert order.total == Decimal("100.00")
+```
+
+## Flaky Test Prevention
+
+| Practice | Why It Helps |
+|----------|--------------|
+| Use factories, not fixtures | Fresh data each test |
+| Avoid shared state | Tests can't pollute each other |
+| Mock time and randomness | Deterministic behavior |
+| Use transactions | Auto-cleanup |
+| Run tests in random order | Catch order dependencies |
+| Run tests in parallel | Catch isolation issues |
+| Set explicit timeouts | Fail fast on hangs |

--- a/src/skills/foundations/SKILL.md
+++ b/src/skills/foundations/SKILL.md
@@ -34,6 +34,7 @@ Engineering foundations for consistent, secure, and well-documented code.
 |-------|-----------|---------|
 | Code Style | `reference/code-style.md` | Python/TypeScript conventions, naming, patterns |
 | Commits | `reference/commits.md` | Commit messages, branches, PRs, Linear integration |
+| Diagrams | `reference/diagrams.md` | Mermaid syntax, when to diagram, storage patterns |
 | Documentation | `reference/documentation.md` | ADRs, API docs, changelogs |
 | Security | `reference/security.md` | Threat modeling, secrets, compliance |
 | Permissions | `reference/permissions.md` | Tool allowlists, sandbox config, agent permissions |

--- a/src/skills/foundations/references/diagrams.md
+++ b/src/skills/foundations/references/diagrams.md
@@ -1,0 +1,248 @@
+# Architecture Diagrams
+
+Guidelines for creating Mermaid diagrams to visualize system architecture and data flows.
+
+## When to Create Diagrams
+
+Create architecture diagrams when work involves:
+
+| Scenario | Diagram Type | Why |
+|----------|--------------|-----|
+| Multi-service changes | Component/flowchart | Shows interaction points and dependencies |
+| Data flow changes | Sequence/flowchart | Traces data through the system |
+| Schema modifications | ERD | Visualizes table relationships |
+| API design | Sequence | Documents request/response flows |
+| State machine logic | State diagram | Clarifies transitions and conditions |
+| Complex conditionals | Flowchart | Makes branching logic explicit |
+
+### Skip Diagrams When
+
+- Single-file changes with obvious scope
+- Bug fixes with no architectural impact
+- Configuration-only changes
+- Test additions (unless testing complex flows)
+
+## Mermaid Syntax Quick Reference
+
+### Flowchart (Most Common)
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Action 1]
+    B -->|No| D[Action 2]
+    C --> E[End]
+    D --> E
+```
+
+**Direction options:** `TD` (top-down), `LR` (left-right), `BT` (bottom-top), `RL` (right-left)
+
+**Node shapes:**
+- `[Rectangle]` - Process/action
+- `{Diamond}` - Decision
+- `([Stadium])` - Start/end
+- `[(Database)]` - Database
+- `((Circle))` - Connector
+
+### Sequence Diagram (API/Service Interaction)
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as API
+    participant D as Database
+
+    C->>A: POST /auth/login
+    A->>D: Query user
+    D-->>A: User record
+    A-->>C: JWT token
+```
+
+**Arrow types:**
+- `->>` Solid line with arrowhead (sync call)
+- `-->>` Dashed line with arrowhead (response)
+- `--)` Async message
+
+### Entity Relationship Diagram (Schema)
+
+```mermaid
+erDiagram
+    USER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT ||--o{ LINE_ITEM : "ordered in"
+
+    USER {
+        uuid id PK
+        string email
+        timestamp created_at
+    }
+    ORDER {
+        uuid id PK
+        uuid user_id FK
+        decimal total
+    }
+```
+
+**Relationship notation:**
+- `||` One (required)
+- `o|` Zero or one
+- `}|` One or many
+- `}o` Zero or many
+
+### State Diagram (State Machines)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Pending: submit
+    Pending --> Approved: approve
+    Pending --> Rejected: reject
+    Approved --> [*]
+    Rejected --> Draft: revise
+```
+
+### Component Diagram (System Architecture)
+
+```mermaid
+flowchart LR
+    subgraph Frontend
+        UI[Web App]
+    end
+
+    subgraph Backend
+        API[FastAPI]
+        Worker[Celery]
+    end
+
+    subgraph Data
+        DB[(PostgreSQL)]
+        Cache[(Redis)]
+    end
+
+    UI --> API
+    API --> DB
+    API --> Cache
+    API --> Worker
+    Worker --> DB
+```
+
+## Storage Patterns
+
+### Inline in Session File
+
+Best for: Diagrams specific to current work, temporary visualizations
+
+```markdown
+## Architecture Diagrams
+
+### Auth Flow
+```mermaid
+sequenceDiagram
+    User->>API: Login request
+    API->>DB: Validate credentials
+    DB-->>API: User record
+    API-->>User: JWT token
+```
+**Purpose**: Visualize the authentication flow being implemented
+**Files involved**: `backend/auth/`, `backend/models/user.py`
+```
+
+### Stored in `.agents/diagrams/`
+
+Best for: Reusable diagrams, cross-session reference, team documentation
+
+```
+.agents/diagrams/
+├── system-architecture.md
+├── auth-flow.md
+└── data-pipeline.md
+```
+
+**Diagram file format:**
+
+```markdown
+---
+created: 2025-01-23T14:00:00Z
+last_updated: 2025-01-23T14:00:00Z
+tags: [auth, api, security]
+---
+
+# Auth Flow Diagram
+
+## Overview
+
+Documents the authentication and authorization flow for the API.
+
+## Diagram
+
+```mermaid
+[diagram content]
+```
+
+## Related Files
+
+- `backend/auth/jwt.py` - JWT generation
+- `backend/middleware/auth.py` - Auth middleware
+- `backend/models/user.py` - User model
+
+## Notes
+
+Any additional context about this diagram.
+```
+
+### When to Store vs Inline
+
+| Store in `.agents/diagrams/` | Keep Inline in Session |
+|------------------------------|------------------------|
+| Referenced by multiple sessions | One-time visualization |
+| Documents stable architecture | Documents work-in-progress |
+| Shared across team members | Personal understanding aid |
+| Likely to be updated | Disposable after task |
+
+## Best Practices
+
+### Keep Diagrams Focused
+
+```markdown
+# Good: Single concern
+Auth flow diagram showing login -> validate -> token
+
+# Bad: Everything at once
+Entire system with auth, billing, notifications, logging...
+```
+
+### Use Consistent Naming
+
+```markdown
+# In diagrams, use actual names from code
+API[auth-service]  # Matches service name
+DB[(users)]        # Matches table name
+
+# Not generic placeholders
+API[Service A]
+DB[(Database)]
+```
+
+### Add Context
+
+Every diagram needs:
+1. **Purpose** - Why this diagram exists
+2. **Files involved** - What code it represents
+3. **Limitations** - What it does NOT show
+
+### Update When Code Changes
+
+Diagrams are documentation. When the code they represent changes:
+1. Update the diagram
+2. Update `last_updated` timestamp
+3. Note the change in session log
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Diagram everything | Diagram only complex flows |
+| Include implementation details | Show architectural relationships |
+| Create diagrams after code | Create during planning |
+| Leave stale diagrams | Update or delete |
+| Use inconsistent notation | Follow Mermaid conventions |

--- a/src/skills/orchestration/SKILL.md
+++ b/src/skills/orchestration/SKILL.md
@@ -36,11 +36,18 @@ Every release should be complete, polished, and delightful - no MVPs or quick ha
 | Stuck on task | Check circuit breaker, consider reshaping |
 | Pre-compaction | Spawn context-archiver to preserve state |
 | Low-priority work | Spawn background-runner with run_in_background |
+| New feature workflow | Research → Architecture → PRD → Specs → Tasks |
+| Create specification | Use `/specs` with requirement reference |
+| Break down spec | Use `/tasks` to generate atomic work items |
+| Task-coupled session | Use `/start-session TASK-XXX` for traceability |
 
 ## Topics
 
 | Topic | Reference | Key Content |
 |-------|-----------|-------------|
+| Product Development | [reference/product-development.md](reference/product-development.md) | Full workflow: Research → Vision → Architecture → Requirements → Specs → Tasks |
+| Specifications | [reference/specs.md](reference/specs.md) | Spec format, lifecycle, shaping, test conditions |
+| Local Tasks | [reference/local-tasks.md](reference/local-tasks.md) | Task format, abstraction layer, Linear/local backend |
 | Agent Delegation | [reference/delegation.md](reference/delegation.md) | Agent capabilities, spawn patterns, decision tree |
 | Background Agents | [reference/background-agents.md](reference/background-agents.md) | Non-interactive work, spawn with run_in_background |
 | Council Workflow | [reference/councils.md](reference/councils.md) | Composition, deliberation, synthesis, user approval |

--- a/src/skills/orchestration/SKILL.md
+++ b/src/skills/orchestration/SKILL.md
@@ -35,12 +35,14 @@ Every release should be complete, polished, and delightful - no MVPs or quick ha
 | Agent selection | Match domain expertise to task |
 | Stuck on task | Check circuit breaker, consider reshaping |
 | Pre-compaction | Spawn context-archiver to preserve state |
+| Low-priority work | Spawn background-runner with run_in_background |
 
 ## Topics
 
 | Topic | Reference | Key Content |
 |-------|-----------|-------------|
 | Agent Delegation | [reference/delegation.md](reference/delegation.md) | Agent capabilities, spawn patterns, decision tree |
+| Background Agents | [reference/background-agents.md](reference/background-agents.md) | Non-interactive work, spawn with run_in_background |
 | Council Workflow | [reference/councils.md](reference/councils.md) | Composition, deliberation, synthesis, user approval |
 | Session Management | [reference/sessions.md](reference/sessions.md) | Lifecycle, file format, handoffs, validation |
 | Session Resume | [reference/session-resume.md](reference/session-resume.md) | CLI flags, checkpoints, context recovery |

--- a/src/skills/orchestration/references/background-agents.md
+++ b/src/skills/orchestration/references/background-agents.md
@@ -1,0 +1,236 @@
+# Background Agents
+
+Background agents handle low-priority, long-running, or non-interactive work that can run independently while the user continues with other tasks.
+
+## When to Use Background Agents
+
+| Appropriate | Not Appropriate |
+|-------------|-----------------|
+| Security audits | Interactive debugging |
+| Code coverage analysis | User-facing questions |
+| Large-scale refactoring reports | Time-sensitive fixes |
+| Codebase-wide linting reports | Tasks requiring immediate feedback |
+| Documentation audits | Work needing user decisions mid-task |
+| Dependency vulnerability scans | Blocking tasks for current work |
+
+**Good candidates:**
+- Results can be processed later
+- No user interaction required
+- Task is well-defined with clear completion criteria
+- Output is a report or artifact, not a conversation
+
+**Poor candidates:**
+- Needs clarification mid-task
+- Time-sensitive (user waiting for result)
+- Requires real-time coordination with other agents
+
+## Spawning Background Agents
+
+### Claude Code
+
+Use the Task tool with `run_in_background: true`:
+
+```python
+Task(
+    subagent_type="background-runner",
+    prompt="""
+    Run full security audit on backend codebase.
+
+    Scope:
+    - src/api/
+    - src/services/
+
+    Write report to: .agents/reports/YYYYMMDD-HHMMSS-security-audit.md
+
+    Session: .agents/sessions/20260123-143000-auth-feature.md
+    """,
+    run_in_background=True
+)
+```
+
+### Cursor
+
+Background agents are configured via the `is_background: true` YAML property. When spawning:
+
+```
+@background-runner Run security audit on backend codebase.
+Write report to .agents/reports/
+```
+
+## Background Agent Tracking
+
+Track background agents in session frontmatter:
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-security-scan"
+    agent: background-runner
+    task: "Full security audit of backend"
+    status: running  # running | completed | failed
+    result_location: null
+  - id: "bg-20260123-144500-coverage"
+    agent: background-runner
+    task: "Test coverage analysis"
+    status: completed
+    result_location: ".agents/reports/20260123-144500-coverage-report.md"
+```
+
+### Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `running` | Agent still executing |
+| `completed` | Work finished, results available |
+| `failed` | Agent encountered error |
+
+### ID Convention
+
+Background agent IDs follow: `bg-YYYYMMDD-HHMMSS-<description>`
+
+Generate with:
+```bash
+echo "bg-$(date -u +"%Y%m%d-%H%M%S")-<description>"
+```
+
+## Result Retrieval
+
+Background agents write results to `.agents/reports/` with standard frontmatter:
+
+```yaml
+---
+report:
+  title: "Security Audit Report"
+  type: background-agent-output
+  status: unprocessed  # unprocessed | processed | archived
+  created: "2026-01-23T14:30:00Z"
+  background_agent_id: "bg-20260123-143000-security-scan"
+  session_reference: "20260123-140000-auth-feature.md"
+---
+```
+
+### Processing Results
+
+1. SessionStart hook alerts user to completed background work
+2. User or PM reviews report in `.agents/reports/`
+3. PM updates session frontmatter:
+   - Change `status` from `running` to `completed`
+   - Set `result_location` to report path
+4. Process findings as needed (spawn agents, create issues)
+5. Set report `status` to `processed`
+
+## Workflow Example
+
+### 1. PM Identifies Low-Priority Work
+
+During auth feature implementation, PM identifies need for security audit but it is not blocking current work.
+
+### 2. PM Spawns Background Agent
+
+```python
+Task(
+    subagent_type="background-runner",
+    prompt="""
+    Run comprehensive security audit on auth implementation.
+
+    Files to audit:
+    - src/auth/endpoints.py
+    - src/auth/token.py
+    - src/auth/middleware.py
+
+    Check for:
+    - OWASP Top 10 vulnerabilities
+    - Secrets in code
+    - SQL injection risks
+    - Authentication bypasses
+
+    Write report to: .agents/reports/20260123-143000-auth-security.md
+
+    Session: .agents/sessions/20260123-140000-auth-feature.md
+    """,
+    run_in_background=True
+)
+```
+
+### 3. PM Updates Session Frontmatter
+
+```yaml
+background_agents:
+  - id: "bg-20260123-143000-auth-security"
+    agent: background-runner
+    task: "Auth security audit"
+    status: running
+    result_location: null
+```
+
+### 4. Work Continues
+
+PM and other agents continue with main implementation while background agent works.
+
+### 5. Session Resumes Later
+
+SessionStart hook detects completed background work:
+
+```
+# Background Work Completed
+
+The following background agents have completed:
+
+- **bg-20260123-143000-auth-security** (background-runner)
+  - Task: Auth security audit
+  - Result: .agents/reports/20260123-143000-auth-security.md
+
+Review reports and update session frontmatter after processing.
+```
+
+### 6. Results Processed
+
+PM reads report, creates issues for findings, updates session.
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Use for blocking work | Keep blocking work in foreground |
+| Spawn without tracking | Always update session frontmatter |
+| Ignore completed results | Process results when alerted |
+| Use for interactive tasks | Reserve for autonomous work |
+| Spawn many concurrent background agents | Limit to 2-3 to avoid resource contention |
+| Skip result location in prompt | Always specify where to write output |
+
+## Integration Points
+
+### SessionStart Hook
+
+Checks session frontmatter for `background_agents` with `status: completed`. Alerts user to review results.
+
+### PreCompact Hook
+
+Includes background agent state in preservation. Context-archiver captures:
+- Active background agent list
+- Current status of each
+- Result locations for completed agents
+
+### Session Frontmatter
+
+Full template with background agents:
+
+```yaml
+---
+session:
+  title: "Feature implementation"
+  status: in_progress
+  # ... other session fields ...
+
+background_agents:
+  - id: "bg-20260123-143000-security"
+    agent: background-runner
+    task: "Security audit"
+    status: completed
+    result_location: ".agents/reports/20260123-143000-security.md"
+  - id: "bg-20260123-150000-coverage"
+    agent: background-runner
+    task: "Coverage analysis"
+    status: running
+    result_location: null
+---
+```

--- a/src/skills/orchestration/references/cross-session.md
+++ b/src/skills/orchestration/references/cross-session.md
@@ -1,0 +1,200 @@
+# Cross-Session References
+
+Patterns for importing decisions and context from past sessions into current work without duplicating full context.
+
+## When to Reference Past Sessions
+
+### Good Reasons to Reference
+
+- **Continuing related work**: Building on previous feature decisions
+- **Consistency**: Ensuring alignment with prior architectural choices
+- **Avoiding re-deliberation**: Council decisions already made on similar topics
+- **Context recovery**: Picking up work after long gaps
+
+### Skip Referencing When
+
+- Starting genuinely new work unrelated to past sessions
+- Past decisions are documented in ADRs (use ADRs instead)
+- Context would create more noise than value
+- Decisions were superseded or invalidated
+
+## What to Import
+
+### Decisions Only (Default)
+
+Import the distilled outcomes:
+
+```markdown
+## Referenced Decisions
+
+### From: 20250115-140000-auth-jwt.md
+
+#### Decision: Token Rotation Strategy
+**Decision**: Rotate every 15 minutes
+**Rationale**: Security/UX balance
+```
+
+**Why decisions only:**
+- Minimal context footprint
+- Focus on outcomes, not process
+- Easy to scan and validate relevance
+
+### Context Summary (When Needed)
+
+Import broader context when:
+- Problem space is complex and unfamiliar
+- Technical approach was non-obvious
+- Multiple related decisions form a coherent strategy
+
+```markdown
+## Referenced Context
+
+### From: 20250115-140000-auth-jwt.md
+
+**Problem**: Session management for distributed services
+**Approach**: JWT with refresh token rotation
+**Key Files**: `src/auth/`, `src/middleware/auth.py`
+**Outcome**: Implemented, deployed to production 2025-01-20
+```
+
+## Session Frontmatter for Tracking
+
+Track all cross-session references in frontmatter:
+
+```yaml
+---
+session:
+  title: "Auth V2 Implementation"
+  status: in_progress
+  created: "2025-01-23T10:00:00Z"
+  last_updated: "2025-01-23T14:30:00Z"
+  linear_issue: "PLT-200"
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"
+      imported_at: "2025-01-23T14:30:00Z"
+      content_type: decisions
+      decisions_imported:
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+    - session: "20250110-090000-auth-oauth.md"
+      imported_at: "2025-01-23T14:35:00Z"
+      content_type: context
+      summary: "OAuth provider integration patterns"
+
+orchestration:
+  current_task: "Implement token refresh endpoint"
+---
+```
+
+## Decision Memory Format
+
+When sessions are archived, decisions are extracted to Serena memory:
+
+```markdown
+# Memory: session-auth-jwt-decisions.md
+
+## Session Context
+- **Session**: 20250115-140000-auth-jwt.md
+- **Archived**: 2025-01-15T18:00:00Z
+- **Linear Issue**: PLT-123
+
+## Key Decisions
+
+### Decision 1: JWT Token Rotation Strategy
+**Decision**: Rotate tokens every 15 minutes with sliding window refresh
+**Rationale**: Balances security (limited token lifetime) with UX (seamless refresh)
+**Council**: None - backend-dev recommendation accepted
+
+### Decision 2: Refresh Token Storage
+**Decision**: Store refresh tokens in HttpOnly cookies, not localStorage
+**Rationale**: Prevents XSS-based token theft; aligns with OWASP recommendations
+**Council**: Security council (5 agents) - unanimous
+
+### Decision 3: Token Validation Order
+**Decision**: Validate signature before parsing claims
+**Rationale**: Fail fast on tampered tokens; reduce processing for invalid requests
+**Council**: None - standard security practice
+```
+
+## Workflow
+
+### At Archive Time (context-archiver)
+
+1. Read session file
+2. Check for `## Decisions` section
+3. If present, run `extract-decisions.py`
+4. Write output to Serena memory via MCP
+
+### At Reference Time (/reference-session)
+
+1. Search Serena memories for matching sessions
+2. Read selected decision memory
+3. Import into current session
+4. Track in `referenced_sessions` frontmatter
+
+## Serena MCP Integration
+
+### List Available Decision Memories
+
+```python
+mcp__serena__list_memories()
+# Filter results for: session-*-decisions.md
+```
+
+### Read Decision Memory
+
+```python
+mcp__serena__read_memory(name="session-auth-jwt-decisions.md")
+```
+
+### Write Decision Memory (at archive time)
+
+```python
+mcp__serena__write_memory(
+    name="session-auth-jwt-decisions.md",
+    content=extracted_decisions_markdown
+)
+```
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Import entire session files | Import only decisions/summaries |
+| Import without tracking | Update `referenced_sessions` in frontmatter |
+| Import unrelated sessions | Search by topic, Linear issue, or keyword |
+| Duplicate ADR content | Reference the ADR directly |
+| Import stale decisions | Verify decisions are still relevant |
+| Over-reference | Import only what's needed for current work |
+| Reference without reading | Always review imported content for relevance |
+
+## When Decisions Conflict
+
+If imported decisions conflict with current approach:
+
+1. **Note the conflict** in session file
+2. **Assess if prior decision still applies**
+   - Different context? Proceed with new approach
+   - Same context? Consider why original decision was made
+3. **Document the change** if deviating
+4. **Consider council** if uncertainty remains
+5. **Update ADRs** if architectural decision changes
+
+## Best Practices
+
+1. **Reference early** - Import relevant decisions before planning
+2. **Validate relevance** - Review each decision's applicability
+3. **Track everything** - All imports go in frontmatter
+4. **Summarize in session log** - Note what was imported and why
+5. **Don't over-import** - Less is more for context management
+6. **Update if superseding** - Mark old decisions as superseded when creating new ones
+
+## Example Session Log Entry
+
+```markdown
+### 2025-01-23 14:30 - PM
+Referenced decisions from auth-jwt session (PLT-123):
+- Token rotation strategy (15-min window)
+- Refresh token storage (HttpOnly cookies)
+Relevant to current auth-v2 work; maintaining consistency.
+```

--- a/src/skills/orchestration/references/local-tasks.md
+++ b/src/skills/orchestration/references/local-tasks.md
@@ -1,0 +1,276 @@
+# Local Task Management
+
+Break specs into atomic tasks using local files when Linear isn't available.
+
+## Task Abstraction Layer
+
+Tasks work identically whether backed by Linear or local files.
+
+### Configuration
+
+```yaml
+# .agents/loaf.yaml
+task_management:
+  backend: linear  # or "local"
+
+  linear:
+    team: ProjectName
+    default_labels: []
+
+  local:
+    archive_completed: true
+    directory: .agents/tasks
+```
+
+### Abstracted Operations
+
+| Operation | Linear | Local |
+|-----------|--------|-------|
+| Create task | Create issue | Write `.agents/tasks/active/TASK-*.md` |
+| Fetch task | Get issue | Read task file |
+| Update status | Update issue | Edit frontmatter |
+| List tasks | List issues | Glob task files |
+| Complete | Move to Done | Move to archive |
+
+## Local Task Format
+
+```yaml
+---
+id: TASK-001
+title: OAuth Provider Integration
+spec: SPEC-001
+status: todo  # todo | in_progress | review | done
+priority: P1  # P0 (urgent) | P1 (high) | P2 (normal) | P3 (low)
+created: 2026-01-23T14:30:00Z
+updated: 2026-01-23T14:30:00Z
+files:
+  - src/auth/oauth.py
+  - tests/auth/test_oauth.py
+verify: pytest tests/auth/test_oauth.py
+done: OAuth flow works for Google and GitHub
+---
+
+# TASK-001: OAuth Provider Integration
+
+## Description
+
+Implement OAuth provider integration for Google and GitHub following
+the approach outlined in SPEC-001.
+
+## Acceptance Criteria
+
+- [ ] Google OAuth flow completes successfully
+- [ ] GitHub OAuth flow completes successfully
+- [ ] Tokens stored securely in session
+- [ ] Error handling for failed auth
+- [ ] Unit tests pass
+
+## Context
+
+See SPEC-001 for full context and constraints.
+Reference ADR-001 for session storage decisions.
+
+## Work Log
+
+<!-- Updated by session as work progresses -->
+```
+
+**Location:** `.agents/tasks/active/TASK-001-oauth-provider.md`
+
+## Task Lifecycle
+
+```
+todo → in_progress → review → done
+  │        │           │        │
+  └────────┴───────────┴────────┘
+           can return to earlier states
+```
+
+| Status | Meaning |
+|--------|---------|
+| `todo` | Ready to work, not started |
+| `in_progress` | Actively being worked |
+| `review` | Implementation complete, needs verification |
+| `done` | Verified complete, ready for archive |
+
+## Creating Tasks from Specs
+
+### Input
+
+- Spec ID (e.g., `SPEC-001`)
+- Optional: priority override
+
+### Task Breakdown Rules
+
+1. **One concern per task** - Don't mix backend + tests + frontend
+2. **Clear done condition** - Observable, verifiable outcome
+3. **Verification command** - How to prove it works
+4. **File hints** - Which files will likely be modified
+
+### Example Breakdown
+
+```
+SPEC-001: User Authentication with OAuth
+        ↓
+TASK-001: OAuth Provider Integration
+  - Google OAuth client setup
+  - GitHub OAuth client setup
+  - Token exchange logic
+  verify: pytest tests/auth/test_oauth.py
+
+TASK-002: Session Management
+  - Session cookie handling
+  - Session storage (Redis/DB)
+  - Session expiry logic
+  verify: pytest tests/auth/test_session.py
+
+TASK-003: Login UI Components
+  - Login page layout
+  - Provider buttons
+  - Error states
+  verify: npm run test:e2e -- auth
+```
+
+## Directory Structure
+
+```
+.agents/tasks/
+├── active/                    # Current work
+│   ├── TASK-001-oauth-provider.md
+│   ├── TASK-002-session-management.md
+│   └── TASK-003-login-ui.md
+└── archive/                   # Completed work
+    └── 2026-01/              # Organized by month
+        └── TASK-000-initial-setup.md
+```
+
+## Task ID Generation
+
+Format: `TASK-{number}-{slug}`
+
+```bash
+# Find next available number
+ls .agents/tasks/active/ .agents/tasks/archive/*/ 2>/dev/null | \
+  grep -oE 'TASK-[0-9]+' | \
+  sort -t- -k2 -n | \
+  tail -1 | \
+  awk -F- '{print $2 + 1}'
+```
+
+## Archiving Tasks
+
+When a task is done:
+
+1. Update status to `done`
+2. Add completion timestamp
+3. Move to archive:
+
+```bash
+mkdir -p .agents/tasks/archive/$(date +%Y-%m)
+mv .agents/tasks/active/TASK-001-*.md .agents/tasks/archive/$(date +%Y-%m)/
+```
+
+## Session Integration
+
+When `/start-session TASK-001`:
+
+1. Read task file for context
+2. Read linked spec for full picture
+3. Create session with traceability:
+
+```yaml
+session:
+  title: "OAuth Provider Integration"
+  task: TASK-001
+  spec: SPEC-001
+  status: in_progress
+
+traceability:
+  requirement: "2.1 User Authentication"
+  architecture:
+    - "Session Management"
+  decisions:
+    - ADR-001
+```
+
+## Priority Levels
+
+| Priority | Meaning | Response |
+|----------|---------|----------|
+| P0 | Urgent/blocking | Drop everything |
+| P1 | High | Work next |
+| P2 | Normal | Scheduled work |
+| P3 | Low | When time permits |
+
+## Listing Tasks
+
+### All Active Tasks
+
+```bash
+for f in .agents/tasks/active/TASK-*.md; do
+  id=$(grep '^id:' "$f" | cut -d: -f2 | tr -d ' ')
+  title=$(grep '^title:' "$f" | cut -d: -f2-)
+  status=$(grep '^status:' "$f" | cut -d: -f2 | tr -d ' ')
+  echo "$id [$status] $title"
+done
+```
+
+### Tasks for a Spec
+
+```bash
+grep -l "spec: SPEC-001" .agents/tasks/active/*.md
+```
+
+## Work Log Updates
+
+As work progresses, append to the Work Log section:
+
+```markdown
+## Work Log
+
+### 2026-01-23 14:30 UTC
+Started OAuth integration. Set up Google OAuth client credentials.
+
+### 2026-01-23 15:45 UTC
+Google OAuth working. Moving to GitHub integration.
+
+### 2026-01-23 17:00 UTC
+Both providers working. Tests pass. Moving to review.
+```
+
+## Verification
+
+Before marking `done`:
+
+1. Run the `verify` command from frontmatter
+2. Check all acceptance criteria are checked
+3. Ensure no regressions in related tests
+
+```bash
+# Run task verification
+verify_cmd=$(grep '^verify:' TASK-001-*.md | cut -d: -f2-)
+eval "$verify_cmd"
+```
+
+## Local vs Linear Comparison
+
+| Feature | Local | Linear |
+|---------|-------|--------|
+| No external dependency | yes | no |
+| Rich UI | no | yes |
+| Team collaboration | git-based | native |
+| Notifications | none | email/slack |
+| Reporting | manual | built-in |
+| Offline work | yes | limited |
+
+**Use local when:**
+- Solo project
+- No Linear access
+- Offline development
+- Simple task tracking
+
+**Use Linear when:**
+- Team collaboration needed
+- Rich workflow automation
+- Integration with other tools
+- Reporting requirements

--- a/src/skills/orchestration/references/product-development.md
+++ b/src/skills/orchestration/references/product-development.md
@@ -1,0 +1,234 @@
+# Product Development Workflow
+
+A Research → Vision → Architecture → Requirements → Specs → Tasks → Session workflow for structured product development.
+
+## Core Insight
+
+**Separate permanent project knowledge from ephemeral orchestration.**
+
+```
+docs/                               # Permanent project knowledge
+├── VISION.md                       # Strategic direction (evolves rarely)
+├── ARCHITECTURE.md                 # Technical design (evolves with learnings)
+├── REQUIREMENTS.md                 # Business/product rules (evolves with feedback)
+├── decisions/                      # Architecture Decision Records
+│   └── ADR-001-database-choice.md
+└── specs/                          # Feature specifications (temporary)
+    ├── SPEC-001-user-auth.md
+    └── archive/                    # Completed specs
+
+.agents/                            # Ephemeral orchestration
+├── loaf.yaml                       # Project config (task backend, etc.)
+├── sessions/                       # Active work contexts
+├── plans/                          # Implementation plans
+├── councils/                       # Deliberation records
+├── transcripts/                    # Archived conversation transcripts
+├── tasks/                          # Local tasks (when not using Linear)
+│   ├── active/
+│   │   └── TASK-001-oauth-provider.md
+│   └── archive/
+└── debug/                          # Persistent debug sessions
+```
+
+## The Hierarchy
+
+```
+RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS → SESSION
+    │         │          │              │           │        │        │
+/research  (manual)  /architecture    /prd       /specs   /tasks  /start-session
+    │                    │              │           │        │
+    └─► evolves ─────────┴──────────────┴───────────┴────────┘
+        VISION                                      (feedback loops)
+```
+
+**Each level breaks down the one above:**
+- Research informs/evolves Vision
+- Vision shapes Architecture
+- Architecture constrains Requirements
+- Requirements break into Specs
+- Specs break into Tasks
+- Tasks become Sessions
+
+## Commands Overview
+
+| Command | Input | Output | Purpose |
+|---------|-------|--------|---------|
+| `/research` | Topic or "project state" | Insights, brainstorm | Zoom out, evolve VISION |
+| `/architecture` | Decision question | ARCHITECTURE.md + ADR | Technical decisions |
+| `/prd` | Feature area | REQUIREMENTS.md section | Product/business rules |
+| `/specs` | Requirement reference | SPEC-001-*.md | Feature specifications |
+| `/tasks` | Spec reference | TASK-* files/issues | Atomic work items |
+| `/start-session` | TASK-ID | Session file | Execute a task |
+
+## Document Formats
+
+### VISION.md
+
+Strategic direction that evolves rarely. Contains:
+- Product purpose and target users
+- Core principles and values
+- Long-term direction
+- What makes this product unique
+
+### ARCHITECTURE.md
+
+Technical design that evolves with learnings:
+- System architecture overview
+- Technology choices and rationale
+- Integration patterns
+- Deployment model
+
+### REQUIREMENTS.md
+
+Business and product rules organized by domain:
+
+```markdown
+## 2. Identity & Access
+
+### 2.1 User Authentication
+
+**Business Rules**
+- Users authenticate via OAuth (Google, GitHub)
+- Sessions expire after 24 hours of inactivity
+- Failed login attempts logged for security
+
+**Acceptance Criteria**
+- [ ] User can sign in with Google
+- [ ] User can sign in with GitHub
+- [ ] Session persists across browser refresh
+- [ ] Logout clears session completely
+```
+
+### Architecture Decision Records (ADRs)
+
+```yaml
+---
+id: ADR-001
+title: "PostgreSQL as Required Database"
+status: Accepted  # Proposed | Accepted | Deprecated | Superseded
+date: 2026-01-23
+---
+
+# ADR-001: PostgreSQL as Required Database
+
+## Context
+[Why this decision is needed]
+
+## Decision
+[What was decided]
+
+## Consequences
+[Tradeoffs and implications]
+```
+
+**Location:** `docs/decisions/ADR-001-*.md`
+
+## Configuration
+
+```yaml
+# .agents/loaf.yaml
+project:
+  name: "My Project"
+
+task_management:
+  backend: linear  # or "local"
+
+  linear:
+    team: ProjectName
+
+  local:
+    archive_completed: true
+
+docs:
+  vision: docs/VISION.md
+  architecture: docs/ARCHITECTURE.md
+  requirements: docs/REQUIREMENTS.md
+  decisions: docs/decisions/
+  specs: docs/specs/
+```
+
+## Workflow Examples
+
+### Full Workflow (New Feature)
+
+```bash
+# 1. Zoom out, check project state
+/research "project state"
+# → Lessons learned, ideas for auth improvement
+
+# 2. Make architecture decision
+/architecture "OAuth vs custom auth"
+# → Interview → ADR-001-auth-approach.md
+
+# 3. Capture requirements
+/prd "user authentication"
+# → Interview → REQUIREMENTS.md section 2.1
+
+# 4. Create specification
+/specs "2.1 User Authentication"
+# → Interview → SPEC-001-user-auth.md
+
+# 5. Generate tasks
+/tasks SPEC-001
+# → TASK-001, TASK-002, TASK-003
+
+# 6. Work on tasks
+/start-session TASK-001
+# → Session → Implementation → Done
+```
+
+### Quick Fix (Ad-hoc)
+
+```bash
+# Create task directly (bug report, small fix)
+/start-session TASK-099
+# PM: "No parent spec. Proceed?"
+# User: "Yes, small fix"
+# → Session → Fix → Done
+```
+
+## Feedback Loops
+
+The workflow is not rigid. Each level can feed back to higher levels:
+
+| Discovery | Action |
+|-----------|--------|
+| Implementation reveals design flaw | Update ARCHITECTURE.md |
+| Edge case invalidates requirement | Update REQUIREMENTS.md |
+| Spec too ambitious for appetite | Re-scope or split |
+| Task reveals missing requirement | Add to REQUIREMENTS.md |
+
+## Transcript Archival
+
+After `/compact` or `/clear`, archive conversation transcripts for future reference:
+
+1. **Copy transcript** to `.agents/transcripts/`
+2. **Link from session file** in frontmatter:
+
+```yaml
+session:
+  title: "Feature Implementation"
+  transcripts:
+    - 20260123-143500-pre-compact.jsonl
+    - 20260123-160000-final.jsonl
+```
+
+This preserves full context for debugging, knowledge extraction, and audit trails.
+
+## Flexibility Preserved
+
+1. **Skip steps** - Quick fixes don't need full workflow
+2. **Feedback loops** - Any level can evolve from learnings
+3. **Agents adapt** - Not a rigid harness
+
+## Critical Files
+
+| File | Purpose |
+|------|---------|
+| `docs/VISION.md` | Strategic direction |
+| `docs/ARCHITECTURE.md` | Technical design |
+| `docs/REQUIREMENTS.md` | Product rules |
+| `docs/decisions/ADR-*.md` | Architecture decisions |
+| `docs/specs/SPEC-*.md` | Feature specifications |
+| `.agents/tasks/active/TASK-*.md` | Local tasks |
+| `.agents/loaf.yaml` | Project configuration |

--- a/src/skills/orchestration/references/sessions.md
+++ b/src/skills/orchestration/references/sessions.md
@@ -68,6 +68,7 @@ session:
   branch: "username/back-123-feature"          # Optional: working branch
   transcripts: []                              # Archived Claude Code transcripts (filenames only)
                                                # Example: ["2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl"]
+  referenced_sessions: []                      # Cross-session references (see below)
 
 plans: []  # List of plan files in .agents/plans/ used by this session
            # Example: ["20251204-143500-api-design.md", "20251204-150000-frontend.md"]
@@ -79,8 +80,42 @@ orchestration:
       task: "Brief task description"
       status: completed                        # pending|in_progress|completed
       summary: "Outcome summary"
+
+background_agents:                             # Background work running independently
+  - id: "bg-20260123-143000-security-scan"     # ID: bg-YYYYMMDD-HHMMSS-description
+    agent: background-runner                   # Agent type
+    task: "Full security audit"                # Brief description
+    status: running                            # running|completed|failed
+    result_location: null                      # Path to report when complete
 ---
 ```
+
+### Cross-Session References
+
+Track decisions imported from past sessions via `/reference-session`:
+
+```yaml
+session:
+  # ... other fields ...
+  referenced_sessions:
+    - session: "20250115-140000-auth-jwt.md"     # Source session filename
+      imported_at: "2025-01-23T14:30:00Z"        # When imported
+      content_type: decisions                     # decisions|context|all
+      decisions_imported:                         # List of decision titles
+        - "JWT token rotation strategy"
+        - "Refresh token storage approach"
+    - session: "20250110-090000-auth-oauth.md"
+      imported_at: "2025-01-23T14:35:00Z"
+      content_type: context
+      summary: "OAuth provider integration patterns"
+```
+
+**Why track references:**
+- Audit trail of where context came from
+- Avoids re-importing same decisions
+- Enables tracing decision lineage across sessions
+
+See `references/cross-session.md` for full patterns.
 
 ### Required Sections
 
@@ -160,6 +195,29 @@ Implementation plans for this session (stored in `.agents/plans/`):
 |------|--------|-------------|
 | [api-design](../plans/20251204-143500-api-design.md) | approved | API endpoint structure |
 | [frontend](../plans/20251204-150000-frontend.md) | pending | UI component design |
+
+## Architecture Diagrams
+
+### [Diagram Name]
+
+```mermaid
+[diagram content]
+```
+
+**Purpose**: Why this diagram helps understand the work
+**Files involved**: List of related file paths
+**Created**: When diagram was created (update if modified)
+
+<!--
+When to add diagrams:
+- Multi-service changes: Show interaction points
+- Data flow changes: Trace data through system
+- Schema modifications: Visualize relationships
+- API design: Document request/response flows
+
+For reusable diagrams, store in .agents/diagrams/ instead.
+See foundations skill reference/diagrams.md for Mermaid syntax.
+-->
 
 ## Council Outcomes
 

--- a/src/skills/orchestration/references/specs.md
+++ b/src/skills/orchestration/references/specs.md
@@ -1,0 +1,255 @@
+# Feature Specifications
+
+Break VISION + ARCHITECTURE + REQUIREMENTS into specific, implementable specs.
+
+## Philosophy
+
+**Specs are shaped solutions, not detailed designs.**
+
+A spec defines:
+- What problem we're solving
+- Boundaries (in/out of scope)
+- High-level approach
+- Test conditions
+
+A spec does NOT define:
+- Implementation details
+- Code structure
+- Exact UI layouts
+
+## Spec Format
+
+```yaml
+---
+id: SPEC-001
+title: "User Authentication with OAuth"
+requirement: "2.1 User Authentication"
+created: 2026-01-23T14:30:00Z
+status: drafting  # drafting | approved | implementing | complete
+appetite: "1 week"
+---
+
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+[From REQUIREMENTS 2.1 - why this matters to users and the business]
+
+## Proposed Solution
+
+[Shaped solution - high-level approach, not implementation details]
+
+## Scope
+
+### In Scope
+- OAuth: Google, GitHub
+- Session management with secure cookies
+- Login/logout UI
+
+### Out of Scope (Rabbit Holes)
+- Custom OAuth providers (avoid this complexity)
+- MFA (future spec if needed)
+- Password-based auth
+
+### No-Gos
+- Passwords in plaintext
+- Tokens in local storage
+- Session data in URLs
+
+## Test Conditions
+
+- [ ] OAuth flow completes for Google
+- [ ] OAuth flow completes for GitHub
+- [ ] Session persists across page refresh
+- [ ] Logout clears session completely
+- [ ] Invalid tokens are rejected
+
+## Implementation Notes
+
+[Architecture references, technical constraints, relevant ADRs]
+
+## Circuit Breaker
+
+At 50% appetite: if OAuth integration is problematic, simplify to single provider (Google only).
+```
+
+**Location:** `docs/specs/SPEC-001-feature-name.md`
+
+## Spec Lifecycle
+
+```
+drafting → approved → implementing → complete
+    │         │           │           │
+    └─────────┴───────────┴───────────┘
+              can return to drafting
+```
+
+| Status | Meaning |
+|--------|---------|
+| `drafting` | Being refined, not ready for work |
+| `approved` | User approved, ready for task breakdown |
+| `implementing` | Tasks created, work in progress |
+| `complete` | All tasks done, spec archived |
+
+## Creating Specs
+
+### Input Required
+
+1. **Requirement reference** - Which section of REQUIREMENTS.md
+2. **Appetite** - How much time is it worth (from Shape Up)
+
+### Interview Questions
+
+Before drafting, clarify:
+
+| Area | Questions |
+|------|-----------|
+| Scope | What's definitely in? What's definitely out? |
+| Rabbit holes | What seems related but should be avoided? |
+| No-gos | What approaches are forbidden? |
+| Test conditions | How do we know it works? |
+| Dependencies | What must exist first? |
+| Edge cases | What could go wrong? |
+
+### Writing the Spec
+
+1. **Start with Problem Statement** - Not "build X" but "solve Y"
+2. **Shape the solution** - Direction, not blueprint
+3. **Define boundaries explicitly** - In/out/no-gos
+4. **Write test conditions** - Observable outcomes
+5. **Set circuit breaker** - When to stop and reassess
+
+## Appetite Levels
+
+| Appetite | Size | Suitable For |
+|----------|------|--------------|
+| Small | 1-2 days | Bug fixes, minor enhancements |
+| Medium | 3-5 days | Feature additions, refactors |
+| Large | 1-2 weeks | Major features (rare) |
+
+If a spec can't fit the appetite, it needs more shaping or should be split.
+
+## Splitting Large Specs
+
+When a spec is too big:
+
+```
+SPEC-001-user-auth.md (large, 2 weeks)
+        ↓ split into
+SPEC-001a-oauth-integration.md (medium, 3 days)
+SPEC-001b-session-management.md (small, 2 days)
+SPEC-001c-login-ui.md (medium, 3 days)
+```
+
+Each sub-spec:
+- Has its own appetite
+- Can be worked independently
+- References the original requirement
+
+## Archiving Specs
+
+When all tasks for a spec are complete:
+
+1. Update status to `complete`
+2. Add completion date to frontmatter
+3. Move to `docs/specs/archive/`
+
+```bash
+mv docs/specs/SPEC-001-user-auth.md docs/specs/archive/
+```
+
+## Spec vs Plan
+
+| Spec | Plan |
+|------|------|
+| **What** to build | **How** to build it |
+| Lives in `docs/specs/` | Lives in `.agents/plans/` |
+| Survives sessions | Tied to session |
+| User-facing | Implementation detail |
+| Shape Up shaped | Tactical steps |
+
+Specs define the target. Plans define the route to get there.
+
+## Validation Checklist
+
+Before approving a spec:
+
+- [ ] Problem statement is clear and user-focused
+- [ ] Scope boundaries are explicit (in/out/no-gos)
+- [ ] Test conditions are observable and testable
+- [ ] Appetite is realistic for the scope
+- [ ] Circuit breaker is defined
+- [ ] Requirement reference is valid
+- [ ] No implementation details (those go in plans)
+
+## Example: Good vs Bad Specs
+
+### Bad Spec
+
+```markdown
+# SPEC-001: Add OAuth
+
+Add OAuth to the app.
+
+## Requirements
+- Add Google OAuth
+- Add session management
+- Add logout
+```
+
+Problems:
+- No problem statement
+- No scope boundaries
+- No test conditions
+- No appetite
+- Too vague to implement
+
+### Good Spec
+
+```markdown
+# SPEC-001: User Authentication with OAuth
+
+## Problem Statement
+
+Users currently can't access the application. We need a secure,
+frictionless login flow that leverages existing identity providers
+so users don't need to create yet another password.
+
+## Proposed Solution
+
+Implement OAuth 2.0 flow with Google and GitHub as initial providers.
+Store session in secure HTTP-only cookies. Provide clear login/logout UI.
+
+## Scope
+
+### In Scope
+- Google OAuth integration
+- GitHub OAuth integration
+- Session cookie management
+- Login page with provider buttons
+- Logout functionality
+
+### Out of Scope
+- Apple/Microsoft providers (future)
+- MFA (separate spec if needed)
+- Account linking (complex, avoid)
+
+### No-Gos
+- Storing tokens in localStorage
+- Custom password auth
+- Session data in URLs
+
+## Test Conditions
+
+- [ ] New user can sign in with Google
+- [ ] New user can sign in with GitHub
+- [ ] Session persists across browser tabs
+- [ ] Session survives page refresh
+- [ ] Logout clears all session data
+- [ ] Expired sessions redirect to login
+
+## Circuit Breaker
+
+At 50% appetite: if both providers are problematic, ship with Google only.
+GitHub can be a follow-up spec.
+```

--- a/src/skills/orchestration/scripts/extract-decisions.py
+++ b/src/skills/orchestration/scripts/extract-decisions.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Extract decisions from a session file and format as Serena memory.
+
+Usage: extract-decisions.py <session-file>
+
+Reads a session file, extracts the ## Decisions section, and outputs
+formatted Serena memory content to stdout. The output can be piped to
+Serena MCP's write_memory tool.
+
+Exit codes:
+  0 - Success (decisions extracted)
+  1 - Error (file not found, parse error)
+  2 - No decisions found
+"""
+
+import sys
+import re
+import yaml
+from pathlib import Path
+from datetime import datetime, timezone
+
+
+def parse_frontmatter(content: str) -> tuple[dict, str]:
+    """Extract YAML frontmatter from markdown content."""
+    if not content.startswith('---'):
+        return {}, content
+
+    parts = content.split('---', 2)
+    if len(parts) < 3:
+        return {}, content
+
+    try:
+        frontmatter = yaml.safe_load(parts[1])
+        body = parts[2]
+        return frontmatter or {}, body
+    except yaml.YAMLError as e:
+        print(f"Warning: Could not parse frontmatter: {e}", file=sys.stderr)
+        return {}, content
+
+
+def extract_decisions_section(body: str) -> str | None:
+    """Extract the ## Decisions section from markdown body."""
+    # Match ## Decisions followed by content until next ## or end
+    pattern = r'^## Decisions\s*\n(.*?)(?=^## |\Z)'
+    match = re.search(pattern, body, re.MULTILINE | re.DOTALL)
+
+    if match:
+        content = match.group(1).strip()
+        if content:
+            return content
+    return None
+
+
+def parse_decisions(decisions_text: str) -> list[dict]:
+    """Parse individual decisions from the decisions section."""
+    decisions = []
+
+    # Match ### Decision N: Title or ### Title patterns
+    pattern = r'^###\s+(?:Decision\s+\d+:\s+)?(.+?)\n(.*?)(?=^### |\Z)'
+    matches = re.findall(pattern, decisions_text, re.MULTILINE | re.DOTALL)
+
+    for title, content in matches:
+        decision = {
+            'title': title.strip(),
+            'decision': '',
+            'rationale': '',
+            'council': ''
+        }
+
+        # Extract **Decision**: value
+        decision_match = re.search(
+            r'\*\*Decision\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if decision_match:
+            decision['decision'] = decision_match.group(1).strip()
+
+        # Extract **Rationale**: value
+        rationale_match = re.search(
+            r'\*\*Rationale\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if rationale_match:
+            decision['rationale'] = rationale_match.group(1).strip()
+
+        # Extract **Council**: value (optional)
+        council_match = re.search(
+            r'\*\*Council\*\*:\s*(.+?)(?=\n\*\*|\Z)',
+            content, re.DOTALL
+        )
+        if council_match:
+            decision['council'] = council_match.group(1).strip()
+
+        # Only add if we have at least a title and decision
+        if decision['title'] and decision['decision']:
+            decisions.append(decision)
+
+    return decisions
+
+
+def format_memory(
+    session_file: str,
+    frontmatter: dict,
+    decisions: list[dict]
+) -> str:
+    """Format decisions as Serena memory markdown."""
+    session = frontmatter.get('session', {})
+    title = session.get('title', 'Unknown Session')
+    linear_issue = session.get('linear_issue', 'N/A')
+    archived_at = session.get('archived_at', datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'))
+
+    # Generate slug from filename
+    filename = Path(session_file).stem
+    slug = re.sub(r'^\d{8}-\d{6}-', '', filename)
+
+    lines = [
+        f"# Memory: session-{slug}-decisions.md",
+        "",
+        "## Session Context",
+        f"- **Session**: {Path(session_file).name}",
+        f"- **Title**: {title}",
+        f"- **Archived**: {archived_at}",
+        f"- **Linear Issue**: {linear_issue}",
+        "",
+        "## Key Decisions",
+        ""
+    ]
+
+    for i, d in enumerate(decisions, 1):
+        lines.append(f"### Decision {i}: {d['title']}")
+        lines.append(f"**Decision**: {d['decision']}")
+        if d['rationale']:
+            lines.append(f"**Rationale**: {d['rationale']}")
+        if d['council']:
+            lines.append(f"**Council**: {d['council']}")
+        lines.append("")
+
+    return '\n'.join(lines)
+
+
+def generate_memory_name(session_file: str) -> str:
+    """Generate Serena memory name from session filename."""
+    filename = Path(session_file).stem
+    slug = re.sub(r'^\d{8}-\d{6}-', '', filename)
+    return f"session-{slug}-decisions.md"
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: extract-decisions.py <session-file>", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Extracts decisions from a session file and outputs Serena memory format.", file=sys.stderr)
+        print("The memory name will be: session-<slug>-decisions.md", file=sys.stderr)
+        sys.exit(1)
+
+    session_file = sys.argv[1]
+    filepath = Path(session_file)
+
+    if not filepath.exists():
+        print(f"Error: File not found: {session_file}", file=sys.stderr)
+        sys.exit(1)
+
+    content = filepath.read_text()
+    frontmatter, body = parse_frontmatter(content)
+
+    decisions_text = extract_decisions_section(body)
+    if not decisions_text:
+        print(f"No ## Decisions section found in: {session_file}", file=sys.stderr)
+        sys.exit(2)
+
+    decisions = parse_decisions(decisions_text)
+    if not decisions:
+        print(f"No parseable decisions found in: {session_file}", file=sys.stderr)
+        sys.exit(2)
+
+    # Output memory content to stdout
+    memory_content = format_memory(session_file, frontmatter, decisions)
+    print(memory_content)
+
+    # Output memory name to stderr for scripting
+    memory_name = generate_memory_name(session_file)
+    print(f"\n# Memory name: {memory_name}", file=sys.stderr)
+    print(f"# Decisions extracted: {len(decisions)}", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/skills/orchestration/scripts/git-context-summary.sh
+++ b/src/skills/orchestration/scripts/git-context-summary.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Generate git context summary for sessions
+# Usage: git-context-summary.sh [--brief]
+#
+# Output includes:
+#   - Current branch name
+#   - Uncommitted changes count
+#   - Recent commits (last 3-5)
+#   - Summary of changes from main/master (if on feature branch)
+#
+# Options:
+#   --brief   Output only branch and uncommitted changes (for hooks)
+
+set -e
+
+BRIEF_MODE=false
+if [[ "$1" == "--brief" ]]; then
+    BRIEF_MODE=true
+fi
+
+# Check if we're in a git repository
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+    echo "Not a git repository"
+    exit 0
+fi
+
+# Get current branch
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if [[ -z "$CURRENT_BRANCH" ]]; then
+    # Detached HEAD state
+    CURRENT_BRANCH="(detached HEAD at $(git rev-parse --short HEAD 2>/dev/null || echo 'unknown'))"
+fi
+
+# Count uncommitted changes (staged + unstaged + untracked)
+UNCOMMITTED_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+
+# Brief mode: just branch and changes
+if [[ "$BRIEF_MODE" == "true" ]]; then
+    echo "## Git Context"
+    echo "- **Branch**: $CURRENT_BRANCH"
+    echo "- **Uncommitted changes**: $UNCOMMITTED_COUNT file(s)"
+    exit 0
+fi
+
+# Full output
+echo "## Git Context"
+echo ""
+echo "**Branch**: \`$CURRENT_BRANCH\`"
+echo ""
+echo "**Uncommitted changes**: $UNCOMMITTED_COUNT file(s)"
+
+# Show brief status if there are changes
+if [[ "$UNCOMMITTED_COUNT" -gt 0 ]]; then
+    echo ""
+    echo "**Changed files**:"
+    # Show first 10 files max
+    git status --porcelain 2>/dev/null | head -10 | while read -r line; do
+        STATUS="${line:0:2}"
+        FILE="${line:3}"
+        case "$STATUS" in
+            "M "| " M"|"MM") echo "  - Modified: \`$FILE\`" ;;
+            "A ") echo "  - Added: \`$FILE\`" ;;
+            "D "| " D") echo "  - Deleted: \`$FILE\`" ;;
+            "R ") echo "  - Renamed: \`$FILE\`" ;;
+            "??") echo "  - Untracked: \`$FILE\`" ;;
+            *) echo "  - Changed: \`$FILE\`" ;;
+        esac
+    done
+    TOTAL=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$TOTAL" -gt 10 ]]; then
+        echo "  - ... and $((TOTAL - 10)) more"
+    fi
+fi
+
+# Recent commits (last 5)
+echo ""
+echo "**Recent commits**:"
+git log --oneline -5 2>/dev/null | while read -r line; do
+    echo "  - \`$line\`"
+done
+
+# Detect main branch (main or master)
+MAIN_BRANCH=""
+if git show-ref --verify --quiet refs/heads/main 2>/dev/null; then
+    MAIN_BRANCH="main"
+elif git show-ref --verify --quiet refs/heads/master 2>/dev/null; then
+    MAIN_BRANCH="master"
+fi
+
+# Summary of changes from main (if on feature branch)
+if [[ -n "$MAIN_BRANCH" && "$CURRENT_BRANCH" != "$MAIN_BRANCH" && "$CURRENT_BRANCH" != "(detached"* ]]; then
+    # Count commits ahead of main
+    COMMITS_AHEAD=$(git rev-list --count "$MAIN_BRANCH..$CURRENT_BRANCH" 2>/dev/null || echo "0")
+    COMMITS_BEHIND=$(git rev-list --count "$CURRENT_BRANCH..$MAIN_BRANCH" 2>/dev/null || echo "0")
+
+    echo ""
+    echo "**Relative to \`$MAIN_BRANCH\`**:"
+    echo "  - $COMMITS_AHEAD commit(s) ahead"
+    echo "  - $COMMITS_BEHIND commit(s) behind"
+
+    # Files changed from main
+    if [[ "$COMMITS_AHEAD" -gt 0 ]]; then
+        FILES_CHANGED=$(git diff --name-only "$MAIN_BRANCH...$CURRENT_BRANCH" 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "$FILES_CHANGED" -gt 0 ]]; then
+            echo "  - $FILES_CHANGED file(s) changed from \`$MAIN_BRANCH\`"
+        fi
+    fi
+fi

--- a/src/skills/orchestration/scripts/list-session-decisions.sh
+++ b/src/skills/orchestration/scripts/list-session-decisions.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# List available session decision memories from Serena.
+#
+# Usage: list-session-decisions.sh
+#
+# This script lists Serena memories matching the pattern session-*-decisions.md
+# and displays session name and metadata.
+#
+# Note: This is a helper script. In practice, agents should use Serena MCP
+# directly via mcp__serena__list_memories() for programmatic access.
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Session Decision Memories${NC}"
+echo "========================="
+echo ""
+
+# Check if .serena directory exists
+if [[ ! -d ".serena" ]]; then
+    echo -e "${YELLOW}No .serena directory found in current project.${NC}"
+    echo "Serena memories are stored per-project. Make sure you're in a Serena-enabled project."
+    exit 0
+fi
+
+# Check for memories directory
+MEMORIES_DIR=".serena/memories"
+if [[ ! -d "$MEMORIES_DIR" ]]; then
+    echo -e "${YELLOW}No memories directory found.${NC}"
+    echo "No session decisions have been extracted yet."
+    echo ""
+    echo "To extract decisions from a session:"
+    echo "  python3 extract-decisions.py <session-file>"
+    echo "  Then use Serena MCP to write the memory."
+    exit 0
+fi
+
+# Find session decision memories
+MEMORIES=$(find "$MEMORIES_DIR" -name "session-*-decisions.md" 2>/dev/null | sort -r)
+
+if [[ -z "$MEMORIES" ]]; then
+    echo -e "${YELLOW}No session decision memories found.${NC}"
+    echo ""
+    echo "Session decision memories are created when sessions are archived."
+    echo "Pattern: session-<slug>-decisions.md"
+    exit 0
+fi
+
+# Display memories
+count=0
+echo -e "${GREEN}Available Decision Memories:${NC}"
+echo ""
+
+for memory in $MEMORIES; do
+    count=$((count + 1))
+    filename=$(basename "$memory")
+
+    # Extract slug from filename
+    slug=$(echo "$filename" | sed 's/^session-//' | sed 's/-decisions\.md$//')
+
+    # Try to read session info from memory content
+    if [[ -f "$memory" ]]; then
+        session_name=$(grep -m1 "^\- \*\*Session\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "Unknown")
+        archived=$(grep -m1 "^\- \*\*Archived\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "Unknown")
+        linear=$(grep -m1 "^\- \*\*Linear Issue\*\*:" "$memory" 2>/dev/null | sed 's/.*: //' || echo "N/A")
+        decision_count=$(grep -c "^### Decision" "$memory" 2>/dev/null || echo "0")
+
+        printf "  %2d. %s\n" "$count" "$slug"
+        printf "      Session:  %s\n" "$session_name"
+        printf "      Archived: %s\n" "$archived"
+        printf "      Linear:   %s\n" "$linear"
+        printf "      Decisions: %s\n" "$decision_count"
+        echo ""
+    else
+        printf "  %2d. %s (unreadable)\n" "$count" "$filename"
+    fi
+done
+
+echo "------------------------"
+echo "Total: $count decision memories"
+echo ""
+echo -e "${BLUE}Usage:${NC}"
+echo "  /reference-session <search-term>    # Import decisions to current session"
+echo "  mcp__serena__read_memory(name=...)  # Read memory directly via MCP"

--- a/src/skills/orchestration/scripts/validate-session.py
+++ b/src/skills/orchestration/scripts/validate-session.py
@@ -60,7 +60,7 @@ def validate_frontmatter(fm: dict) -> list[str]:
             errors.append(f"Empty required field: session.{field}")
 
     # Validate status values
-    valid_statuses = ['in_progress', 'paused', 'completed']
+    valid_statuses = ['in_progress', 'paused', 'completed', 'archived']
     if session.get('status') and session['status'] not in valid_statuses:
         errors.append(f"Invalid session.status: {session['status']} (must be one of: {', '.join(valid_statuses)})")
 
@@ -72,6 +72,20 @@ def validate_frontmatter(fm: dict) -> list[str]:
                 datetime.fromisoformat(value.replace('Z', '+00:00'))
             except ValueError:
                 errors.append(f"Invalid ISO 8601 timestamp in session.{field}: {value}")
+
+    # Validate branch field format if present (optional field)
+    branch = session.get('branch', '')
+    if branch:
+        # Branch names should be non-empty strings without spaces
+        # Common formats: feature/name, username/ticket-desc, bugfix/name, etc.
+        if not isinstance(branch, str):
+            errors.append(f"Invalid session.branch: must be a string, got {type(branch).__name__}")
+        elif ' ' in branch:
+            errors.append(f"Invalid session.branch: '{branch}' contains spaces (branch names cannot have spaces)")
+        elif branch.startswith('/') or branch.endswith('/'):
+            errors.append(f"Invalid session.branch: '{branch}' cannot start or end with '/'")
+        elif '//' in branch:
+            errors.append(f"Invalid session.branch: '{branch}' contains consecutive slashes")
 
     # Check orchestration block
     orch = fm.get('orchestration', {})

--- a/src/skills/research/SKILL.md
+++ b/src/skills/research/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: research
+description: >-
+  Use for project reflection, brainstorming, and vision evolution. Covers assessing project state,
+  exploring problem spaces, generating ideas, and evolving strategic direction. Activate when
+  stepping back to think, researching topics, or updating VISION.md.
+---
+
+# Research
+
+Patterns for zooming out, brainstorming, and evolving project direction.
+
+## Philosophy
+
+**Research is about understanding before doing.**
+
+Research activities:
+1. Assess project state and lessons learned
+2. Explore problem spaces with structured inquiry
+3. Generate and refine ideas through brainstorming
+4. Evolve strategic direction when evidence supports it
+
+Research is NOT about:
+- Implementing solutions
+- Making tactical decisions
+- Writing code or specifications
+
+## Quick Reference
+
+| Need | Action |
+|------|--------|
+| Understand project state | Review sessions, docs, recent changes |
+| Explore a topic | Structured inquiry with confidence hierarchy |
+| Generate ideas | Brainstorm with interview and synthesis |
+| Evolve VISION | Propose changes with evidence |
+
+## Research Modes
+
+### Mode 1: Project State Assessment
+
+**Trigger:** "What's the current state?" / "Catch me up"
+
+**Process:**
+1. Read existing docs (VISION, ARCHITECTURE, REQUIREMENTS)
+2. Check recent sessions for lessons learned
+3. Review recent commits for context
+4. Identify gaps, contradictions, or stale information
+5. Summarize current state with recommendations
+
+**Output:** State assessment with actionable insights
+
+### Mode 2: Topic Exploration
+
+**Trigger:** "Research X" / "How should we approach Y?"
+
+**Process:**
+1. Interview user to understand the question deeply
+2. Apply confidence hierarchy for sources
+3. Synthesize findings with tradeoffs
+4. Present options with recommendations
+
+**Output:** Research findings with options and recommendation
+
+### Mode 3: Brainstorming
+
+**Trigger:** "Let's brainstorm" / "Ideas for X"
+
+**Process:**
+1. Interview to understand constraints and goals
+2. Generate diverse options (quantity over quality initially)
+3. Filter through constraints
+4. Refine promising directions
+5. Present shaped options for decision
+
+**Output:** Curated options with pros/cons
+
+### Mode 4: Vision Evolution
+
+**Trigger:** "Should we change direction?" / "Update VISION"
+
+**Process:**
+1. Gather evidence (sessions, feedback, market changes)
+2. Identify what's changed since last VISION update
+3. Propose specific changes with rationale
+4. Get user approval before any edits
+
+**Output:** VISION.md change proposal (not direct edit)
+
+## Confidence Hierarchy
+
+When researching, prioritize sources in this order:
+
+```
+1. Project context (highest confidence)
+   - VISION.md, ARCHITECTURE.md, REQUIREMENTS.md
+   - Session files and lessons learned
+   - Existing codebase patterns
+
+2. Authoritative documentation
+   - Context7 for library docs
+   - Official documentation sites
+   - RFCs and specifications
+
+3. Community knowledge
+   - Stack Overflow (verified answers)
+   - GitHub issues and discussions
+   - Blog posts from recognized experts
+
+4. General web (lowest confidence)
+   - Search results
+   - Forum posts
+   - Unverified sources
+```
+
+**Rule:** Always check project context first. External research should supplement, not replace, understanding of existing decisions.
+
+## Interview Patterns
+
+### Before Any Research
+
+Ask clarifying questions:
+
+| Area | Questions |
+|------|-----------|
+| Scope | What specifically are you trying to understand? |
+| Context | What do you already know? What have you tried? |
+| Constraints | What constraints should guide the research? |
+| Output | What decision will this research inform? |
+
+### For Topic Exploration
+
+```
+1. What problem are we trying to solve?
+2. What constraints exist (technical, time, team)?
+3. What would success look like?
+4. What have we already considered and rejected?
+5. Are there non-obvious angles to explore?
+```
+
+### For Brainstorming
+
+```
+1. What's the ideal outcome if constraints didn't exist?
+2. What's the minimum viable approach?
+3. What approaches have we seen work elsewhere?
+4. What would we do if we had 10x the resources? 1/10?
+5. What's the contrarian view?
+```
+
+## Output Formats
+
+### State Assessment
+
+```markdown
+## Project State Assessment
+
+**Date:** YYYY-MM-DD
+
+### Current Position
+- [Summary of where the project stands]
+
+### Recent Progress
+- [Key accomplishments from recent sessions]
+
+### Lessons Learned
+- [Insights from implementation feedback]
+
+### Open Questions
+- [Unresolved decisions or gaps]
+
+### Recommendations
+1. [Actionable next step]
+2. [Actionable next step]
+```
+
+### Research Findings
+
+```markdown
+## Research: [Topic]
+
+**Question:** [What we're trying to understand]
+
+### Summary
+[One-paragraph answer with confidence level]
+
+### Options Considered
+
+#### Option A: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Best for:** ...
+
+#### Option B: [Name]
+- **Pros:** ...
+- **Cons:** ...
+- **Best for:** ...
+
+### Recommendation
+[Which option and why, with caveats]
+
+### Sources
+- [Source 1 with confidence level]
+- [Source 2 with confidence level]
+```
+
+### Vision Change Proposal
+
+```markdown
+## VISION.md Change Proposal
+
+**Proposed by:** [Session/Date]
+**Evidence:** [What prompted this]
+
+### Current State
+[Quote relevant VISION.md section]
+
+### Proposed Change
+[New text]
+
+### Rationale
+[Why this change is warranted]
+
+### Impact
+- [What this changes downstream]
+- [ADRs that may need updating]
+- [Requirements that may be affected]
+
+### Approval Required
+This proposal requires user approval before implementation.
+```
+
+## Integration with Workflow
+
+Research fits at the top of the product development hierarchy:
+
+```
+RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS
+    │         │
+    └─────────┘
+    evolves
+```
+
+**Research informs Vision changes.** Vision changes cascade down through Architecture, Requirements, and Specs.
+
+## When to Research
+
+| Situation | Research Mode |
+|-----------|---------------|
+| Starting new project | Project state + Topic exploration |
+| Stuck on approach | Topic exploration + Brainstorming |
+| Finishing major work | Project state (capture learnings) |
+| External change | Vision evolution |
+| Quarterly review | Project state + Vision evolution |
+
+## When NOT to Research
+
+- **When action is clear** - Don't research to avoid doing
+- **When already decided** - Check ADRs first
+- **When time-critical** - Act, then document learnings
+- **For trivial questions** - Just answer them
+
+## Critical Rules
+
+### Always
+- Interview before researching
+- Check project context first
+- Cite sources with confidence levels
+- Present options, let user decide
+- Get approval before editing VISION
+
+### Never
+- Edit VISION without explicit approval
+- Research indefinitely (set time bounds)
+- Ignore existing project decisions
+- Present research as implementation plan
+- Skip the interview step
+
+## Scripts
+
+| Script | Usage | Description |
+|--------|-------|-------------|
+| `check-sessions.sh` | Review recent sessions | Find lessons learned |
+| `git-context-summary.sh` | Summarize git history | Understand recent changes |
+
+## Related Skills
+
+- **orchestration** - For acting on research findings
+- **foundations** - For documentation standards


### PR DESCRIPTION
## Summary

- Add structured product development workflow: Research → Vision → Architecture → Requirements → Specs → Tasks → Session
- New commands: `/research`, `/architecture`, `/prd`, `/specs`, `/tasks`
- New research skill for project reflection and brainstorming
- Enhanced `/start-session` with task-coupled sessions and traceability
- Local task management as alternative to Linear

## New Commands

| Command | Purpose |
|---------|---------|
| `/research` | Project state assessment, brainstorming, vision evolution |
| `/architecture` | Technical decisions and ADR creation |
| `/prd` | Product requirements discovery |
| `/specs` | Feature specification from requirements |
| `/tasks` | Break specs into atomic work items |

## Key Features

- **Document hierarchy**: Separates permanent knowledge (`docs/`) from ephemeral orchestration (`.agents/`)
- **Traceability**: Task → Spec → Requirement → Architecture → ADRs
- **Transcript archival**: Preserve conversation history for future reference
- **Task abstraction**: Works with Linear or local files identically

## Test Plan

- [x] `npm run build` succeeds
- [x] New commands present in plugins/loaf/commands/
- [x] New skill present in plugins/loaf/skills/research/
- [x] New references present in plugins/loaf/skills/orchestration/references/
- [ ] Manual testing of workflow commands