### PR TITLE
feat: knowledge management (SPEC-009)

### DIFF
--- a/.agents/TASKS.json
+++ b/.agents/TASKS.json
@@ -610,7 +610,7 @@
         "dist/",
         "CLAUDE.md",
         ".claude/CLAUDE.md",
-        ".agents/ARCHITECTURE.md"
+        "docs/ARCHITECTURE.md"
       ],
       "verify": "loaf build && loaf install --to all && loaf --help",
       "done": "dist/ is cleaner, old directories removed, all documentation updated, all spec test conditions pass",

--- a/.agents/specs/SPEC-009-knowledge-management.md
+++ b/.agents/specs/SPEC-009-knowledge-management.md
@@ -1,55 +1,247 @@
 ---
 id: SPEC-009
 title: Knowledge Management
+source: .agents/drafts/brainstorm-loaf-cli-knowledge-harness.md
 created: '2026-03-14T19:48:00.000Z'
-status: drafting
-appetite: TBD
-requirement: Loaf should manage project knowledge with staleness detection
+updated: '2026-03-24T00:00:00.000Z'
+status: approved
+appetite: 3 weeks (big batch)
 ---
 
 # SPEC-009: Knowledge Management
 
 ## Problem Statement
 
-Knowledge accumulates across overlapping surfaces, drifts silently, and no tool detects stale instructions. Projects need living knowledge bases where decay is visible and maintenance is woven into work.
+Knowledge accumulates across overlapping surfaces (docs/knowledge, docs/decisions,
+MEMORY.md, session files), drifts silently, and no tool detects when instructions go
+stale. A developer changes `src/pipeline/registry.py` but the knowledge file describing
+the pipeline's contract sits unchanged. Agents work with outdated context. Humans don't
+know what to review.
 
-## Proposed Solution
+Projects need a living knowledge base where **decay is visible** and **maintenance is
+woven into the work loop**, not a separate chore.
 
-`loaf kb` commands + knowledge-base skill + QMD integration + lifecycle hooks.
+## Strategic Alignment
 
-Core innovation: `covers:` field in knowledge file frontmatter links files to code paths. Combined with `git log --since={last_reviewed}`, this detects staleness automatically.
+- **Vision:** Knowledge Management is Pillar 2 of Loaf's evolution (after Skills &
+  Distribution, before Autonomous Execution). This is the next major capability.
+- **Personas:** Benefits both the developer (knows what's stale, can review efficiently)
+  and the agent (gets nudged to update knowledge as a side-effect of coding).
+- **Architecture:** Aligns with ADR-003 (QMD as retrieval backend), ADR-004 (knowledge
+  naming convention), ADR-006 (agent-creates, human-curates). The `covers:` field +
+  git-based staleness detection is the core innovation no other AI tool provides.
+
+## Solution Direction
+
+`loaf kb` CLI commands for knowledge lifecycle management, a `knowledge-base` skill for
+agent guidance, and lifecycle hooks that surface staleness in real-time.
+
+**Core innovation:** The `covers:` frontmatter field links knowledge files to code paths
+via globs. Combined with `git log --since={last_reviewed}`, this detects staleness
+automatically. Git handles globs natively in pathspecs, so staleness checks are a single
+`git log` invocation per knowledge file — no glob expansion needed.
+
+**QMD is a soft dependency.** Core commands (check, validate, status, review) work
+without QMD via direct file parsing + git. Commands that manage collections (init
+registration, import) use QMD if present and fail gracefully with an install message if
+not. This delivers the core value prop immediately while laying the foundation for
+QMD-powered retrieval at scale.
 
 ## Scope
 
 ### In Scope
-- `loaf kb init` — scaffold + QMD collection registration
-- `loaf kb check` — staleness detection (`covers:` + git)
-- `loaf kb validate` — frontmatter consistency
-- `loaf kb status` — summary view
-- `loaf kb review <file>` — mark as reviewed
-- `loaf kb import` — interactive fuzzy import from another project
-- `knowledge-base` skill — agent guidance for creating/updating knowledge
-- SessionStart, PostToolUse, SessionEnd hooks
+
+**CLI Commands** (`loaf kb`):
+
+| Command | Purpose | Requires QMD |
+|---------|---------|:---:|
+| `kb init` | Scaffold dirs, register QMD collections, update loaf.json | Partial (dirs always, collections if QMD present) |
+| `kb check` | Staleness report: covers × git log | No |
+| `kb check --file <path>` | Reverse lookup: which knowledge files cover this path? | No |
+| `kb validate` | Frontmatter consistency (required fields, valid globs, broken refs) | No |
+| `kb status` | Summary view (total files, stale count, avg review age) | No |
+| `kb review <file>` | Reset `last_reviewed` to now | No |
+| `kb import <name>` | Register external project's QMD collection | Yes |
+
+All display commands support `--json` for hook consumption.
+
+**knowledge-base Skill** (`content/skills/knowledge-base/`):
+- Agent guidance for creating, updating, and reviewing knowledge files
+- Reference docs: frontmatter schema, naming conventions (per ADR-004)
+- Template: knowledge file scaffold with standard frontmatter
+- Sidecar: `user-invocable: false` (pure reference, not a workflow)
+
+**Lifecycle Hooks:**
+- **SessionStart:** Run `loaf kb status --json`, surface stale count alongside
+  existing session context
+- **PostToolUse:** On Edit/Write to a file, check if any knowledge file's `covers:`
+  matches the path. If the knowledge file is stale, nudge once per session (per-session
+  single nudge — temp file tracks already-nudged files, cleaned up at SessionEnd)
+- **SessionEnd:** If covered files were modified during the session, prompt for
+  knowledge consolidation
+
+**Configuration** (`.agents/loaf.json` expansion):
+```json
+{
+  "knowledge": {
+    "local": ["docs/knowledge", "docs/decisions"],
+    "staleness_threshold_days": 30,
+    "imports": []
+  }
+}
+```
+
+**Knowledge File Schema** (enforced by `kb validate`):
+```yaml
+---
+topics: [tag1, tag2]             # Required (min 1)
+last_reviewed: 2026-03-14        # Required (ISO 8601 date)
+covers:                          # Recommended (enables staleness detection)
+  - "cli/lib/kb/*.ts"
+  - "config/hooks.yaml"
+consumers: [backend-dev, pm]     # Optional (agent routing hints)
+depends_on: [other-file.md]      # Optional (cross-references)
+implementation_status: stable    # Optional (in-progress | stable | deprecated)
+---
+```
+
+`covers:` globs resolve relative to the **git repository root**.
 
 ### Out of Scope
-- Personal knowledge base
-- Knowledge repos
-- CI/CD integration
-- Overnight implementation loop
+
+- Personal knowledge base / cross-career knowledge (Phase 4+)
+- Knowledge repos / cross-project sharing beyond QMD import (Phase 4)
+- CI/CD integration (future spec)
+- Overnight implementation loop (Phase 5)
+- Knowledge versioning / time travel
+- Quality scoring of agent-written knowledge
+- Search — QMD handles retrieval; this spec handles lifecycle
+- `loaf health` / `loaf doctor` — generic project health aggregation (separate spec;
+  SPEC-009's SessionStart hook is kb-only, designed to be replaced by `loaf health`)
+
+### Rabbit Holes
+
+- **Glob expansion performance:** Don't expand globs into file lists then query git
+  per-file. Use `git log --since={date} -- <glob>` directly — git handles pathspec
+  globs natively. Single invocation per knowledge file.
+- **Building an index file (like TASKS.json):** Knowledge files are simpler than tasks.
+  Frontmatter IS the index. Directory scanning is fast enough for tens of files. Add
+  caching only if profiling shows a need.
+- **Interactive fuzzy search for import:** Keep `kb import` simple — accept a name
+  argument, register the QMD collection. Don't build a TUI picker in v1.
+- **TypeScript hooks:** Existing hooks are all bash. Don't switch languages for
+  knowledge hooks. Keep bash wrappers thin; heavy logic lives in `loaf kb` commands.
+- **Cross-project `local-covers` mapping:** Designed in the knowledge-management-design
+  doc but too complex for v1. Import registers the collection; local staleness mapping
+  is a follow-up.
 
 ### No-Gos
-- Don't build a search engine (QMD exists)
-- Don't auto-commit knowledge changes (human reviews)
+
+- Don't build a search engine (QMD exists for retrieval)
+- Don't auto-commit knowledge changes (agent-creates, human-curates per ADR-006)
+- Don't block agent work on stale knowledge (advisory nudges only, never blocking)
+- Don't add unnecessary dependencies (glob matching uses `picomatch` — added as direct
+  dep; git pathspecs handle forward lookups)
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Broad `covers:` globs cause constant staleness | Medium | Medium | `staleness_threshold_days` config (default 30); `kb validate` warns on very broad globs |
+| QMD not installed → confusing errors | Medium | Low | Graceful detection with `which qmd`; helpful install message; core commands work without it |
+| PostToolUse hook adds latency to every edit | Low | Medium | Hook shells out to `loaf kb check --file <path> --json` which is a single git query; fast path if no knowledge files have matching covers |
+| `covers:` paths reference old/renamed code paths | Medium | Low | `kb validate` reports "no files match this covers: pattern" as a warning; organic discovery of stale paths |
+| Alert fatigue from too many nudges | Medium | High | Per-session single nudge (each knowledge file nudged at most once per session via temp file tracking) |
+
+## Resolved Questions
+
+- [x] **Glob matching:** Use `picomatch` (add as direct dep). Only needed for reverse
+  lookups (`kb check --file`, PostToolUse hook). Git pathspecs handle forward lookups.
+- [x] **Coverage %:** Skip for v1. Show total/stale/fresh counts and avg review age.
+- [x] **Spark surfacing:** Out of scope for SPEC-009. Build a generic `loaf health`
+  (or `loaf doctor`) command separately that aggregates stale knowledge, unprocessed
+  sparks, overdue tasks, etc. SPEC-009's SessionStart hook focuses on kb status only.
+  The future `loaf health` command becomes the SessionStart aggregation point.
 
 ## Test Conditions
-- `loaf kb init` creates docs/knowledge/, docs/decisions/, QMD collections
-- `loaf kb check` correctly identifies stale files (modified covers: paths since last_reviewed)
-- `loaf kb validate` catches missing frontmatter fields, broken covers: globs
-- `loaf kb import` shows fuzzy-searchable list of registered KBs
-- SessionStart hook surfaces stale knowledge count
-- PostToolUse hook nudges when editing covered code
+
+- [ ] `loaf kb init` creates `docs/knowledge/` and `docs/decisions/` if missing; is
+  idempotent (re-running doesn't error or duplicate)
+- [ ] `loaf kb init` registers QMD collections if QMD is available; skips gracefully if
+  not
+- [ ] `loaf kb check` correctly identifies stale files (covered paths modified after
+  `last_reviewed`)
+- [ ] `loaf kb check` reports fresh files when no commits exist since `last_reviewed`
+- [ ] `loaf kb check` handles knowledge files without `covers:` (skip, not error)
+- [ ] `loaf kb check --file src/foo.ts` lists all knowledge files whose `covers:` match
+  that path
+- [ ] `loaf kb validate` catches: missing `topics`, missing `last_reviewed`, invalid
+  date format, `covers:` globs matching no files
+- [ ] `loaf kb status` shows total count, stale count, and average review age
+- [ ] `loaf kb review <file>` updates `last_reviewed` to current date
+- [ ] `loaf kb import <name>` registers a QMD collection and updates `loaf.json`
+  imports; errors helpfully if QMD not installed
+- [ ] All display commands support `--json` for structured output
+- [ ] PostToolUse hook fires on first covered-file edit and is silent on subsequent
+  edits to same coverage area within a session
+- [ ] SessionEnd hook prompts for consolidation only if covered files were edited
+
+## Circuit Breaker
+
+**At 50% appetite (end of week 1.5):** Core library + `kb validate`, `kb status`, and
+`kb review` must be working with tests. If not, cut `kb import` and simplify hooks to
+SessionStart-only.
+
+**At 75% appetite (end of week 2):** Staleness detection (`kb check`) must be working
+with hooks. If QMD integration is not started, defer it entirely — the core value
+(staleness lifecycle) ships without QMD. Import becomes a follow-up spec.
+
+## Implementation Phasing
+
+**Week 1 — Core library + basic commands:**
+- `cli/lib/kb/types.ts`, `resolve.ts`, `loader.ts`, `validate.ts`
+- `cli/commands/kb.ts` with: `validate`, `status`, `review`
+- Register `registerKbCommand()` in `cli/index.ts`
+- Unit tests for loader and validation
+- Config expansion in loaf.json
+
+**Week 2 — Staleness detection + hooks:**
+- `cli/lib/kb/staleness.ts` (git log integration, pathspec matching)
+- `kb check` and `kb check --file <path>` subcommands
+- SessionStart, PostToolUse, SessionEnd hooks
+- Register hooks in `config/hooks.yaml`
+- Unit + integration tests for staleness
+
+**Week 3 — QMD integration + skill + import:**
+- `cli/lib/kb/qmd.ts` (availability check, collection CRUD)
+- `kb init` (scaffold + QMD collections)
+- `kb import <name>` (QMD collection registration)
+- `content/skills/knowledge-base/` (SKILL.md, sidecar, references, template)
+- Register skill in plugin-groups
+- Integration tests for init idempotency
+
+## Key Files
+
+**Patterns to follow:**
+- `cli/commands/task.ts` — command registration, ANSI output, `--json`, subcommands
+- `cli/lib/tasks/types.ts` — type definitions module pattern
+- `cli/lib/tasks/resolve.ts` — project root resolution, `findAgentsDir()`
+- `content/hooks/post-tool/orchestration-generate-task-board.sh` — PostToolUse hook
+  parsing `$TOOL_INPUT`
+- `config/hooks.yaml` — hook registration DSL
+
+**Design references:**
+- `docs/knowledge/knowledge-management-design.md` — authoritative design document
+- `docs/decisions/ADR-003-qmd-as-retrieval-backend.md` — QMD integration decision
+- `docs/decisions/ADR-004-knowledge-naming-convention.md` — naming conventions
+- `docs/decisions/ADR-006-agent-creates-human-curates.md` — authoring model
 
 ## Notes
 
-See [ADR-003](../../docs/decisions/ADR-003-qmd-as-retrieval-backend.md) and [ADR-004](../../docs/decisions/ADR-004-knowledge-naming-convention.md).
-See `.agents/drafts/brainstorm-loaf-cli-knowledge-harness.md` for full brainstorm context.
+- Existing knowledge files already use the `covers:` frontmatter informally (e.g.,
+  `build-system.md`). The tooling formalizes what's already in practice.
+- Some existing `covers:` paths reference `src/` which has been restructured to
+  `content/`, `cli/`, `config/`. Running `kb validate` post-ship will surface these
+  organically.
+- This spec supersedes the original SPEC-009 draft. See brainstorm context at
+  `.agents/drafts/brainstorm-loaf-cli-knowledge-harness.md`.

--- a/.agents/tasks/TASK-033-kb-core-library.md
+++ b/.agents/tasks/TASK-033-kb-core-library.md
@@ -1,0 +1,52 @@
+---
+id: TASK-033
+title: KB core library — types, loader, resolve, config
+spec: SPEC-009
+status: todo
+priority: P1
+created: '2026-03-24T19:29:16Z'
+depends_on: []
+files:
+  - cli/lib/kb/types.ts
+  - cli/lib/kb/loader.ts
+  - cli/lib/kb/resolve.ts
+  - cli/commands/kb.ts
+  - cli/index.ts
+  - .agents/loaf.json
+  - package.json
+verify: npm run typecheck && npm run test
+done: >-
+  loader.ts can scan docs/knowledge/ and docs/decisions/, parse frontmatter via
+  gray-matter, and return typed KnowledgeFile objects. resolve.ts finds git root
+  and loads loaf.json config. picomatch is a direct dependency. registerKbCommand()
+  is registered in index.ts (even if subcommands are stubs).
+---
+
+# TASK-033: KB core library — types, loader, resolve, config
+
+## Description
+
+Build the foundation modules that all `loaf kb` commands depend on. This is pure
+library code — no user-facing commands yet (except the registered parent command).
+
+## Acceptance Criteria
+
+- [ ] `cli/lib/kb/types.ts` defines: `KnowledgeFile`, `KnowledgeFrontmatter`,
+  `KbConfig`, `StalenessResult`, `ValidationResult`
+- [ ] `cli/lib/kb/resolve.ts` finds git root (`git rev-parse --show-toplevel`),
+  loads `.agents/loaf.json`, returns typed config with defaults
+- [ ] `cli/lib/kb/loader.ts` scans configured `local` directories, parses YAML
+  frontmatter via `gray-matter`, returns `KnowledgeFile[]`
+- [ ] `picomatch` added as direct dependency in `package.json`
+- [ ] `.agents/loaf.json` schema expanded: `staleness_threshold_days` (default 30),
+  `imports` (default [])
+- [ ] `registerKbCommand(program)` registered in `cli/index.ts`
+- [ ] Unit tests for loader (valid/invalid frontmatter, multi-dir scanning, missing dirs)
+- [ ] Unit tests for resolve (config loading, defaults, missing config)
+- [ ] `npm run typecheck` passes
+- [ ] `npm run test` passes
+
+## Context
+
+See SPEC-009 for full context. Follow patterns from `cli/lib/tasks/` (types.ts,
+resolve.ts). Use `gray-matter` for frontmatter parsing (already a dependency).

--- a/.agents/tasks/TASK-033-kb-core-library.md
+++ b/.agents/tasks/TASK-033-kb-core-library.md
@@ -2,7 +2,8 @@
 id: TASK-033
 title: KB core library — types, loader, resolve, config
 spec: SPEC-009
-status: todo
+status: in_progress
+session: 20260324-194808-task-033.md
 priority: P1
 created: '2026-03-24T19:29:16Z'
 depends_on: []

--- a/.agents/tasks/TASK-034-kb-validate-status-review-commands.md
+++ b/.agents/tasks/TASK-034-kb-validate-status-review-commands.md
@@ -2,7 +2,8 @@
 id: TASK-034
 title: KB validate, status, and review commands
 spec: SPEC-009
-status: todo
+status: in_progress
+session: 20260324-194808-task-033.md
 priority: P1
 created: '2026-03-24T19:29:16Z'
 depends_on: [TASK-033]

--- a/.agents/tasks/TASK-034-kb-validate-status-review-commands.md
+++ b/.agents/tasks/TASK-034-kb-validate-status-review-commands.md
@@ -1,0 +1,47 @@
+---
+id: TASK-034
+title: KB validate, status, and review commands
+spec: SPEC-009
+status: todo
+priority: P1
+created: '2026-03-24T19:29:16Z'
+depends_on: [TASK-033]
+files:
+  - cli/lib/kb/validate.ts
+  - cli/commands/kb.ts
+verify: npm run typecheck && npm run test
+done: >-
+  loaf kb validate reports missing topics/last_reviewed, invalid dates, and
+  unmatched covers: globs. loaf kb status shows total file count and average
+  review age. loaf kb review updates last_reviewed. All support --json.
+---
+
+# TASK-034: KB validate, status, and review commands
+
+## Description
+
+Implement three kb subcommands that use the core library: validate (schema checking),
+status (summary view), and review (mark as reviewed). These are the Week 1 deliverables
+that make the knowledge system usable before staleness detection ships.
+
+## Acceptance Criteria
+
+- [ ] `cli/lib/kb/validate.ts` checks: required `topics` (min 1), required
+  `last_reviewed` (valid ISO 8601 date), `covers:` globs that match no files
+  (warning, not error), broken `depends_on` references
+- [ ] `loaf kb validate` displays results with ANSI colors (green pass, yellow warn,
+  red error) and exits non-zero on errors
+- [ ] `loaf kb status` shows: total knowledge file count, files with `covers:` vs
+  without, average review age in days (stale count added in TASK-035)
+- [ ] `loaf kb review <file>` updates `last_reviewed` to current date, preserving
+  all other frontmatter
+- [ ] All three commands support `--json` flag
+- [ ] Unit tests for validation logic (all error cases)
+- [ ] `npm run typecheck` passes
+- [ ] `npm run test` passes
+
+## Context
+
+See SPEC-009 for full context. Follow output patterns from `cli/commands/task.ts`
+(ANSI colors, `--json` support). Use `git ls-files -- <glob>` to check if covers:
+globs match any tracked files in validate.

--- a/.agents/tasks/TASK-035-kb-staleness-detection-check.md
+++ b/.agents/tasks/TASK-035-kb-staleness-detection-check.md
@@ -1,0 +1,58 @@
+---
+id: TASK-035
+title: KB staleness detection + check command
+spec: SPEC-009
+status: todo
+priority: P1
+created: '2026-03-24T19:29:16Z'
+depends_on: [TASK-033]
+files:
+  - cli/lib/kb/staleness.ts
+  - cli/commands/kb.ts
+verify: npm run typecheck && npm run test
+done: >-
+  loaf kb check reports which knowledge files are stale (covered paths modified
+  after last_reviewed via git log). loaf kb check --file <path> lists which
+  knowledge files cover that path. loaf kb status now includes stale count.
+---
+
+# TASK-035: KB staleness detection + check command
+
+## Description
+
+Implement the core innovation: staleness detection via `covers:` + `git log`. This is
+the feature no other AI tool provides. Also add the `kb check` command (forward and
+reverse lookup) and enhance `kb status` with stale count.
+
+## Acceptance Criteria
+
+- [ ] `cli/lib/kb/staleness.ts` implements:
+  - Forward lookup: for each knowledge file with `covers:`, run
+    `git log --since={last_reviewed} --format=%H -- <glob1> <glob2>` — if commits
+    exist, file is stale
+  - Reverse lookup: given a file path, use `picomatch` to test against all `covers:`
+    patterns, return matching knowledge files
+  - Respects `staleness_threshold_days` from config
+- [ ] Uses `execFileNoThrow` from `src/utils/execFileNoThrow.ts` (not raw
+  `child_process.exec`) for git commands to prevent command injection
+- [ ] `loaf kb check` displays staleness report: stale files (with commit count and
+  most recent author), fresh files, files without `covers:`
+- [ ] `loaf kb check --file <path>` lists knowledge files whose `covers:` match the
+  given path
+- [ ] `loaf kb status` now includes stale count (enhances TASK-034's output)
+- [ ] Both commands support `--json`
+- [ ] Unit tests: mock execFileNoThrow for git log output; test stale/fresh
+  classification, threshold logic, no-covers handling, reverse lookup via picomatch
+- [ ] Integration tests with git fixtures (if feasible within scope)
+- [ ] `npm run typecheck` passes
+- [ ] `npm run test` passes
+
+## Context
+
+See SPEC-009 for full context. Key insight: use `git log --since={date} -- <glob>`
+directly — git handles pathspec globs natively. Single process invocation per knowledge
+file, not per matched file.
+
+**Important:** Use `execFileNoThrow` (not `exec`) for all shell commands — this
+codebase has a safer alternative that prevents injection. See
+`src/utils/execFileNoThrow.ts`.

--- a/.agents/tasks/TASK-035-kb-staleness-detection-check.md
+++ b/.agents/tasks/TASK-035-kb-staleness-detection-check.md
@@ -2,7 +2,8 @@
 id: TASK-035
 title: KB staleness detection + check command
 spec: SPEC-009
-status: todo
+status: in_progress
+session: 20260324-194808-task-033.md
 priority: P1
 created: '2026-03-24T19:29:16Z'
 depends_on: [TASK-033]

--- a/.agents/tasks/TASK-036-kb-lifecycle-hooks.md
+++ b/.agents/tasks/TASK-036-kb-lifecycle-hooks.md
@@ -2,7 +2,8 @@
 id: TASK-036
 title: KB lifecycle hooks (SessionStart, PostToolUse, SessionEnd)
 spec: SPEC-009
-status: todo
+status: in_progress
+session: 20260324-194808-task-033.md
 priority: P2
 created: '2026-03-24T19:29:16Z'
 depends_on: [TASK-035]

--- a/.agents/tasks/TASK-036-kb-lifecycle-hooks.md
+++ b/.agents/tasks/TASK-036-kb-lifecycle-hooks.md
@@ -1,0 +1,53 @@
+---
+id: TASK-036
+title: KB lifecycle hooks (SessionStart, PostToolUse, SessionEnd)
+spec: SPEC-009
+status: todo
+priority: P2
+created: '2026-03-24T19:29:16Z'
+depends_on: [TASK-035]
+files:
+  - content/hooks/session/kb-session-start.sh
+  - content/hooks/post-tool/kb-staleness-nudge.sh
+  - content/hooks/session/kb-session-end.sh
+  - config/hooks.yaml
+verify: loaf build && npm run typecheck
+done: >-
+  SessionStart hook surfaces stale knowledge count. PostToolUse hook nudges once
+  per session when editing covered-file paths. SessionEnd hook prompts for
+  knowledge consolidation if covered files were edited. All hooks registered in
+  hooks.yaml.
+---
+
+# TASK-036: KB lifecycle hooks
+
+## Description
+
+Wire up the three lifecycle hooks that make staleness awareness automatic during
+agent sessions. These are bash scripts that call `loaf kb` commands and format output.
+
+## Acceptance Criteria
+
+- [ ] **SessionStart hook** calls `loaf kb status --json`, formats output:
+  "N knowledge files. M stale." (or nothing if no stale files)
+- [ ] **PostToolUse hook** on Edit/Write:
+  - Parses `$TOOL_INPUT` for file path
+  - Calls `loaf kb check --file <path> --json`
+  - If any matching knowledge files are stale, outputs nudge
+  - Per-session single nudge: uses temp file (`/tmp/loaf-kb-nudged-$$`) to track
+    already-nudged knowledge files; skips if already nudged this session
+  - Temp file cleaned up by SessionEnd hook
+- [ ] **SessionEnd hook** checks if covered files were modified, prompts for
+  knowledge consolidation
+- [ ] All hooks registered in `config/hooks.yaml` with correct matchers, skills,
+  timeouts
+- [ ] PostToolUse hook matcher: `Edit|Write` (same pattern as existing hooks)
+- [ ] `loaf build` succeeds with new hooks included
+
+## Context
+
+See SPEC-009 for full context. Follow hook patterns from
+`content/hooks/post-tool/orchestration-generate-task-board.sh` (parses $TOOL_INPUT)
+and `config/hooks.yaml` DSL.
+
+**Circuit breaker:** If hitting 75% appetite, simplify to SessionStart-only.

--- a/.agents/tasks/TASK-037-qmd-integration-kb-init.md
+++ b/.agents/tasks/TASK-037-qmd-integration-kb-init.md
@@ -1,0 +1,50 @@
+---
+id: TASK-037
+title: QMD soft integration + kb init command
+spec: SPEC-009
+status: todo
+priority: P2
+created: '2026-03-24T19:29:16Z'
+depends_on: [TASK-033]
+files:
+  - cli/lib/kb/qmd.ts
+  - cli/commands/kb.ts
+verify: npm run typecheck && npm run test
+done: >-
+  loaf kb init creates docs/knowledge/ and docs/decisions/ idempotently. If QMD is
+  installed, registers collections. If not, skips gracefully with a message.
+  qmd.ts exports isQmdAvailable() and collection management functions.
+---
+
+# TASK-037: QMD soft integration + kb init command
+
+## Description
+
+Implement the QMD integration module (soft dependency pattern) and the `kb init`
+command that scaffolds the knowledge directory structure.
+
+## Acceptance Criteria
+
+- [ ] `cli/lib/kb/qmd.ts` implements:
+  - `isQmdAvailable(): boolean` — checks via `which qmd`
+  - `registerCollection(name, path)` — calls `qmd collection add`
+  - `removeCollection(name)` — calls `qmd collection remove`
+  - All QMD calls wrapped in try/catch with helpful error messages
+- [ ] `loaf kb init`:
+  - Creates `docs/knowledge/` and `docs/decisions/` if missing
+  - Creates/updates `.agents/loaf.json` with knowledge config
+  - If QMD available: registers `{repo}-knowledge` and `{repo}-decisions` collections
+  - If QMD not available: prints info message suggesting install, continues without error
+  - Idempotent: re-running doesn't error, duplicate, or overwrite
+  - Reports what it did (created/skipped/registered)
+- [ ] `--json` support for init output
+- [ ] Unit tests for QMD availability detection (mock execSync)
+- [ ] Integration tests for init idempotency
+- [ ] `npm run typecheck` passes
+- [ ] `npm run test` passes
+
+## Context
+
+See SPEC-009 for full context. QMD lightweight mode (BM25-only) is sufficient — no
+model downloads needed. Collection naming: `{repo-folder}-knowledge`,
+`{repo-folder}-decisions`.

--- a/.agents/tasks/TASK-037-qmd-integration-kb-init.md
+++ b/.agents/tasks/TASK-037-qmd-integration-kb-init.md
@@ -2,7 +2,8 @@
 id: TASK-037
 title: QMD soft integration + kb init command
 spec: SPEC-009
-status: todo
+status: in_progress
+session: 20260324-194808-task-033.md
 priority: P2
 created: '2026-03-24T19:29:16Z'
 depends_on: [TASK-033]

--- a/.agents/tasks/TASK-038-kb-import-command.md
+++ b/.agents/tasks/TASK-038-kb-import-command.md
@@ -2,7 +2,8 @@
 id: TASK-038
 title: KB import command (stretch goal)
 spec: SPEC-009
-status: todo
+status: in_progress
+session: 20260324-194808-task-033.md
 priority: P3
 created: '2026-03-24T19:29:16Z'
 depends_on: [TASK-037]

--- a/.agents/tasks/TASK-038-kb-import-command.md
+++ b/.agents/tasks/TASK-038-kb-import-command.md
@@ -1,0 +1,42 @@
+---
+id: TASK-038
+title: KB import command (stretch goal)
+spec: SPEC-009
+status: todo
+priority: P3
+created: '2026-03-24T19:29:16Z'
+depends_on: [TASK-037]
+files:
+  - cli/commands/kb.ts
+  - .agents/loaf.json
+verify: npm run typecheck && npm run test
+done: >-
+  loaf kb import <name> registers an external QMD collection and updates loaf.json
+  imports array. Errors helpfully if QMD not installed.
+---
+
+# TASK-038: KB import command (stretch goal)
+
+## Description
+
+Implement the `kb import` command for registering external project knowledge via QMD
+collections. This is the stretch goal — first to be cut if appetite runs out.
+
+## Acceptance Criteria
+
+- [ ] `loaf kb import <name>` registers a QMD collection pointing to the named
+  project's knowledge directory
+- [ ] Updates `.agents/loaf.json` `imports` array with the new entry
+- [ ] Errors helpfully if QMD is not installed (suggests `loaf kb init` first)
+- [ ] Prevents duplicate imports (checks existing imports before adding)
+- [ ] `--json` support
+- [ ] `npm run typecheck` passes
+- [ ] `npm run test` passes
+
+## Context
+
+See SPEC-009 for full context. Keep this simple — accept a name argument, register the
+collection. No TUI picker, no fuzzy search, no `local-covers` mapping (all explicitly
+out of scope per spec rabbit holes).
+
+**Circuit breaker:** This task is cut entirely if at 75% appetite.

--- a/.agents/tasks/TASK-039-knowledge-base-skill.md
+++ b/.agents/tasks/TASK-039-knowledge-base-skill.md
@@ -1,0 +1,52 @@
+---
+id: TASK-039
+title: knowledge-base skill
+spec: SPEC-009
+status: todo
+priority: P2
+created: '2026-03-24T19:29:16Z'
+depends_on: []
+files:
+  - content/skills/knowledge-base/SKILL.md
+  - content/skills/knowledge-base/SKILL.claude-code.yaml
+  - content/skills/knowledge-base/references/frontmatter-schema.md
+  - content/skills/knowledge-base/templates/knowledge-file.md
+  - config/hooks.yaml
+verify: loaf build
+done: >-
+  knowledge-base skill exists with SKILL.md, sidecar, frontmatter reference,
+  and knowledge file template. Registered in plugin-groups in hooks.yaml.
+  loaf build includes it in output.
+---
+
+# TASK-039: knowledge-base skill
+
+## Description
+
+Create the knowledge-base skill that provides agent guidance for creating, updating,
+and reviewing knowledge files. This is pure content — no code changes to the CLI.
+Can be done in parallel with any other task.
+
+## Acceptance Criteria
+
+- [ ] `content/skills/knowledge-base/SKILL.md`:
+  - Name: `knowledge-base`
+  - Description starts with action verb, includes user-intent phrases
+  - Covers: creating knowledge files, updating stale content, reviewing process,
+    frontmatter requirements, naming conventions
+  - References table linking to reference docs
+  - Negative routing: "Not for retrieval/search (use QMD directly)"
+- [ ] `SKILL.claude-code.yaml` sidecar: `user-invocable: false` (pure reference)
+- [ ] `references/frontmatter-schema.md`: full schema documentation with required
+  vs optional fields, valid values, examples
+- [ ] `templates/knowledge-file.md`: scaffold template with standard frontmatter
+  and section structure
+- [ ] Registered in `config/hooks.yaml` plugin-groups (appropriate group)
+- [ ] `loaf build` succeeds and includes the skill in output
+
+## Context
+
+See SPEC-009 for full context. Follow skill development guidelines in CLAUDE.md:
+action-verb descriptions, sidecar for Claude-specific fields, reference table with
+"Use When" column. See `docs/decisions/ADR-004-knowledge-naming-convention.md` for
+naming conventions to include in the skill.

--- a/.agents/tasks/TASK-039-knowledge-base-skill.md
+++ b/.agents/tasks/TASK-039-knowledge-base-skill.md
@@ -2,7 +2,8 @@
 id: TASK-039
 title: knowledge-base skill
 spec: SPEC-009
-status: todo
+status: in_progress
+session: 20260324-194808-task-033.md
 priority: P2
 created: '2026-03-24T19:29:16Z'
 depends_on: []

--- a/cli/commands/kb.ts
+++ b/cli/commands/kb.ts
@@ -1,0 +1,14 @@
+/**
+ * loaf kb command
+ *
+ * Parent command for knowledge base management. Subcommands will be
+ * added in subsequent tasks (TASK-034, TASK-035).
+ */
+
+import { Command } from "commander";
+
+export function registerKbCommand(program: Command): void {
+  program
+    .command("kb")
+    .description("Knowledge base management");
+}

--- a/cli/commands/kb.ts
+++ b/cli/commands/kb.ts
@@ -542,4 +542,125 @@ export function registerKbCommand(program: Command): void {
       console.log(`  ${green("\u2713")} Knowledge base initialized`);
       console.log();
     });
+
+  // ── loaf kb import ────────────────────────────────────────────────────
+
+  kb
+    .command("import")
+    .description("Import external project knowledge via QMD collection")
+    .argument("<name>", "Name of the external project's knowledge collection")
+    .option("--json", "Output results as JSON")
+    .action(async (name: string, options: { json?: boolean }) => {
+      // ── Require QMD ────────────────────────────────────────────────────
+      if (!isQmdAvailable()) {
+        if (options.json) {
+          process.stdout.write(
+            JSON.stringify({ error: "QMD is required for importing external knowledge" }, null, 2) + "\n",
+          );
+        } else {
+          console.error(
+            `  ${red("error:")} QMD is required for importing external knowledge. Install QMD: ${cyan("https://github.com/tobi/qmd")}`,
+          );
+        }
+        process.exit(1);
+      }
+
+      // ── Resolve git root ───────────────────────────────────────────────
+      let gitRoot: string;
+      try {
+        gitRoot = findGitRoot();
+      } catch {
+        if (!options.json) {
+          console.error(`  ${red("error:")} Not inside a git repository`);
+        }
+        process.exit(1);
+      }
+
+      const config = loadKbConfig(gitRoot);
+      const collectionName = `${name}-knowledge`;
+
+      // ── Check for duplicates ───────────────────────────────────────────
+
+      // Already in config?
+      if (config.imports.some((i) => i.name === name)) {
+        if (options.json) {
+          process.stdout.write(
+            JSON.stringify({ name, collection: collectionName, status: "already_imported" }, null, 2) + "\n",
+          );
+        } else {
+          console.log(`  Already imported: ${bold(name)}`);
+        }
+        process.exit(0);
+      }
+
+      // QMD collection already registered?
+      const existing = listCollections();
+      if (existing.includes(collectionName)) {
+        if (options.json) {
+          process.stdout.write(
+            JSON.stringify({ name, collection: collectionName, status: "already_imported" }, null, 2) + "\n",
+          );
+        } else {
+          console.log(`  Already imported: ${bold(name)}`);
+        }
+        process.exit(0);
+      }
+
+      // ── Register QMD collection ────────────────────────────────────────
+      try {
+        registerCollection(collectionName, ".");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (options.json) {
+          process.stdout.write(
+            JSON.stringify({ error: `Failed to register collection: ${message}` }, null, 2) + "\n",
+          );
+        } else {
+          console.error(`  ${red("error:")} Failed to register QMD collection: ${message}`);
+        }
+        process.exit(1);
+      }
+
+      // ── Update .agents/loaf.json ───────────────────────────────────────
+      const configPath = join(gitRoot, ".agents", "loaf.json");
+      let parsed: Record<string, unknown> = {};
+
+      if (existsSync(configPath)) {
+        try {
+          const raw = readFileSync(configPath, "utf-8");
+          parsed = JSON.parse(raw);
+        } catch {
+          // If JSON is malformed, start fresh but preserve whatever was there
+          parsed = {};
+        }
+      } else {
+        // Ensure .agents/ exists
+        const agentsDir = join(gitRoot, ".agents");
+        if (!existsSync(agentsDir)) {
+          mkdirSync(agentsDir, { recursive: true });
+        }
+      }
+
+      // Ensure knowledge.imports exists
+      if (!parsed.knowledge || typeof parsed.knowledge !== "object") {
+        parsed.knowledge = { local: ["docs/knowledge", "docs/decisions"], staleness_threshold_days: 30, imports: [] };
+      }
+      const kb = parsed.knowledge as Record<string, unknown>;
+      if (!Array.isArray(kb.imports)) {
+        kb.imports = [];
+      }
+
+      (kb.imports as Array<{ name: string }>).push({ name });
+      writeFileSync(configPath, JSON.stringify(parsed, null, 2) + "\n", "utf-8");
+
+      // ── Output ─────────────────────────────────────────────────────────
+      if (options.json) {
+        process.stdout.write(
+          JSON.stringify({ name, collection: collectionName, status: "imported" }, null, 2) + "\n",
+        );
+        return;
+      }
+
+      console.log(`  Imported: ${bold(name)}`);
+    });
 }

--- a/cli/commands/kb.ts
+++ b/cli/commands/kb.ts
@@ -549,8 +549,9 @@ export function registerKbCommand(program: Command): void {
     .command("import")
     .description("Import external project knowledge via QMD collection")
     .argument("<name>", "Name of the external project's knowledge collection")
+    .option("--path <path>", "Path to the external project's knowledge directory")
     .option("--json", "Output results as JSON")
-    .action(async (name: string, options: { json?: boolean }) => {
+    .action(async (name: string, options: { json?: boolean; path?: string }) => {
       // ── Require QMD ────────────────────────────────────────────────────
       if (!isQmdAvailable()) {
         if (options.json) {
@@ -600,7 +601,8 @@ export function registerKbCommand(program: Command): void {
       // ── Register QMD collection (skip if already exists) ─────────────
       if (!collectionExists) {
         try {
-          registerCollection(collectionName, name);
+          const collectionPath = options.path ?? name;
+          registerCollection(collectionName, collectionPath);
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           if (options.json) {

--- a/cli/commands/kb.ts
+++ b/cli/commands/kb.ts
@@ -1,14 +1,245 @@
 /**
  * loaf kb command
  *
- * Parent command for knowledge base management. Subcommands will be
- * added in subsequent tasks (TASK-034, TASK-035).
+ * Subcommands for knowledge base validation, status overview, and review tracking.
  */
 
 import { Command } from "commander";
+import { readFileSync, writeFileSync } from "fs";
+import { join, relative, isAbsolute } from "path";
+import matter from "gray-matter";
+
+import { findGitRoot, loadKbConfig } from "../lib/kb/resolve.js";
+import { loadKnowledgeFiles } from "../lib/kb/loader.js";
+import { validateLoadedFiles, findSkippedFiles } from "../lib/kb/validate.js";
+import type { ValidationResult } from "../lib/kb/types.js";
+
+// ANSI color helpers (matching project conventions)
+const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
+const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+const gray = (s: string) => `\x1b[90m${s}\x1b[0m`;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command Registration
+// ─────────────────────────────────────────────────────────────────────────────
 
 export function registerKbCommand(program: Command): void {
-  program
+  const kb = program
     .command("kb")
     .description("Knowledge base management");
+
+  // ── loaf kb validate ───────────────────────────────────────────────────
+
+  kb
+    .command("validate")
+    .description("Validate knowledge file frontmatter")
+    .option("--json", "Output results as JSON")
+    .action(async (options: { json?: boolean }) => {
+      let gitRoot: string;
+      try {
+        gitRoot = findGitRoot();
+      } catch {
+        if (!options.json) {
+          console.error(`  ${red("error:")} Not inside a git repository`);
+        }
+        process.exit(1);
+      }
+
+      const config = loadKbConfig(gitRoot);
+
+      // Validate files the loader accepted (warnings)
+      const loadedFiles = loadKnowledgeFiles(gitRoot, config);
+      const loadedResults = validateLoadedFiles(gitRoot, loadedFiles);
+
+      // Find files the loader skipped (errors)
+      const skippedResults = findSkippedFiles(gitRoot, config);
+
+      const allResults = [...loadedResults, ...skippedResults];
+
+      // --json: output array of ValidationResult objects
+      if (options.json) {
+        const jsonOutput = allResults.map((r) => ({
+          file: r.file.relativePath,
+          errors: r.errors,
+          warnings: r.warnings,
+        }));
+        process.stdout.write(JSON.stringify(jsonOutput, null, 2) + "\n");
+        const hasErrors = allResults.some((r) => r.errors.length > 0);
+        if (hasErrors) process.exit(1);
+        return;
+      }
+
+      // Human-readable output
+      console.log(`\n  ${bold("loaf kb validate")}\n`);
+
+      let totalErrors = 0;
+      let totalWarnings = 0;
+
+      for (const result of allResults) {
+        const hasIssues = result.errors.length > 0 || result.warnings.length > 0;
+
+        if (!hasIssues) {
+          console.log(`  ${green("\u2713")} ${result.file.relativePath}`);
+        } else {
+          console.log(`  ${result.file.relativePath}`);
+
+          for (const error of result.errors) {
+            console.log(`    ${red("error:")} ${error.field} \u2014 ${error.message}`);
+            totalErrors++;
+          }
+
+          for (const warning of result.warnings) {
+            console.log(`    ${yellow("warn:")} ${warning.field} \u2014 ${warning.message}`);
+            totalWarnings++;
+          }
+        }
+      }
+
+      // Summary
+      console.log();
+      console.log(`  ${bold(String(allResults.length))} files, ${red(String(totalErrors))} errors, ${yellow(String(totalWarnings))} warnings`);
+      console.log();
+
+      if (totalErrors > 0) {
+        process.exit(1);
+      }
+    });
+
+  // ── loaf kb status ─────────────────────────────────────────────────────
+
+  kb
+    .command("status")
+    .description("Show knowledge base overview")
+    .option("--json", "Output status as JSON")
+    .action(async (options: { json?: boolean }) => {
+      let gitRoot: string;
+      try {
+        gitRoot = findGitRoot();
+      } catch {
+        if (!options.json) {
+          console.error(`  ${red("error:")} Not inside a git repository`);
+        }
+        process.exit(1);
+      }
+
+      const config = loadKbConfig(gitRoot);
+      const files = loadKnowledgeFiles(gitRoot, config);
+
+      // Compute stats
+      const totalFiles = files.length;
+      const filesWithCovers = files.filter((f) => f.frontmatter.covers && f.frontmatter.covers.length > 0).length;
+      const filesWithoutCovers = totalFiles - filesWithCovers;
+
+      // Average review age
+      const now = new Date();
+      let totalAgeDays = 0;
+      let reviewedCount = 0;
+
+      for (const file of files) {
+        const reviewed = new Date(file.frontmatter.last_reviewed);
+        if (!isNaN(reviewed.getTime())) {
+          const ageDays = Math.floor((now.getTime() - reviewed.getTime()) / (1000 * 60 * 60 * 24));
+          totalAgeDays += ageDays;
+          reviewedCount++;
+        }
+      }
+
+      const avgReviewAgeDays = reviewedCount > 0 ? Math.round(totalAgeDays / reviewedCount) : 0;
+
+      // Per-directory breakdown
+      const dirCounts: Record<string, number> = {};
+      for (const file of files) {
+        // Extract directory portion of relativePath
+        const parts = file.relativePath.split("/");
+        const dir = parts.length > 1 ? parts.slice(0, -1).join("/") : ".";
+        dirCounts[dir] = (dirCounts[dir] || 0) + 1;
+      }
+
+      // --json: output structured summary
+      if (options.json) {
+        const summary = {
+          total_files: totalFiles,
+          files_with_covers: filesWithCovers,
+          files_without_covers: filesWithoutCovers,
+          avg_review_age_days: avgReviewAgeDays,
+          directories: dirCounts,
+        };
+        process.stdout.write(JSON.stringify(summary, null, 2) + "\n");
+        return;
+      }
+
+      // Human-readable output
+      console.log(`\n  ${bold("loaf kb status")}\n`);
+
+      console.log(`  Files:    ${bold(String(totalFiles))}`);
+      console.log(`  Covers:   ${green(String(filesWithCovers))} with ${gray(String(filesWithoutCovers))} without`);
+      console.log(`  Avg age:  ${bold(String(avgReviewAgeDays))} days since last review`);
+      console.log();
+
+      // Directory breakdown
+      console.log(`  ${bold("Directories")}`);
+      const sortedDirs = Object.entries(dirCounts).sort(([a], [b]) => a.localeCompare(b));
+      for (const [dir, count] of sortedDirs) {
+        console.log(`    ${cyan(dir)}: ${count} files`);
+      }
+
+      console.log();
+    });
+
+  // ── loaf kb review ─────────────────────────────────────────────────────
+
+  kb
+    .command("review")
+    .description("Mark a knowledge file as reviewed today")
+    .argument("<file>", "File path (relative to git root or absolute)")
+    .option("--json", "Output updated frontmatter as JSON")
+    .action(async (filePath: string, options: { json?: boolean }) => {
+      let gitRoot: string;
+      try {
+        gitRoot = findGitRoot();
+      } catch {
+        if (!options.json) {
+          console.error(`  ${red("error:")} Not inside a git repository`);
+        }
+        process.exit(1);
+      }
+
+      // Resolve the file path
+      const absPath = isAbsolute(filePath) ? filePath : join(gitRoot, filePath);
+      const relPath = relative(gitRoot, absPath);
+
+      let raw: string;
+      try {
+        raw = readFileSync(absPath, "utf-8");
+      } catch {
+        if (!options.json) {
+          console.error(`  ${red("error:")} File not found: ${relPath}`);
+        }
+        process.exit(1);
+        return; // unreachable, but helps TS
+      }
+
+      const { data, content } = matter(raw);
+
+      // Update last_reviewed to today
+      const today = new Date().toISOString().slice(0, 10);
+      data.last_reviewed = today;
+
+      // Serialize back using gray-matter
+      const updated = matter.stringify(content, data);
+      writeFileSync(absPath, updated, "utf-8");
+
+      // --json: output the updated frontmatter
+      if (options.json) {
+        process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+        return;
+      }
+
+      console.log(`\n  ${green("\u2713")} Updated last_reviewed for ${bold(relPath)}`);
+      console.log(`    last_reviewed: ${today}`);
+      console.log();
+    });
 }

--- a/cli/commands/kb.ts
+++ b/cli/commands/kb.ts
@@ -1,7 +1,8 @@
 /**
  * loaf kb command
  *
- * Subcommands for knowledge base validation, status overview, and review tracking.
+ * Subcommands for knowledge base validation, status overview, staleness
+ * checking, and review tracking.
  */
 
 import { Command } from "commander";
@@ -12,7 +13,8 @@ import matter from "gray-matter";
 import { findGitRoot, loadKbConfig } from "../lib/kb/resolve.js";
 import { loadKnowledgeFiles } from "../lib/kb/loader.js";
 import { validateLoadedFiles, findSkippedFiles } from "../lib/kb/validate.js";
-import type { ValidationResult } from "../lib/kb/types.js";
+import { checkAllStaleness, checkStaleness, findCoveringFiles } from "../lib/kb/staleness.js";
+import type { StalenessResult, ValidationResult } from "../lib/kb/types.js";
 
 // ANSI color helpers (matching project conventions)
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
@@ -133,6 +135,10 @@ export function registerKbCommand(program: Command): void {
       const filesWithCovers = files.filter((f) => f.frontmatter.covers && f.frontmatter.covers.length > 0).length;
       const filesWithoutCovers = totalFiles - filesWithCovers;
 
+      // Staleness check
+      const stalenessResults = checkAllStaleness(gitRoot, files, config);
+      const staleCount = stalenessResults.filter((r) => r.isStale).length;
+
       // Average review age
       const now = new Date();
       let totalAgeDays = 0;
@@ -164,6 +170,7 @@ export function registerKbCommand(program: Command): void {
           total_files: totalFiles,
           files_with_covers: filesWithCovers,
           files_without_covers: filesWithoutCovers,
+          stale: staleCount,
           avg_review_age_days: avgReviewAgeDays,
           directories: dirCounts,
         };
@@ -176,6 +183,7 @@ export function registerKbCommand(program: Command): void {
 
       console.log(`  Files:    ${bold(String(totalFiles))}`);
       console.log(`  Covers:   ${green(String(filesWithCovers))} with ${gray(String(filesWithoutCovers))} without`);
+      console.log(`  Stale:    ${staleCount > 0 ? red(String(staleCount)) : green("0")}`);
       console.log(`  Avg age:  ${bold(String(avgReviewAgeDays))} days since last review`);
       console.log();
 
@@ -186,6 +194,140 @@ export function registerKbCommand(program: Command): void {
         console.log(`    ${cyan(dir)}: ${count} files`);
       }
 
+      console.log();
+    });
+
+  // ── loaf kb check ──────────────────────────────────────────────────────
+
+  kb
+    .command("check")
+    .description("Check knowledge file staleness against git history")
+    .option("--file <path>", "Reverse lookup: find knowledge files covering this path")
+    .option("--json", "Output results as JSON")
+    .action(async (options: { file?: string; json?: boolean }) => {
+      let gitRoot: string;
+      try {
+        gitRoot = findGitRoot();
+      } catch {
+        if (!options.json) {
+          console.error(`  ${red("error:")} Not inside a git repository`);
+        }
+        process.exit(1);
+      }
+
+      const config = loadKbConfig(gitRoot);
+      const files = loadKnowledgeFiles(gitRoot, config);
+
+      // ── Reverse lookup mode: --file <path> ──────────────────────────────
+      if (options.file) {
+        // Normalize to a relative path from git root
+        const filePath = isAbsolute(options.file)
+          ? relative(gitRoot, options.file)
+          : options.file;
+
+        const coveringFiles = findCoveringFiles(files, filePath);
+
+        // Get staleness for each covering file
+        const results: StalenessResult[] = coveringFiles.map((f) =>
+          checkStaleness(gitRoot, f, config),
+        );
+
+        if (options.json) {
+          const jsonOutput = results.map((r) => ({
+            file: r.file.relativePath,
+            isStale: r.isStale,
+            commitCount: r.commitCount,
+            lastCommitAuthor: r.lastCommitAuthor,
+            lastCommitDate: r.lastCommitDate,
+            lastReviewed: r.file.frontmatter.last_reviewed,
+          }));
+          process.stdout.write(JSON.stringify(jsonOutput, null, 2) + "\n");
+          return;
+        }
+
+        console.log(`\n  ${bold("loaf kb check")} --file ${filePath}\n`);
+
+        if (results.length === 0) {
+          console.log(`  ${gray("No knowledge files cover this path")}`);
+          console.log();
+          return;
+        }
+
+        for (const result of results) {
+          const statusLabel = result.isStale
+            ? red("stale")
+            : green("fresh");
+          console.log(`  ${statusLabel}  ${result.file.relativePath}`);
+          console.log(`    last_reviewed: ${result.file.frontmatter.last_reviewed}`);
+          if (result.isStale) {
+            console.log(`    ${result.commitCount} commit${result.commitCount === 1 ? "" : "s"} since review`);
+            if (result.lastCommitAuthor) {
+              console.log(`    last by: ${result.lastCommitAuthor} (${result.lastCommitDate})`);
+            }
+          }
+        }
+
+        console.log();
+        return;
+      }
+
+      // ── Default mode: check all files ───────────────────────────────────
+      const results = checkAllStaleness(gitRoot, files, config);
+
+      if (options.json) {
+        const jsonOutput = results.map((r) => ({
+          file: r.file.relativePath,
+          isStale: r.isStale,
+          hasCoverage: r.hasCoverage,
+          commitCount: r.commitCount,
+          lastCommitAuthor: r.lastCommitAuthor,
+          lastCommitDate: r.lastCommitDate,
+          lastReviewed: r.file.frontmatter.last_reviewed,
+        }));
+        process.stdout.write(JSON.stringify(jsonOutput, null, 2) + "\n");
+        return;
+      }
+
+      console.log(`\n  ${bold("loaf kb check")}\n`);
+
+      // Group results
+      const stale = results.filter((r) => r.isStale);
+      const fresh = results.filter((r) => !r.isStale && r.hasCoverage);
+      const noCoverage = results.filter((r) => !r.hasCoverage);
+
+      // Stale files
+      if (stale.length > 0) {
+        console.log(`  ${red(bold("Stale"))}`);
+        for (const result of stale) {
+          console.log(`    ${red("\u2717")} ${result.file.relativePath}`);
+          console.log(`      ${result.commitCount} commit${result.commitCount === 1 ? "" : "s"} since ${result.file.frontmatter.last_reviewed}`);
+          if (result.lastCommitAuthor) {
+            console.log(`      last by: ${result.lastCommitAuthor} (${result.lastCommitDate})`);
+          }
+        }
+        console.log();
+      }
+
+      // Fresh files
+      if (fresh.length > 0) {
+        console.log(`  ${green(bold("Fresh"))}`);
+        for (const result of fresh) {
+          console.log(`    ${green("\u2713")} ${result.file.relativePath}  ${gray("reviewed " + result.file.frontmatter.last_reviewed)}`);
+        }
+        console.log();
+      }
+
+      // No coverage files
+      if (noCoverage.length > 0) {
+        console.log(`  ${gray(bold("No coverage"))}`);
+        for (const result of noCoverage) {
+          console.log(`    ${gray("-")} ${gray(result.file.relativePath)}`);
+        }
+        console.log();
+      }
+
+      // Summary
+      console.log(`  ${red(String(stale.length))} stale, ${green(String(fresh.length))} fresh, ${gray(String(noCoverage.length))} without coverage`);
       console.log();
     });
 

--- a/cli/commands/kb.ts
+++ b/cli/commands/kb.ts
@@ -607,29 +607,7 @@ export function registerKbCommand(program: Command): void {
         process.exit(0);
       }
 
-      // QMD collection already registered? Skip registration but still persist to config
-      const existing = listCollections();
-      const collectionExists = existing.includes(collectionName);
-
-      // ── Register QMD collection (skip if already exists) ─────────────
-      if (!collectionExists) {
-        try {
-          const collectionPath = options.path ?? name;
-          registerCollection(collectionName, collectionPath);
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          if (options.json) {
-            process.stdout.write(
-              JSON.stringify({ error: `Failed to register collection: ${message}` }, null, 2) + "\n",
-            );
-          } else {
-            console.error(`  ${red("error:")} Failed to register QMD collection: ${message}`);
-          }
-          process.exit(1);
-        }
-      }
-
-      // ── Update .agents/loaf.json ───────────────────────────────────────
+      // ── Validate .agents/loaf.json before any side effects ──────────
       const configPath = join(gitRoot, ".agents", "loaf.json");
       let parsed: Record<string, unknown> = {};
 
@@ -652,6 +630,27 @@ export function registerKbCommand(program: Command): void {
         const agentsDir = join(gitRoot, ".agents");
         if (!existsSync(agentsDir)) {
           mkdirSync(agentsDir, { recursive: true });
+        }
+      }
+
+      // ── Register QMD collection (skip if already exists) ─────────────
+      const existing = listCollections();
+      const collectionExists = existing.includes(collectionName);
+
+      if (!collectionExists) {
+        try {
+          const collectionPath = options.path ?? name;
+          registerCollection(collectionName, collectionPath);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (options.json) {
+            process.stdout.write(
+              JSON.stringify({ error: `Failed to register collection: ${message}` }, null, 2) + "\n",
+            );
+          } else {
+            console.error(`  ${red("error:")} Failed to register QMD collection: ${message}`);
+          }
+          process.exit(1);
         }
       }
 

--- a/cli/commands/kb.ts
+++ b/cli/commands/kb.ts
@@ -638,8 +638,14 @@ export function registerKbCommand(program: Command): void {
           const raw = readFileSync(configPath, "utf-8");
           parsed = JSON.parse(raw);
         } catch {
-          // If JSON is malformed, start fresh but preserve whatever was there
-          parsed = {};
+          if (options.json) {
+            process.stdout.write(
+              JSON.stringify({ error: "Cannot parse .agents/loaf.json — fix or remove it before importing" }, null, 2) + "\n",
+            );
+          } else {
+            console.error(`  ${red("error:")} Cannot parse .agents/loaf.json — fix or remove it before importing`);
+          }
+          process.exit(1);
         }
       } else {
         // Ensure .agents/ exists

--- a/cli/commands/kb.ts
+++ b/cli/commands/kb.ts
@@ -460,7 +460,10 @@ export function registerKbCommand(program: Command): void {
           const raw = readFileSync(configPath, "utf-8");
           const parsed = JSON.parse(raw);
 
-          if (!parsed.knowledge) {
+          if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            // Malformed — leave it alone
+            configStatus = "exists";
+          } else if (!parsed.knowledge || typeof parsed.knowledge !== "object" || Array.isArray(parsed.knowledge)) {
             parsed.knowledge = {
               local: ["docs/knowledge", "docs/decisions"],
               staleness_threshold_days: 30,
@@ -659,7 +662,7 @@ export function registerKbCommand(program: Command): void {
       }
 
       // Ensure knowledge.imports exists
-      if (!parsed.knowledge || typeof parsed.knowledge !== "object") {
+      if (!parsed.knowledge || typeof parsed.knowledge !== "object" || Array.isArray(parsed.knowledge)) {
         parsed.knowledge = { local: ["docs/knowledge", "docs/decisions"], staleness_threshold_days: 30, imports: [] };
       }
       const kb = parsed.knowledge as Record<string, unknown>;

--- a/cli/commands/kb.ts
+++ b/cli/commands/kb.ts
@@ -367,6 +367,19 @@ export function registerKbCommand(program: Command): void {
 
       const { data, content } = matter(raw);
 
+      // Guard: only operate on files with knowledge frontmatter
+      if (!data || !Array.isArray(data.topics)) {
+        if (options.json) {
+          process.stdout.write(
+            JSON.stringify({ error: `Not a knowledge file (missing topics field): ${relPath}` }, null, 2) + "\n",
+          );
+        } else {
+          console.error(`  ${red("error:")} Not a knowledge file (missing topics field): ${relPath}`);
+        }
+        process.exit(1);
+        return;
+      }
+
       // Update last_reviewed to today
       const today = new Date().toISOString().slice(0, 10);
       data.last_reviewed = today;

--- a/cli/commands/kb.ts
+++ b/cli/commands/kb.ts
@@ -6,14 +6,15 @@
  */
 
 import { Command } from "commander";
-import { readFileSync, writeFileSync } from "fs";
-import { join, relative, isAbsolute } from "path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join, basename, relative, isAbsolute } from "path";
 import matter from "gray-matter";
 
 import { findGitRoot, loadKbConfig } from "../lib/kb/resolve.js";
 import { loadKnowledgeFiles } from "../lib/kb/loader.js";
 import { validateLoadedFiles, findSkippedFiles } from "../lib/kb/validate.js";
 import { checkAllStaleness, checkStaleness, findCoveringFiles } from "../lib/kb/staleness.js";
+import { isQmdAvailable, registerCollection, listCollections } from "../lib/kb/qmd.js";
 import type { StalenessResult, ValidationResult } from "../lib/kb/types.js";
 
 // ANSI color helpers (matching project conventions)
@@ -382,6 +383,163 @@ export function registerKbCommand(program: Command): void {
 
       console.log(`\n  ${green("\u2713")} Updated last_reviewed for ${bold(relPath)}`);
       console.log(`    last_reviewed: ${today}`);
+      console.log();
+    });
+
+  // ── loaf kb init ──────────────────────────────────────────────────────
+
+  kb
+    .command("init")
+    .description("Initialize knowledge base directories and QMD collections")
+    .option("--json", "Output results as JSON")
+    .action(async (options: { json?: boolean }) => {
+      let gitRoot: string;
+      try {
+        gitRoot = findGitRoot();
+      } catch {
+        if (!options.json) {
+          console.error(`  ${red("error:")} Not inside a git repository`);
+        }
+        process.exit(1);
+      }
+
+      const repoName = basename(gitRoot);
+      const actions: Array<{ action: string; target: string; status: "created" | "exists" }> = [];
+
+      // ── Create directories ──────────────────────────────────────────────
+
+      const dirs = ["docs/knowledge", "docs/decisions"];
+
+      for (const dir of dirs) {
+        const fullPath = join(gitRoot, dir);
+        if (existsSync(fullPath)) {
+          actions.push({ action: "directory", target: dir, status: "exists" });
+        } else {
+          mkdirSync(fullPath, { recursive: true });
+          actions.push({ action: "directory", target: dir, status: "created" });
+        }
+      }
+
+      // ── Create/update .agents/loaf.json ─────────────────────────────────
+
+      const configPath = join(gitRoot, ".agents", "loaf.json");
+      let configStatus: "created" | "exists" | "updated" = "exists";
+
+      if (!existsSync(configPath)) {
+        // Ensure .agents/ exists
+        const agentsDir = join(gitRoot, ".agents");
+        if (!existsSync(agentsDir)) {
+          mkdirSync(agentsDir, { recursive: true });
+        }
+
+        const config = {
+          knowledge: {
+            local: ["docs/knowledge", "docs/decisions"],
+            staleness_threshold_days: 30,
+            imports: [],
+          },
+        };
+        writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+        configStatus = "created";
+      } else {
+        // Read existing, add knowledge section if missing
+        try {
+          const raw = readFileSync(configPath, "utf-8");
+          const parsed = JSON.parse(raw);
+
+          if (!parsed.knowledge) {
+            parsed.knowledge = {
+              local: ["docs/knowledge", "docs/decisions"],
+              staleness_threshold_days: 30,
+              imports: [],
+            };
+            writeFileSync(configPath, JSON.stringify(parsed, null, 2) + "\n", "utf-8");
+            configStatus = "updated";
+          }
+        } catch {
+          // If JSON is malformed, leave it alone
+          configStatus = "exists";
+        }
+      }
+
+      actions.push({
+        action: "config",
+        target: ".agents/loaf.json",
+        status: configStatus === "updated" ? "created" : configStatus,
+      });
+
+      // ── QMD integration ─────────────────────────────────────────────────
+
+      const qmdAvailable = isQmdAvailable();
+      const qmdActions: Array<{ collection: string; path: string; status: "registered" | "exists" }> = [];
+
+      if (qmdAvailable) {
+        const existing = listCollections();
+
+        const collections = [
+          { name: `${repoName}-knowledge`, path: join(gitRoot, "docs/knowledge") },
+          { name: `${repoName}-decisions`, path: join(gitRoot, "docs/decisions") },
+        ];
+
+        for (const col of collections) {
+          if (existing.includes(col.name)) {
+            qmdActions.push({ collection: col.name, path: col.path, status: "exists" });
+          } else {
+            registerCollection(col.name, col.path);
+            qmdActions.push({ collection: col.name, path: col.path, status: "registered" });
+          }
+        }
+      }
+
+      // ── Output ────────────────────────────────────────────────────────
+
+      if (options.json) {
+        const output: Record<string, unknown> = {
+          directories: actions.filter((a) => a.action === "directory"),
+          config: { path: ".agents/loaf.json", status: configStatus },
+          qmd: {
+            available: qmdAvailable,
+            collections: qmdActions,
+          },
+        };
+        process.stdout.write(JSON.stringify(output, null, 2) + "\n");
+        return;
+      }
+
+      // Human-readable output
+      console.log(`\n  ${bold("loaf kb init")}\n`);
+
+      for (const a of actions) {
+        if (a.status === "created") {
+          console.log(`  ${green("+")} Created ${a.target}`);
+        } else {
+          console.log(`  ${gray("-")} Already exists: ${a.target}`);
+        }
+      }
+
+      if (configStatus === "updated") {
+        console.log(`  ${green("+")} Added knowledge section to .agents/loaf.json`);
+      }
+
+      console.log();
+
+      if (qmdAvailable) {
+        console.log(`  ${bold("QMD")}`);
+        for (const qa of qmdActions) {
+          if (qa.status === "registered") {
+            console.log(`  ${green("+")} Registered collection: ${cyan(qa.collection)}`);
+          } else {
+            console.log(`  ${gray("-")} Collection exists: ${cyan(qa.collection)}`);
+          }
+        }
+      } else {
+        console.log(`  ${bold("QMD")}`);
+        console.log(`  ${yellow("info:")} QMD not found. Install QMD for knowledge retrieval:`);
+        console.log(`        ${cyan("https://github.com/tobi/qmd")}`);
+      }
+
+      console.log();
+      console.log(`  ${green("\u2713")} Knowledge base initialized`);
       console.log();
     });
 }

--- a/cli/commands/kb.ts
+++ b/cli/commands/kb.ts
@@ -614,7 +614,11 @@ export function registerKbCommand(program: Command): void {
       if (existsSync(configPath)) {
         try {
           const raw = readFileSync(configPath, "utf-8");
-          parsed = JSON.parse(raw);
+          const result = JSON.parse(raw);
+          if (!result || typeof result !== "object" || Array.isArray(result)) {
+            throw new Error("Expected a JSON object");
+          }
+          parsed = result;
         } catch {
           if (options.json) {
             process.stdout.write(

--- a/cli/commands/kb.ts
+++ b/cli/commands/kb.ts
@@ -593,32 +593,25 @@ export function registerKbCommand(program: Command): void {
         process.exit(0);
       }
 
-      // QMD collection already registered?
+      // QMD collection already registered? Skip registration but still persist to config
       const existing = listCollections();
-      if (existing.includes(collectionName)) {
-        if (options.json) {
-          process.stdout.write(
-            JSON.stringify({ name, collection: collectionName, status: "already_imported" }, null, 2) + "\n",
-          );
-        } else {
-          console.log(`  Already imported: ${bold(name)}`);
-        }
-        process.exit(0);
-      }
+      const collectionExists = existing.includes(collectionName);
 
-      // ── Register QMD collection ────────────────────────────────────────
-      try {
-        registerCollection(collectionName, ".");
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (options.json) {
-          process.stdout.write(
-            JSON.stringify({ error: `Failed to register collection: ${message}` }, null, 2) + "\n",
-          );
-        } else {
-          console.error(`  ${red("error:")} Failed to register QMD collection: ${message}`);
+      // ── Register QMD collection (skip if already exists) ─────────────
+      if (!collectionExists) {
+        try {
+          registerCollection(collectionName, name);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (options.json) {
+            process.stdout.write(
+              JSON.stringify({ error: `Failed to register collection: ${message}` }, null, 2) + "\n",
+            );
+          } else {
+            console.error(`  ${red("error:")} Failed to register QMD collection: ${message}`);
+          }
+          process.exit(1);
         }
-        process.exit(1);
       }
 
       // ── Update .agents/loaf.json ───────────────────────────────────────

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -8,6 +8,7 @@ import { registerInitCommand } from "./commands/init.js";
 import { registerReleaseCommand } from "./commands/release.js";
 import { registerTaskCommand } from "./commands/task.js";
 import { registerSpecCommand } from "./commands/spec.js";
+import { registerKbCommand } from "./commands/kb.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -40,6 +41,7 @@ registerInitCommand(program);
 registerReleaseCommand(program);
 registerTaskCommand(program);
 registerSpecCommand(program);
+registerKbCommand(program);
 
 // Show help when no subcommand is given (exit 0, not error)
 if (process.argv.length <= 2) {

--- a/cli/lib/kb/loader.test.ts
+++ b/cli/lib/kb/loader.test.ts
@@ -198,6 +198,6 @@ describe("loadKnowledgeFiles", () => {
     const invalid = files.find((f) => f.relativePath.includes("invalid-status"));
 
     expect(deprecated?.frontmatter.implementation_status).toBe("deprecated");
-    expect(invalid?.frontmatter.implementation_status).toBeUndefined();
+    expect(invalid?.frontmatter.implementation_status).toBe("banana");
   });
 });

--- a/cli/lib/kb/loader.test.ts
+++ b/cli/lib/kb/loader.test.ts
@@ -1,0 +1,203 @@
+/**
+ * KB Loader Tests
+ *
+ * Tests for loadKnowledgeFiles() — scanning directories and parsing
+ * knowledge file frontmatter.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+
+import { loadKnowledgeFiles } from "./loader.js";
+import type { KbConfig } from "./types.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TEST_ROOT = join(process.cwd(), ".test-kb-loader");
+
+const DEFAULT_CONFIG: KbConfig = {
+  local: ["kb-a", "kb-b"],
+  staleness_threshold_days: 30,
+  imports: [],
+};
+
+/** Create a .md file with frontmatter in a test directory */
+function writeKbFile(dir: string, name: string, frontmatter: string, body: string = ""): void {
+  const dirPath = join(TEST_ROOT, dir);
+  if (!existsSync(dirPath)) {
+    mkdirSync(dirPath, { recursive: true });
+  }
+  const content = `---\n${frontmatter}\n---\n${body}`;
+  writeFileSync(join(dirPath, name), content, "utf-8");
+}
+
+/** Create a plain .md file without frontmatter */
+function writePlainFile(dir: string, name: string, content: string): void {
+  const dirPath = join(TEST_ROOT, dir);
+  if (!existsSync(dirPath)) {
+    mkdirSync(dirPath, { recursive: true });
+  }
+  writeFileSync(join(dirPath, name), content, "utf-8");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Setup / Teardown
+// ─────────────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mkdirSync(TEST_ROOT, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("loadKnowledgeFiles", () => {
+  it("loads files with valid frontmatter", () => {
+    writeKbFile("kb-a", "api-design.md",
+      'topics:\n  - api\n  - rest\nlast_reviewed: "2026-03-01"',
+      "\n# API Design\n\nGuidance for REST APIs.",
+    );
+
+    const files = loadKnowledgeFiles(TEST_ROOT, DEFAULT_CONFIG);
+
+    expect(files).toHaveLength(1);
+    expect(files[0].frontmatter.topics).toEqual(["api", "rest"]);
+    expect(files[0].frontmatter.last_reviewed).toBe("2026-03-01");
+    expect(files[0].content).toContain("API Design");
+    expect(files[0].path).toBe(join(TEST_ROOT, "kb-a", "api-design.md"));
+    expect(files[0].relativePath).toBe(join("kb-a", "api-design.md"));
+  });
+
+  it("skips files without frontmatter (like README.md)", () => {
+    writePlainFile("kb-a", "README.md", "# Knowledge Base\n\nJust a readme.");
+
+    const files = loadKnowledgeFiles(TEST_ROOT, DEFAULT_CONFIG);
+
+    expect(files).toHaveLength(0);
+  });
+
+  it("skips files without topics field", () => {
+    writeKbFile("kb-a", "no-topics.md",
+      'last_reviewed: "2026-03-01"\ncovers:\n  - src/**',
+    );
+
+    const files = loadKnowledgeFiles(TEST_ROOT, DEFAULT_CONFIG);
+
+    expect(files).toHaveLength(0);
+  });
+
+  it("skips files with empty topics array", () => {
+    writeKbFile("kb-a", "empty-topics.md",
+      'topics: []\nlast_reviewed: "2026-03-01"',
+    );
+
+    const files = loadKnowledgeFiles(TEST_ROOT, DEFAULT_CONFIG);
+
+    expect(files).toHaveLength(0);
+  });
+
+  it("handles missing directories gracefully", () => {
+    // kb-a and kb-b don't exist — should warn but not throw
+    const files = loadKnowledgeFiles(TEST_ROOT, {
+      ...DEFAULT_CONFIG,
+      local: ["nonexistent-dir"],
+    });
+
+    expect(files).toHaveLength(0);
+  });
+
+  it("scans multiple directories", () => {
+    writeKbFile("kb-a", "file-a.md",
+      'topics:\n  - alpha\nlast_reviewed: "2026-03-01"',
+    );
+    writeKbFile("kb-b", "file-b.md",
+      'topics:\n  - beta\nlast_reviewed: "2026-02-15"',
+    );
+
+    const files = loadKnowledgeFiles(TEST_ROOT, DEFAULT_CONFIG);
+
+    expect(files).toHaveLength(2);
+
+    const topics = files.map((f) => f.frontmatter.topics[0]).sort();
+    expect(topics).toEqual(["alpha", "beta"]);
+  });
+
+  it("returns correct absolute and relative paths", () => {
+    writeKbFile("kb-a", "paths-test.md",
+      'topics:\n  - testing\nlast_reviewed: "2026-03-01"',
+    );
+
+    const files = loadKnowledgeFiles(TEST_ROOT, DEFAULT_CONFIG);
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe(join(TEST_ROOT, "kb-a", "paths-test.md"));
+    expect(files[0].relativePath).toBe(join("kb-a", "paths-test.md"));
+  });
+
+  it("parses optional frontmatter fields", () => {
+    writeKbFile("kb-a", "full.md", [
+      "topics:",
+      "  - deployment",
+      'last_reviewed: "2026-03-10"',
+      "covers:",
+      '  - "infra/**"',
+      '  - "k8s/**"',
+      "consumers:",
+      "  - backend-dev",
+      "depends_on:",
+      "  - docs/knowledge/networking.md",
+      "implementation_status: stable",
+    ].join("\n"));
+
+    const files = loadKnowledgeFiles(TEST_ROOT, DEFAULT_CONFIG);
+
+    expect(files).toHaveLength(1);
+    const fm = files[0].frontmatter;
+    expect(fm.covers).toEqual(["infra/**", "k8s/**"]);
+    expect(fm.consumers).toEqual(["backend-dev"]);
+    expect(fm.depends_on).toEqual(["docs/knowledge/networking.md"]);
+    expect(fm.implementation_status).toBe("stable");
+  });
+
+  it("ignores non-.md files", () => {
+    writeKbFile("kb-a", "valid.md",
+      'topics:\n  - test\nlast_reviewed: "2026-03-01"',
+    );
+
+    // Write a .txt file that would match frontmatter if parsed
+    const dirPath = join(TEST_ROOT, "kb-a");
+    writeFileSync(join(dirPath, "notes.txt"), "---\ntopics:\n  - test\nlast_reviewed: 2026-03-01\n---\n", "utf-8");
+
+    const files = loadKnowledgeFiles(TEST_ROOT, DEFAULT_CONFIG);
+
+    expect(files).toHaveLength(1);
+    expect(files[0].relativePath).toBe(join("kb-a", "valid.md"));
+  });
+
+  it("normalizes implementation_status to valid values", () => {
+    writeKbFile("kb-a", "deprecated.md",
+      'topics:\n  - legacy\nlast_reviewed: "2026-01-01"\nimplementation_status: deprecated',
+    );
+    writeKbFile("kb-a", "invalid-status.md",
+      'topics:\n  - misc\nlast_reviewed: "2026-01-01"\nimplementation_status: banana',
+    );
+
+    const files = loadKnowledgeFiles(TEST_ROOT, DEFAULT_CONFIG);
+
+    expect(files).toHaveLength(2);
+
+    const deprecated = files.find((f) => f.relativePath.includes("deprecated"));
+    const invalid = files.find((f) => f.relativePath.includes("invalid-status"));
+
+    expect(deprecated?.frontmatter.implementation_status).toBe("deprecated");
+    expect(invalid?.frontmatter.implementation_status).toBeUndefined();
+  });
+});

--- a/cli/lib/kb/loader.ts
+++ b/cli/lib/kb/loader.ts
@@ -1,0 +1,146 @@
+/**
+ * Knowledge File Loader
+ *
+ * Scans configured directories for .md files with knowledge frontmatter,
+ * parses them via gray-matter, and returns KnowledgeFile objects.
+ * Uses the same frontmatter parsing approach as cli/lib/tasks/parser.ts.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join, relative } from "path";
+import matter from "gray-matter";
+
+import type { KbConfig, KnowledgeFile, KnowledgeFrontmatter } from "./types.js";
+
+// ANSI color helpers (matching project conventions)
+const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
+
+/**
+ * Load all knowledge files from directories configured in KbConfig.
+ *
+ * For each directory in `config.local`:
+ * - Resolves the path relative to `gitRoot`
+ * - Scans for .md files (non-recursive)
+ * - Parses YAML frontmatter via gray-matter
+ * - Skips files without frontmatter or without a `topics` field
+ * - Returns KnowledgeFile objects with absolute and relative paths
+ *
+ * Missing directories are skipped with a warning (not an error).
+ */
+export function loadKnowledgeFiles(
+  gitRoot: string,
+  config: KbConfig,
+): KnowledgeFile[] {
+  const files: KnowledgeFile[] = [];
+
+  for (const dir of config.local) {
+    const absDir = join(gitRoot, dir);
+
+    if (!existsSync(absDir)) {
+      console.warn(`  ${yellow("warn:")} KB directory not found: ${dir}`);
+      continue;
+    }
+
+    let entries: string[];
+    try {
+      entries = readdirSync(absDir);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`  ${yellow("warn:")} Failed to read directory ${dir}: ${message}`);
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.endsWith(".md")) continue;
+
+      const absPath = join(absDir, entry);
+      const relPath = relative(gitRoot, absPath);
+
+      try {
+        const raw = readFileSync(absPath, "utf-8");
+        const { data, content } = matter(raw);
+
+        // Skip files without frontmatter or without topics
+        if (!data || typeof data !== "object") continue;
+        if (!Array.isArray(data.topics) || data.topics.length === 0) continue;
+
+        const frontmatter: KnowledgeFrontmatter = {
+          topics: data.topics,
+          last_reviewed: normalizeDate(data.last_reviewed),
+          covers: Array.isArray(data.covers) ? data.covers : undefined,
+          consumers: Array.isArray(data.consumers) ? data.consumers : undefined,
+          depends_on: Array.isArray(data.depends_on) ? data.depends_on : undefined,
+          implementation_status: normalizeImplementationStatus(data.implementation_status),
+        };
+
+        files.push({
+          path: absPath,
+          relativePath: relPath,
+          frontmatter,
+          content,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`  ${yellow("warn:")} Failed to parse ${relPath}: ${message}`);
+      }
+    }
+  }
+
+  return files;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Normalize a date value to an ISO 8601 date string.
+ * Handles Date objects (gray-matter auto-parsing), ISO strings, bare dates.
+ */
+function normalizeDate(value: unknown): string {
+  if (!value) return new Date().toISOString().slice(0, 10);
+
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+
+    // Already a bare date
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      return trimmed;
+    }
+
+    // ISO timestamp — extract date portion
+    if (trimmed.includes("T")) {
+      return trimmed.slice(0, 10);
+    }
+
+    // Try parsing
+    const parsed = new Date(trimmed);
+    if (!isNaN(parsed.getTime())) {
+      return parsed.toISOString().slice(0, 10);
+    }
+  }
+
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Normalize implementation_status to a valid value or undefined.
+ */
+function normalizeImplementationStatus(
+  value: unknown,
+): KnowledgeFrontmatter["implementation_status"] {
+  if (typeof value !== "string") return undefined;
+
+  const valid = ["in-progress", "stable", "deprecated"];
+  const lower = value.trim().toLowerCase();
+
+  if (valid.includes(lower)) {
+    return lower as KnowledgeFrontmatter["implementation_status"];
+  }
+
+  return undefined;
+}

--- a/cli/lib/kb/loader.ts
+++ b/cli/lib/kb/loader.ts
@@ -96,9 +96,10 @@ export function loadKnowledgeFiles(
 /**
  * Normalize a date value to an ISO 8601 date string.
  * Handles Date objects (gray-matter auto-parsing), ISO strings, bare dates.
+ * Preserves invalid/missing values as-is so downstream validation can flag them.
  */
 function normalizeDate(value: unknown): string {
-  if (!value) return new Date().toISOString().slice(0, 10);
+  if (!value) return "";
 
   if (value instanceof Date) {
     return value.toISOString().slice(0, 10);
@@ -124,7 +125,8 @@ function normalizeDate(value: unknown): string {
     }
   }
 
-  return new Date().toISOString().slice(0, 10);
+  // Preserve the raw value so validate can report it
+  return String(value);
 }
 
 /**

--- a/cli/lib/kb/loader.ts
+++ b/cli/lib/kb/loader.ts
@@ -130,19 +130,11 @@ function normalizeDate(value: unknown): string {
 }
 
 /**
- * Normalize implementation_status to a valid value or undefined.
+ * Normalize implementation_status, preserving invalid values for validation.
  */
 function normalizeImplementationStatus(
   value: unknown,
-): KnowledgeFrontmatter["implementation_status"] {
+): string | undefined {
   if (typeof value !== "string") return undefined;
-
-  const valid = ["in-progress", "stable", "deprecated"];
-  const lower = value.trim().toLowerCase();
-
-  if (valid.includes(lower)) {
-    return lower as KnowledgeFrontmatter["implementation_status"];
-  }
-
-  return undefined;
+  return value.trim().toLowerCase();
 }

--- a/cli/lib/kb/qmd.test.ts
+++ b/cli/lib/kb/qmd.test.ts
@@ -1,0 +1,137 @@
+/**
+ * QMD Integration Tests
+ *
+ * Tests for the QMD soft dependency module. All child_process calls are
+ * mocked to avoid requiring QMD to be installed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { execFileSync } from "child_process";
+import {
+  isQmdAvailable,
+  registerCollection,
+  removeCollection,
+  listCollections,
+} from "./qmd.js";
+
+vi.mock("child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+beforeEach(() => {
+  mockExecFileSync.mockReset();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isQmdAvailable
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("isQmdAvailable", () => {
+  it("returns true when which qmd succeeds", () => {
+    mockExecFileSync.mockReturnValueOnce(Buffer.from("/usr/local/bin/qmd"));
+
+    expect(isQmdAvailable()).toBe(true);
+    expect(mockExecFileSync).toHaveBeenCalledWith("which", ["qmd"], {
+      stdio: "pipe",
+    });
+  });
+
+  it("returns false when which qmd throws", () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error("not found");
+    });
+
+    expect(isQmdAvailable()).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// registerCollection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("registerCollection", () => {
+  it("calls qmd with correct args", () => {
+    mockExecFileSync.mockReturnValueOnce("");
+
+    registerCollection("my-knowledge", "/path/to/docs");
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "qmd",
+      ["collection", "add", "my-knowledge", "/path/to/docs"],
+      { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+  });
+
+  it("throws with helpful message on failure", () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error("command failed");
+    });
+
+    expect(() => registerCollection("bad-col", "/nope")).toThrow(
+      /Failed to register QMD collection "bad-col"/,
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// removeCollection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("removeCollection", () => {
+  it("calls qmd collection remove with correct args", () => {
+    mockExecFileSync.mockReturnValueOnce("");
+
+    removeCollection("my-knowledge");
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "qmd",
+      ["collection", "remove", "my-knowledge"],
+      { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+  });
+
+  it("throws with helpful message on failure", () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error("not found");
+    });
+
+    expect(() => removeCollection("missing")).toThrow(
+      /Failed to remove QMD collection "missing"/,
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// listCollections
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("listCollections", () => {
+  it("parses output correctly", () => {
+    mockExecFileSync.mockReturnValueOnce("loaf-knowledge\nloaf-decisions\n");
+
+    const result = listCollections();
+
+    expect(result).toEqual(["loaf-knowledge", "loaf-decisions"]);
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "qmd",
+      ["collection", "list"],
+      { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+  });
+
+  it("returns empty array on failure", () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error("qmd not installed");
+    });
+
+    expect(listCollections()).toEqual([]);
+  });
+
+  it("filters out empty lines", () => {
+    mockExecFileSync.mockReturnValueOnce("col-a\n\ncol-b\n");
+
+    expect(listCollections()).toEqual(["col-a", "col-b"]);
+  });
+});

--- a/cli/lib/kb/qmd.test.ts
+++ b/cli/lib/kb/qmd.test.ts
@@ -59,7 +59,7 @@ describe("registerCollection", () => {
 
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "qmd",
-      ["collection", "add", "my-knowledge", "/path/to/docs"],
+      ["collection", "add", "/path/to/docs", "--name", "my-knowledge"],
       { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
     );
   });

--- a/cli/lib/kb/qmd.ts
+++ b/cli/lib/kb/qmd.ts
@@ -1,0 +1,68 @@
+/**
+ * QMD Soft Dependency
+ *
+ * Optional integration with QMD (https://github.com/tobi/qmd) for knowledge
+ * retrieval. All functions gracefully handle QMD not being installed.
+ * Uses execFileSync exclusively for subprocess calls.
+ */
+
+import { execFileSync } from "child_process";
+
+/**
+ * Check if QMD CLI is available on the system.
+ */
+export function isQmdAvailable(): boolean {
+  try {
+    execFileSync("which", ["qmd"], { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Register a QMD collection. Requires QMD to be installed.
+ * @param name Collection name (e.g., "loaf-knowledge")
+ * @param path Path to the directory
+ */
+export function registerCollection(name: string, path: string): void {
+  try {
+    execFileSync("qmd", ["collection", "add", name, path], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to register QMD collection "${name}": ${message}`);
+  }
+}
+
+/**
+ * Remove a QMD collection.
+ */
+export function removeCollection(name: string): void {
+  try {
+    execFileSync("qmd", ["collection", "remove", name], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to remove QMD collection "${name}": ${message}`);
+  }
+}
+
+/**
+ * List registered QMD collections. Returns collection names.
+ */
+export function listCollections(): string[] {
+  try {
+    const output = execFileSync("qmd", ["collection", "list"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return output.trim().split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/cli/lib/kb/qmd.ts
+++ b/cli/lib/kb/qmd.ts
@@ -27,7 +27,7 @@ export function isQmdAvailable(): boolean {
  */
 export function registerCollection(name: string, path: string): void {
   try {
-    execFileSync("qmd", ["collection", "add", name, path], {
+    execFileSync("qmd", ["collection", "add", path, "--name", name], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     });

--- a/cli/lib/kb/resolve.test.ts
+++ b/cli/lib/kb/resolve.test.ts
@@ -1,0 +1,74 @@
+/**
+ * KB Resolve Tests
+ *
+ * Tests for findGitRoot() and loadKbConfig() — config resolution for the
+ * knowledge base system.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { findGitRoot, loadKbConfig } from "./resolve.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// findGitRoot
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("findGitRoot", () => {
+  it("returns a valid directory path", () => {
+    const root = findGitRoot();
+    expect(root).toBeTruthy();
+    expect(typeof root).toBe("string");
+    // Should not contain trailing newline
+    expect(root).not.toMatch(/\n/);
+  });
+
+  it("returns a path that contains .git", () => {
+    const root = findGitRoot();
+    // The git root should contain a .git directory
+    expect(existsSync(`${root}/.git`)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// loadKbConfig
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("loadKbConfig", () => {
+  it("loads config from existing loaf.json", () => {
+    const root = findGitRoot();
+    const config = loadKbConfig(root);
+
+    expect(config.local).toEqual(["docs/knowledge", "docs/decisions"]);
+    expect(config.staleness_threshold_days).toBe(30);
+    expect(config.imports).toEqual([]);
+  });
+
+  it("returns defaults when file is missing", () => {
+    // Use a path that definitely has no .agents/loaf.json
+    const config = loadKbConfig("/tmp/nonexistent-repo-path");
+
+    expect(config.local).toEqual(["docs/knowledge", "docs/decisions"]);
+    expect(config.staleness_threshold_days).toBe(30);
+    expect(config.imports).toEqual([]);
+  });
+
+  it("returns defaults when knowledge section is absent", () => {
+    // We test this by mocking — create a temp scenario
+    // Since loaf.json exists in the real repo, we test with a nonexistent path
+    // which exercises the same "missing" branch
+    const config = loadKbConfig("/tmp/no-loaf-json-here");
+
+    expect(config.local).toEqual(["docs/knowledge", "docs/decisions"]);
+    expect(config.staleness_threshold_days).toBe(30);
+    expect(config.imports).toEqual([]);
+  });
+
+  it("returns a new object each time (no shared references)", () => {
+    const config1 = loadKbConfig("/tmp/nonexistent");
+    const config2 = loadKbConfig("/tmp/nonexistent");
+
+    expect(config1).toEqual(config2);
+    expect(config1).not.toBe(config2);
+    expect(config1.local).not.toBe(config2.local);
+  });
+});

--- a/cli/lib/kb/resolve.ts
+++ b/cli/lib/kb/resolve.ts
@@ -1,0 +1,84 @@
+/**
+ * KB Config Resolution
+ *
+ * Locates the git root and loads knowledge base configuration from
+ * .agents/loaf.json. Follows the same resolution pattern as
+ * cli/lib/tasks/resolve.ts.
+ */
+
+import { execFileSync } from "child_process";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+import type { KbConfig } from "./types.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Defaults
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_KB_CONFIG: KbConfig = {
+  local: ["docs/knowledge", "docs/decisions"],
+  staleness_threshold_days: 30,
+  imports: [],
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Git Root
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Find the git repository root by calling `git rev-parse --show-toplevel`.
+ * Throws if not inside a git repository.
+ */
+export function findGitRoot(): string {
+  try {
+    const result = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return result.trim();
+  } catch {
+    throw new Error("Not inside a git repository");
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config Loading
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Load KB configuration from `.agents/loaf.json`.
+ *
+ * Returns the `knowledge` section with defaults applied for any missing
+ * fields. If the file is missing or has no `knowledge` section, returns
+ * the full default config.
+ */
+export function loadKbConfig(gitRoot: string): KbConfig {
+  const configPath = join(gitRoot, ".agents", "loaf.json");
+
+  if (!existsSync(configPath)) {
+    return { ...DEFAULT_KB_CONFIG, local: [...DEFAULT_KB_CONFIG.local], imports: [...DEFAULT_KB_CONFIG.imports] };
+  }
+
+  try {
+    const raw = readFileSync(configPath, "utf-8");
+    const parsed = JSON.parse(raw);
+
+    if (!parsed || typeof parsed !== "object" || !parsed.knowledge) {
+      return { ...DEFAULT_KB_CONFIG, local: [...DEFAULT_KB_CONFIG.local], imports: [...DEFAULT_KB_CONFIG.imports] };
+    }
+
+    const kb = parsed.knowledge;
+
+    return {
+      local: Array.isArray(kb.local) ? kb.local : DEFAULT_KB_CONFIG.local,
+      staleness_threshold_days:
+        typeof kb.staleness_threshold_days === "number"
+          ? kb.staleness_threshold_days
+          : DEFAULT_KB_CONFIG.staleness_threshold_days,
+      imports: Array.isArray(kb.imports) ? kb.imports : DEFAULT_KB_CONFIG.imports,
+    };
+  } catch {
+    return { ...DEFAULT_KB_CONFIG, local: [...DEFAULT_KB_CONFIG.local], imports: [...DEFAULT_KB_CONFIG.imports] };
+  }
+}

--- a/cli/lib/kb/staleness.test.ts
+++ b/cli/lib/kb/staleness.test.ts
@@ -196,9 +196,9 @@ describe("checkStaleness", () => {
         "--since=2026-03-01",
         "--format=%H%n%an%n%aI",
         "--",
-        "cli/**/*.ts",
-        "config/**/*.yaml",
-        "docs/**",
+        ":(glob)cli/**/*.ts",
+        ":(glob)config/**/*.yaml",
+        ":(glob)docs/**",
       ],
       expect.objectContaining({
         cwd: FAKE_GIT_ROOT,

--- a/cli/lib/kb/staleness.test.ts
+++ b/cli/lib/kb/staleness.test.ts
@@ -1,0 +1,370 @@
+/**
+ * KB Staleness Detection Tests
+ *
+ * Tests for checkStaleness(), checkAllStaleness(), findCoveringFiles(),
+ * and parseGitLogOutput(). Mocks execFileSync for git log output.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { KbConfig, KnowledgeFile, KnowledgeFrontmatter } from "./types.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock child_process
+// ─────────────────────────────────────────────────────────────────────────────
+
+vi.mock("child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+import { execFileSync } from "child_process";
+import {
+  checkStaleness,
+  checkAllStaleness,
+  findCoveringFiles,
+  parseGitLogOutput,
+} from "./staleness.js";
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FAKE_GIT_ROOT = "/fake/root";
+
+const DEFAULT_CONFIG: KbConfig = {
+  local: ["docs/knowledge"],
+  staleness_threshold_days: 30,
+  imports: [],
+};
+
+/** Build a minimal KnowledgeFile for testing */
+function makeFile(
+  overrides: Partial<KnowledgeFrontmatter> = {},
+  relPath = "docs/knowledge/test.md",
+): KnowledgeFile {
+  const frontmatter: KnowledgeFrontmatter = {
+    topics: ["testing"],
+    last_reviewed: "2026-03-01",
+    ...overrides,
+  };
+
+  return {
+    path: `${FAKE_GIT_ROOT}/${relPath}`,
+    relativePath: relPath,
+    frontmatter,
+    content: "# Test\n\nBody content.",
+  };
+}
+
+/** Sample git log output: 2 commits */
+const TWO_COMMITS_OUTPUT = [
+  "abc123def456789012345678901234567890abcd",
+  "Alice Developer",
+  "2026-03-15T10:30:00+00:00",
+  "def456abc789012345678901234567890abcdef12",
+  "Bob Reviewer",
+  "2026-03-10T08:15:00+00:00",
+].join("\n");
+
+/** Sample git log output: 1 commit */
+const ONE_COMMIT_OUTPUT = [
+  "abc123def456789012345678901234567890abcd",
+  "Alice Developer",
+  "2026-03-15T10:30:00+00:00",
+].join("\n");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests: parseGitLogOutput
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("parseGitLogOutput", () => {
+  it("parses empty output as zero commits", () => {
+    const result = parseGitLogOutput("");
+    expect(result.commitCount).toBe(0);
+    expect(result.lastAuthor).toBeUndefined();
+    expect(result.lastDate).toBeUndefined();
+  });
+
+  it("parses whitespace-only output as zero commits", () => {
+    const result = parseGitLogOutput("   \n  \n  ");
+    expect(result.commitCount).toBe(0);
+  });
+
+  it("parses a single commit correctly", () => {
+    const result = parseGitLogOutput(ONE_COMMIT_OUTPUT);
+    expect(result.commitCount).toBe(1);
+    expect(result.lastAuthor).toBe("Alice Developer");
+    expect(result.lastDate).toBe("2026-03-15T10:30:00+00:00");
+  });
+
+  it("parses multiple commits and returns the most recent author/date", () => {
+    const result = parseGitLogOutput(TWO_COMMITS_OUTPUT);
+    expect(result.commitCount).toBe(2);
+    expect(result.lastAuthor).toBe("Alice Developer");
+    expect(result.lastDate).toBe("2026-03-15T10:30:00+00:00");
+  });
+
+  it("ignores trailing incomplete commit groups", () => {
+    // 4 lines = 1 full group + 1 leftover line
+    const partial = ONE_COMMIT_OUTPUT + "\nextra-partial-line";
+    const result = parseGitLogOutput(partial);
+    expect(result.commitCount).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests: checkStaleness
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("checkStaleness", () => {
+  beforeEach(() => {
+    mockExecFileSync.mockReset();
+  });
+
+  it("returns not stale with hasCoverage=false when file has no covers", () => {
+    const file = makeFile({ covers: undefined });
+
+    const result = checkStaleness(FAKE_GIT_ROOT, file, DEFAULT_CONFIG);
+
+    expect(result.isStale).toBe(false);
+    expect(result.hasCoverage).toBe(false);
+    expect(result.commitCount).toBe(0);
+    // Should not call git at all
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it("returns not stale with hasCoverage=false when covers is empty array", () => {
+    const file = makeFile({ covers: [] });
+
+    const result = checkStaleness(FAKE_GIT_ROOT, file, DEFAULT_CONFIG);
+
+    expect(result.isStale).toBe(false);
+    expect(result.hasCoverage).toBe(false);
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it("returns stale when commits exist since last_reviewed", () => {
+    const file = makeFile({
+      covers: ["cli/**/*.ts"],
+      last_reviewed: "2026-03-01",
+    });
+
+    mockExecFileSync.mockReturnValue(TWO_COMMITS_OUTPUT);
+
+    const result = checkStaleness(FAKE_GIT_ROOT, file, DEFAULT_CONFIG);
+
+    expect(result.isStale).toBe(true);
+    expect(result.hasCoverage).toBe(true);
+    expect(result.commitCount).toBe(2);
+    expect(result.lastCommitAuthor).toBe("Alice Developer");
+    expect(result.lastCommitDate).toBe("2026-03-15T10:30:00+00:00");
+  });
+
+  it("returns fresh when no commits exist since last_reviewed", () => {
+    const file = makeFile({
+      covers: ["cli/**/*.ts"],
+      last_reviewed: "2026-03-20",
+    });
+
+    mockExecFileSync.mockReturnValue("");
+
+    const result = checkStaleness(FAKE_GIT_ROOT, file, DEFAULT_CONFIG);
+
+    expect(result.isStale).toBe(false);
+    expect(result.hasCoverage).toBe(true);
+    expect(result.commitCount).toBe(0);
+    expect(result.lastCommitAuthor).toBeUndefined();
+    expect(result.lastCommitDate).toBeUndefined();
+  });
+
+  it("passes all covers globs as pathspec args to git log", () => {
+    const file = makeFile({
+      covers: ["cli/**/*.ts", "config/**/*.yaml", "docs/**"],
+      last_reviewed: "2026-03-01",
+    });
+
+    mockExecFileSync.mockReturnValue("");
+
+    checkStaleness(FAKE_GIT_ROOT, file, DEFAULT_CONFIG);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      [
+        "log",
+        "--since=2026-03-01",
+        "--format=%H%n%an%n%aI",
+        "--",
+        "cli/**/*.ts",
+        "config/**/*.yaml",
+        "docs/**",
+      ],
+      expect.objectContaining({
+        cwd: FAKE_GIT_ROOT,
+        encoding: "utf-8",
+      }),
+    );
+  });
+
+  it("handles git log failure gracefully (returns fresh)", () => {
+    const file = makeFile({
+      covers: ["broken-path/**"],
+      last_reviewed: "2026-03-01",
+    });
+
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("fatal: bad revision");
+    });
+
+    const result = checkStaleness(FAKE_GIT_ROOT, file, DEFAULT_CONFIG);
+
+    expect(result.isStale).toBe(false);
+    expect(result.hasCoverage).toBe(true);
+    expect(result.commitCount).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests: checkAllStaleness
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("checkAllStaleness", () => {
+  beforeEach(() => {
+    mockExecFileSync.mockReset();
+  });
+
+  it("checks all files and returns results in order", () => {
+    const staleFile = makeFile(
+      { covers: ["src/**"], last_reviewed: "2026-01-01" },
+      "docs/knowledge/stale.md",
+    );
+    const freshFile = makeFile(
+      { covers: ["lib/**"], last_reviewed: "2026-03-20" },
+      "docs/knowledge/fresh.md",
+    );
+    const noCoverFile = makeFile(
+      { covers: undefined },
+      "docs/knowledge/nocover.md",
+    );
+
+    // First call (staleFile) returns commits, second call (freshFile) returns empty
+    mockExecFileSync
+      .mockReturnValueOnce(ONE_COMMIT_OUTPUT)
+      .mockReturnValueOnce("");
+
+    const results = checkAllStaleness(
+      FAKE_GIT_ROOT,
+      [staleFile, freshFile, noCoverFile],
+      DEFAULT_CONFIG,
+    );
+
+    expect(results).toHaveLength(3);
+    expect(results[0].isStale).toBe(true);
+    expect(results[0].hasCoverage).toBe(true);
+    expect(results[1].isStale).toBe(false);
+    expect(results[1].hasCoverage).toBe(true);
+    expect(results[2].isStale).toBe(false);
+    expect(results[2].hasCoverage).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests: findCoveringFiles
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("findCoveringFiles", () => {
+  it("returns files whose covers globs match the given path", () => {
+    const cliFile = makeFile(
+      { covers: ["cli/**/*.ts"] },
+      "docs/knowledge/cli-guide.md",
+    );
+    const configFile = makeFile(
+      { covers: ["config/**/*.yaml"] },
+      "docs/knowledge/config-guide.md",
+    );
+
+    const matches = findCoveringFiles(
+      [cliFile, configFile],
+      "cli/lib/kb/staleness.ts",
+    );
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].relativePath).toBe("docs/knowledge/cli-guide.md");
+  });
+
+  it("returns empty array when no covers match", () => {
+    const file = makeFile(
+      { covers: ["backend/**"] },
+      "docs/knowledge/backend.md",
+    );
+
+    const matches = findCoveringFiles([file], "frontend/app.tsx");
+
+    expect(matches).toHaveLength(0);
+  });
+
+  it("returns multiple files when several cover the same path", () => {
+    const broadFile = makeFile(
+      { covers: ["cli/**"] },
+      "docs/knowledge/broad.md",
+    );
+    const specificFile = makeFile(
+      { covers: ["cli/lib/kb/**"] },
+      "docs/knowledge/specific.md",
+    );
+    const unrelatedFile = makeFile(
+      { covers: ["docs/**"] },
+      "docs/knowledge/unrelated.md",
+    );
+
+    const matches = findCoveringFiles(
+      [broadFile, specificFile, unrelatedFile],
+      "cli/lib/kb/staleness.ts",
+    );
+
+    expect(matches).toHaveLength(2);
+    const paths = matches.map((m) => m.relativePath).sort();
+    expect(paths).toEqual([
+      "docs/knowledge/broad.md",
+      "docs/knowledge/specific.md",
+    ]);
+  });
+
+  it("skips files without covers field", () => {
+    const withCovers = makeFile(
+      { covers: ["cli/**"] },
+      "docs/knowledge/with.md",
+    );
+    const withoutCovers = makeFile(
+      { covers: undefined },
+      "docs/knowledge/without.md",
+    );
+
+    const matches = findCoveringFiles(
+      [withCovers, withoutCovers],
+      "cli/index.ts",
+    );
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].relativePath).toBe("docs/knowledge/with.md");
+  });
+
+  it("skips files with empty covers array", () => {
+    const file = makeFile({ covers: [] }, "docs/knowledge/empty.md");
+
+    const matches = findCoveringFiles([file], "cli/index.ts");
+
+    expect(matches).toHaveLength(0);
+  });
+
+  it("matches glob patterns with extensions", () => {
+    const file = makeFile(
+      { covers: ["**/*.yaml"] },
+      "docs/knowledge/config.md",
+    );
+
+    expect(findCoveringFiles([file], "config/hooks.yaml")).toHaveLength(1);
+    expect(findCoveringFiles([file], "config/hooks.ts")).toHaveLength(0);
+  });
+});

--- a/cli/lib/kb/staleness.ts
+++ b/cli/lib/kb/staleness.ts
@@ -45,6 +45,18 @@ export function checkStaleness(
 
   const lastReviewed = file.frontmatter.last_reviewed;
 
+  // Invalid or missing last_reviewed — treat as stale (can't determine freshness)
+  if (!lastReviewed || isNaN(new Date(lastReviewed).getTime())) {
+    return {
+      file,
+      isStale: true,
+      hasCoverage: true,
+      commitCount: 0,
+      lastCommitAuthor: undefined,
+      lastCommitDate: undefined,
+    };
+  }
+
   try {
     const output = execFileSync(
       "git",

--- a/cli/lib/kb/staleness.ts
+++ b/cli/lib/kb/staleness.ts
@@ -1,0 +1,184 @@
+/**
+ * KB Staleness Detection
+ *
+ * Core innovation: detect when knowledge files are stale by checking if
+ * the source code they `covers:` has changed since `last_reviewed`. Uses
+ * git log to find commits affecting covered paths, and picomatch for
+ * reverse lookups (given a file path, find covering knowledge files).
+ */
+
+import { execFileSync } from "child_process";
+import picomatch from "picomatch";
+
+import type { KbConfig, KnowledgeFile, StalenessResult } from "./types.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Forward Lookup — is a knowledge file stale?
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Check whether a single knowledge file is stale.
+ *
+ * A file is stale when commits have been made to its `covers:` paths since
+ * its `last_reviewed` date. Files without `covers:` cannot be checked and
+ * return `{ isStale: false, hasCoverage: false }`.
+ *
+ * Uses a single `git log` invocation per file, passing all covers globs
+ * as pathspec arguments.
+ */
+export function checkStaleness(
+  gitRoot: string,
+  file: KnowledgeFile,
+  _config: KbConfig,
+): StalenessResult {
+  const covers = file.frontmatter.covers;
+
+  // No covers field — can't determine staleness
+  if (!covers || covers.length === 0) {
+    return {
+      file,
+      isStale: false,
+      hasCoverage: false,
+      commitCount: 0,
+    };
+  }
+
+  const lastReviewed = file.frontmatter.last_reviewed;
+
+  try {
+    const output = execFileSync(
+      "git",
+      [
+        "log",
+        `--since=${lastReviewed}`,
+        "--format=%H%n%an%n%aI",
+        "--",
+        ...covers,
+      ],
+      {
+        cwd: gitRoot,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+
+    const parsed = parseGitLogOutput(output);
+
+    if (parsed.commitCount === 0) {
+      return {
+        file,
+        isStale: false,
+        hasCoverage: true,
+        commitCount: 0,
+      };
+    }
+
+    return {
+      file,
+      isStale: true,
+      hasCoverage: true,
+      commitCount: parsed.commitCount,
+      lastCommitAuthor: parsed.lastAuthor,
+      lastCommitDate: parsed.lastDate,
+    };
+  } catch {
+    // git log can fail if the repo is corrupted, path doesn't exist, etc.
+    // Treat as indeterminate — not stale, but has coverage
+    return {
+      file,
+      isStale: false,
+      hasCoverage: true,
+      commitCount: 0,
+    };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Batch Check
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Run staleness checks on all knowledge files.
+ *
+ * Files without `covers:` get `{ isStale: false, hasCoverage: false }`.
+ * Files with `covers:` are checked against git log.
+ */
+export function checkAllStaleness(
+  gitRoot: string,
+  files: KnowledgeFile[],
+  config: KbConfig,
+): StalenessResult[] {
+  return files.map((file) => checkStaleness(gitRoot, file, config));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reverse Lookup — which knowledge files cover a given path?
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Find all knowledge files whose `covers:` globs match the given file path.
+ *
+ * Uses picomatch for glob matching. The file path should be relative to
+ * the git root (same coordinate system as covers globs).
+ */
+export function findCoveringFiles(
+  files: KnowledgeFile[],
+  filePath: string,
+): KnowledgeFile[] {
+  return files.filter((file) => {
+    const covers = file.frontmatter.covers;
+    if (!covers || covers.length === 0) return false;
+
+    return covers.some((pattern) => {
+      const matcher = picomatch(pattern);
+      return matcher(filePath);
+    });
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Git Log Parsing
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ParsedGitLog {
+  commitCount: number;
+  lastAuthor?: string;
+  lastDate?: string;
+}
+
+/**
+ * Parse git log output formatted with `--format=%H%n%an%n%aI`.
+ *
+ * Each commit produces 3 lines:
+ *   - Commit hash
+ *   - Author name
+ *   - Author date (ISO 8601)
+ *
+ * The first commit in the output is the most recent.
+ */
+export function parseGitLogOutput(output: string): ParsedGitLog {
+  const trimmed = output.trim();
+
+  if (trimmed.length === 0) {
+    return { commitCount: 0 };
+  }
+
+  const lines = trimmed.split("\n");
+
+  // Each commit is 3 lines; ignore any trailing incomplete group
+  const commitCount = Math.floor(lines.length / 3);
+
+  if (commitCount === 0) {
+    return { commitCount: 0 };
+  }
+
+  // First commit in output is the most recent
+  const lastAuthor = lines[1];
+  const lastDate = lines[2];
+
+  return {
+    commitCount,
+    lastAuthor,
+    lastDate,
+  };
+}

--- a/cli/lib/kb/staleness.ts
+++ b/cli/lib/kb/staleness.ts
@@ -53,7 +53,7 @@ export function checkStaleness(
         `--since=${lastReviewed}`,
         "--format=%H%n%an%n%aI",
         "--",
-        ...covers,
+        ...covers.map((g) => `:(glob)${g}`),
       ],
       {
         cwd: gitRoot,

--- a/cli/lib/kb/staleness.ts
+++ b/cli/lib/kb/staleness.ts
@@ -46,7 +46,13 @@ export function checkStaleness(
   const lastReviewed = file.frontmatter.last_reviewed;
 
   // Invalid or missing last_reviewed — treat as stale (can't determine freshness)
-  if (!lastReviewed || isNaN(new Date(lastReviewed).getTime())) {
+  // Strict YYYY-MM-DD check with round-trip, consistent with validate.ts
+  const isValidDate = /^\d{4}-\d{2}-\d{2}$/.test(lastReviewed) &&
+    (() => {
+      const d = new Date(lastReviewed + "T00:00:00Z");
+      return !isNaN(d.getTime()) && d.toISOString().slice(0, 10) === lastReviewed;
+    })();
+  if (!lastReviewed || !isValidDate) {
     return {
       file,
       isStale: true,

--- a/cli/lib/kb/types.ts
+++ b/cli/lib/kb/types.ts
@@ -83,6 +83,8 @@ export interface KbConfig {
 export interface StalenessResult {
   file: KnowledgeFile;
   isStale: boolean;
+  /** Whether the file has a `covers:` field (false = can't determine staleness) */
+  hasCoverage: boolean;
   commitCount: number;
   lastCommitAuthor?: string;
   lastCommitDate?: string;

--- a/cli/lib/kb/types.ts
+++ b/cli/lib/kb/types.ts
@@ -36,8 +36,8 @@ export interface KnowledgeFrontmatter {
   consumers?: string[];
   /** Cross-references to other knowledge files */
   depends_on?: string[];
-  /** Lifecycle status */
-  implementation_status?: ImplementationStatus;
+  /** Lifecycle status (raw value — may be invalid; validator checks) */
+  implementation_status?: string;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/cli/lib/kb/types.ts
+++ b/cli/lib/kb/types.ts
@@ -1,0 +1,102 @@
+/**
+ * Knowledge Base Types
+ *
+ * Type definitions for the knowledge management system. Knowledge files
+ * are .md files with YAML frontmatter containing topic metadata, staleness
+ * tracking, and coverage hints. The KB config in .agents/loaf.json defines
+ * which directories to scan and staleness thresholds.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation Status
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Lifecycle status of a knowledge file */
+export type ImplementationStatus = "in-progress" | "stable" | "deprecated";
+
+export const IMPLEMENTATION_STATUSES: ImplementationStatus[] = [
+  "in-progress",
+  "stable",
+  "deprecated",
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Knowledge File Frontmatter
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** YAML frontmatter schema for knowledge .md files */
+export interface KnowledgeFrontmatter {
+  /** Topic tags for routing and discovery (min 1 required) */
+  topics: string[];
+  /** ISO 8601 date of last human review */
+  last_reviewed: string;
+  /** Glob patterns for files this knowledge covers (resolved from git root) */
+  covers?: string[];
+  /** Agent routing hints */
+  consumers?: string[];
+  /** Cross-references to other knowledge files */
+  depends_on?: string[];
+  /** Lifecycle status */
+  implementation_status?: ImplementationStatus;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Loaded Knowledge File
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A parsed knowledge file with resolved paths and content */
+export interface KnowledgeFile {
+  /** Absolute path to the file */
+  path: string;
+  /** Path relative to git root */
+  relativePath: string;
+  /** Parsed YAML frontmatter */
+  frontmatter: KnowledgeFrontmatter;
+  /** Markdown body (without frontmatter) */
+  content: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// KB Config (from .agents/loaf.json)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Import entry for external knowledge sources */
+export interface KbImport {
+  name: string;
+}
+
+/** Knowledge base configuration extracted from .agents/loaf.json */
+export interface KbConfig {
+  /** Directory paths relative to git root */
+  local: string[];
+  /** Days before a file is considered stale */
+  staleness_threshold_days: number;
+  /** External knowledge imports */
+  imports: KbImport[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Result Types (for downstream commands: TASK-034, TASK-035)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Staleness check result for a single knowledge file */
+export interface StalenessResult {
+  file: KnowledgeFile;
+  isStale: boolean;
+  commitCount: number;
+  lastCommitAuthor?: string;
+  lastCommitDate?: string;
+}
+
+/** Validation result for a single knowledge file */
+export interface ValidationResult {
+  file: KnowledgeFile;
+  errors: ValidationIssue[];
+  warnings: ValidationIssue[];
+}
+
+/** A single validation issue (error or warning) */
+export interface ValidationIssue {
+  field: string;
+  message: string;
+}

--- a/cli/lib/kb/validate.test.ts
+++ b/cli/lib/kb/validate.test.ts
@@ -1,0 +1,253 @@
+/**
+ * KB Validation Tests
+ *
+ * Tests for validateLoadedFiles() and findSkippedFiles() — checking
+ * frontmatter for errors and warnings.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+
+import { validateLoadedFiles, findSkippedFiles } from "./validate.js";
+import type { KnowledgeFile, KnowledgeFrontmatter } from "./types.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Build a minimal KnowledgeFile for testing */
+function makeFile(overrides: Partial<KnowledgeFrontmatter> = {}, relPath = "docs/knowledge/test.md"): KnowledgeFile {
+  const frontmatter: KnowledgeFrontmatter = {
+    topics: ["testing"],
+    last_reviewed: "2026-03-01",
+    ...overrides,
+  };
+
+  return {
+    path: `/fake/root/${relPath}`,
+    relativePath: relPath,
+    frontmatter,
+    content: "# Test\n\nBody content.",
+  };
+}
+
+const FAKE_GIT_ROOT = "/fake/root";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock child_process.execFileSync for git ls-files
+// ─────────────────────────────────────────────────────────────────────────────
+
+vi.mock("child_process", () => ({
+  execFileSync: vi.fn((_cmd: string, args: string[]) => {
+    // Simulate git ls-files: return empty for "nonexistent/**", non-empty for others
+    const glob = args[args.length - 1];
+    if (glob.includes("nonexistent") || glob.includes("missing")) {
+      return "";
+    }
+    return "some/file.ts\n";
+  }),
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock fs.existsSync for depends_on checks
+// ─────────────────────────────────────────────────────────────────────────────
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual("fs");
+  return {
+    ...actual,
+    existsSync: vi.fn((path: string) => {
+      // Only return false for paths containing "nonexistent" or "broken"
+      if (typeof path === "string" && (path.includes("nonexistent") || path.includes("broken"))) {
+        return false;
+      }
+      return true;
+    }),
+  };
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests: validateLoadedFiles
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("validateLoadedFiles", () => {
+  it("returns no errors or warnings for valid frontmatter", () => {
+    const file = makeFile({
+      topics: ["api", "rest"],
+      last_reviewed: "2026-03-01",
+      covers: ["cli/**/*.ts"],
+      depends_on: ["docs/knowledge/other.md"],
+      implementation_status: "stable",
+    });
+
+    const results = validateLoadedFiles(FAKE_GIT_ROOT, [file]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].errors).toHaveLength(0);
+    expect(results[0].warnings).toHaveLength(0);
+  });
+
+  it("produces an error for invalid last_reviewed date", () => {
+    const file = makeFile({ last_reviewed: "not-a-date" });
+
+    const results = validateLoadedFiles(FAKE_GIT_ROOT, [file]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].errors).toHaveLength(1);
+    expect(results[0].errors[0].field).toBe("last_reviewed");
+    expect(results[0].errors[0].message).toContain("Invalid date format");
+  });
+
+  it("produces a warning for covers glob matching nothing", () => {
+    const file = makeFile({ covers: ["nonexistent/**/*.ts"] });
+
+    const results = validateLoadedFiles(FAKE_GIT_ROOT, [file]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].warnings).toHaveLength(1);
+    expect(results[0].warnings[0].field).toBe("covers");
+    expect(results[0].warnings[0].message).toContain("matches no tracked files");
+  });
+
+  it("produces a warning for broken depends_on reference", () => {
+    const file = makeFile({ depends_on: ["docs/knowledge/broken-ref.md"] });
+
+    const results = validateLoadedFiles(FAKE_GIT_ROOT, [file]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].warnings).toHaveLength(1);
+    expect(results[0].warnings[0].field).toBe("depends_on");
+    expect(results[0].warnings[0].message).toContain("does not exist");
+  });
+
+  it("produces a warning for unrecognized implementation_status", () => {
+    // The loader normalizes unrecognized values to undefined, but if
+    // somehow an invalid value slips through, the validator catches it.
+    // We test by directly setting a bad value via type assertion.
+    const file = makeFile({
+      implementation_status: "banana" as KnowledgeFrontmatter["implementation_status"],
+    });
+
+    const results = validateLoadedFiles(FAKE_GIT_ROOT, [file]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].warnings).toHaveLength(1);
+    expect(results[0].warnings[0].field).toBe("implementation_status");
+    expect(results[0].warnings[0].message).toContain("Unrecognized value");
+  });
+
+  it("does not warn for valid covers globs", () => {
+    const file = makeFile({ covers: ["cli/**/*.ts", "config/*.yaml"] });
+
+    const results = validateLoadedFiles(FAKE_GIT_ROOT, [file]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].warnings).toHaveLength(0);
+  });
+
+  it("validates multiple files independently", () => {
+    const good = makeFile({}, "docs/knowledge/good.md");
+    const bad = makeFile({ covers: ["missing/**"] }, "docs/knowledge/bad.md");
+
+    const results = validateLoadedFiles(FAKE_GIT_ROOT, [good, bad]);
+
+    expect(results).toHaveLength(2);
+
+    const goodResult = results.find((r) => r.file.relativePath.includes("good"));
+    const badResult = results.find((r) => r.file.relativePath.includes("bad"));
+
+    expect(goodResult?.warnings).toHaveLength(0);
+    expect(badResult?.warnings).toHaveLength(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests: findSkippedFiles
+// ─────────────────────────────────────────────────────────────────────────────
+
+// findSkippedFiles reads actual files from disk, so we use the same temp
+// directory pattern as loader.test.ts.
+
+describe("findSkippedFiles", () => {
+  const TEST_ROOT = join(process.cwd(), ".test-kb-validate");
+
+  function writeKbFile(dir: string, name: string, frontmatter: string, body = ""): void {
+    const dirPath = join(TEST_ROOT, dir);
+    mkdirSync(dirPath, { recursive: true });
+    writeFileSync(join(dirPath, name), `---\n${frontmatter}\n---\n${body}`, "utf-8");
+  }
+
+  beforeEach(() => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("detects files missing topics", () => {
+    writeKbFile("kb", "no-topics.md", 'last_reviewed: "2026-03-01"\ncovers:\n  - src/**');
+
+    const results = findSkippedFiles(TEST_ROOT, {
+      local: ["kb"],
+      staleness_threshold_days: 30,
+      imports: [],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].errors.some((e) => e.field === "topics")).toBe(true);
+  });
+
+  it("detects files with empty topics array", () => {
+    writeKbFile("kb", "empty-topics.md", 'topics: []\nlast_reviewed: "2026-03-01"');
+
+    const results = findSkippedFiles(TEST_ROOT, {
+      local: ["kb"],
+      staleness_threshold_days: 30,
+      imports: [],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].errors.some((e) => e.field === "topics")).toBe(true);
+  });
+
+  it("detects files missing last_reviewed", () => {
+    writeKbFile("kb", "no-reviewed.md", "topics:\n  - testing");
+
+    const results = findSkippedFiles(TEST_ROOT, {
+      local: ["kb"],
+      staleness_threshold_days: 30,
+      imports: [],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].errors.some((e) => e.field === "last_reviewed")).toBe(true);
+  });
+
+  it("skips files with no frontmatter", () => {
+    const dirPath = join(TEST_ROOT, "kb");
+    mkdirSync(dirPath, { recursive: true });
+    writeFileSync(join(dirPath, "readme.md"), "# Just a readme\n\nNo frontmatter here.", "utf-8");
+
+    const results = findSkippedFiles(TEST_ROOT, {
+      local: ["kb"],
+      staleness_threshold_days: 30,
+      imports: [],
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
+  it("skips valid files that the loader would accept", () => {
+    writeKbFile("kb", "valid.md", 'topics:\n  - testing\nlast_reviewed: "2026-03-01"');
+
+    const results = findSkippedFiles(TEST_ROOT, {
+      local: ["kb"],
+      staleness_threshold_days: 30,
+      imports: [],
+    });
+
+    expect(results).toHaveLength(0);
+  });
+});

--- a/cli/lib/kb/validate.ts
+++ b/cli/lib/kb/validate.ts
@@ -20,7 +20,7 @@ import type {
   ValidationResult,
   ValidationIssue,
 } from "./types.js";
-import { IMPLEMENTATION_STATUSES } from "./types.js";
+import { IMPLEMENTATION_STATUSES, type ImplementationStatus } from "./types.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Public API
@@ -173,7 +173,7 @@ function validateLoadedFile(gitRoot: string, file: KnowledgeFile): ValidationRes
 
   // Check implementation_status is recognized
   if (fm.implementation_status !== undefined) {
-    if (!IMPLEMENTATION_STATUSES.includes(fm.implementation_status)) {
+    if (!IMPLEMENTATION_STATUSES.includes(fm.implementation_status as ImplementationStatus)) {
       warnings.push({
         field: "implementation_status",
         message: `Unrecognized value: "${fm.implementation_status}"`,

--- a/cli/lib/kb/validate.ts
+++ b/cli/lib/kb/validate.ts
@@ -1,0 +1,201 @@
+/**
+ * Knowledge File Validation
+ *
+ * Validates knowledge file frontmatter for errors (missing required fields,
+ * bad date formats) and warnings (unresolvable globs, broken depends_on,
+ * unrecognized implementation_status).
+ *
+ * Returns pure data — the command layer formats output.
+ */
+
+import { execFileSync } from "child_process";
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join, relative } from "path";
+import matter from "gray-matter";
+
+import type {
+  KbConfig,
+  KnowledgeFile,
+  KnowledgeFrontmatter,
+  ValidationResult,
+  ValidationIssue,
+} from "./types.js";
+import { IMPLEMENTATION_STATUSES } from "./types.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Validate already-loaded knowledge files for warnings.
+ *
+ * These files passed the loader's requirements (have topics, etc.) so we
+ * only check for soft issues: unresolvable globs, broken depends_on,
+ * unrecognized implementation_status.
+ */
+export function validateLoadedFiles(
+  gitRoot: string,
+  files: KnowledgeFile[],
+): ValidationResult[] {
+  return files.map((file) => validateLoadedFile(gitRoot, file));
+}
+
+/**
+ * Scan configured directories for .md files that have YAML frontmatter but
+ * were skipped by the loader (missing required fields). Returns
+ * ValidationResult objects with errors for the missing fields.
+ *
+ * This catches files that authors intended to be knowledge files but have
+ * incomplete frontmatter.
+ */
+export function findSkippedFiles(
+  gitRoot: string,
+  config: KbConfig,
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  for (const dir of config.local) {
+    const absDir = join(gitRoot, dir);
+
+    if (!existsSync(absDir)) continue;
+
+    let entries: string[];
+    try {
+      entries = readdirSync(absDir);
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.endsWith(".md")) continue;
+
+      const absPath = join(absDir, entry);
+      const relPath = relative(gitRoot, absPath);
+
+      try {
+        const raw = readFileSync(absPath, "utf-8");
+        const { data, content } = matter(raw);
+
+        // Skip files without any YAML frontmatter — these aren't knowledge files
+        if (!data || typeof data !== "object" || Object.keys(data).length === 0) {
+          continue;
+        }
+
+        // Check for missing/empty topics
+        const hasTopics = Array.isArray(data.topics) && data.topics.length > 0;
+
+        // Check for missing/invalid last_reviewed
+        const hasLastReviewed = data.last_reviewed !== undefined && data.last_reviewed !== null;
+
+        // If the loader would have accepted this file, skip it — it's validated elsewhere
+        if (hasTopics && hasLastReviewed) continue;
+
+        const errors: ValidationIssue[] = [];
+
+        if (!data.topics) {
+          errors.push({ field: "topics", message: "Missing required field" });
+        } else if (Array.isArray(data.topics) && data.topics.length === 0) {
+          errors.push({ field: "topics", message: "Must contain at least one topic" });
+        }
+
+        if (!hasLastReviewed) {
+          errors.push({ field: "last_reviewed", message: "Missing required field" });
+        }
+
+        // Build a minimal KnowledgeFile for reporting
+        const frontmatter: KnowledgeFrontmatter = {
+          topics: Array.isArray(data.topics) ? data.topics : [],
+          last_reviewed: typeof data.last_reviewed === "string" ? data.last_reviewed : "",
+          covers: Array.isArray(data.covers) ? data.covers : undefined,
+          depends_on: Array.isArray(data.depends_on) ? data.depends_on : undefined,
+          implementation_status: undefined,
+        };
+
+        results.push({
+          file: { path: absPath, relativePath: relPath, frontmatter, content },
+          errors,
+          warnings: [],
+        });
+      } catch {
+        // Can't parse — skip silently (loader already warns)
+      }
+    }
+  }
+
+  return results;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Validate a single loaded knowledge file for warnings.
+ */
+function validateLoadedFile(gitRoot: string, file: KnowledgeFile): ValidationResult {
+  const warnings: ValidationIssue[] = [];
+  const errors: ValidationIssue[] = [];
+  const fm = file.frontmatter;
+
+  // Check last_reviewed date is valid
+  if (fm.last_reviewed) {
+    const parsed = new Date(fm.last_reviewed);
+    if (isNaN(parsed.getTime())) {
+      errors.push({ field: "last_reviewed", message: `Invalid date format: "${fm.last_reviewed}"` });
+    }
+  }
+
+  // Check covers globs resolve to tracked files
+  if (fm.covers) {
+    for (const glob of fm.covers) {
+      if (!globMatchesTrackedFiles(gitRoot, glob)) {
+        warnings.push({
+          field: "covers",
+          message: `Glob pattern matches no tracked files: "${glob}"`,
+        });
+      }
+    }
+  }
+
+  // Check depends_on references exist
+  if (fm.depends_on) {
+    for (const dep of fm.depends_on) {
+      const absPath = join(gitRoot, dep);
+      if (!existsSync(absPath)) {
+        warnings.push({
+          field: "depends_on",
+          message: `Referenced file does not exist: "${dep}"`,
+        });
+      }
+    }
+  }
+
+  // Check implementation_status is recognized
+  if (fm.implementation_status !== undefined) {
+    if (!IMPLEMENTATION_STATUSES.includes(fm.implementation_status)) {
+      warnings.push({
+        field: "implementation_status",
+        message: `Unrecognized value: "${fm.implementation_status}"`,
+      });
+    }
+  }
+
+  return { file, errors, warnings };
+}
+
+/**
+ * Check if a glob pattern matches any git-tracked files.
+ * Uses `git ls-files` which respects .gitignore and only returns tracked files.
+ */
+function globMatchesTrackedFiles(gitRoot: string, glob: string): boolean {
+  try {
+    const result = execFileSync("git", ["ls-files", "--", glob], {
+      cwd: gitRoot,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return result.trim().length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/cli/lib/kb/validate.ts
+++ b/cli/lib/kb/validate.ts
@@ -84,8 +84,8 @@ export function findSkippedFiles(
         // Check for missing/empty topics
         const hasTopics = Array.isArray(data.topics) && data.topics.length > 0;
 
-        // Check for missing/invalid last_reviewed
-        const hasLastReviewed = data.last_reviewed !== undefined && data.last_reviewed !== null;
+        // Check for missing/empty last_reviewed
+        const hasLastReviewed = data.last_reviewed !== undefined && data.last_reviewed !== null && data.last_reviewed !== "";
 
         // If the loader would have accepted this file, skip it — it's validated elsewhere
         if (hasTopics && hasLastReviewed) continue;
@@ -118,8 +118,18 @@ export function findSkippedFiles(
           errors,
           warnings: [],
         });
-      } catch {
-        // Can't parse — skip silently (loader already warns)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        results.push({
+          file: {
+            path: absPath,
+            relativePath: relPath,
+            frontmatter: { topics: [], last_reviewed: "" },
+            content: "",
+          },
+          errors: [{ field: "frontmatter", message: `Failed to parse: ${message}` }],
+          warnings: [],
+        });
       }
     }
   }

--- a/cli/lib/kb/validate.ts
+++ b/cli/lib/kb/validate.ts
@@ -10,7 +10,7 @@
 
 import { execFileSync } from "child_process";
 import { existsSync, readdirSync, readFileSync } from "fs";
-import { join, relative } from "path";
+import { dirname, join, relative } from "path";
 import matter from "gray-matter";
 
 import type {
@@ -157,11 +157,12 @@ function validateLoadedFile(gitRoot: string, file: KnowledgeFile): ValidationRes
     }
   }
 
-  // Check depends_on references exist
+  // Check depends_on references exist (resolve from git root or file's directory)
   if (fm.depends_on) {
     for (const dep of fm.depends_on) {
-      const absPath = join(gitRoot, dep);
-      if (!existsSync(absPath)) {
+      const fromRoot = join(gitRoot, dep);
+      const fromFileDir = join(dirname(file.path), dep);
+      if (!existsSync(fromRoot) && !existsSync(fromFileDir)) {
         warnings.push({
           field: "depends_on",
           message: `Referenced file does not exist: "${dep}"`,

--- a/cli/lib/kb/validate.ts
+++ b/cli/lib/kb/validate.ts
@@ -156,11 +156,15 @@ function validateLoadedFile(gitRoot: string, file: KnowledgeFile): ValidationRes
     if (!dateMatch) {
       errors.push({ field: "last_reviewed", message: `Invalid date format (expected YYYY-MM-DD): "${dateStr}"` });
     } else {
-      // Round-trip check: reject impossible dates like 2026-02-30
+      // Round-trip check: reject impossible dates like 2026-02-30 or 2026-13-01
       const parsed = new Date(dateStr + "T00:00:00Z");
-      const roundTrip = parsed.toISOString().slice(0, 10);
-      if (roundTrip !== dateStr) {
+      if (isNaN(parsed.getTime())) {
         errors.push({ field: "last_reviewed", message: `Invalid calendar date: "${dateStr}"` });
+      } else {
+        const roundTrip = parsed.toISOString().slice(0, 10);
+        if (roundTrip !== dateStr) {
+          errors.push({ field: "last_reviewed", message: `Invalid calendar date: "${dateStr}"` });
+        }
       }
     }
   }

--- a/cli/lib/kb/validate.ts
+++ b/cli/lib/kb/validate.ts
@@ -149,11 +149,19 @@ function validateLoadedFile(gitRoot: string, file: KnowledgeFile): ValidationRes
   const errors: ValidationIssue[] = [];
   const fm = file.frontmatter;
 
-  // Check last_reviewed date is valid
+  // Check last_reviewed date is valid (strict YYYY-MM-DD with round-trip check)
   if (fm.last_reviewed) {
-    const parsed = new Date(fm.last_reviewed);
-    if (isNaN(parsed.getTime())) {
-      errors.push({ field: "last_reviewed", message: `Invalid date format: "${fm.last_reviewed}"` });
+    const dateStr = fm.last_reviewed;
+    const dateMatch = /^\d{4}-\d{2}-\d{2}$/.test(dateStr);
+    if (!dateMatch) {
+      errors.push({ field: "last_reviewed", message: `Invalid date format (expected YYYY-MM-DD): "${dateStr}"` });
+    } else {
+      // Round-trip check: reject impossible dates like 2026-02-30
+      const parsed = new Date(dateStr + "T00:00:00Z");
+      const roundTrip = parsed.toISOString().slice(0, 10);
+      if (roundTrip !== dateStr) {
+        errors.push({ field: "last_reviewed", message: `Invalid calendar date: "${dateStr}"` });
+      }
     }
   }
 

--- a/cli/lib/kb/validate.ts
+++ b/cli/lib/kb/validate.ts
@@ -94,7 +94,9 @@ export function findSkippedFiles(
 
         if (!data.topics) {
           errors.push({ field: "topics", message: "Missing required field" });
-        } else if (Array.isArray(data.topics) && data.topics.length === 0) {
+        } else if (!Array.isArray(data.topics)) {
+          errors.push({ field: "topics", message: `Must be an array, got ${typeof data.topics}: "${data.topics}"` });
+        } else if (data.topics.length === 0) {
           errors.push({ field: "topics", message: "Must contain at least one topic" });
         }
 

--- a/config/hooks.yaml
+++ b/config/hooks.yaml
@@ -261,6 +261,13 @@ hooks:
       matcher: "Edit|Write"
       description: Regenerate TASKS.md when task files change
 
+    # Knowledge Base - Staleness nudge
+    - id: kb-staleness-nudge
+      skill: knowledge-base
+      script: hooks/post-tool/kb-staleness-nudge.sh
+      matcher: "Edit|Write"
+      description: Alert when editing files covered by stale knowledge
+
   session:
     # Session lifecycle
     - id: session-start
@@ -281,6 +288,19 @@ hooks:
       event: PreCompact
       timeout: 60000
       description: Identify active sessions and prompt for context-archiver agent to preserve state
+
+    # Knowledge Base - Session lifecycle
+    - id: kb-session-start
+      skill: knowledge-base
+      script: hooks/session/kb-session-start.sh
+      event: SessionStart
+      description: Surface stale knowledge count at session start
+
+    - id: kb-session-end
+      skill: knowledge-base
+      script: hooks/session/kb-session-end.sh
+      event: SessionEnd
+      description: Prompt for knowledge consolidation if stale files were flagged
 
 # Legacy plugin groupings (kept for documentation purposes)
 # NOTE: Claude Code build now creates a single unified "loaf" plugin
@@ -384,6 +404,15 @@ plugin-groups:
     skills: [interface-design, foundations]
     related-hooks:
       post-tool: [design-a11y-validation, design-token-check, design-a11y-audit]
+
+  # Knowledge Base
+  knowledge-base:
+    description: Knowledge base lifecycle hooks for staleness tracking and review nudges
+    agents: []
+    skills: [knowledge-base]
+    related-hooks:
+      post-tool: [kb-staleness-nudge]
+      session: [kb-session-start, kb-session-end]
 
   # Domain-specific
   power-systems:

--- a/content/hooks/post-tool/kb-staleness-nudge.sh
+++ b/content/hooks/post-tool/kb-staleness-nudge.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# KB staleness nudge — alerts when editing files covered by stale knowledge
+# Post-tool hook for Edit|Write
+#
+# Per-session single nudge: each knowledge file mentioned at most once.
+# Tracks nudged files in a temp file keyed on PPID (stable within a session).
+
+set -euo pipefail
+
+# Check if loaf is available
+if ! command -v loaf &>/dev/null; then
+  exit 0
+fi
+
+# Parse the edited file path from TOOL_INPUT JSON
+# TOOL_INPUT contains the tool's input as a JSON string
+if [ -z "${TOOL_INPUT:-}" ]; then
+  exit 0
+fi
+
+# Extract file_path (primary field for Edit/Write tools)
+file_path=$(echo "$TOOL_INPUT" | grep -oE '"file_path"[[:space:]]*:[[:space:]]*"[^"]+"' | sed 's/.*: *"//' | sed 's/"$//' || true)
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+# Check which knowledge files cover this path
+result=$(loaf kb check --file "$file_path" --json 2>/dev/null || true)
+if [ -z "$result" ] || [ "$result" = "[]" ]; then
+  exit 0
+fi
+
+# Track already-nudged files per session
+# PPID is the parent process (Claude Code), stable across hook invocations in one session
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+nudge_file="/tmp/loaf-kb-nudged-${PPID}-$(echo "$PROJECT_DIR" | md5sum 2>/dev/null | cut -c1-8 || echo "$PROJECT_DIR" | md5 2>/dev/null | cut -c1-8 || echo "default")"
+
+# The JSON output is an array of objects with "file", "isStale", etc.
+# Parse each entry: look for "file":"..." and "isStale":true pairs
+# Process line-by-line, tracking the current object's fields
+current_file=""
+current_stale=""
+
+while IFS= read -r line; do
+  # Detect file field
+  f=$(echo "$line" | grep -o '"file":[[:space:]]*"[^"]*"' | sed 's/"file":[[:space:]]*"//;s/"$//' || true)
+  if [ -n "$f" ]; then
+    current_file="$f"
+  fi
+
+  # Detect isStale field
+  s=$(echo "$line" | grep -o '"isStale":[[:space:]]*true' || true)
+  if [ -n "$s" ]; then
+    current_stale="true"
+  fi
+
+  # Reset on isStale: false
+  sf=$(echo "$line" | grep -o '"isStale":[[:space:]]*false' || true)
+  if [ -n "$sf" ]; then
+    current_stale=""
+  fi
+
+  # On closing brace, check if we have a stale file to report
+  if echo "$line" | grep -q '}'; then
+    if [ -n "$current_stale" ] && [ -n "$current_file" ]; then
+      # Check if already nudged this session
+      if [ -f "$nudge_file" ] && grep -qF "$current_file" "$nudge_file"; then
+        # Already nudged, skip
+        :
+      else
+        # Record as nudged
+        echo "$current_file" >> "$nudge_file"
+        echo "Knowledge file \`$current_file\` covers this code and may be stale. Consider reviewing with \`loaf kb review $current_file\`."
+      fi
+    fi
+    current_file=""
+    current_stale=""
+  fi
+done <<< "$result"
+
+exit 0

--- a/content/hooks/post-tool/kb-staleness-nudge.sh
+++ b/content/hooks/post-tool/kb-staleness-nudge.sh
@@ -61,17 +61,19 @@ while IFS= read -r line; do
     current_stale=""
   fi
 
-  # On closing brace, check if we have a stale file to report
+  # On closing brace, process the parsed entry
   if echo "$line" | grep -q '}'; then
-    if [ -n "$current_stale" ] && [ -n "$current_file" ]; then
-      # Check if already nudged this session
+    if [ -n "$current_file" ]; then
+      # Always track covered edits (for SessionEnd consolidation prompt)
       if [ -f "$nudge_file" ] && grep -qF "$current_file" "$nudge_file"; then
-        # Already nudged, skip
+        # Already tracked, skip
         :
       else
-        # Record as nudged
         echo "$current_file" >> "$nudge_file"
-        echo "Knowledge file \`$current_file\` covers this code and may be stale. Consider reviewing with \`loaf kb review $current_file\`."
+        # Only nudge in-session when stale
+        if [ -n "$current_stale" ]; then
+          echo "Knowledge file \`$current_file\` covers this code and may be stale. Consider reviewing with \`loaf kb review $current_file\`."
+        fi
       fi
     fi
     current_file=""

--- a/content/hooks/session/kb-session-end.sh
+++ b/content/hooks/session/kb-session-end.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Hook: KB consolidation prompt (INFORMATIONAL)
+# SessionEnd hook - reminds about stale knowledge at session end
+#
+# Reads the nudge tracking file created by kb-staleness-nudge post-tool hook
+# and reports how many stale knowledge files were flagged during the session
+
+# Match the nudge file key from the post-tool hook
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+nudge_file="/tmp/loaf-kb-nudged-${PPID}-$(echo "$PROJECT_DIR" | md5sum 2>/dev/null | cut -c1-8 || echo "$PROJECT_DIR" | md5 2>/dev/null | cut -c1-8 || echo "default")"
+
+if [ ! -f "$nudge_file" ]; then
+  exit 0
+fi
+
+# Read the list of nudged files before cleanup
+nudged_files=()
+while IFS= read -r line; do
+  [ -n "$line" ] && nudged_files+=("$line")
+done < "$nudge_file"
+
+# Clean up the tracking file
+rm -f "$nudge_file"
+
+nudged_count=${#nudged_files[@]}
+
+if [ "$nudged_count" -gt 0 ]; then
+  echo ""
+  echo "## Knowledge Base"
+  echo ""
+  echo "**${nudged_count}** stale knowledge file(s) were flagged during this session:"
+  echo ""
+  for f in "${nudged_files[@]}"; do
+    echo "- \`$f\`"
+  done
+  echo ""
+  echo "Run \`loaf kb check\` to review or \`loaf kb review <file>\` to mark as reviewed."
+fi
+
+exit 0

--- a/content/hooks/session/kb-session-start.sh
+++ b/content/hooks/session/kb-session-start.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Hook: KB staleness advisory (INFORMATIONAL)
+# SessionStart hook - surfaces stale knowledge count at session start
+#
+# Triggers on session start
+# Displays count of stale knowledge files if any exist
+
+# Check if loaf is available
+if ! command -v loaf &>/dev/null; then
+  exit 0
+fi
+
+# Get KB status as JSON
+status=$(loaf kb status --json 2>/dev/null)
+if [ $? -ne 0 ] || [ -z "$status" ]; then
+  exit 0
+fi
+
+# Extract counts from JSON (no jq dependency)
+# JSON fields: total_files, stale
+stale=$(echo "$status" | grep -o '"stale":[[:space:]]*[0-9]*' | grep -o '[0-9]*$')
+total=$(echo "$status" | grep -o '"total_files":[[:space:]]*[0-9]*' | grep -o '[0-9]*$')
+
+if [ -z "$stale" ] || [ "$stale" = "0" ]; then
+  exit 0
+fi
+
+echo ""
+echo "## Knowledge Base"
+echo ""
+echo "**${total}** knowledge files tracked. **${stale}** stale."
+echo ""
+echo "Run \`loaf kb check\` for details or \`loaf kb review <file>\` to mark reviewed."
+
+exit 0

--- a/content/skills/brainstorm/SKILL.md
+++ b/content/skills/brainstorm/SKILL.md
@@ -42,8 +42,10 @@ Unlike `/idea` (quick capture) or `/shape` (rigorous bounding), brainstorming is
 2. Gather context: VISION.md, STRATEGY.md, ARCHITECTURE.md, related ideas
 3. **Deep exploration**: ask about user value, problem depth, alternatives, risks, dependencies, scope (minimal vs maximal)
 4. Generate options: conventional, minimal, ambitious, contrarian approaches
-5. Document with core insight, explored directions (approach/pros/cons), open questions, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](templates/brainstorm.md)
 6. Update idea file status if proceeding
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Problem Exploration
 
@@ -51,7 +53,9 @@ Unlike `/idea` (quick capture) or `/shape` (rigorous bounding), brainstorming is
 2. Gather strategic context
 3. **Diverge**: first principles, inversion, analogy, extreme constraints, persona lens
 4. **Converge**: filter by strategy alignment, feasibility, value
-5. Document with problem statement, options, analysis, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](templates/brainstorm.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Open Brainstorm
 

--- a/content/skills/brainstorm/templates/brainstorm.md
+++ b/content/skills/brainstorm/templates/brainstorm.md
@@ -1,0 +1,43 @@
+# Brainstorm Document Template
+
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "Brainstorm: [Topic]"
+type: brainstorm
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active (has unprocessed sparks) | archived
+tags: []
+related: []            # Optional: idea files, spec IDs, session files
+---
+
+# Brainstorm: [Topic]
+
+**Date:** YYYY-MM-DD
+**Session:** [Brief description of session scope]
+
+## Session Journey
+
+[How the brainstorm evolved -- pivots, reframes, key realizations]
+
+## [Main Content Sections]
+
+[Organized by the brainstorm's natural structure -- options explored,
+analysis, trade-offs, convergence points]
+
+## Recommendation
+
+[If applicable -- the direction that emerged]
+
+## Open Questions
+
+- [Unresolved questions for further exploration]
+
+## Sparks
+
+- **[Title]** -- [one-line description]
+- **[Title]** -- [one-line description]
+```

--- a/content/skills/breakdown/SKILL.md
+++ b/content/skills/breakdown/SKILL.md
@@ -76,17 +76,24 @@ Extract: test conditions, scope, implementation notes, appetite.
 
 Break down by concern (DBA, Backend, Frontend, QA, DevOps). One concern per task. Explicit dependencies for sequential tasks.
 
-### Step 4: Interview for Priorities
+### Step 4: Decide Priorities and Granularity
 
-Ask about highest priority parts, required ordering, preferred implementation sequence.
+Own the granularity and priority decisions. Apply the Right Size Test, assign priorities
+based on dependencies and circuit breaker alignment, and do a self-review pass. Do not
+defer these decisions to the user — they trust agent judgment here.
+
+If genuinely uncertain (e.g., two equally valid orderings with different trade-offs),
+ask. Otherwise, decide and move on.
 
 ### Step 5: Draft Task List
 
 Create tasks following [task template](templates/task.md). Each task needs: clear title, priority, file hints, verification command, observable done condition.
 
-### Step 6: Present for Approval
+### Step 6: Present and Create
 
-Show tasks with priorities, dependencies, and dependency graph. **Do NOT create tasks without explicit approval.** User may adjust priorities, combine/split, add tasks, or change dependencies.
+Show the dependency graph and task summary for awareness, then create the tasks.
+Present it as "here's what I'm creating" not "which option do you prefer?" The user
+can still adjust after creation, but the default is to proceed.
 
 ### Step 7: Create Tasks
 
@@ -117,7 +124,7 @@ Set spec status to `implementing`. Announce created tasks with next steps.
 2. **Clear verification** -- how to prove it works
 3. **Observable done condition** -- not subjective
 4. **File hints** -- help session know where to look
-5. **Get approval** -- don't create without confirmation
+5. **Own the decisions** -- decide granularity and priorities, don't defer
 6. **Update spec status** -- mark as implementing
 
 ---

--- a/content/skills/idea/SKILL.md
+++ b/content/skills/idea/SKILL.md
@@ -28,7 +28,7 @@ Ideas are raw nuggets -- unprocessed, unshaped, but worth remembering. The goal 
 If `$ARGUMENTS` contains the idea, capture directly.
 
 If `$ARGUMENTS` is empty, **scan for sparks** in brainstorm documents:
-1. Search `.agents/drafts/brainstorm-*.md` for `## Sparks` sections
+1. Search `.agents/drafts/*brainstorm*.md` for `## Sparks` sections
 2. List unprocessed sparks (not marked as promoted or abandoned)
 3. Present the list and let the user pick one to promote
 4. When promoting: create idea file with `origin:` field, mark spark as `*(promoted)*` in source document
@@ -39,7 +39,7 @@ If no sparks found and no arguments, ask **at most 2-3 questions**: core idea, p
 
 Create file in `.agents/ideas/` following [idea template](templates/idea.md).
 
-**Filename:** `{YYYYMMDD}-{slug}.md`
+**Filename:** `{YYYYMMDD}-{HHMMSS}-{slug}.md`
 
 ### Step 3: Create and Announce
 

--- a/content/skills/idea/templates/idea.md
+++ b/content/skills/idea/templates/idea.md
@@ -1,13 +1,17 @@
 # Idea File Template
 
-**Location:** `.agents/ideas/{YYYYMMDD}-{slug}.md`
+**Location:** `.agents/ideas/{YYYYMMDD}-{HHMMSS}-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
 
 ```yaml
 ---
+title: "[Idea Title]"
 captured: YYYY-MM-DDTHH:MM:SSZ
 status: raw
 tags: []
-origin:              # Optional: brainstorm document this spark came from
+related: []            # Optional: spec IDs, file paths, or other idea files
+origin:                # Optional: brainstorm document this spark came from
 ---
 
 # [Idea Title]

--- a/content/skills/knowledge-base/SKILL.claude-code.yaml
+++ b/content/skills/knowledge-base/SKILL.claude-code.yaml
@@ -1,0 +1,5 @@
+# Claude Code extensions for Knowledge Base skill
+# Base name/description in SKILL.md
+
+user-invocable: false
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep

--- a/content/skills/knowledge-base/SKILL.md
+++ b/content/skills/knowledge-base/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: knowledge-base
+description: >-
+  Provides guidance for creating, updating, and reviewing project knowledge files.
+  Covers frontmatter schema, naming conventions, staleness detection via covers:
+  field, and the review workflow. Use when creating new knowledge files, updating
+  existing ones, or when the agent needs to understand knowledge management
+  conventions. Not for retrieval or search (use QMD directly). Not for
+  architectural decisions (use ADRs). Not for agent instructions (use CLAUDE.md).
+---
+
+# Knowledge Base
+
+Conventions and workflows for managing project knowledge files -- structured
+domain knowledge that lives in `docs/knowledge/` and persists across sessions.
+
+## Contents
+- When to Create a Knowledge File
+- Topics
+- The covers: Field
+- Review Workflow
+- What Goes Where
+- Critical Rules
+
+## When to Create a Knowledge File
+
+Create a knowledge file when information:
+
+1. **Requires context beyond the code** -- domain rules, business logic constraints,
+   cross-cutting patterns that cannot be expressed in types or docstrings
+2. **Spans multiple files or modules** -- conventions or contracts that apply across
+   the codebase, not localized to one function
+3. **Would be lost between sessions** -- insights that an agent needs repeatedly but
+   cannot derive from code alone
+4. **Serves as extended agent memory** -- roadmap context, implementation plans,
+   strategic direction that informs decisions
+
+Do NOT create knowledge files for:
+- Self-documenting code (types, docstrings, comments are sufficient)
+- One-off architectural decisions (write an ADR instead)
+- Agent behavior instructions (put those in CLAUDE.md)
+- User preferences or session pointers (those belong in MEMORY.md)
+
+## Topics
+
+| Topic | Reference | Use When |
+|-------|-----------|----------|
+| Frontmatter Schema | [frontmatter-schema.md](references/frontmatter-schema.md) | Creating or validating knowledge file frontmatter |
+| Naming Conventions | [naming-conventions.md](references/naming-conventions.md) | Deciding where to put knowledge and what to name it |
+
+| Template | Use When |
+|----------|----------|
+| [knowledge-file.md](templates/knowledge-file.md) | Creating a new knowledge file from scratch |
+
+## The covers: Field
+
+The `covers:` field is the core innovation of the knowledge management system.
+It links knowledge to code paths via glob patterns, enabling automatic staleness
+detection.
+
+### How It Works
+
+1. Author declares `covers:` globs in knowledge file frontmatter
+2. Globs resolve from the git repository root
+3. `loaf kb check` queries `git log --since={last_reviewed}` for matching files
+4. If commits exist since last review, the knowledge file is flagged as potentially stale
+
+### Good covers: Patterns
+
+```yaml
+covers:
+  - "src/pipeline/registry.py"          # Specific file
+  - "src/models/engine_*.py"            # Wildcard within directory
+  - "src/thermal/**/*.py"               # Recursive directory
+```
+
+### Patterns to Avoid
+
+```yaml
+covers:
+  - "src/**"                            # Too broad -- constant false positives
+  - "**/*.py"                           # Covers everything, means nothing
+  - "*.md"                              # Documentation changes != knowledge staleness
+```
+
+The goal is precision: cover the code paths whose changes would actually
+invalidate the knowledge. Broad globs lead to alert fatigue.
+
+### When to Omit covers:
+
+Files without `covers:` are valid knowledge files but cannot use automated
+staleness detection. Omit `covers:` when:
+
+- The knowledge is purely conceptual (no specific code paths)
+- The file covers external domain rules not tied to implementation
+- You are unsure which paths to cover (add them later when the mapping is clear)
+
+## Review Workflow
+
+### Check What Is Stale
+
+```bash
+loaf kb check
+```
+
+Shows knowledge files where covered code paths have changed since `last_reviewed`.
+
+### Validate Frontmatter
+
+```bash
+loaf kb validate
+```
+
+Checks all knowledge files for valid frontmatter: required fields present,
+correct types, valid glob patterns.
+
+### Review a File
+
+```bash
+loaf kb review <file>
+```
+
+After reading and updating a knowledge file, mark it as reviewed. This updates
+the `last_reviewed` date to today.
+
+### Overview
+
+```bash
+loaf kb status
+```
+
+Summary of all knowledge files: total count, stale count, files missing
+`covers:`, last review dates.
+
+## What Goes Where
+
+| Surface | Contains | Decision Test |
+|---------|----------|---------------|
+| **Code** (docstrings, types) | What the code does | Is it self-documenting? |
+| **Knowledge files** | Domain rules, cross-cutting context, roadmap | Requires context beyond the code? |
+| **ADRs** | Why we chose this approach | Is it an architectural decision? |
+| **CLAUDE.md** | Agent instructions, conventions | Is it about how agents should behave? |
+| **MEMORY.md** | User preferences, session pointers | Is it personal or ephemeral? |
+
+CLAUDE.md may reference knowledge files but should never duplicate their content.
+
+For the authoritative design document covering the full knowledge management
+system (QMD integration, growth loops, cross-project sharing), see
+`docs/knowledge/knowledge-management-design.md`.
+
+## Critical Rules
+
+### Always
+- Include `topics` (min 1) and `last_reviewed` in frontmatter
+- Use kebab-case filenames in `docs/knowledge/`
+- Add `covers:` globs when the knowledge maps to specific code paths
+- Run `loaf kb validate` before committing new knowledge files
+- Mark files reviewed with `loaf kb review` after updating
+
+### Never
+- Duplicate code documentation in knowledge files
+- Use date prefixes on knowledge filenames (unlike sessions or ideas)
+- Use overly broad `covers:` globs that trigger constant staleness alerts
+- Skip the `last_reviewed` field -- it is required for the lifecycle to work
+- Store knowledge files outside `docs/knowledge/` (ADRs go in `docs/decisions/`)

--- a/content/skills/knowledge-base/references/frontmatter-schema.md
+++ b/content/skills/knowledge-base/references/frontmatter-schema.md
@@ -1,0 +1,147 @@
+# Frontmatter Schema
+
+Detailed reference for knowledge file YAML frontmatter.
+
+## Contents
+- Required Fields
+- Recommended Fields
+- Optional Fields
+- Complete Example
+- Common Mistakes
+
+## Required Fields
+
+### topics
+
+- **Type:** list of strings (min 1)
+- **Purpose:** Semantic tags for routing and discovery. Agents and QMD use these
+  to find relevant knowledge files.
+
+```yaml
+topics: [engine-registry, strategy-pattern]
+```
+
+Choose tags that are specific enough to be useful for routing but general enough
+to remain stable as the codebase evolves. Prefer domain terms over implementation
+terms (e.g., `thermal-physics` over `heat-calc-module`).
+
+### last_reviewed
+
+- **Type:** string, ISO 8601 date (YYYY-MM-DD)
+- **Purpose:** Records when a human last verified the file's accuracy. Used by
+  `loaf kb check` to determine staleness.
+
+```yaml
+last_reviewed: 2026-03-14
+```
+
+Update this field only after genuinely reviewing the content -- do not bump it
+during routine edits that do not involve verification. Use `loaf kb review <file>`
+to update it properly.
+
+## Recommended Fields
+
+### covers
+
+- **Type:** list of glob strings
+- **Purpose:** Links knowledge to code paths. Globs resolve from the git
+  repository root. Enables automatic staleness detection.
+
+```yaml
+covers:
+  - "src/pipeline/registry.py"
+  - "src/models/engine_*.py"
+```
+
+**Glob resolution rules:**
+- Paths are relative to the git root (not the knowledge file location)
+- Standard glob syntax: `*` matches within a directory, `**` matches recursively
+- Patterns that match no files are silently ignored (but may indicate drift)
+
+**Precision guidelines:**
+- Cover the specific files whose changes would invalidate this knowledge
+- Avoid `src/**` or `**/*.py` -- too broad, causes alert fatigue
+- When unsure, start narrow and widen as you learn which paths matter
+
+## Optional Fields
+
+### consumers
+
+- **Type:** list of strings
+- **Purpose:** Agent routing hints. Indicates which agents or roles should be
+  aware of this knowledge.
+
+```yaml
+consumers: [backend, power-systems]
+```
+
+Values are freeform but should correspond to agent names or plugin-group names
+from `hooks.yaml`.
+
+### depends_on
+
+- **Type:** list of strings (filenames)
+- **Purpose:** Cross-references to other knowledge files. Indicates that this
+  file's content assumes or builds on another.
+
+```yaml
+depends_on: [thermal-physics.md, conductor-limits.md]
+```
+
+Use bare filenames (not paths). All knowledge files live in `docs/knowledge/`,
+so paths are implicit.
+
+### implementation_status
+
+- **Type:** enum string
+- **Valid values:** `in-progress` | `stable` | `deprecated`
+- **Default:** omit if stable (absence implies stable)
+- **Purpose:** Signals whether the knowledge reflects current, evolving, or
+  obsolete state.
+
+```yaml
+implementation_status: in-progress
+```
+
+| Value | Meaning |
+|-------|---------|
+| `in-progress` | Knowledge is being actively developed or the code it covers is in flux |
+| `stable` | Knowledge is current and verified |
+| `deprecated` | Knowledge is outdated; the domain or code has moved on |
+
+## Complete Example
+
+```yaml
+---
+topics: [engine-registry, strategy-pattern, pipeline]
+last_reviewed: 2026-03-14
+covers:
+  - "src/pipeline/registry.py"
+  - "src/models/engine_*.py"
+  - "src/pipeline/strategies/**/*.py"
+consumers: [backend, power-systems]
+depends_on: [thermal-physics.md]
+implementation_status: stable
+---
+
+# Engine Registry
+
+Domain rules for the engine registration and strategy selection system.
+
+## Key Rules
+
+- All engines must register via `EngineRegistry.register()`
+- Strategy selection is deterministic given the same input parameters
+- ...
+```
+
+## Common Mistakes
+
+| Mistake | Why It Is Wrong | Fix |
+|---------|-----------------|-----|
+| Missing `topics` | Required for routing; file is invisible to discovery | Add at least one topic |
+| `last_reviewed` in the future | Implies review that has not happened | Use today's date or earlier |
+| `covers: ["src/**"]` | Too broad; every commit triggers staleness | Narrow to specific paths |
+| `depends_on: ["docs/knowledge/foo.md"]` | Uses full path instead of filename | Use `depends_on: [foo.md]` |
+| `implementation_status: done` | Not a valid enum value | Use `stable` |
+| Topics that match code identifiers | Brittle; breaks on rename | Use domain-level terms |

--- a/content/skills/knowledge-base/references/naming-conventions.md
+++ b/content/skills/knowledge-base/references/naming-conventions.md
@@ -1,0 +1,57 @@
+# Naming Conventions
+
+Where knowledge files live, how to name them, and how they relate to other
+documentation surfaces. Based on ADR-004.
+
+## Directory Structure
+
+```
+docs/
+├── knowledge/          # Domain knowledge (cross-cutting context, rules)
+│   ├── build-system.md
+│   ├── thermal-physics.md
+│   └── knowledge-management-design.md
+└── decisions/          # Architecture Decision Records (immutable)
+    ├── ADR-001-some-decision.md
+    └── ADR-004-knowledge-naming-convention.md
+```
+
+- `docs/knowledge/` for domain knowledge files
+- `docs/decisions/` for ADRs
+- These directory names are deliberate: `knowledge` and `decisions` are
+  unambiguous, similar in length, and scan well together
+
+## Filename Rules
+
+| Rule | Example | Rationale |
+|------|---------|-----------|
+| Kebab-case | `build-system.md` | Consistent, URL-safe |
+| Descriptive | `thermal-physics.md` | Self-documenting |
+| No date prefixes | `build-system.md` | Knowledge is living; dates imply snapshots |
+| No abbreviations | `knowledge-management-design.md` | Clarity over brevity |
+
+**Contrast with other artifacts that DO use date prefixes:**
+- Sessions: `YYYYMMDD-HHMMSS-session-slug.md`
+- Ideas: `YYYYMMDD-HHMMSS-idea-slug.md`
+
+Knowledge files are living documents, not point-in-time snapshots.
+
+## CLI Abbreviation
+
+Per ADR-004, the CLI uses `kb` for ergonomics:
+
+- `loaf kb check` (not `loaf knowledge check`)
+- `loaf kb validate` (not `loaf knowledge validate`)
+
+The full word `knowledge` is for storage paths (directories, QMD collections).
+The abbreviation `kb` is for typing (CLI commands).
+
+## QMD Collection Naming
+
+When indexed by QMD:
+
+- `{repo-folder}-knowledge` for knowledge files
+- `{repo-folder}-decisions` for ADRs
+
+Example: a repo in `~/Code/gridsight-core-gds/` produces collections
+`gridsight-core-gds-knowledge` and `gridsight-core-gds-decisions`.

--- a/content/skills/knowledge-base/templates/knowledge-file.md
+++ b/content/skills/knowledge-base/templates/knowledge-file.md
@@ -1,0 +1,32 @@
+# Knowledge File Template
+
+**Location:** `docs/knowledge/{slug}.md`
+
+```yaml
+---
+topics: []                          # Required (min 1) -- semantic tags for routing
+last_reviewed: YYYY-MM-DD           # Required -- ISO 8601 date of last human review
+covers:                             # Recommended -- glob patterns from git root
+  - "path/to/covered/**/*.ts"
+consumers: []                       # Optional -- agent routing hints
+depends_on: []                      # Optional -- other knowledge file names
+implementation_status: in-progress  # Optional -- in-progress | stable | deprecated
+---
+
+# [Title]
+
+Brief description of what this knowledge covers and why it exists.
+
+## Key Rules
+
+- [Rule 1]
+- [Rule 2]
+
+## [Domain Section]
+
+[Domain-specific content organized by topic]
+
+## Cross-References
+
+- [Related knowledge file or ADR]
+```

--- a/content/skills/research/SKILL.md
+++ b/content/skills/research/SKILL.md
@@ -60,7 +60,9 @@ Always check project context first. Rate findings: **High** (official/verified),
 1. **Interview** with AskUserQuestion: what are you trying to understand? What context do you have? What decision will this inform?
 2. Check project context first (ADRs, ARCHITECTURE, sessions)
 3. Apply confidence hierarchy for external sources
-4. Synthesize following [findings template](templates/findings.md)
+4. Create findings document following [findings template](templates/findings.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-research-{slug}.md`
 
 ### Brainstorming
 

--- a/content/skills/research/templates/findings.md
+++ b/content/skills/research/templates/findings.md
@@ -1,42 +1,62 @@
-# Research Findings Output Template
+# Research Findings Template
 
-```markdown
-## Research: [Topic]
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-research-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "Research: [Topic]"
+type: research
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active | archived
+tags: []
+related: []            # Optional: spec IDs, idea files, ADRs
+---
+
+# Research: [Topic]
 
 **Question:** [What we're trying to understand]
 
-### Summary
+## Summary
+
 [One-paragraph answer with confidence level]
 
-### Key Findings
+## Key Findings
+
 1. [Finding 1]
 2. [Finding 2]
 
-### Project Context
+## Project Context
+
 [How this relates to our existing decisions/architecture]
 
-### Options Considered
+## Options Considered
 
-#### Option A: [Name]
+### Option A: [Name]
 - **Pros:** ...
 - **Cons:** ...
 - **Best for:** ...
 
-#### Option B: [Name]
+### Option B: [Name]
 - **Pros:** ...
 - **Cons:** ...
 - **Best for:** ...
 
-### Recommendation
+## Recommendation
+
 [Which option and why, with caveats]
 
-### Sources
+## Sources
+
 - [Source 1 with confidence level]
 - [Source 2 with confidence level]
 
-### Implications
+## Implications
+
 - [What this means for our work]
 
-### Open Questions
+## Open Questions
+
 - [What's still unclear]
 ```

--- a/content/skills/research/templates/state-assessment.md
+++ b/content/skills/research/templates/state-assessment.md
@@ -1,38 +1,58 @@
-# State Assessment Output Template
+# State Assessment Template
 
-```markdown
-## Project State Assessment
+State assessments are typically presented in-conversation. If saved to a file:
 
-**Date:** YYYY-MM-DD
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-state-assessment.md`
 
-### Current Position
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "State Assessment: [YYYY-MM-DD]"
+type: state-assessment
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active | archived
+tags: []
+---
+
+# Project State Assessment
+
+## Current Position
+
 - [Summary of where the project stands]
 
-### Strategic Context
+## Strategic Context
+
 - **Vision:** [Brief summary]
 - **Key personas:** [Who we're building for]
 - **Current focus:** [Active specs/work]
 
-### Recent Progress
+## Recent Progress
+
 - [Key accomplishments from recent sessions]
 
-### In Flight
+## In Flight
+
 | Spec/Task | Status | Notes |
 |-----------|--------|-------|
 | SPEC-001 | implementing | [progress] |
 | SPEC-002 | approved | [next up] |
 
-### Ideas Pipeline
+## Ideas Pipeline
+
 - [Idea 1] -- raw
 - [Idea 2] -- raw
 
-### Lessons Learned (Recent)
+## Lessons Learned (Recent)
+
 - [Insights from implementation feedback]
 
-### Open Questions
+## Open Questions
+
 - [Unresolved decisions or gaps]
 
-### Recommendations
+## Recommendations
+
 1. [Actionable next step]
 2. [Actionable next step]
 ```

--- a/dist/codex/skills/brainstorm/SKILL.md
+++ b/dist/codex/skills/brainstorm/SKILL.md
@@ -44,8 +44,10 @@ Unlike `/idea` (quick capture) or `/shape` (rigorous bounding), brainstorming is
 2. Gather context: VISION.md, STRATEGY.md, ARCHITECTURE.md, related ideas
 3. **Deep exploration**: ask about user value, problem depth, alternatives, risks, dependencies, scope (minimal vs maximal)
 4. Generate options: conventional, minimal, ambitious, contrarian approaches
-5. Document with core insight, explored directions (approach/pros/cons), open questions, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](templates/brainstorm.md)
 6. Update idea file status if proceeding
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Problem Exploration
 
@@ -53,7 +55,9 @@ Unlike `/idea` (quick capture) or `/shape` (rigorous bounding), brainstorming is
 2. Gather strategic context
 3. **Diverge**: first principles, inversion, analogy, extreme constraints, persona lens
 4. **Converge**: filter by strategy alignment, feasibility, value
-5. Document with problem statement, options, analysis, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](templates/brainstorm.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Open Brainstorm
 

--- a/dist/codex/skills/brainstorm/templates/brainstorm.md
+++ b/dist/codex/skills/brainstorm/templates/brainstorm.md
@@ -1,0 +1,43 @@
+# Brainstorm Document Template
+
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "Brainstorm: [Topic]"
+type: brainstorm
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active (has unprocessed sparks) | archived
+tags: []
+related: []            # Optional: idea files, spec IDs, session files
+---
+
+# Brainstorm: [Topic]
+
+**Date:** YYYY-MM-DD
+**Session:** [Brief description of session scope]
+
+## Session Journey
+
+[How the brainstorm evolved -- pivots, reframes, key realizations]
+
+## [Main Content Sections]
+
+[Organized by the brainstorm's natural structure -- options explored,
+analysis, trade-offs, convergence points]
+
+## Recommendation
+
+[If applicable -- the direction that emerged]
+
+## Open Questions
+
+- [Unresolved questions for further exploration]
+
+## Sparks
+
+- **[Title]** -- [one-line description]
+- **[Title]** -- [one-line description]
+```

--- a/dist/codex/skills/breakdown/SKILL.md
+++ b/dist/codex/skills/breakdown/SKILL.md
@@ -77,17 +77,24 @@ Extract: test conditions, scope, implementation notes, appetite.
 
 Break down by concern (DBA, Backend, Frontend, QA, DevOps). One concern per task. Explicit dependencies for sequential tasks.
 
-### Step 4: Interview for Priorities
+### Step 4: Decide Priorities and Granularity
 
-Ask about highest priority parts, required ordering, preferred implementation sequence.
+Own the granularity and priority decisions. Apply the Right Size Test, assign priorities
+based on dependencies and circuit breaker alignment, and do a self-review pass. Do not
+defer these decisions to the user — they trust agent judgment here.
+
+If genuinely uncertain (e.g., two equally valid orderings with different trade-offs),
+ask. Otherwise, decide and move on.
 
 ### Step 5: Draft Task List
 
 Create tasks following [task template](templates/task.md). Each task needs: clear title, priority, file hints, verification command, observable done condition.
 
-### Step 6: Present for Approval
+### Step 6: Present and Create
 
-Show tasks with priorities, dependencies, and dependency graph. **Do NOT create tasks without explicit approval.** User may adjust priorities, combine/split, add tasks, or change dependencies.
+Show the dependency graph and task summary for awareness, then create the tasks.
+Present it as "here's what I'm creating" not "which option do you prefer?" The user
+can still adjust after creation, but the default is to proceed.
 
 ### Step 7: Create Tasks
 
@@ -118,7 +125,7 @@ Set spec status to `implementing`. Announce created tasks with next steps.
 2. **Clear verification** -- how to prove it works
 3. **Observable done condition** -- not subjective
 4. **File hints** -- help session know where to look
-5. **Get approval** -- don't create without confirmation
+5. **Own the decisions** -- decide granularity and priorities, don't defer
 6. **Update spec status** -- mark as implementing
 
 ---

--- a/dist/codex/skills/idea/SKILL.md
+++ b/dist/codex/skills/idea/SKILL.md
@@ -29,7 +29,7 @@ Ideas are raw nuggets -- unprocessed, unshaped, but worth remembering. The goal 
 If `$ARGUMENTS` contains the idea, capture directly.
 
 If `$ARGUMENTS` is empty, **scan for sparks** in brainstorm documents:
-1. Search `.agents/drafts/brainstorm-*.md` for `## Sparks` sections
+1. Search `.agents/drafts/*brainstorm*.md` for `## Sparks` sections
 2. List unprocessed sparks (not marked as promoted or abandoned)
 3. Present the list and let the user pick one to promote
 4. When promoting: create idea file with `origin:` field, mark spark as `*(promoted)*` in source document
@@ -40,7 +40,7 @@ If no sparks found and no arguments, ask **at most 2-3 questions**: core idea, p
 
 Create file in `.agents/ideas/` following [idea template](templates/idea.md).
 
-**Filename:** `{YYYYMMDD}-{slug}.md`
+**Filename:** `{YYYYMMDD}-{HHMMSS}-{slug}.md`
 
 ### Step 3: Create and Announce
 

--- a/dist/codex/skills/idea/templates/idea.md
+++ b/dist/codex/skills/idea/templates/idea.md
@@ -1,13 +1,17 @@
 # Idea File Template
 
-**Location:** `.agents/ideas/{YYYYMMDD}-{slug}.md`
+**Location:** `.agents/ideas/{YYYYMMDD}-{HHMMSS}-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
 
 ```yaml
 ---
+title: "[Idea Title]"
 captured: YYYY-MM-DDTHH:MM:SSZ
 status: raw
 tags: []
-origin:              # Optional: brainstorm document this spark came from
+related: []            # Optional: spec IDs, file paths, or other idea files
+origin:                # Optional: brainstorm document this spark came from
 ---
 
 # [Idea Title]

--- a/dist/codex/skills/knowledge-base/SKILL.md
+++ b/dist/codex/skills/knowledge-base/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: knowledge-base
+description: >-
+  Provides guidance for creating, updating, and reviewing project knowledge
+  files. Covers frontmatter schema, naming conventions, staleness detection via
+  covers: field, and the review workflow. Use when creating new knowledge files,
+  updating existing ones, or when the agent needs to understand knowledge
+  management conventions. Not for retrieval or search (use QMD directly). Not
+  for architectural decisions (use ADRs). Not for agent instructions (use
+  CLAUDE.md).
+version: 2.0.0-dev.0
+---
+
+# Knowledge Base
+
+Conventions and workflows for managing project knowledge files -- structured
+domain knowledge that lives in `docs/knowledge/` and persists across sessions.
+
+## Contents
+- When to Create a Knowledge File
+- Topics
+- The covers: Field
+- Review Workflow
+- What Goes Where
+- Critical Rules
+
+## When to Create a Knowledge File
+
+Create a knowledge file when information:
+
+1. **Requires context beyond the code** -- domain rules, business logic constraints,
+   cross-cutting patterns that cannot be expressed in types or docstrings
+2. **Spans multiple files or modules** -- conventions or contracts that apply across
+   the codebase, not localized to one function
+3. **Would be lost between sessions** -- insights that an agent needs repeatedly but
+   cannot derive from code alone
+4. **Serves as extended agent memory** -- roadmap context, implementation plans,
+   strategic direction that informs decisions
+
+Do NOT create knowledge files for:
+- Self-documenting code (types, docstrings, comments are sufficient)
+- One-off architectural decisions (write an ADR instead)
+- Agent behavior instructions (put those in CLAUDE.md)
+- User preferences or session pointers (those belong in MEMORY.md)
+
+## Topics
+
+| Topic | Reference | Use When |
+|-------|-----------|----------|
+| Frontmatter Schema | [frontmatter-schema.md](references/frontmatter-schema.md) | Creating or validating knowledge file frontmatter |
+| Naming Conventions | [naming-conventions.md](references/naming-conventions.md) | Deciding where to put knowledge and what to name it |
+
+| Template | Use When |
+|----------|----------|
+| [knowledge-file.md](templates/knowledge-file.md) | Creating a new knowledge file from scratch |
+
+## The covers: Field
+
+The `covers:` field is the core innovation of the knowledge management system.
+It links knowledge to code paths via glob patterns, enabling automatic staleness
+detection.
+
+### How It Works
+
+1. Author declares `covers:` globs in knowledge file frontmatter
+2. Globs resolve from the git repository root
+3. `loaf kb check` queries `git log --since={last_reviewed}` for matching files
+4. If commits exist since last review, the knowledge file is flagged as potentially stale
+
+### Good covers: Patterns
+
+```yaml
+covers:
+  - "src/pipeline/registry.py"          # Specific file
+  - "src/models/engine_*.py"            # Wildcard within directory
+  - "src/thermal/**/*.py"               # Recursive directory
+```
+
+### Patterns to Avoid
+
+```yaml
+covers:
+  - "src/**"                            # Too broad -- constant false positives
+  - "**/*.py"                           # Covers everything, means nothing
+  - "*.md"                              # Documentation changes != knowledge staleness
+```
+
+The goal is precision: cover the code paths whose changes would actually
+invalidate the knowledge. Broad globs lead to alert fatigue.
+
+### When to Omit covers:
+
+Files without `covers:` are valid knowledge files but cannot use automated
+staleness detection. Omit `covers:` when:
+
+- The knowledge is purely conceptual (no specific code paths)
+- The file covers external domain rules not tied to implementation
+- You are unsure which paths to cover (add them later when the mapping is clear)
+
+## Review Workflow
+
+### Check What Is Stale
+
+```bash
+loaf kb check
+```
+
+Shows knowledge files where covered code paths have changed since `last_reviewed`.
+
+### Validate Frontmatter
+
+```bash
+loaf kb validate
+```
+
+Checks all knowledge files for valid frontmatter: required fields present,
+correct types, valid glob patterns.
+
+### Review a File
+
+```bash
+loaf kb review <file>
+```
+
+After reading and updating a knowledge file, mark it as reviewed. This updates
+the `last_reviewed` date to today.
+
+### Overview
+
+```bash
+loaf kb status
+```
+
+Summary of all knowledge files: total count, stale count, files missing
+`covers:`, last review dates.
+
+## What Goes Where
+
+| Surface | Contains | Decision Test |
+|---------|----------|---------------|
+| **Code** (docstrings, types) | What the code does | Is it self-documenting? |
+| **Knowledge files** | Domain rules, cross-cutting context, roadmap | Requires context beyond the code? |
+| **ADRs** | Why we chose this approach | Is it an architectural decision? |
+| **CLAUDE.md** | Agent instructions, conventions | Is it about how agents should behave? |
+| **MEMORY.md** | User preferences, session pointers | Is it personal or ephemeral? |
+
+CLAUDE.md may reference knowledge files but should never duplicate their content.
+
+For the authoritative design document covering the full knowledge management
+system (QMD integration, growth loops, cross-project sharing), see
+`docs/knowledge/knowledge-management-design.md`.
+
+## Critical Rules
+
+### Always
+- Include `topics` (min 1) and `last_reviewed` in frontmatter
+- Use kebab-case filenames in `docs/knowledge/`
+- Add `covers:` globs when the knowledge maps to specific code paths
+- Run `loaf kb validate` before committing new knowledge files
+- Mark files reviewed with `loaf kb review` after updating
+
+### Never
+- Duplicate code documentation in knowledge files
+- Use date prefixes on knowledge filenames (unlike sessions or ideas)
+- Use overly broad `covers:` globs that trigger constant staleness alerts
+- Skip the `last_reviewed` field -- it is required for the lifecycle to work
+- Store knowledge files outside `docs/knowledge/` (ADRs go in `docs/decisions/`)

--- a/dist/codex/skills/knowledge-base/references/frontmatter-schema.md
+++ b/dist/codex/skills/knowledge-base/references/frontmatter-schema.md
@@ -1,0 +1,147 @@
+# Frontmatter Schema
+
+Detailed reference for knowledge file YAML frontmatter.
+
+## Contents
+- Required Fields
+- Recommended Fields
+- Optional Fields
+- Complete Example
+- Common Mistakes
+
+## Required Fields
+
+### topics
+
+- **Type:** list of strings (min 1)
+- **Purpose:** Semantic tags for routing and discovery. Agents and QMD use these
+  to find relevant knowledge files.
+
+```yaml
+topics: [engine-registry, strategy-pattern]
+```
+
+Choose tags that are specific enough to be useful for routing but general enough
+to remain stable as the codebase evolves. Prefer domain terms over implementation
+terms (e.g., `thermal-physics` over `heat-calc-module`).
+
+### last_reviewed
+
+- **Type:** string, ISO 8601 date (YYYY-MM-DD)
+- **Purpose:** Records when a human last verified the file's accuracy. Used by
+  `loaf kb check` to determine staleness.
+
+```yaml
+last_reviewed: 2026-03-14
+```
+
+Update this field only after genuinely reviewing the content -- do not bump it
+during routine edits that do not involve verification. Use `loaf kb review <file>`
+to update it properly.
+
+## Recommended Fields
+
+### covers
+
+- **Type:** list of glob strings
+- **Purpose:** Links knowledge to code paths. Globs resolve from the git
+  repository root. Enables automatic staleness detection.
+
+```yaml
+covers:
+  - "src/pipeline/registry.py"
+  - "src/models/engine_*.py"
+```
+
+**Glob resolution rules:**
+- Paths are relative to the git root (not the knowledge file location)
+- Standard glob syntax: `*` matches within a directory, `**` matches recursively
+- Patterns that match no files are silently ignored (but may indicate drift)
+
+**Precision guidelines:**
+- Cover the specific files whose changes would invalidate this knowledge
+- Avoid `src/**` or `**/*.py` -- too broad, causes alert fatigue
+- When unsure, start narrow and widen as you learn which paths matter
+
+## Optional Fields
+
+### consumers
+
+- **Type:** list of strings
+- **Purpose:** Agent routing hints. Indicates which agents or roles should be
+  aware of this knowledge.
+
+```yaml
+consumers: [backend, power-systems]
+```
+
+Values are freeform but should correspond to agent names or plugin-group names
+from `hooks.yaml`.
+
+### depends_on
+
+- **Type:** list of strings (filenames)
+- **Purpose:** Cross-references to other knowledge files. Indicates that this
+  file's content assumes or builds on another.
+
+```yaml
+depends_on: [thermal-physics.md, conductor-limits.md]
+```
+
+Use bare filenames (not paths). All knowledge files live in `docs/knowledge/`,
+so paths are implicit.
+
+### implementation_status
+
+- **Type:** enum string
+- **Valid values:** `in-progress` | `stable` | `deprecated`
+- **Default:** omit if stable (absence implies stable)
+- **Purpose:** Signals whether the knowledge reflects current, evolving, or
+  obsolete state.
+
+```yaml
+implementation_status: in-progress
+```
+
+| Value | Meaning |
+|-------|---------|
+| `in-progress` | Knowledge is being actively developed or the code it covers is in flux |
+| `stable` | Knowledge is current and verified |
+| `deprecated` | Knowledge is outdated; the domain or code has moved on |
+
+## Complete Example
+
+```yaml
+---
+topics: [engine-registry, strategy-pattern, pipeline]
+last_reviewed: 2026-03-14
+covers:
+  - "src/pipeline/registry.py"
+  - "src/models/engine_*.py"
+  - "src/pipeline/strategies/**/*.py"
+consumers: [backend, power-systems]
+depends_on: [thermal-physics.md]
+implementation_status: stable
+---
+
+# Engine Registry
+
+Domain rules for the engine registration and strategy selection system.
+
+## Key Rules
+
+- All engines must register via `EngineRegistry.register()`
+- Strategy selection is deterministic given the same input parameters
+- ...
+```
+
+## Common Mistakes
+
+| Mistake | Why It Is Wrong | Fix |
+|---------|-----------------|-----|
+| Missing `topics` | Required for routing; file is invisible to discovery | Add at least one topic |
+| `last_reviewed` in the future | Implies review that has not happened | Use today's date or earlier |
+| `covers: ["src/**"]` | Too broad; every commit triggers staleness | Narrow to specific paths |
+| `depends_on: ["docs/knowledge/foo.md"]` | Uses full path instead of filename | Use `depends_on: [foo.md]` |
+| `implementation_status: done` | Not a valid enum value | Use `stable` |
+| Topics that match code identifiers | Brittle; breaks on rename | Use domain-level terms |

--- a/dist/codex/skills/knowledge-base/references/naming-conventions.md
+++ b/dist/codex/skills/knowledge-base/references/naming-conventions.md
@@ -1,0 +1,57 @@
+# Naming Conventions
+
+Where knowledge files live, how to name them, and how they relate to other
+documentation surfaces. Based on ADR-004.
+
+## Directory Structure
+
+```
+docs/
+├── knowledge/          # Domain knowledge (cross-cutting context, rules)
+│   ├── build-system.md
+│   ├── thermal-physics.md
+│   └── knowledge-management-design.md
+└── decisions/          # Architecture Decision Records (immutable)
+    ├── ADR-001-some-decision.md
+    └── ADR-004-knowledge-naming-convention.md
+```
+
+- `docs/knowledge/` for domain knowledge files
+- `docs/decisions/` for ADRs
+- These directory names are deliberate: `knowledge` and `decisions` are
+  unambiguous, similar in length, and scan well together
+
+## Filename Rules
+
+| Rule | Example | Rationale |
+|------|---------|-----------|
+| Kebab-case | `build-system.md` | Consistent, URL-safe |
+| Descriptive | `thermal-physics.md` | Self-documenting |
+| No date prefixes | `build-system.md` | Knowledge is living; dates imply snapshots |
+| No abbreviations | `knowledge-management-design.md` | Clarity over brevity |
+
+**Contrast with other artifacts that DO use date prefixes:**
+- Sessions: `YYYYMMDD-HHMMSS-session-slug.md`
+- Ideas: `YYYYMMDD-HHMMSS-idea-slug.md`
+
+Knowledge files are living documents, not point-in-time snapshots.
+
+## CLI Abbreviation
+
+Per ADR-004, the CLI uses `kb` for ergonomics:
+
+- `loaf kb check` (not `loaf knowledge check`)
+- `loaf kb validate` (not `loaf knowledge validate`)
+
+The full word `knowledge` is for storage paths (directories, QMD collections).
+The abbreviation `kb` is for typing (CLI commands).
+
+## QMD Collection Naming
+
+When indexed by QMD:
+
+- `{repo-folder}-knowledge` for knowledge files
+- `{repo-folder}-decisions` for ADRs
+
+Example: a repo in `~/Code/gridsight-core-gds/` produces collections
+`gridsight-core-gds-knowledge` and `gridsight-core-gds-decisions`.

--- a/dist/codex/skills/knowledge-base/templates/knowledge-file.md
+++ b/dist/codex/skills/knowledge-base/templates/knowledge-file.md
@@ -1,0 +1,32 @@
+# Knowledge File Template
+
+**Location:** `docs/knowledge/{slug}.md`
+
+```yaml
+---
+topics: []                          # Required (min 1) -- semantic tags for routing
+last_reviewed: YYYY-MM-DD           # Required -- ISO 8601 date of last human review
+covers:                             # Recommended -- glob patterns from git root
+  - "path/to/covered/**/*.ts"
+consumers: []                       # Optional -- agent routing hints
+depends_on: []                      # Optional -- other knowledge file names
+implementation_status: in-progress  # Optional -- in-progress | stable | deprecated
+---
+
+# [Title]
+
+Brief description of what this knowledge covers and why it exists.
+
+## Key Rules
+
+- [Rule 1]
+- [Rule 2]
+
+## [Domain Section]
+
+[Domain-specific content organized by topic]
+
+## Cross-References
+
+- [Related knowledge file or ADR]
+```

--- a/dist/codex/skills/research/SKILL.md
+++ b/dist/codex/skills/research/SKILL.md
@@ -61,7 +61,9 @@ Always check project context first. Rate findings: **High** (official/verified),
 1. **Interview** with AskUserQuestion: what are you trying to understand? What context do you have? What decision will this inform?
 2. Check project context first (ADRs, ARCHITECTURE, sessions)
 3. Apply confidence hierarchy for external sources
-4. Synthesize following [findings template](templates/findings.md)
+4. Create findings document following [findings template](templates/findings.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-research-{slug}.md`
 
 ### Brainstorming
 

--- a/dist/codex/skills/research/templates/findings.md
+++ b/dist/codex/skills/research/templates/findings.md
@@ -1,42 +1,62 @@
-# Research Findings Output Template
+# Research Findings Template
 
-```markdown
-## Research: [Topic]
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-research-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "Research: [Topic]"
+type: research
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active | archived
+tags: []
+related: []            # Optional: spec IDs, idea files, ADRs
+---
+
+# Research: [Topic]
 
 **Question:** [What we're trying to understand]
 
-### Summary
+## Summary
+
 [One-paragraph answer with confidence level]
 
-### Key Findings
+## Key Findings
+
 1. [Finding 1]
 2. [Finding 2]
 
-### Project Context
+## Project Context
+
 [How this relates to our existing decisions/architecture]
 
-### Options Considered
+## Options Considered
 
-#### Option A: [Name]
+### Option A: [Name]
 - **Pros:** ...
 - **Cons:** ...
 - **Best for:** ...
 
-#### Option B: [Name]
+### Option B: [Name]
 - **Pros:** ...
 - **Cons:** ...
 - **Best for:** ...
 
-### Recommendation
+## Recommendation
+
 [Which option and why, with caveats]
 
-### Sources
+## Sources
+
 - [Source 1 with confidence level]
 - [Source 2 with confidence level]
 
-### Implications
+## Implications
+
 - [What this means for our work]
 
-### Open Questions
+## Open Questions
+
 - [What's still unclear]
 ```

--- a/dist/codex/skills/research/templates/state-assessment.md
+++ b/dist/codex/skills/research/templates/state-assessment.md
@@ -1,38 +1,58 @@
-# State Assessment Output Template
+# State Assessment Template
 
-```markdown
-## Project State Assessment
+State assessments are typically presented in-conversation. If saved to a file:
 
-**Date:** YYYY-MM-DD
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-state-assessment.md`
 
-### Current Position
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "State Assessment: [YYYY-MM-DD]"
+type: state-assessment
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active | archived
+tags: []
+---
+
+# Project State Assessment
+
+## Current Position
+
 - [Summary of where the project stands]
 
-### Strategic Context
+## Strategic Context
+
 - **Vision:** [Brief summary]
 - **Key personas:** [Who we're building for]
 - **Current focus:** [Active specs/work]
 
-### Recent Progress
+## Recent Progress
+
 - [Key accomplishments from recent sessions]
 
-### In Flight
+## In Flight
+
 | Spec/Task | Status | Notes |
 |-----------|--------|-------|
 | SPEC-001 | implementing | [progress] |
 | SPEC-002 | approved | [next up] |
 
-### Ideas Pipeline
+## Ideas Pipeline
+
 - [Idea 1] -- raw
 - [Idea 2] -- raw
 
-### Lessons Learned (Recent)
+## Lessons Learned (Recent)
+
 - [Insights from implementation feedback]
 
-### Open Questions
+## Open Questions
+
 - [Unresolved decisions or gaps]
 
-### Recommendations
+## Recommendations
+
 1. [Actionable next step]
 2. [Actionable next step]
 ```

--- a/dist/cursor/hooks.json
+++ b/dist/cursor/hooks.json
@@ -163,17 +163,30 @@
         "command": "bash $HOME/.cursor/hooks/post-tool/orchestration-generate-task-board.sh",
         "timeout": 30,
         "matcher": "Edit|Write"
+      },
+      {
+        "command": "bash $HOME/.cursor/hooks/post-tool/kb-staleness-nudge.sh",
+        "timeout": 30,
+        "matcher": "Edit|Write"
       }
     ],
     "sessionStart": [
       {
         "command": "bash $HOME/.cursor/hooks/session/session-start.sh",
         "timeout": 60
+      },
+      {
+        "command": "bash $HOME/.cursor/hooks/session/kb-session-start.sh",
+        "timeout": 60
       }
     ],
     "sessionEnd": [
       {
         "command": "bash $HOME/.cursor/hooks/session/session-end.sh",
+        "timeout": 60
+      },
+      {
+        "command": "bash $HOME/.cursor/hooks/session/kb-session-end.sh",
         "timeout": 60
       }
     ],

--- a/dist/cursor/hooks/post-tool/kb-staleness-nudge.sh
+++ b/dist/cursor/hooks/post-tool/kb-staleness-nudge.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# KB staleness nudge — alerts when editing files covered by stale knowledge
+# Post-tool hook for Edit|Write
+#
+# Per-session single nudge: each knowledge file mentioned at most once.
+# Tracks nudged files in a temp file keyed on PPID (stable within a session).
+
+set -euo pipefail
+
+# Check if loaf is available
+if ! command -v loaf &>/dev/null; then
+  exit 0
+fi
+
+# Parse the edited file path from TOOL_INPUT JSON
+# TOOL_INPUT contains the tool's input as a JSON string
+if [ -z "${TOOL_INPUT:-}" ]; then
+  exit 0
+fi
+
+# Extract file_path (primary field for Edit/Write tools)
+file_path=$(echo "$TOOL_INPUT" | grep -oE '"file_path"[[:space:]]*:[[:space:]]*"[^"]+"' | sed 's/.*: *"//' | sed 's/"$//' || true)
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+# Check which knowledge files cover this path
+result=$(loaf kb check --file "$file_path" --json 2>/dev/null || true)
+if [ -z "$result" ] || [ "$result" = "[]" ]; then
+  exit 0
+fi
+
+# Track already-nudged files per session
+# PPID is the parent process (Claude Code), stable across hook invocations in one session
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+nudge_file="/tmp/loaf-kb-nudged-${PPID}-$(echo "$PROJECT_DIR" | md5sum 2>/dev/null | cut -c1-8 || echo "$PROJECT_DIR" | md5 2>/dev/null | cut -c1-8 || echo "default")"
+
+# The JSON output is an array of objects with "file", "isStale", etc.
+# Parse each entry: look for "file":"..." and "isStale":true pairs
+# Process line-by-line, tracking the current object's fields
+current_file=""
+current_stale=""
+
+while IFS= read -r line; do
+  # Detect file field
+  f=$(echo "$line" | grep -o '"file":[[:space:]]*"[^"]*"' | sed 's/"file":[[:space:]]*"//;s/"$//' || true)
+  if [ -n "$f" ]; then
+    current_file="$f"
+  fi
+
+  # Detect isStale field
+  s=$(echo "$line" | grep -o '"isStale":[[:space:]]*true' || true)
+  if [ -n "$s" ]; then
+    current_stale="true"
+  fi
+
+  # Reset on isStale: false
+  sf=$(echo "$line" | grep -o '"isStale":[[:space:]]*false' || true)
+  if [ -n "$sf" ]; then
+    current_stale=""
+  fi
+
+  # On closing brace, check if we have a stale file to report
+  if echo "$line" | grep -q '}'; then
+    if [ -n "$current_stale" ] && [ -n "$current_file" ]; then
+      # Check if already nudged this session
+      if [ -f "$nudge_file" ] && grep -qF "$current_file" "$nudge_file"; then
+        # Already nudged, skip
+        :
+      else
+        # Record as nudged
+        echo "$current_file" >> "$nudge_file"
+        echo "Knowledge file \`$current_file\` covers this code and may be stale. Consider reviewing with \`loaf kb review $current_file\`."
+      fi
+    fi
+    current_file=""
+    current_stale=""
+  fi
+done <<< "$result"
+
+exit 0

--- a/dist/cursor/hooks/session/kb-session-end.sh
+++ b/dist/cursor/hooks/session/kb-session-end.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Hook: KB consolidation prompt (INFORMATIONAL)
+# SessionEnd hook - reminds about stale knowledge at session end
+#
+# Reads the nudge tracking file created by kb-staleness-nudge post-tool hook
+# and reports how many stale knowledge files were flagged during the session
+
+# Match the nudge file key from the post-tool hook
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+nudge_file="/tmp/loaf-kb-nudged-${PPID}-$(echo "$PROJECT_DIR" | md5sum 2>/dev/null | cut -c1-8 || echo "$PROJECT_DIR" | md5 2>/dev/null | cut -c1-8 || echo "default")"
+
+if [ ! -f "$nudge_file" ]; then
+  exit 0
+fi
+
+# Read the list of nudged files before cleanup
+nudged_files=()
+while IFS= read -r line; do
+  [ -n "$line" ] && nudged_files+=("$line")
+done < "$nudge_file"
+
+# Clean up the tracking file
+rm -f "$nudge_file"
+
+nudged_count=${#nudged_files[@]}
+
+if [ "$nudged_count" -gt 0 ]; then
+  echo ""
+  echo "## Knowledge Base"
+  echo ""
+  echo "**${nudged_count}** stale knowledge file(s) were flagged during this session:"
+  echo ""
+  for f in "${nudged_files[@]}"; do
+    echo "- \`$f\`"
+  done
+  echo ""
+  echo "Run \`loaf kb check\` to review or \`loaf kb review <file>\` to mark as reviewed."
+fi
+
+exit 0

--- a/dist/cursor/hooks/session/kb-session-start.sh
+++ b/dist/cursor/hooks/session/kb-session-start.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Hook: KB staleness advisory (INFORMATIONAL)
+# SessionStart hook - surfaces stale knowledge count at session start
+#
+# Triggers on session start
+# Displays count of stale knowledge files if any exist
+
+# Check if loaf is available
+if ! command -v loaf &>/dev/null; then
+  exit 0
+fi
+
+# Get KB status as JSON
+status=$(loaf kb status --json 2>/dev/null)
+if [ $? -ne 0 ] || [ -z "$status" ]; then
+  exit 0
+fi
+
+# Extract counts from JSON (no jq dependency)
+# JSON fields: total_files, stale
+stale=$(echo "$status" | grep -o '"stale":[[:space:]]*[0-9]*' | grep -o '[0-9]*$')
+total=$(echo "$status" | grep -o '"total_files":[[:space:]]*[0-9]*' | grep -o '[0-9]*$')
+
+if [ -z "$stale" ] || [ "$stale" = "0" ]; then
+  exit 0
+fi
+
+echo ""
+echo "## Knowledge Base"
+echo ""
+echo "**${total}** knowledge files tracked. **${stale}** stale."
+echo ""
+echo "Run \`loaf kb check\` for details or \`loaf kb review <file>\` to mark reviewed."
+
+exit 0

--- a/dist/cursor/skills/brainstorm/SKILL.md
+++ b/dist/cursor/skills/brainstorm/SKILL.md
@@ -44,8 +44,10 @@ Unlike `/idea` (quick capture) or `/shape` (rigorous bounding), brainstorming is
 2. Gather context: VISION.md, STRATEGY.md, ARCHITECTURE.md, related ideas
 3. **Deep exploration**: ask about user value, problem depth, alternatives, risks, dependencies, scope (minimal vs maximal)
 4. Generate options: conventional, minimal, ambitious, contrarian approaches
-5. Document with core insight, explored directions (approach/pros/cons), open questions, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](templates/brainstorm.md)
 6. Update idea file status if proceeding
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Problem Exploration
 
@@ -53,7 +55,9 @@ Unlike `/idea` (quick capture) or `/shape` (rigorous bounding), brainstorming is
 2. Gather strategic context
 3. **Diverge**: first principles, inversion, analogy, extreme constraints, persona lens
 4. **Converge**: filter by strategy alignment, feasibility, value
-5. Document with problem statement, options, analysis, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](templates/brainstorm.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Open Brainstorm
 

--- a/dist/cursor/skills/brainstorm/templates/brainstorm.md
+++ b/dist/cursor/skills/brainstorm/templates/brainstorm.md
@@ -1,0 +1,43 @@
+# Brainstorm Document Template
+
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "Brainstorm: [Topic]"
+type: brainstorm
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active (has unprocessed sparks) | archived
+tags: []
+related: []            # Optional: idea files, spec IDs, session files
+---
+
+# Brainstorm: [Topic]
+
+**Date:** YYYY-MM-DD
+**Session:** [Brief description of session scope]
+
+## Session Journey
+
+[How the brainstorm evolved -- pivots, reframes, key realizations]
+
+## [Main Content Sections]
+
+[Organized by the brainstorm's natural structure -- options explored,
+analysis, trade-offs, convergence points]
+
+## Recommendation
+
+[If applicable -- the direction that emerged]
+
+## Open Questions
+
+- [Unresolved questions for further exploration]
+
+## Sparks
+
+- **[Title]** -- [one-line description]
+- **[Title]** -- [one-line description]
+```

--- a/dist/cursor/skills/breakdown/SKILL.md
+++ b/dist/cursor/skills/breakdown/SKILL.md
@@ -77,17 +77,24 @@ Extract: test conditions, scope, implementation notes, appetite.
 
 Break down by concern (DBA, Backend, Frontend, QA, DevOps). One concern per task. Explicit dependencies for sequential tasks.
 
-### Step 4: Interview for Priorities
+### Step 4: Decide Priorities and Granularity
 
-Ask about highest priority parts, required ordering, preferred implementation sequence.
+Own the granularity and priority decisions. Apply the Right Size Test, assign priorities
+based on dependencies and circuit breaker alignment, and do a self-review pass. Do not
+defer these decisions to the user — they trust agent judgment here.
+
+If genuinely uncertain (e.g., two equally valid orderings with different trade-offs),
+ask. Otherwise, decide and move on.
 
 ### Step 5: Draft Task List
 
 Create tasks following [task template](templates/task.md). Each task needs: clear title, priority, file hints, verification command, observable done condition.
 
-### Step 6: Present for Approval
+### Step 6: Present and Create
 
-Show tasks with priorities, dependencies, and dependency graph. **Do NOT create tasks without explicit approval.** User may adjust priorities, combine/split, add tasks, or change dependencies.
+Show the dependency graph and task summary for awareness, then create the tasks.
+Present it as "here's what I'm creating" not "which option do you prefer?" The user
+can still adjust after creation, but the default is to proceed.
 
 ### Step 7: Create Tasks
 
@@ -118,7 +125,7 @@ Set spec status to `implementing`. Announce created tasks with next steps.
 2. **Clear verification** -- how to prove it works
 3. **Observable done condition** -- not subjective
 4. **File hints** -- help session know where to look
-5. **Get approval** -- don't create without confirmation
+5. **Own the decisions** -- decide granularity and priorities, don't defer
 6. **Update spec status** -- mark as implementing
 
 ---

--- a/dist/cursor/skills/idea/SKILL.md
+++ b/dist/cursor/skills/idea/SKILL.md
@@ -29,7 +29,7 @@ Ideas are raw nuggets -- unprocessed, unshaped, but worth remembering. The goal 
 If `$ARGUMENTS` contains the idea, capture directly.
 
 If `$ARGUMENTS` is empty, **scan for sparks** in brainstorm documents:
-1. Search `.agents/drafts/brainstorm-*.md` for `## Sparks` sections
+1. Search `.agents/drafts/*brainstorm*.md` for `## Sparks` sections
 2. List unprocessed sparks (not marked as promoted or abandoned)
 3. Present the list and let the user pick one to promote
 4. When promoting: create idea file with `origin:` field, mark spark as `*(promoted)*` in source document
@@ -40,7 +40,7 @@ If no sparks found and no arguments, ask **at most 2-3 questions**: core idea, p
 
 Create file in `.agents/ideas/` following [idea template](templates/idea.md).
 
-**Filename:** `{YYYYMMDD}-{slug}.md`
+**Filename:** `{YYYYMMDD}-{HHMMSS}-{slug}.md`
 
 ### Step 3: Create and Announce
 

--- a/dist/cursor/skills/idea/templates/idea.md
+++ b/dist/cursor/skills/idea/templates/idea.md
@@ -1,13 +1,17 @@
 # Idea File Template
 
-**Location:** `.agents/ideas/{YYYYMMDD}-{slug}.md`
+**Location:** `.agents/ideas/{YYYYMMDD}-{HHMMSS}-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
 
 ```yaml
 ---
+title: "[Idea Title]"
 captured: YYYY-MM-DDTHH:MM:SSZ
 status: raw
 tags: []
-origin:              # Optional: brainstorm document this spark came from
+related: []            # Optional: spec IDs, file paths, or other idea files
+origin:                # Optional: brainstorm document this spark came from
 ---
 
 # [Idea Title]

--- a/dist/cursor/skills/knowledge-base/SKILL.md
+++ b/dist/cursor/skills/knowledge-base/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: knowledge-base
+description: >-
+  Provides guidance for creating, updating, and reviewing project knowledge
+  files. Covers frontmatter schema, naming conventions, staleness detection via
+  covers: field, and the review workflow. Use when creating new knowledge files,
+  updating existing ones, or when the agent needs to understand knowledge
+  management conventions. Not for retrieval or search (use QMD directly). Not
+  for architectural decisions (use ADRs). Not for agent instructions (use
+  CLAUDE.md).
+version: 2.0.0-dev.0
+---
+
+# Knowledge Base
+
+Conventions and workflows for managing project knowledge files -- structured
+domain knowledge that lives in `docs/knowledge/` and persists across sessions.
+
+## Contents
+- When to Create a Knowledge File
+- Topics
+- The covers: Field
+- Review Workflow
+- What Goes Where
+- Critical Rules
+
+## When to Create a Knowledge File
+
+Create a knowledge file when information:
+
+1. **Requires context beyond the code** -- domain rules, business logic constraints,
+   cross-cutting patterns that cannot be expressed in types or docstrings
+2. **Spans multiple files or modules** -- conventions or contracts that apply across
+   the codebase, not localized to one function
+3. **Would be lost between sessions** -- insights that an agent needs repeatedly but
+   cannot derive from code alone
+4. **Serves as extended agent memory** -- roadmap context, implementation plans,
+   strategic direction that informs decisions
+
+Do NOT create knowledge files for:
+- Self-documenting code (types, docstrings, comments are sufficient)
+- One-off architectural decisions (write an ADR instead)
+- Agent behavior instructions (put those in CLAUDE.md)
+- User preferences or session pointers (those belong in MEMORY.md)
+
+## Topics
+
+| Topic | Reference | Use When |
+|-------|-----------|----------|
+| Frontmatter Schema | [frontmatter-schema.md](references/frontmatter-schema.md) | Creating or validating knowledge file frontmatter |
+| Naming Conventions | [naming-conventions.md](references/naming-conventions.md) | Deciding where to put knowledge and what to name it |
+
+| Template | Use When |
+|----------|----------|
+| [knowledge-file.md](templates/knowledge-file.md) | Creating a new knowledge file from scratch |
+
+## The covers: Field
+
+The `covers:` field is the core innovation of the knowledge management system.
+It links knowledge to code paths via glob patterns, enabling automatic staleness
+detection.
+
+### How It Works
+
+1. Author declares `covers:` globs in knowledge file frontmatter
+2. Globs resolve from the git repository root
+3. `loaf kb check` queries `git log --since={last_reviewed}` for matching files
+4. If commits exist since last review, the knowledge file is flagged as potentially stale
+
+### Good covers: Patterns
+
+```yaml
+covers:
+  - "src/pipeline/registry.py"          # Specific file
+  - "src/models/engine_*.py"            # Wildcard within directory
+  - "src/thermal/**/*.py"               # Recursive directory
+```
+
+### Patterns to Avoid
+
+```yaml
+covers:
+  - "src/**"                            # Too broad -- constant false positives
+  - "**/*.py"                           # Covers everything, means nothing
+  - "*.md"                              # Documentation changes != knowledge staleness
+```
+
+The goal is precision: cover the code paths whose changes would actually
+invalidate the knowledge. Broad globs lead to alert fatigue.
+
+### When to Omit covers:
+
+Files without `covers:` are valid knowledge files but cannot use automated
+staleness detection. Omit `covers:` when:
+
+- The knowledge is purely conceptual (no specific code paths)
+- The file covers external domain rules not tied to implementation
+- You are unsure which paths to cover (add them later when the mapping is clear)
+
+## Review Workflow
+
+### Check What Is Stale
+
+```bash
+loaf kb check
+```
+
+Shows knowledge files where covered code paths have changed since `last_reviewed`.
+
+### Validate Frontmatter
+
+```bash
+loaf kb validate
+```
+
+Checks all knowledge files for valid frontmatter: required fields present,
+correct types, valid glob patterns.
+
+### Review a File
+
+```bash
+loaf kb review <file>
+```
+
+After reading and updating a knowledge file, mark it as reviewed. This updates
+the `last_reviewed` date to today.
+
+### Overview
+
+```bash
+loaf kb status
+```
+
+Summary of all knowledge files: total count, stale count, files missing
+`covers:`, last review dates.
+
+## What Goes Where
+
+| Surface | Contains | Decision Test |
+|---------|----------|---------------|
+| **Code** (docstrings, types) | What the code does | Is it self-documenting? |
+| **Knowledge files** | Domain rules, cross-cutting context, roadmap | Requires context beyond the code? |
+| **ADRs** | Why we chose this approach | Is it an architectural decision? |
+| **CLAUDE.md** | Agent instructions, conventions | Is it about how agents should behave? |
+| **MEMORY.md** | User preferences, session pointers | Is it personal or ephemeral? |
+
+CLAUDE.md may reference knowledge files but should never duplicate their content.
+
+For the authoritative design document covering the full knowledge management
+system (QMD integration, growth loops, cross-project sharing), see
+`docs/knowledge/knowledge-management-design.md`.
+
+## Critical Rules
+
+### Always
+- Include `topics` (min 1) and `last_reviewed` in frontmatter
+- Use kebab-case filenames in `docs/knowledge/`
+- Add `covers:` globs when the knowledge maps to specific code paths
+- Run `loaf kb validate` before committing new knowledge files
+- Mark files reviewed with `loaf kb review` after updating
+
+### Never
+- Duplicate code documentation in knowledge files
+- Use date prefixes on knowledge filenames (unlike sessions or ideas)
+- Use overly broad `covers:` globs that trigger constant staleness alerts
+- Skip the `last_reviewed` field -- it is required for the lifecycle to work
+- Store knowledge files outside `docs/knowledge/` (ADRs go in `docs/decisions/`)

--- a/dist/cursor/skills/knowledge-base/references/frontmatter-schema.md
+++ b/dist/cursor/skills/knowledge-base/references/frontmatter-schema.md
@@ -1,0 +1,147 @@
+# Frontmatter Schema
+
+Detailed reference for knowledge file YAML frontmatter.
+
+## Contents
+- Required Fields
+- Recommended Fields
+- Optional Fields
+- Complete Example
+- Common Mistakes
+
+## Required Fields
+
+### topics
+
+- **Type:** list of strings (min 1)
+- **Purpose:** Semantic tags for routing and discovery. Agents and QMD use these
+  to find relevant knowledge files.
+
+```yaml
+topics: [engine-registry, strategy-pattern]
+```
+
+Choose tags that are specific enough to be useful for routing but general enough
+to remain stable as the codebase evolves. Prefer domain terms over implementation
+terms (e.g., `thermal-physics` over `heat-calc-module`).
+
+### last_reviewed
+
+- **Type:** string, ISO 8601 date (YYYY-MM-DD)
+- **Purpose:** Records when a human last verified the file's accuracy. Used by
+  `loaf kb check` to determine staleness.
+
+```yaml
+last_reviewed: 2026-03-14
+```
+
+Update this field only after genuinely reviewing the content -- do not bump it
+during routine edits that do not involve verification. Use `loaf kb review <file>`
+to update it properly.
+
+## Recommended Fields
+
+### covers
+
+- **Type:** list of glob strings
+- **Purpose:** Links knowledge to code paths. Globs resolve from the git
+  repository root. Enables automatic staleness detection.
+
+```yaml
+covers:
+  - "src/pipeline/registry.py"
+  - "src/models/engine_*.py"
+```
+
+**Glob resolution rules:**
+- Paths are relative to the git root (not the knowledge file location)
+- Standard glob syntax: `*` matches within a directory, `**` matches recursively
+- Patterns that match no files are silently ignored (but may indicate drift)
+
+**Precision guidelines:**
+- Cover the specific files whose changes would invalidate this knowledge
+- Avoid `src/**` or `**/*.py` -- too broad, causes alert fatigue
+- When unsure, start narrow and widen as you learn which paths matter
+
+## Optional Fields
+
+### consumers
+
+- **Type:** list of strings
+- **Purpose:** Agent routing hints. Indicates which agents or roles should be
+  aware of this knowledge.
+
+```yaml
+consumers: [backend, power-systems]
+```
+
+Values are freeform but should correspond to agent names or plugin-group names
+from `hooks.yaml`.
+
+### depends_on
+
+- **Type:** list of strings (filenames)
+- **Purpose:** Cross-references to other knowledge files. Indicates that this
+  file's content assumes or builds on another.
+
+```yaml
+depends_on: [thermal-physics.md, conductor-limits.md]
+```
+
+Use bare filenames (not paths). All knowledge files live in `docs/knowledge/`,
+so paths are implicit.
+
+### implementation_status
+
+- **Type:** enum string
+- **Valid values:** `in-progress` | `stable` | `deprecated`
+- **Default:** omit if stable (absence implies stable)
+- **Purpose:** Signals whether the knowledge reflects current, evolving, or
+  obsolete state.
+
+```yaml
+implementation_status: in-progress
+```
+
+| Value | Meaning |
+|-------|---------|
+| `in-progress` | Knowledge is being actively developed or the code it covers is in flux |
+| `stable` | Knowledge is current and verified |
+| `deprecated` | Knowledge is outdated; the domain or code has moved on |
+
+## Complete Example
+
+```yaml
+---
+topics: [engine-registry, strategy-pattern, pipeline]
+last_reviewed: 2026-03-14
+covers:
+  - "src/pipeline/registry.py"
+  - "src/models/engine_*.py"
+  - "src/pipeline/strategies/**/*.py"
+consumers: [backend, power-systems]
+depends_on: [thermal-physics.md]
+implementation_status: stable
+---
+
+# Engine Registry
+
+Domain rules for the engine registration and strategy selection system.
+
+## Key Rules
+
+- All engines must register via `EngineRegistry.register()`
+- Strategy selection is deterministic given the same input parameters
+- ...
+```
+
+## Common Mistakes
+
+| Mistake | Why It Is Wrong | Fix |
+|---------|-----------------|-----|
+| Missing `topics` | Required for routing; file is invisible to discovery | Add at least one topic |
+| `last_reviewed` in the future | Implies review that has not happened | Use today's date or earlier |
+| `covers: ["src/**"]` | Too broad; every commit triggers staleness | Narrow to specific paths |
+| `depends_on: ["docs/knowledge/foo.md"]` | Uses full path instead of filename | Use `depends_on: [foo.md]` |
+| `implementation_status: done` | Not a valid enum value | Use `stable` |
+| Topics that match code identifiers | Brittle; breaks on rename | Use domain-level terms |

--- a/dist/cursor/skills/knowledge-base/references/naming-conventions.md
+++ b/dist/cursor/skills/knowledge-base/references/naming-conventions.md
@@ -1,0 +1,57 @@
+# Naming Conventions
+
+Where knowledge files live, how to name them, and how they relate to other
+documentation surfaces. Based on ADR-004.
+
+## Directory Structure
+
+```
+docs/
+├── knowledge/          # Domain knowledge (cross-cutting context, rules)
+│   ├── build-system.md
+│   ├── thermal-physics.md
+│   └── knowledge-management-design.md
+└── decisions/          # Architecture Decision Records (immutable)
+    ├── ADR-001-some-decision.md
+    └── ADR-004-knowledge-naming-convention.md
+```
+
+- `docs/knowledge/` for domain knowledge files
+- `docs/decisions/` for ADRs
+- These directory names are deliberate: `knowledge` and `decisions` are
+  unambiguous, similar in length, and scan well together
+
+## Filename Rules
+
+| Rule | Example | Rationale |
+|------|---------|-----------|
+| Kebab-case | `build-system.md` | Consistent, URL-safe |
+| Descriptive | `thermal-physics.md` | Self-documenting |
+| No date prefixes | `build-system.md` | Knowledge is living; dates imply snapshots |
+| No abbreviations | `knowledge-management-design.md` | Clarity over brevity |
+
+**Contrast with other artifacts that DO use date prefixes:**
+- Sessions: `YYYYMMDD-HHMMSS-session-slug.md`
+- Ideas: `YYYYMMDD-HHMMSS-idea-slug.md`
+
+Knowledge files are living documents, not point-in-time snapshots.
+
+## CLI Abbreviation
+
+Per ADR-004, the CLI uses `kb` for ergonomics:
+
+- `loaf kb check` (not `loaf knowledge check`)
+- `loaf kb validate` (not `loaf knowledge validate`)
+
+The full word `knowledge` is for storage paths (directories, QMD collections).
+The abbreviation `kb` is for typing (CLI commands).
+
+## QMD Collection Naming
+
+When indexed by QMD:
+
+- `{repo-folder}-knowledge` for knowledge files
+- `{repo-folder}-decisions` for ADRs
+
+Example: a repo in `~/Code/gridsight-core-gds/` produces collections
+`gridsight-core-gds-knowledge` and `gridsight-core-gds-decisions`.

--- a/dist/cursor/skills/knowledge-base/templates/knowledge-file.md
+++ b/dist/cursor/skills/knowledge-base/templates/knowledge-file.md
@@ -1,0 +1,32 @@
+# Knowledge File Template
+
+**Location:** `docs/knowledge/{slug}.md`
+
+```yaml
+---
+topics: []                          # Required (min 1) -- semantic tags for routing
+last_reviewed: YYYY-MM-DD           # Required -- ISO 8601 date of last human review
+covers:                             # Recommended -- glob patterns from git root
+  - "path/to/covered/**/*.ts"
+consumers: []                       # Optional -- agent routing hints
+depends_on: []                      # Optional -- other knowledge file names
+implementation_status: in-progress  # Optional -- in-progress | stable | deprecated
+---
+
+# [Title]
+
+Brief description of what this knowledge covers and why it exists.
+
+## Key Rules
+
+- [Rule 1]
+- [Rule 2]
+
+## [Domain Section]
+
+[Domain-specific content organized by topic]
+
+## Cross-References
+
+- [Related knowledge file or ADR]
+```

--- a/dist/cursor/skills/research/SKILL.md
+++ b/dist/cursor/skills/research/SKILL.md
@@ -61,7 +61,9 @@ Always check project context first. Rate findings: **High** (official/verified),
 1. **Interview** with AskUserQuestion: what are you trying to understand? What context do you have? What decision will this inform?
 2. Check project context first (ADRs, ARCHITECTURE, sessions)
 3. Apply confidence hierarchy for external sources
-4. Synthesize following [findings template](templates/findings.md)
+4. Create findings document following [findings template](templates/findings.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-research-{slug}.md`
 
 ### Brainstorming
 

--- a/dist/cursor/skills/research/templates/findings.md
+++ b/dist/cursor/skills/research/templates/findings.md
@@ -1,42 +1,62 @@
-# Research Findings Output Template
+# Research Findings Template
 
-```markdown
-## Research: [Topic]
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-research-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "Research: [Topic]"
+type: research
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active | archived
+tags: []
+related: []            # Optional: spec IDs, idea files, ADRs
+---
+
+# Research: [Topic]
 
 **Question:** [What we're trying to understand]
 
-### Summary
+## Summary
+
 [One-paragraph answer with confidence level]
 
-### Key Findings
+## Key Findings
+
 1. [Finding 1]
 2. [Finding 2]
 
-### Project Context
+## Project Context
+
 [How this relates to our existing decisions/architecture]
 
-### Options Considered
+## Options Considered
 
-#### Option A: [Name]
+### Option A: [Name]
 - **Pros:** ...
 - **Cons:** ...
 - **Best for:** ...
 
-#### Option B: [Name]
+### Option B: [Name]
 - **Pros:** ...
 - **Cons:** ...
 - **Best for:** ...
 
-### Recommendation
+## Recommendation
+
 [Which option and why, with caveats]
 
-### Sources
+## Sources
+
 - [Source 1 with confidence level]
 - [Source 2 with confidence level]
 
-### Implications
+## Implications
+
 - [What this means for our work]
 
-### Open Questions
+## Open Questions
+
 - [What's still unclear]
 ```

--- a/dist/cursor/skills/research/templates/state-assessment.md
+++ b/dist/cursor/skills/research/templates/state-assessment.md
@@ -1,38 +1,58 @@
-# State Assessment Output Template
+# State Assessment Template
 
-```markdown
-## Project State Assessment
+State assessments are typically presented in-conversation. If saved to a file:
 
-**Date:** YYYY-MM-DD
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-state-assessment.md`
 
-### Current Position
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "State Assessment: [YYYY-MM-DD]"
+type: state-assessment
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active | archived
+tags: []
+---
+
+# Project State Assessment
+
+## Current Position
+
 - [Summary of where the project stands]
 
-### Strategic Context
+## Strategic Context
+
 - **Vision:** [Brief summary]
 - **Key personas:** [Who we're building for]
 - **Current focus:** [Active specs/work]
 
-### Recent Progress
+## Recent Progress
+
 - [Key accomplishments from recent sessions]
 
-### In Flight
+## In Flight
+
 | Spec/Task | Status | Notes |
 |-----------|--------|-------|
 | SPEC-001 | implementing | [progress] |
 | SPEC-002 | approved | [next up] |
 
-### Ideas Pipeline
+## Ideas Pipeline
+
 - [Idea 1] -- raw
 - [Idea 2] -- raw
 
-### Lessons Learned (Recent)
+## Lessons Learned (Recent)
+
 - [Insights from implementation feedback]
 
-### Open Questions
+## Open Questions
+
 - [Unresolved decisions or gaps]
 
-### Recommendations
+## Recommendations
+
 1. [Actionable next step]
 2. [Actionable next step]
 ```

--- a/dist/gemini/skills/brainstorm/SKILL.md
+++ b/dist/gemini/skills/brainstorm/SKILL.md
@@ -44,8 +44,10 @@ Unlike `/idea` (quick capture) or `/shape` (rigorous bounding), brainstorming is
 2. Gather context: VISION.md, STRATEGY.md, ARCHITECTURE.md, related ideas
 3. **Deep exploration**: ask about user value, problem depth, alternatives, risks, dependencies, scope (minimal vs maximal)
 4. Generate options: conventional, minimal, ambitious, contrarian approaches
-5. Document with core insight, explored directions (approach/pros/cons), open questions, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](templates/brainstorm.md)
 6. Update idea file status if proceeding
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Problem Exploration
 
@@ -53,7 +55,9 @@ Unlike `/idea` (quick capture) or `/shape` (rigorous bounding), brainstorming is
 2. Gather strategic context
 3. **Diverge**: first principles, inversion, analogy, extreme constraints, persona lens
 4. **Converge**: filter by strategy alignment, feasibility, value
-5. Document with problem statement, options, analysis, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](templates/brainstorm.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Open Brainstorm
 

--- a/dist/gemini/skills/brainstorm/templates/brainstorm.md
+++ b/dist/gemini/skills/brainstorm/templates/brainstorm.md
@@ -1,0 +1,43 @@
+# Brainstorm Document Template
+
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "Brainstorm: [Topic]"
+type: brainstorm
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active (has unprocessed sparks) | archived
+tags: []
+related: []            # Optional: idea files, spec IDs, session files
+---
+
+# Brainstorm: [Topic]
+
+**Date:** YYYY-MM-DD
+**Session:** [Brief description of session scope]
+
+## Session Journey
+
+[How the brainstorm evolved -- pivots, reframes, key realizations]
+
+## [Main Content Sections]
+
+[Organized by the brainstorm's natural structure -- options explored,
+analysis, trade-offs, convergence points]
+
+## Recommendation
+
+[If applicable -- the direction that emerged]
+
+## Open Questions
+
+- [Unresolved questions for further exploration]
+
+## Sparks
+
+- **[Title]** -- [one-line description]
+- **[Title]** -- [one-line description]
+```

--- a/dist/gemini/skills/breakdown/SKILL.md
+++ b/dist/gemini/skills/breakdown/SKILL.md
@@ -77,17 +77,24 @@ Extract: test conditions, scope, implementation notes, appetite.
 
 Break down by concern (DBA, Backend, Frontend, QA, DevOps). One concern per task. Explicit dependencies for sequential tasks.
 
-### Step 4: Interview for Priorities
+### Step 4: Decide Priorities and Granularity
 
-Ask about highest priority parts, required ordering, preferred implementation sequence.
+Own the granularity and priority decisions. Apply the Right Size Test, assign priorities
+based on dependencies and circuit breaker alignment, and do a self-review pass. Do not
+defer these decisions to the user — they trust agent judgment here.
+
+If genuinely uncertain (e.g., two equally valid orderings with different trade-offs),
+ask. Otherwise, decide and move on.
 
 ### Step 5: Draft Task List
 
 Create tasks following [task template](templates/task.md). Each task needs: clear title, priority, file hints, verification command, observable done condition.
 
-### Step 6: Present for Approval
+### Step 6: Present and Create
 
-Show tasks with priorities, dependencies, and dependency graph. **Do NOT create tasks without explicit approval.** User may adjust priorities, combine/split, add tasks, or change dependencies.
+Show the dependency graph and task summary for awareness, then create the tasks.
+Present it as "here's what I'm creating" not "which option do you prefer?" The user
+can still adjust after creation, but the default is to proceed.
 
 ### Step 7: Create Tasks
 
@@ -118,7 +125,7 @@ Set spec status to `implementing`. Announce created tasks with next steps.
 2. **Clear verification** -- how to prove it works
 3. **Observable done condition** -- not subjective
 4. **File hints** -- help session know where to look
-5. **Get approval** -- don't create without confirmation
+5. **Own the decisions** -- decide granularity and priorities, don't defer
 6. **Update spec status** -- mark as implementing
 
 ---

--- a/dist/gemini/skills/idea/SKILL.md
+++ b/dist/gemini/skills/idea/SKILL.md
@@ -29,7 +29,7 @@ Ideas are raw nuggets -- unprocessed, unshaped, but worth remembering. The goal 
 If `$ARGUMENTS` contains the idea, capture directly.
 
 If `$ARGUMENTS` is empty, **scan for sparks** in brainstorm documents:
-1. Search `.agents/drafts/brainstorm-*.md` for `## Sparks` sections
+1. Search `.agents/drafts/*brainstorm*.md` for `## Sparks` sections
 2. List unprocessed sparks (not marked as promoted or abandoned)
 3. Present the list and let the user pick one to promote
 4. When promoting: create idea file with `origin:` field, mark spark as `*(promoted)*` in source document
@@ -40,7 +40,7 @@ If no sparks found and no arguments, ask **at most 2-3 questions**: core idea, p
 
 Create file in `.agents/ideas/` following [idea template](templates/idea.md).
 
-**Filename:** `{YYYYMMDD}-{slug}.md`
+**Filename:** `{YYYYMMDD}-{HHMMSS}-{slug}.md`
 
 ### Step 3: Create and Announce
 

--- a/dist/gemini/skills/idea/templates/idea.md
+++ b/dist/gemini/skills/idea/templates/idea.md
@@ -1,13 +1,17 @@
 # Idea File Template
 
-**Location:** `.agents/ideas/{YYYYMMDD}-{slug}.md`
+**Location:** `.agents/ideas/{YYYYMMDD}-{HHMMSS}-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
 
 ```yaml
 ---
+title: "[Idea Title]"
 captured: YYYY-MM-DDTHH:MM:SSZ
 status: raw
 tags: []
-origin:              # Optional: brainstorm document this spark came from
+related: []            # Optional: spec IDs, file paths, or other idea files
+origin:                # Optional: brainstorm document this spark came from
 ---
 
 # [Idea Title]

--- a/dist/gemini/skills/knowledge-base/SKILL.md
+++ b/dist/gemini/skills/knowledge-base/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: knowledge-base
+description: >-
+  Provides guidance for creating, updating, and reviewing project knowledge
+  files. Covers frontmatter schema, naming conventions, staleness detection via
+  covers: field, and the review workflow. Use when creating new knowledge files,
+  updating existing ones, or when the agent needs to understand knowledge
+  management conventions. Not for retrieval or search (use QMD directly). Not
+  for architectural decisions (use ADRs). Not for agent instructions (use
+  CLAUDE.md).
+version: 2.0.0-dev.0
+---
+
+# Knowledge Base
+
+Conventions and workflows for managing project knowledge files -- structured
+domain knowledge that lives in `docs/knowledge/` and persists across sessions.
+
+## Contents
+- When to Create a Knowledge File
+- Topics
+- The covers: Field
+- Review Workflow
+- What Goes Where
+- Critical Rules
+
+## When to Create a Knowledge File
+
+Create a knowledge file when information:
+
+1. **Requires context beyond the code** -- domain rules, business logic constraints,
+   cross-cutting patterns that cannot be expressed in types or docstrings
+2. **Spans multiple files or modules** -- conventions or contracts that apply across
+   the codebase, not localized to one function
+3. **Would be lost between sessions** -- insights that an agent needs repeatedly but
+   cannot derive from code alone
+4. **Serves as extended agent memory** -- roadmap context, implementation plans,
+   strategic direction that informs decisions
+
+Do NOT create knowledge files for:
+- Self-documenting code (types, docstrings, comments are sufficient)
+- One-off architectural decisions (write an ADR instead)
+- Agent behavior instructions (put those in CLAUDE.md)
+- User preferences or session pointers (those belong in MEMORY.md)
+
+## Topics
+
+| Topic | Reference | Use When |
+|-------|-----------|----------|
+| Frontmatter Schema | [frontmatter-schema.md](references/frontmatter-schema.md) | Creating or validating knowledge file frontmatter |
+| Naming Conventions | [naming-conventions.md](references/naming-conventions.md) | Deciding where to put knowledge and what to name it |
+
+| Template | Use When |
+|----------|----------|
+| [knowledge-file.md](templates/knowledge-file.md) | Creating a new knowledge file from scratch |
+
+## The covers: Field
+
+The `covers:` field is the core innovation of the knowledge management system.
+It links knowledge to code paths via glob patterns, enabling automatic staleness
+detection.
+
+### How It Works
+
+1. Author declares `covers:` globs in knowledge file frontmatter
+2. Globs resolve from the git repository root
+3. `loaf kb check` queries `git log --since={last_reviewed}` for matching files
+4. If commits exist since last review, the knowledge file is flagged as potentially stale
+
+### Good covers: Patterns
+
+```yaml
+covers:
+  - "src/pipeline/registry.py"          # Specific file
+  - "src/models/engine_*.py"            # Wildcard within directory
+  - "src/thermal/**/*.py"               # Recursive directory
+```
+
+### Patterns to Avoid
+
+```yaml
+covers:
+  - "src/**"                            # Too broad -- constant false positives
+  - "**/*.py"                           # Covers everything, means nothing
+  - "*.md"                              # Documentation changes != knowledge staleness
+```
+
+The goal is precision: cover the code paths whose changes would actually
+invalidate the knowledge. Broad globs lead to alert fatigue.
+
+### When to Omit covers:
+
+Files without `covers:` are valid knowledge files but cannot use automated
+staleness detection. Omit `covers:` when:
+
+- The knowledge is purely conceptual (no specific code paths)
+- The file covers external domain rules not tied to implementation
+- You are unsure which paths to cover (add them later when the mapping is clear)
+
+## Review Workflow
+
+### Check What Is Stale
+
+```bash
+loaf kb check
+```
+
+Shows knowledge files where covered code paths have changed since `last_reviewed`.
+
+### Validate Frontmatter
+
+```bash
+loaf kb validate
+```
+
+Checks all knowledge files for valid frontmatter: required fields present,
+correct types, valid glob patterns.
+
+### Review a File
+
+```bash
+loaf kb review <file>
+```
+
+After reading and updating a knowledge file, mark it as reviewed. This updates
+the `last_reviewed` date to today.
+
+### Overview
+
+```bash
+loaf kb status
+```
+
+Summary of all knowledge files: total count, stale count, files missing
+`covers:`, last review dates.
+
+## What Goes Where
+
+| Surface | Contains | Decision Test |
+|---------|----------|---------------|
+| **Code** (docstrings, types) | What the code does | Is it self-documenting? |
+| **Knowledge files** | Domain rules, cross-cutting context, roadmap | Requires context beyond the code? |
+| **ADRs** | Why we chose this approach | Is it an architectural decision? |
+| **CLAUDE.md** | Agent instructions, conventions | Is it about how agents should behave? |
+| **MEMORY.md** | User preferences, session pointers | Is it personal or ephemeral? |
+
+CLAUDE.md may reference knowledge files but should never duplicate their content.
+
+For the authoritative design document covering the full knowledge management
+system (QMD integration, growth loops, cross-project sharing), see
+`docs/knowledge/knowledge-management-design.md`.
+
+## Critical Rules
+
+### Always
+- Include `topics` (min 1) and `last_reviewed` in frontmatter
+- Use kebab-case filenames in `docs/knowledge/`
+- Add `covers:` globs when the knowledge maps to specific code paths
+- Run `loaf kb validate` before committing new knowledge files
+- Mark files reviewed with `loaf kb review` after updating
+
+### Never
+- Duplicate code documentation in knowledge files
+- Use date prefixes on knowledge filenames (unlike sessions or ideas)
+- Use overly broad `covers:` globs that trigger constant staleness alerts
+- Skip the `last_reviewed` field -- it is required for the lifecycle to work
+- Store knowledge files outside `docs/knowledge/` (ADRs go in `docs/decisions/`)

--- a/dist/gemini/skills/knowledge-base/references/frontmatter-schema.md
+++ b/dist/gemini/skills/knowledge-base/references/frontmatter-schema.md
@@ -1,0 +1,147 @@
+# Frontmatter Schema
+
+Detailed reference for knowledge file YAML frontmatter.
+
+## Contents
+- Required Fields
+- Recommended Fields
+- Optional Fields
+- Complete Example
+- Common Mistakes
+
+## Required Fields
+
+### topics
+
+- **Type:** list of strings (min 1)
+- **Purpose:** Semantic tags for routing and discovery. Agents and QMD use these
+  to find relevant knowledge files.
+
+```yaml
+topics: [engine-registry, strategy-pattern]
+```
+
+Choose tags that are specific enough to be useful for routing but general enough
+to remain stable as the codebase evolves. Prefer domain terms over implementation
+terms (e.g., `thermal-physics` over `heat-calc-module`).
+
+### last_reviewed
+
+- **Type:** string, ISO 8601 date (YYYY-MM-DD)
+- **Purpose:** Records when a human last verified the file's accuracy. Used by
+  `loaf kb check` to determine staleness.
+
+```yaml
+last_reviewed: 2026-03-14
+```
+
+Update this field only after genuinely reviewing the content -- do not bump it
+during routine edits that do not involve verification. Use `loaf kb review <file>`
+to update it properly.
+
+## Recommended Fields
+
+### covers
+
+- **Type:** list of glob strings
+- **Purpose:** Links knowledge to code paths. Globs resolve from the git
+  repository root. Enables automatic staleness detection.
+
+```yaml
+covers:
+  - "src/pipeline/registry.py"
+  - "src/models/engine_*.py"
+```
+
+**Glob resolution rules:**
+- Paths are relative to the git root (not the knowledge file location)
+- Standard glob syntax: `*` matches within a directory, `**` matches recursively
+- Patterns that match no files are silently ignored (but may indicate drift)
+
+**Precision guidelines:**
+- Cover the specific files whose changes would invalidate this knowledge
+- Avoid `src/**` or `**/*.py` -- too broad, causes alert fatigue
+- When unsure, start narrow and widen as you learn which paths matter
+
+## Optional Fields
+
+### consumers
+
+- **Type:** list of strings
+- **Purpose:** Agent routing hints. Indicates which agents or roles should be
+  aware of this knowledge.
+
+```yaml
+consumers: [backend, power-systems]
+```
+
+Values are freeform but should correspond to agent names or plugin-group names
+from `hooks.yaml`.
+
+### depends_on
+
+- **Type:** list of strings (filenames)
+- **Purpose:** Cross-references to other knowledge files. Indicates that this
+  file's content assumes or builds on another.
+
+```yaml
+depends_on: [thermal-physics.md, conductor-limits.md]
+```
+
+Use bare filenames (not paths). All knowledge files live in `docs/knowledge/`,
+so paths are implicit.
+
+### implementation_status
+
+- **Type:** enum string
+- **Valid values:** `in-progress` | `stable` | `deprecated`
+- **Default:** omit if stable (absence implies stable)
+- **Purpose:** Signals whether the knowledge reflects current, evolving, or
+  obsolete state.
+
+```yaml
+implementation_status: in-progress
+```
+
+| Value | Meaning |
+|-------|---------|
+| `in-progress` | Knowledge is being actively developed or the code it covers is in flux |
+| `stable` | Knowledge is current and verified |
+| `deprecated` | Knowledge is outdated; the domain or code has moved on |
+
+## Complete Example
+
+```yaml
+---
+topics: [engine-registry, strategy-pattern, pipeline]
+last_reviewed: 2026-03-14
+covers:
+  - "src/pipeline/registry.py"
+  - "src/models/engine_*.py"
+  - "src/pipeline/strategies/**/*.py"
+consumers: [backend, power-systems]
+depends_on: [thermal-physics.md]
+implementation_status: stable
+---
+
+# Engine Registry
+
+Domain rules for the engine registration and strategy selection system.
+
+## Key Rules
+
+- All engines must register via `EngineRegistry.register()`
+- Strategy selection is deterministic given the same input parameters
+- ...
+```
+
+## Common Mistakes
+
+| Mistake | Why It Is Wrong | Fix |
+|---------|-----------------|-----|
+| Missing `topics` | Required for routing; file is invisible to discovery | Add at least one topic |
+| `last_reviewed` in the future | Implies review that has not happened | Use today's date or earlier |
+| `covers: ["src/**"]` | Too broad; every commit triggers staleness | Narrow to specific paths |
+| `depends_on: ["docs/knowledge/foo.md"]` | Uses full path instead of filename | Use `depends_on: [foo.md]` |
+| `implementation_status: done` | Not a valid enum value | Use `stable` |
+| Topics that match code identifiers | Brittle; breaks on rename | Use domain-level terms |

--- a/dist/gemini/skills/knowledge-base/references/naming-conventions.md
+++ b/dist/gemini/skills/knowledge-base/references/naming-conventions.md
@@ -1,0 +1,57 @@
+# Naming Conventions
+
+Where knowledge files live, how to name them, and how they relate to other
+documentation surfaces. Based on ADR-004.
+
+## Directory Structure
+
+```
+docs/
+├── knowledge/          # Domain knowledge (cross-cutting context, rules)
+│   ├── build-system.md
+│   ├── thermal-physics.md
+│   └── knowledge-management-design.md
+└── decisions/          # Architecture Decision Records (immutable)
+    ├── ADR-001-some-decision.md
+    └── ADR-004-knowledge-naming-convention.md
+```
+
+- `docs/knowledge/` for domain knowledge files
+- `docs/decisions/` for ADRs
+- These directory names are deliberate: `knowledge` and `decisions` are
+  unambiguous, similar in length, and scan well together
+
+## Filename Rules
+
+| Rule | Example | Rationale |
+|------|---------|-----------|
+| Kebab-case | `build-system.md` | Consistent, URL-safe |
+| Descriptive | `thermal-physics.md` | Self-documenting |
+| No date prefixes | `build-system.md` | Knowledge is living; dates imply snapshots |
+| No abbreviations | `knowledge-management-design.md` | Clarity over brevity |
+
+**Contrast with other artifacts that DO use date prefixes:**
+- Sessions: `YYYYMMDD-HHMMSS-session-slug.md`
+- Ideas: `YYYYMMDD-HHMMSS-idea-slug.md`
+
+Knowledge files are living documents, not point-in-time snapshots.
+
+## CLI Abbreviation
+
+Per ADR-004, the CLI uses `kb` for ergonomics:
+
+- `loaf kb check` (not `loaf knowledge check`)
+- `loaf kb validate` (not `loaf knowledge validate`)
+
+The full word `knowledge` is for storage paths (directories, QMD collections).
+The abbreviation `kb` is for typing (CLI commands).
+
+## QMD Collection Naming
+
+When indexed by QMD:
+
+- `{repo-folder}-knowledge` for knowledge files
+- `{repo-folder}-decisions` for ADRs
+
+Example: a repo in `~/Code/gridsight-core-gds/` produces collections
+`gridsight-core-gds-knowledge` and `gridsight-core-gds-decisions`.

--- a/dist/gemini/skills/knowledge-base/templates/knowledge-file.md
+++ b/dist/gemini/skills/knowledge-base/templates/knowledge-file.md
@@ -1,0 +1,32 @@
+# Knowledge File Template
+
+**Location:** `docs/knowledge/{slug}.md`
+
+```yaml
+---
+topics: []                          # Required (min 1) -- semantic tags for routing
+last_reviewed: YYYY-MM-DD           # Required -- ISO 8601 date of last human review
+covers:                             # Recommended -- glob patterns from git root
+  - "path/to/covered/**/*.ts"
+consumers: []                       # Optional -- agent routing hints
+depends_on: []                      # Optional -- other knowledge file names
+implementation_status: in-progress  # Optional -- in-progress | stable | deprecated
+---
+
+# [Title]
+
+Brief description of what this knowledge covers and why it exists.
+
+## Key Rules
+
+- [Rule 1]
+- [Rule 2]
+
+## [Domain Section]
+
+[Domain-specific content organized by topic]
+
+## Cross-References
+
+- [Related knowledge file or ADR]
+```

--- a/dist/gemini/skills/research/SKILL.md
+++ b/dist/gemini/skills/research/SKILL.md
@@ -61,7 +61,9 @@ Always check project context first. Rate findings: **High** (official/verified),
 1. **Interview** with AskUserQuestion: what are you trying to understand? What context do you have? What decision will this inform?
 2. Check project context first (ADRs, ARCHITECTURE, sessions)
 3. Apply confidence hierarchy for external sources
-4. Synthesize following [findings template](templates/findings.md)
+4. Create findings document following [findings template](templates/findings.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-research-{slug}.md`
 
 ### Brainstorming
 

--- a/dist/gemini/skills/research/templates/findings.md
+++ b/dist/gemini/skills/research/templates/findings.md
@@ -1,42 +1,62 @@
-# Research Findings Output Template
+# Research Findings Template
 
-```markdown
-## Research: [Topic]
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-research-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "Research: [Topic]"
+type: research
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active | archived
+tags: []
+related: []            # Optional: spec IDs, idea files, ADRs
+---
+
+# Research: [Topic]
 
 **Question:** [What we're trying to understand]
 
-### Summary
+## Summary
+
 [One-paragraph answer with confidence level]
 
-### Key Findings
+## Key Findings
+
 1. [Finding 1]
 2. [Finding 2]
 
-### Project Context
+## Project Context
+
 [How this relates to our existing decisions/architecture]
 
-### Options Considered
+## Options Considered
 
-#### Option A: [Name]
+### Option A: [Name]
 - **Pros:** ...
 - **Cons:** ...
 - **Best for:** ...
 
-#### Option B: [Name]
+### Option B: [Name]
 - **Pros:** ...
 - **Cons:** ...
 - **Best for:** ...
 
-### Recommendation
+## Recommendation
+
 [Which option and why, with caveats]
 
-### Sources
+## Sources
+
 - [Source 1 with confidence level]
 - [Source 2 with confidence level]
 
-### Implications
+## Implications
+
 - [What this means for our work]
 
-### Open Questions
+## Open Questions
+
 - [What's still unclear]
 ```

--- a/dist/gemini/skills/research/templates/state-assessment.md
+++ b/dist/gemini/skills/research/templates/state-assessment.md
@@ -1,38 +1,58 @@
-# State Assessment Output Template
+# State Assessment Template
 
-```markdown
-## Project State Assessment
+State assessments are typically presented in-conversation. If saved to a file:
 
-**Date:** YYYY-MM-DD
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-state-assessment.md`
 
-### Current Position
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "State Assessment: [YYYY-MM-DD]"
+type: state-assessment
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active | archived
+tags: []
+---
+
+# Project State Assessment
+
+## Current Position
+
 - [Summary of where the project stands]
 
-### Strategic Context
+## Strategic Context
+
 - **Vision:** [Brief summary]
 - **Key personas:** [Who we're building for]
 - **Current focus:** [Active specs/work]
 
-### Recent Progress
+## Recent Progress
+
 - [Key accomplishments from recent sessions]
 
-### In Flight
+## In Flight
+
 | Spec/Task | Status | Notes |
 |-----------|--------|-------|
 | SPEC-001 | implementing | [progress] |
 | SPEC-002 | approved | [next up] |
 
-### Ideas Pipeline
+## Ideas Pipeline
+
 - [Idea 1] -- raw
 - [Idea 2] -- raw
 
-### Lessons Learned (Recent)
+## Lessons Learned (Recent)
+
 - [Insights from implementation feedback]
 
-### Open Questions
+## Open Questions
+
 - [Unresolved decisions or gaps]
 
-### Recommendations
+## Recommendations
+
 1. [Actionable next step]
 2. [Actionable next step]
 ```

--- a/dist/opencode/commands/brainstorm.md
+++ b/dist/opencode/commands/brainstorm.md
@@ -45,8 +45,10 @@ Unlike `/idea` (quick capture) or `/shape` (rigorous bounding), brainstorming is
 2. Gather context: VISION.md, STRATEGY.md, ARCHITECTURE.md, related ideas
 3. **Deep exploration**: ask about user value, problem depth, alternatives, risks, dependencies, scope (minimal vs maximal)
 4. Generate options: conventional, minimal, ambitious, contrarian approaches
-5. Document with core insight, explored directions (approach/pros/cons), open questions, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](../skills/brainstorm/templates/brainstorm.md)
 6. Update idea file status if proceeding
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Problem Exploration
 
@@ -54,7 +56,9 @@ Unlike `/idea` (quick capture) or `/shape` (rigorous bounding), brainstorming is
 2. Gather strategic context
 3. **Diverge**: first principles, inversion, analogy, extreme constraints, persona lens
 4. **Converge**: filter by strategy alignment, feasibility, value
-5. Document with problem statement, options, analysis, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](../skills/brainstorm/templates/brainstorm.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Open Brainstorm
 

--- a/dist/opencode/commands/breakdown.md
+++ b/dist/opencode/commands/breakdown.md
@@ -78,17 +78,24 @@ Extract: test conditions, scope, implementation notes, appetite.
 
 Break down by concern (DBA, Backend, Frontend, QA, DevOps). One concern per task. Explicit dependencies for sequential tasks.
 
-### Step 4: Interview for Priorities
+### Step 4: Decide Priorities and Granularity
 
-Ask about highest priority parts, required ordering, preferred implementation sequence.
+Own the granularity and priority decisions. Apply the Right Size Test, assign priorities
+based on dependencies and circuit breaker alignment, and do a self-review pass. Do not
+defer these decisions to the user — they trust agent judgment here.
+
+If genuinely uncertain (e.g., two equally valid orderings with different trade-offs),
+ask. Otherwise, decide and move on.
 
 ### Step 5: Draft Task List
 
 Create tasks following [task template](../skills/breakdown/templates/task.md). Each task needs: clear title, priority, file hints, verification command, observable done condition.
 
-### Step 6: Present for Approval
+### Step 6: Present and Create
 
-Show tasks with priorities, dependencies, and dependency graph. **Do NOT create tasks without explicit approval.** User may adjust priorities, combine/split, add tasks, or change dependencies.
+Show the dependency graph and task summary for awareness, then create the tasks.
+Present it as "here's what I'm creating" not "which option do you prefer?" The user
+can still adjust after creation, but the default is to proceed.
 
 ### Step 7: Create Tasks
 
@@ -119,7 +126,7 @@ Set spec status to `implementing`. Announce created tasks with next steps.
 2. **Clear verification** -- how to prove it works
 3. **Observable done condition** -- not subjective
 4. **File hints** -- help session know where to look
-5. **Get approval** -- don't create without confirmation
+5. **Own the decisions** -- decide granularity and priorities, don't defer
 6. **Update spec status** -- mark as implementing
 
 ---

--- a/dist/opencode/commands/idea.md
+++ b/dist/opencode/commands/idea.md
@@ -30,7 +30,7 @@ Ideas are raw nuggets -- unprocessed, unshaped, but worth remembering. The goal 
 If `$ARGUMENTS` contains the idea, capture directly.
 
 If `$ARGUMENTS` is empty, **scan for sparks** in brainstorm documents:
-1. Search `.agents/drafts/brainstorm-*.md` for `## Sparks` sections
+1. Search `.agents/drafts/*brainstorm*.md` for `## Sparks` sections
 2. List unprocessed sparks (not marked as promoted or abandoned)
 3. Present the list and let the user pick one to promote
 4. When promoting: create idea file with `origin:` field, mark spark as `*(promoted)*` in source document
@@ -41,7 +41,7 @@ If no sparks found and no arguments, ask **at most 2-3 questions**: core idea, p
 
 Create file in `.agents/ideas/` following [idea template](../skills/idea/templates/idea.md).
 
-**Filename:** `{YYYYMMDD}-{slug}.md`
+**Filename:** `{YYYYMMDD}-{HHMMSS}-{slug}.md`
 
 ### Step 3: Create and Announce
 

--- a/dist/opencode/commands/research.md
+++ b/dist/opencode/commands/research.md
@@ -62,7 +62,9 @@ Always check project context first. Rate findings: **High** (official/verified),
 1. **Interview** with AskUserQuestion: what are you trying to understand? What context do you have? What decision will this inform?
 2. Check project context first (ADRs, ARCHITECTURE, sessions)
 3. Apply confidence hierarchy for external sources
-4. Synthesize following [findings template](../skills/research/templates/findings.md)
+4. Create findings document following [findings template](../skills/research/templates/findings.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-research-{slug}.md`
 
 ### Brainstorming
 

--- a/dist/opencode/plugins/hooks.js
+++ b/dist/opencode/plugins/hooks.js
@@ -75,6 +75,7 @@ const postToolHooks = {
     { id: 'design-token-check', script: 'post-tool/design-token-check.sh', timeout: 60000 },
     { id: 'design-a11y-audit', script: 'post-tool/design-a11y-audit.sh', timeout: 60000 },
     { id: 'generate-task-board', script: 'post-tool/orchestration-generate-task-board.sh', timeout: 60000 },
+    { id: 'kb-staleness-nudge', script: 'post-tool/kb-staleness-nudge.sh', timeout: 60000 },
   ],
   'Bash': [
     { id: 'changelog-reminder', script: 'post-tool/foundations-changelog-reminder.sh', timeout: 60000 },
@@ -85,6 +86,8 @@ const sessionHooks = {
   'sessionstart': { id: 'session-start', script: 'session/session-start.sh', timeout: 60000 },
   'sessionend': { id: 'session-end', script: 'session/session-end.sh', timeout: 60000 },
   'precompact': { id: 'pre-compact-archive', script: 'session/pre-compact-archive.sh', timeout: 60000 },
+  'sessionstart': { id: 'kb-session-start', script: 'session/kb-session-start.sh', timeout: 60000 },
+  'sessionend': { id: 'kb-session-end', script: 'session/kb-session-end.sh', timeout: 60000 },
 };
 
 export default async function AgentSkillsPlugin({ client, $ }) {

--- a/dist/opencode/plugins/hooks/post-tool/kb-staleness-nudge.sh
+++ b/dist/opencode/plugins/hooks/post-tool/kb-staleness-nudge.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# KB staleness nudge — alerts when editing files covered by stale knowledge
+# Post-tool hook for Edit|Write
+#
+# Per-session single nudge: each knowledge file mentioned at most once.
+# Tracks nudged files in a temp file keyed on PPID (stable within a session).
+
+set -euo pipefail
+
+# Check if loaf is available
+if ! command -v loaf &>/dev/null; then
+  exit 0
+fi
+
+# Parse the edited file path from TOOL_INPUT JSON
+# TOOL_INPUT contains the tool's input as a JSON string
+if [ -z "${TOOL_INPUT:-}" ]; then
+  exit 0
+fi
+
+# Extract file_path (primary field for Edit/Write tools)
+file_path=$(echo "$TOOL_INPUT" | grep -oE '"file_path"[[:space:]]*:[[:space:]]*"[^"]+"' | sed 's/.*: *"//' | sed 's/"$//' || true)
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+# Check which knowledge files cover this path
+result=$(loaf kb check --file "$file_path" --json 2>/dev/null || true)
+if [ -z "$result" ] || [ "$result" = "[]" ]; then
+  exit 0
+fi
+
+# Track already-nudged files per session
+# PPID is the parent process (Claude Code), stable across hook invocations in one session
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+nudge_file="/tmp/loaf-kb-nudged-${PPID}-$(echo "$PROJECT_DIR" | md5sum 2>/dev/null | cut -c1-8 || echo "$PROJECT_DIR" | md5 2>/dev/null | cut -c1-8 || echo "default")"
+
+# The JSON output is an array of objects with "file", "isStale", etc.
+# Parse each entry: look for "file":"..." and "isStale":true pairs
+# Process line-by-line, tracking the current object's fields
+current_file=""
+current_stale=""
+
+while IFS= read -r line; do
+  # Detect file field
+  f=$(echo "$line" | grep -o '"file":[[:space:]]*"[^"]*"' | sed 's/"file":[[:space:]]*"//;s/"$//' || true)
+  if [ -n "$f" ]; then
+    current_file="$f"
+  fi
+
+  # Detect isStale field
+  s=$(echo "$line" | grep -o '"isStale":[[:space:]]*true' || true)
+  if [ -n "$s" ]; then
+    current_stale="true"
+  fi
+
+  # Reset on isStale: false
+  sf=$(echo "$line" | grep -o '"isStale":[[:space:]]*false' || true)
+  if [ -n "$sf" ]; then
+    current_stale=""
+  fi
+
+  # On closing brace, check if we have a stale file to report
+  if echo "$line" | grep -q '}'; then
+    if [ -n "$current_stale" ] && [ -n "$current_file" ]; then
+      # Check if already nudged this session
+      if [ -f "$nudge_file" ] && grep -qF "$current_file" "$nudge_file"; then
+        # Already nudged, skip
+        :
+      else
+        # Record as nudged
+        echo "$current_file" >> "$nudge_file"
+        echo "Knowledge file \`$current_file\` covers this code and may be stale. Consider reviewing with \`loaf kb review $current_file\`."
+      fi
+    fi
+    current_file=""
+    current_stale=""
+  fi
+done <<< "$result"
+
+exit 0

--- a/dist/opencode/plugins/hooks/session/kb-session-end.sh
+++ b/dist/opencode/plugins/hooks/session/kb-session-end.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Hook: KB consolidation prompt (INFORMATIONAL)
+# SessionEnd hook - reminds about stale knowledge at session end
+#
+# Reads the nudge tracking file created by kb-staleness-nudge post-tool hook
+# and reports how many stale knowledge files were flagged during the session
+
+# Match the nudge file key from the post-tool hook
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+nudge_file="/tmp/loaf-kb-nudged-${PPID}-$(echo "$PROJECT_DIR" | md5sum 2>/dev/null | cut -c1-8 || echo "$PROJECT_DIR" | md5 2>/dev/null | cut -c1-8 || echo "default")"
+
+if [ ! -f "$nudge_file" ]; then
+  exit 0
+fi
+
+# Read the list of nudged files before cleanup
+nudged_files=()
+while IFS= read -r line; do
+  [ -n "$line" ] && nudged_files+=("$line")
+done < "$nudge_file"
+
+# Clean up the tracking file
+rm -f "$nudge_file"
+
+nudged_count=${#nudged_files[@]}
+
+if [ "$nudged_count" -gt 0 ]; then
+  echo ""
+  echo "## Knowledge Base"
+  echo ""
+  echo "**${nudged_count}** stale knowledge file(s) were flagged during this session:"
+  echo ""
+  for f in "${nudged_files[@]}"; do
+    echo "- \`$f\`"
+  done
+  echo ""
+  echo "Run \`loaf kb check\` to review or \`loaf kb review <file>\` to mark as reviewed."
+fi
+
+exit 0

--- a/dist/opencode/plugins/hooks/session/kb-session-start.sh
+++ b/dist/opencode/plugins/hooks/session/kb-session-start.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Hook: KB staleness advisory (INFORMATIONAL)
+# SessionStart hook - surfaces stale knowledge count at session start
+#
+# Triggers on session start
+# Displays count of stale knowledge files if any exist
+
+# Check if loaf is available
+if ! command -v loaf &>/dev/null; then
+  exit 0
+fi
+
+# Get KB status as JSON
+status=$(loaf kb status --json 2>/dev/null)
+if [ $? -ne 0 ] || [ -z "$status" ]; then
+  exit 0
+fi
+
+# Extract counts from JSON (no jq dependency)
+# JSON fields: total_files, stale
+stale=$(echo "$status" | grep -o '"stale":[[:space:]]*[0-9]*' | grep -o '[0-9]*$')
+total=$(echo "$status" | grep -o '"total_files":[[:space:]]*[0-9]*' | grep -o '[0-9]*$')
+
+if [ -z "$stale" ] || [ "$stale" = "0" ]; then
+  exit 0
+fi
+
+echo ""
+echo "## Knowledge Base"
+echo ""
+echo "**${total}** knowledge files tracked. **${stale}** stale."
+echo ""
+echo "Run \`loaf kb check\` for details or \`loaf kb review <file>\` to mark reviewed."
+
+exit 0

--- a/dist/opencode/skills/brainstorm/SKILL.md
+++ b/dist/opencode/skills/brainstorm/SKILL.md
@@ -43,8 +43,10 @@ Unlike `/idea` (quick capture) or `/shape` (rigorous bounding), brainstorming is
 2. Gather context: VISION.md, STRATEGY.md, ARCHITECTURE.md, related ideas
 3. **Deep exploration**: ask about user value, problem depth, alternatives, risks, dependencies, scope (minimal vs maximal)
 4. Generate options: conventional, minimal, ambitious, contrarian approaches
-5. Document with core insight, explored directions (approach/pros/cons), open questions, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](templates/brainstorm.md)
 6. Update idea file status if proceeding
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Problem Exploration
 
@@ -52,7 +54,9 @@ Unlike `/idea` (quick capture) or `/shape` (rigorous bounding), brainstorming is
 2. Gather strategic context
 3. **Diverge**: first principles, inversion, analogy, extreme constraints, persona lens
 4. **Converge**: filter by strategy alignment, feasibility, value
-5. Document with problem statement, options, analysis, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](templates/brainstorm.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Open Brainstorm
 

--- a/dist/opencode/skills/brainstorm/templates/brainstorm.md
+++ b/dist/opencode/skills/brainstorm/templates/brainstorm.md
@@ -1,0 +1,43 @@
+# Brainstorm Document Template
+
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "Brainstorm: [Topic]"
+type: brainstorm
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active (has unprocessed sparks) | archived
+tags: []
+related: []            # Optional: idea files, spec IDs, session files
+---
+
+# Brainstorm: [Topic]
+
+**Date:** YYYY-MM-DD
+**Session:** [Brief description of session scope]
+
+## Session Journey
+
+[How the brainstorm evolved -- pivots, reframes, key realizations]
+
+## [Main Content Sections]
+
+[Organized by the brainstorm's natural structure -- options explored,
+analysis, trade-offs, convergence points]
+
+## Recommendation
+
+[If applicable -- the direction that emerged]
+
+## Open Questions
+
+- [Unresolved questions for further exploration]
+
+## Sparks
+
+- **[Title]** -- [one-line description]
+- **[Title]** -- [one-line description]
+```

--- a/dist/opencode/skills/breakdown/SKILL.md
+++ b/dist/opencode/skills/breakdown/SKILL.md
@@ -76,17 +76,24 @@ Extract: test conditions, scope, implementation notes, appetite.
 
 Break down by concern (DBA, Backend, Frontend, QA, DevOps). One concern per task. Explicit dependencies for sequential tasks.
 
-### Step 4: Interview for Priorities
+### Step 4: Decide Priorities and Granularity
 
-Ask about highest priority parts, required ordering, preferred implementation sequence.
+Own the granularity and priority decisions. Apply the Right Size Test, assign priorities
+based on dependencies and circuit breaker alignment, and do a self-review pass. Do not
+defer these decisions to the user — they trust agent judgment here.
+
+If genuinely uncertain (e.g., two equally valid orderings with different trade-offs),
+ask. Otherwise, decide and move on.
 
 ### Step 5: Draft Task List
 
 Create tasks following [task template](templates/task.md). Each task needs: clear title, priority, file hints, verification command, observable done condition.
 
-### Step 6: Present for Approval
+### Step 6: Present and Create
 
-Show tasks with priorities, dependencies, and dependency graph. **Do NOT create tasks without explicit approval.** User may adjust priorities, combine/split, add tasks, or change dependencies.
+Show the dependency graph and task summary for awareness, then create the tasks.
+Present it as "here's what I'm creating" not "which option do you prefer?" The user
+can still adjust after creation, but the default is to proceed.
 
 ### Step 7: Create Tasks
 
@@ -117,7 +124,7 @@ Set spec status to `implementing`. Announce created tasks with next steps.
 2. **Clear verification** -- how to prove it works
 3. **Observable done condition** -- not subjective
 4. **File hints** -- help session know where to look
-5. **Get approval** -- don't create without confirmation
+5. **Own the decisions** -- decide granularity and priorities, don't defer
 6. **Update spec status** -- mark as implementing
 
 ---

--- a/dist/opencode/skills/idea/SKILL.md
+++ b/dist/opencode/skills/idea/SKILL.md
@@ -28,7 +28,7 @@ Ideas are raw nuggets -- unprocessed, unshaped, but worth remembering. The goal 
 If `$ARGUMENTS` contains the idea, capture directly.
 
 If `$ARGUMENTS` is empty, **scan for sparks** in brainstorm documents:
-1. Search `.agents/drafts/brainstorm-*.md` for `## Sparks` sections
+1. Search `.agents/drafts/*brainstorm*.md` for `## Sparks` sections
 2. List unprocessed sparks (not marked as promoted or abandoned)
 3. Present the list and let the user pick one to promote
 4. When promoting: create idea file with `origin:` field, mark spark as `*(promoted)*` in source document
@@ -39,7 +39,7 @@ If no sparks found and no arguments, ask **at most 2-3 questions**: core idea, p
 
 Create file in `.agents/ideas/` following [idea template](templates/idea.md).
 
-**Filename:** `{YYYYMMDD}-{slug}.md`
+**Filename:** `{YYYYMMDD}-{HHMMSS}-{slug}.md`
 
 ### Step 3: Create and Announce
 

--- a/dist/opencode/skills/idea/templates/idea.md
+++ b/dist/opencode/skills/idea/templates/idea.md
@@ -1,13 +1,17 @@
 # Idea File Template
 
-**Location:** `.agents/ideas/{YYYYMMDD}-{slug}.md`
+**Location:** `.agents/ideas/{YYYYMMDD}-{HHMMSS}-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
 
 ```yaml
 ---
+title: "[Idea Title]"
 captured: YYYY-MM-DDTHH:MM:SSZ
 status: raw
 tags: []
-origin:              # Optional: brainstorm document this spark came from
+related: []            # Optional: spec IDs, file paths, or other idea files
+origin:                # Optional: brainstorm document this spark came from
 ---
 
 # [Idea Title]

--- a/dist/opencode/skills/knowledge-base/SKILL.md
+++ b/dist/opencode/skills/knowledge-base/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: knowledge-base
+description: >-
+  Provides guidance for creating, updating, and reviewing project knowledge
+  files. Covers frontmatter schema, naming conventions, staleness detection via
+  covers: field, and the review workflow. Use when creating new knowledge files,
+  updating existing ones, or when the agent needs to understand knowledge
+  management conventions. Not for retrieval or search (use QMD directly). Not
+  for architectural decisions (use ADRs). Not for agent instructions (use
+  CLAUDE.md).
+---
+
+# Knowledge Base
+
+Conventions and workflows for managing project knowledge files -- structured
+domain knowledge that lives in `docs/knowledge/` and persists across sessions.
+
+## Contents
+- When to Create a Knowledge File
+- Topics
+- The covers: Field
+- Review Workflow
+- What Goes Where
+- Critical Rules
+
+## When to Create a Knowledge File
+
+Create a knowledge file when information:
+
+1. **Requires context beyond the code** -- domain rules, business logic constraints,
+   cross-cutting patterns that cannot be expressed in types or docstrings
+2. **Spans multiple files or modules** -- conventions or contracts that apply across
+   the codebase, not localized to one function
+3. **Would be lost between sessions** -- insights that an agent needs repeatedly but
+   cannot derive from code alone
+4. **Serves as extended agent memory** -- roadmap context, implementation plans,
+   strategic direction that informs decisions
+
+Do NOT create knowledge files for:
+- Self-documenting code (types, docstrings, comments are sufficient)
+- One-off architectural decisions (write an ADR instead)
+- Agent behavior instructions (put those in CLAUDE.md)
+- User preferences or session pointers (those belong in MEMORY.md)
+
+## Topics
+
+| Topic | Reference | Use When |
+|-------|-----------|----------|
+| Frontmatter Schema | [frontmatter-schema.md](references/frontmatter-schema.md) | Creating or validating knowledge file frontmatter |
+| Naming Conventions | [naming-conventions.md](references/naming-conventions.md) | Deciding where to put knowledge and what to name it |
+
+| Template | Use When |
+|----------|----------|
+| [knowledge-file.md](templates/knowledge-file.md) | Creating a new knowledge file from scratch |
+
+## The covers: Field
+
+The `covers:` field is the core innovation of the knowledge management system.
+It links knowledge to code paths via glob patterns, enabling automatic staleness
+detection.
+
+### How It Works
+
+1. Author declares `covers:` globs in knowledge file frontmatter
+2. Globs resolve from the git repository root
+3. `loaf kb check` queries `git log --since={last_reviewed}` for matching files
+4. If commits exist since last review, the knowledge file is flagged as potentially stale
+
+### Good covers: Patterns
+
+```yaml
+covers:
+  - "src/pipeline/registry.py"          # Specific file
+  - "src/models/engine_*.py"            # Wildcard within directory
+  - "src/thermal/**/*.py"               # Recursive directory
+```
+
+### Patterns to Avoid
+
+```yaml
+covers:
+  - "src/**"                            # Too broad -- constant false positives
+  - "**/*.py"                           # Covers everything, means nothing
+  - "*.md"                              # Documentation changes != knowledge staleness
+```
+
+The goal is precision: cover the code paths whose changes would actually
+invalidate the knowledge. Broad globs lead to alert fatigue.
+
+### When to Omit covers:
+
+Files without `covers:` are valid knowledge files but cannot use automated
+staleness detection. Omit `covers:` when:
+
+- The knowledge is purely conceptual (no specific code paths)
+- The file covers external domain rules not tied to implementation
+- You are unsure which paths to cover (add them later when the mapping is clear)
+
+## Review Workflow
+
+### Check What Is Stale
+
+```bash
+loaf kb check
+```
+
+Shows knowledge files where covered code paths have changed since `last_reviewed`.
+
+### Validate Frontmatter
+
+```bash
+loaf kb validate
+```
+
+Checks all knowledge files for valid frontmatter: required fields present,
+correct types, valid glob patterns.
+
+### Review a File
+
+```bash
+loaf kb review <file>
+```
+
+After reading and updating a knowledge file, mark it as reviewed. This updates
+the `last_reviewed` date to today.
+
+### Overview
+
+```bash
+loaf kb status
+```
+
+Summary of all knowledge files: total count, stale count, files missing
+`covers:`, last review dates.
+
+## What Goes Where
+
+| Surface | Contains | Decision Test |
+|---------|----------|---------------|
+| **Code** (docstrings, types) | What the code does | Is it self-documenting? |
+| **Knowledge files** | Domain rules, cross-cutting context, roadmap | Requires context beyond the code? |
+| **ADRs** | Why we chose this approach | Is it an architectural decision? |
+| **CLAUDE.md** | Agent instructions, conventions | Is it about how agents should behave? |
+| **MEMORY.md** | User preferences, session pointers | Is it personal or ephemeral? |
+
+CLAUDE.md may reference knowledge files but should never duplicate their content.
+
+For the authoritative design document covering the full knowledge management
+system (QMD integration, growth loops, cross-project sharing), see
+`docs/knowledge/knowledge-management-design.md`.
+
+## Critical Rules
+
+### Always
+- Include `topics` (min 1) and `last_reviewed` in frontmatter
+- Use kebab-case filenames in `docs/knowledge/`
+- Add `covers:` globs when the knowledge maps to specific code paths
+- Run `loaf kb validate` before committing new knowledge files
+- Mark files reviewed with `loaf kb review` after updating
+
+### Never
+- Duplicate code documentation in knowledge files
+- Use date prefixes on knowledge filenames (unlike sessions or ideas)
+- Use overly broad `covers:` globs that trigger constant staleness alerts
+- Skip the `last_reviewed` field -- it is required for the lifecycle to work
+- Store knowledge files outside `docs/knowledge/` (ADRs go in `docs/decisions/`)

--- a/dist/opencode/skills/knowledge-base/references/frontmatter-schema.md
+++ b/dist/opencode/skills/knowledge-base/references/frontmatter-schema.md
@@ -1,0 +1,147 @@
+# Frontmatter Schema
+
+Detailed reference for knowledge file YAML frontmatter.
+
+## Contents
+- Required Fields
+- Recommended Fields
+- Optional Fields
+- Complete Example
+- Common Mistakes
+
+## Required Fields
+
+### topics
+
+- **Type:** list of strings (min 1)
+- **Purpose:** Semantic tags for routing and discovery. Agents and QMD use these
+  to find relevant knowledge files.
+
+```yaml
+topics: [engine-registry, strategy-pattern]
+```
+
+Choose tags that are specific enough to be useful for routing but general enough
+to remain stable as the codebase evolves. Prefer domain terms over implementation
+terms (e.g., `thermal-physics` over `heat-calc-module`).
+
+### last_reviewed
+
+- **Type:** string, ISO 8601 date (YYYY-MM-DD)
+- **Purpose:** Records when a human last verified the file's accuracy. Used by
+  `loaf kb check` to determine staleness.
+
+```yaml
+last_reviewed: 2026-03-14
+```
+
+Update this field only after genuinely reviewing the content -- do not bump it
+during routine edits that do not involve verification. Use `loaf kb review <file>`
+to update it properly.
+
+## Recommended Fields
+
+### covers
+
+- **Type:** list of glob strings
+- **Purpose:** Links knowledge to code paths. Globs resolve from the git
+  repository root. Enables automatic staleness detection.
+
+```yaml
+covers:
+  - "src/pipeline/registry.py"
+  - "src/models/engine_*.py"
+```
+
+**Glob resolution rules:**
+- Paths are relative to the git root (not the knowledge file location)
+- Standard glob syntax: `*` matches within a directory, `**` matches recursively
+- Patterns that match no files are silently ignored (but may indicate drift)
+
+**Precision guidelines:**
+- Cover the specific files whose changes would invalidate this knowledge
+- Avoid `src/**` or `**/*.py` -- too broad, causes alert fatigue
+- When unsure, start narrow and widen as you learn which paths matter
+
+## Optional Fields
+
+### consumers
+
+- **Type:** list of strings
+- **Purpose:** Agent routing hints. Indicates which agents or roles should be
+  aware of this knowledge.
+
+```yaml
+consumers: [backend, power-systems]
+```
+
+Values are freeform but should correspond to agent names or plugin-group names
+from `hooks.yaml`.
+
+### depends_on
+
+- **Type:** list of strings (filenames)
+- **Purpose:** Cross-references to other knowledge files. Indicates that this
+  file's content assumes or builds on another.
+
+```yaml
+depends_on: [thermal-physics.md, conductor-limits.md]
+```
+
+Use bare filenames (not paths). All knowledge files live in `docs/knowledge/`,
+so paths are implicit.
+
+### implementation_status
+
+- **Type:** enum string
+- **Valid values:** `in-progress` | `stable` | `deprecated`
+- **Default:** omit if stable (absence implies stable)
+- **Purpose:** Signals whether the knowledge reflects current, evolving, or
+  obsolete state.
+
+```yaml
+implementation_status: in-progress
+```
+
+| Value | Meaning |
+|-------|---------|
+| `in-progress` | Knowledge is being actively developed or the code it covers is in flux |
+| `stable` | Knowledge is current and verified |
+| `deprecated` | Knowledge is outdated; the domain or code has moved on |
+
+## Complete Example
+
+```yaml
+---
+topics: [engine-registry, strategy-pattern, pipeline]
+last_reviewed: 2026-03-14
+covers:
+  - "src/pipeline/registry.py"
+  - "src/models/engine_*.py"
+  - "src/pipeline/strategies/**/*.py"
+consumers: [backend, power-systems]
+depends_on: [thermal-physics.md]
+implementation_status: stable
+---
+
+# Engine Registry
+
+Domain rules for the engine registration and strategy selection system.
+
+## Key Rules
+
+- All engines must register via `EngineRegistry.register()`
+- Strategy selection is deterministic given the same input parameters
+- ...
+```
+
+## Common Mistakes
+
+| Mistake | Why It Is Wrong | Fix |
+|---------|-----------------|-----|
+| Missing `topics` | Required for routing; file is invisible to discovery | Add at least one topic |
+| `last_reviewed` in the future | Implies review that has not happened | Use today's date or earlier |
+| `covers: ["src/**"]` | Too broad; every commit triggers staleness | Narrow to specific paths |
+| `depends_on: ["docs/knowledge/foo.md"]` | Uses full path instead of filename | Use `depends_on: [foo.md]` |
+| `implementation_status: done` | Not a valid enum value | Use `stable` |
+| Topics that match code identifiers | Brittle; breaks on rename | Use domain-level terms |

--- a/dist/opencode/skills/knowledge-base/references/naming-conventions.md
+++ b/dist/opencode/skills/knowledge-base/references/naming-conventions.md
@@ -1,0 +1,57 @@
+# Naming Conventions
+
+Where knowledge files live, how to name them, and how they relate to other
+documentation surfaces. Based on ADR-004.
+
+## Directory Structure
+
+```
+docs/
+├── knowledge/          # Domain knowledge (cross-cutting context, rules)
+│   ├── build-system.md
+│   ├── thermal-physics.md
+│   └── knowledge-management-design.md
+└── decisions/          # Architecture Decision Records (immutable)
+    ├── ADR-001-some-decision.md
+    └── ADR-004-knowledge-naming-convention.md
+```
+
+- `docs/knowledge/` for domain knowledge files
+- `docs/decisions/` for ADRs
+- These directory names are deliberate: `knowledge` and `decisions` are
+  unambiguous, similar in length, and scan well together
+
+## Filename Rules
+
+| Rule | Example | Rationale |
+|------|---------|-----------|
+| Kebab-case | `build-system.md` | Consistent, URL-safe |
+| Descriptive | `thermal-physics.md` | Self-documenting |
+| No date prefixes | `build-system.md` | Knowledge is living; dates imply snapshots |
+| No abbreviations | `knowledge-management-design.md` | Clarity over brevity |
+
+**Contrast with other artifacts that DO use date prefixes:**
+- Sessions: `YYYYMMDD-HHMMSS-session-slug.md`
+- Ideas: `YYYYMMDD-HHMMSS-idea-slug.md`
+
+Knowledge files are living documents, not point-in-time snapshots.
+
+## CLI Abbreviation
+
+Per ADR-004, the CLI uses `kb` for ergonomics:
+
+- `loaf kb check` (not `loaf knowledge check`)
+- `loaf kb validate` (not `loaf knowledge validate`)
+
+The full word `knowledge` is for storage paths (directories, QMD collections).
+The abbreviation `kb` is for typing (CLI commands).
+
+## QMD Collection Naming
+
+When indexed by QMD:
+
+- `{repo-folder}-knowledge` for knowledge files
+- `{repo-folder}-decisions` for ADRs
+
+Example: a repo in `~/Code/gridsight-core-gds/` produces collections
+`gridsight-core-gds-knowledge` and `gridsight-core-gds-decisions`.

--- a/dist/opencode/skills/knowledge-base/templates/knowledge-file.md
+++ b/dist/opencode/skills/knowledge-base/templates/knowledge-file.md
@@ -1,0 +1,32 @@
+# Knowledge File Template
+
+**Location:** `docs/knowledge/{slug}.md`
+
+```yaml
+---
+topics: []                          # Required (min 1) -- semantic tags for routing
+last_reviewed: YYYY-MM-DD           # Required -- ISO 8601 date of last human review
+covers:                             # Recommended -- glob patterns from git root
+  - "path/to/covered/**/*.ts"
+consumers: []                       # Optional -- agent routing hints
+depends_on: []                      # Optional -- other knowledge file names
+implementation_status: in-progress  # Optional -- in-progress | stable | deprecated
+---
+
+# [Title]
+
+Brief description of what this knowledge covers and why it exists.
+
+## Key Rules
+
+- [Rule 1]
+- [Rule 2]
+
+## [Domain Section]
+
+[Domain-specific content organized by topic]
+
+## Cross-References
+
+- [Related knowledge file or ADR]
+```

--- a/dist/opencode/skills/research/SKILL.md
+++ b/dist/opencode/skills/research/SKILL.md
@@ -60,7 +60,9 @@ Always check project context first. Rate findings: **High** (official/verified),
 1. **Interview** with AskUserQuestion: what are you trying to understand? What context do you have? What decision will this inform?
 2. Check project context first (ADRs, ARCHITECTURE, sessions)
 3. Apply confidence hierarchy for external sources
-4. Synthesize following [findings template](templates/findings.md)
+4. Create findings document following [findings template](templates/findings.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-research-{slug}.md`
 
 ### Brainstorming
 

--- a/dist/opencode/skills/research/templates/findings.md
+++ b/dist/opencode/skills/research/templates/findings.md
@@ -1,42 +1,62 @@
-# Research Findings Output Template
+# Research Findings Template
 
-```markdown
-## Research: [Topic]
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-research-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "Research: [Topic]"
+type: research
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active | archived
+tags: []
+related: []            # Optional: spec IDs, idea files, ADRs
+---
+
+# Research: [Topic]
 
 **Question:** [What we're trying to understand]
 
-### Summary
+## Summary
+
 [One-paragraph answer with confidence level]
 
-### Key Findings
+## Key Findings
+
 1. [Finding 1]
 2. [Finding 2]
 
-### Project Context
+## Project Context
+
 [How this relates to our existing decisions/architecture]
 
-### Options Considered
+## Options Considered
 
-#### Option A: [Name]
+### Option A: [Name]
 - **Pros:** ...
 - **Cons:** ...
 - **Best for:** ...
 
-#### Option B: [Name]
+### Option B: [Name]
 - **Pros:** ...
 - **Cons:** ...
 - **Best for:** ...
 
-### Recommendation
+## Recommendation
+
 [Which option and why, with caveats]
 
-### Sources
+## Sources
+
 - [Source 1 with confidence level]
 - [Source 2 with confidence level]
 
-### Implications
+## Implications
+
 - [What this means for our work]
 
-### Open Questions
+## Open Questions
+
 - [What's still unclear]
 ```

--- a/dist/opencode/skills/research/templates/state-assessment.md
+++ b/dist/opencode/skills/research/templates/state-assessment.md
@@ -1,38 +1,58 @@
-# State Assessment Output Template
+# State Assessment Template
 
-```markdown
-## Project State Assessment
+State assessments are typically presented in-conversation. If saved to a file:
 
-**Date:** YYYY-MM-DD
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-state-assessment.md`
 
-### Current Position
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "State Assessment: [YYYY-MM-DD]"
+type: state-assessment
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active | archived
+tags: []
+---
+
+# Project State Assessment
+
+## Current Position
+
 - [Summary of where the project stands]
 
-### Strategic Context
+## Strategic Context
+
 - **Vision:** [Brief summary]
 - **Key personas:** [Who we're building for]
 - **Current focus:** [Active specs/work]
 
-### Recent Progress
+## Recent Progress
+
 - [Key accomplishments from recent sessions]
 
-### In Flight
+## In Flight
+
 | Spec/Task | Status | Notes |
 |-----------|--------|-------|
 | SPEC-001 | implementing | [progress] |
 | SPEC-002 | approved | [next up] |
 
-### Ideas Pipeline
+## Ideas Pipeline
+
 - [Idea 1] -- raw
 - [Idea 2] -- raw
 
-### Lessons Learned (Recent)
+## Lessons Learned (Recent)
+
 - [Insights from implementation feedback]
 
-### Open Questions
+## Open Questions
+
 - [Unresolved decisions or gaps]
 
-### Recommendations
+## Recommendations
+
 1. [Actionable next step]
 2. [Actionable next step]
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,19 +11,21 @@
       "dependencies": {
         "commander": "^14.0.3",
         "gray-matter": "^4.0.3",
-        "yaml": "^2.3.4"
+        "picomatch": "^4.0.4",
+        "yaml": "^2.8.2"
       },
       "bin": {
         "loaf": "dist-cli/index.js"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "@types/picomatch": "^4.0.2",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
         "vitest": "^4.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1300,6 +1302,13 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
@@ -2160,10 +2169,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -47,10 +47,12 @@
   "dependencies": {
     "commander": "^14.0.3",
     "gray-matter": "^4.0.3",
+    "picomatch": "^4.0.4",
     "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "@types/picomatch": "^4.0.2",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.0"

--- a/plugins/loaf/.claude-plugin/plugin.json
+++ b/plugins/loaf/.claude-plugin/plugin.json
@@ -199,6 +199,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/orchestration-generate-task-board.sh",
             "description": "Regenerate TASKS.md when task files change"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/kb-staleness-nudge.sh",
+            "description": "Alert when editing files covered by stale knowledge"
           }
         ]
       },
@@ -222,6 +227,15 @@
             "description": "Agent-aware session context and active sessions overview"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/kb-session-start.sh",
+            "description": "Surface stale knowledge count at session start"
+          }
+        ]
       }
     ],
     "SessionEnd": [
@@ -231,6 +245,15 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.sh",
             "description": "Agent-specific completion checklist and session hygiene reminder"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/kb-session-end.sh",
+            "description": "Prompt for knowledge consolidation if stale files were flagged"
           }
         ]
       }

--- a/plugins/loaf/hooks/kb-session-end.sh
+++ b/plugins/loaf/hooks/kb-session-end.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Hook: KB consolidation prompt (INFORMATIONAL)
+# SessionEnd hook - reminds about stale knowledge at session end
+#
+# Reads the nudge tracking file created by kb-staleness-nudge post-tool hook
+# and reports how many stale knowledge files were flagged during the session
+
+# Match the nudge file key from the post-tool hook
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+nudge_file="/tmp/loaf-kb-nudged-${PPID}-$(echo "$PROJECT_DIR" | md5sum 2>/dev/null | cut -c1-8 || echo "$PROJECT_DIR" | md5 2>/dev/null | cut -c1-8 || echo "default")"
+
+if [ ! -f "$nudge_file" ]; then
+  exit 0
+fi
+
+# Read the list of nudged files before cleanup
+nudged_files=()
+while IFS= read -r line; do
+  [ -n "$line" ] && nudged_files+=("$line")
+done < "$nudge_file"
+
+# Clean up the tracking file
+rm -f "$nudge_file"
+
+nudged_count=${#nudged_files[@]}
+
+if [ "$nudged_count" -gt 0 ]; then
+  echo ""
+  echo "## Knowledge Base"
+  echo ""
+  echo "**${nudged_count}** stale knowledge file(s) were flagged during this session:"
+  echo ""
+  for f in "${nudged_files[@]}"; do
+    echo "- \`$f\`"
+  done
+  echo ""
+  echo "Run \`loaf kb check\` to review or \`loaf kb review <file>\` to mark as reviewed."
+fi
+
+exit 0

--- a/plugins/loaf/hooks/kb-session-start.sh
+++ b/plugins/loaf/hooks/kb-session-start.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Hook: KB staleness advisory (INFORMATIONAL)
+# SessionStart hook - surfaces stale knowledge count at session start
+#
+# Triggers on session start
+# Displays count of stale knowledge files if any exist
+
+# Check if loaf is available
+if ! command -v loaf &>/dev/null; then
+  exit 0
+fi
+
+# Get KB status as JSON
+status=$(loaf kb status --json 2>/dev/null)
+if [ $? -ne 0 ] || [ -z "$status" ]; then
+  exit 0
+fi
+
+# Extract counts from JSON (no jq dependency)
+# JSON fields: total_files, stale
+stale=$(echo "$status" | grep -o '"stale":[[:space:]]*[0-9]*' | grep -o '[0-9]*$')
+total=$(echo "$status" | grep -o '"total_files":[[:space:]]*[0-9]*' | grep -o '[0-9]*$')
+
+if [ -z "$stale" ] || [ "$stale" = "0" ]; then
+  exit 0
+fi
+
+echo ""
+echo "## Knowledge Base"
+echo ""
+echo "**${total}** knowledge files tracked. **${stale}** stale."
+echo ""
+echo "Run \`loaf kb check\` for details or \`loaf kb review <file>\` to mark reviewed."
+
+exit 0

--- a/plugins/loaf/hooks/kb-staleness-nudge.sh
+++ b/plugins/loaf/hooks/kb-staleness-nudge.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# KB staleness nudge — alerts when editing files covered by stale knowledge
+# Post-tool hook for Edit|Write
+#
+# Per-session single nudge: each knowledge file mentioned at most once.
+# Tracks nudged files in a temp file keyed on PPID (stable within a session).
+
+set -euo pipefail
+
+# Check if loaf is available
+if ! command -v loaf &>/dev/null; then
+  exit 0
+fi
+
+# Parse the edited file path from TOOL_INPUT JSON
+# TOOL_INPUT contains the tool's input as a JSON string
+if [ -z "${TOOL_INPUT:-}" ]; then
+  exit 0
+fi
+
+# Extract file_path (primary field for Edit/Write tools)
+file_path=$(echo "$TOOL_INPUT" | grep -oE '"file_path"[[:space:]]*:[[:space:]]*"[^"]+"' | sed 's/.*: *"//' | sed 's/"$//' || true)
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+# Check which knowledge files cover this path
+result=$(loaf kb check --file "$file_path" --json 2>/dev/null || true)
+if [ -z "$result" ] || [ "$result" = "[]" ]; then
+  exit 0
+fi
+
+# Track already-nudged files per session
+# PPID is the parent process (Claude Code), stable across hook invocations in one session
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+nudge_file="/tmp/loaf-kb-nudged-${PPID}-$(echo "$PROJECT_DIR" | md5sum 2>/dev/null | cut -c1-8 || echo "$PROJECT_DIR" | md5 2>/dev/null | cut -c1-8 || echo "default")"
+
+# The JSON output is an array of objects with "file", "isStale", etc.
+# Parse each entry: look for "file":"..." and "isStale":true pairs
+# Process line-by-line, tracking the current object's fields
+current_file=""
+current_stale=""
+
+while IFS= read -r line; do
+  # Detect file field
+  f=$(echo "$line" | grep -o '"file":[[:space:]]*"[^"]*"' | sed 's/"file":[[:space:]]*"//;s/"$//' || true)
+  if [ -n "$f" ]; then
+    current_file="$f"
+  fi
+
+  # Detect isStale field
+  s=$(echo "$line" | grep -o '"isStale":[[:space:]]*true' || true)
+  if [ -n "$s" ]; then
+    current_stale="true"
+  fi
+
+  # Reset on isStale: false
+  sf=$(echo "$line" | grep -o '"isStale":[[:space:]]*false' || true)
+  if [ -n "$sf" ]; then
+    current_stale=""
+  fi
+
+  # On closing brace, check if we have a stale file to report
+  if echo "$line" | grep -q '}'; then
+    if [ -n "$current_stale" ] && [ -n "$current_file" ]; then
+      # Check if already nudged this session
+      if [ -f "$nudge_file" ] && grep -qF "$current_file" "$nudge_file"; then
+        # Already nudged, skip
+        :
+      else
+        # Record as nudged
+        echo "$current_file" >> "$nudge_file"
+        echo "Knowledge file \`$current_file\` covers this code and may be stale. Consider reviewing with \`loaf kb review $current_file\`."
+      fi
+    fi
+    current_file=""
+    current_stale=""
+  fi
+done <<< "$result"
+
+exit 0

--- a/plugins/loaf/skills/brainstorm/SKILL.md
+++ b/plugins/loaf/skills/brainstorm/SKILL.md
@@ -44,8 +44,10 @@ Unlike `/loaf:idea` (quick capture) or `/loaf:shape` (rigorous bounding), brains
 2. Gather context: VISION.md, STRATEGY.md, ARCHITECTURE.md, related ideas
 3. **Deep exploration**: ask about user value, problem depth, alternatives, risks, dependencies, scope (minimal vs maximal)
 4. Generate options: conventional, minimal, ambitious, contrarian approaches
-5. Document with core insight, explored directions (approach/pros/cons), open questions, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](templates/brainstorm.md)
 6. Update idea file status if proceeding
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Problem Exploration
 
@@ -53,7 +55,9 @@ Unlike `/loaf:idea` (quick capture) or `/loaf:shape` (rigorous bounding), brains
 2. Gather strategic context
 3. **Diverge**: first principles, inversion, analogy, extreme constraints, persona lens
 4. **Converge**: filter by strategy alignment, feasibility, value
-5. Document with problem statement, options, analysis, recommendation, next steps
+5. Create brainstorm document following [brainstorm template](templates/brainstorm.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
 
 ### Open Brainstorm
 

--- a/plugins/loaf/skills/brainstorm/templates/brainstorm.md
+++ b/plugins/loaf/skills/brainstorm/templates/brainstorm.md
@@ -1,0 +1,43 @@
+# Brainstorm Document Template
+
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "Brainstorm: [Topic]"
+type: brainstorm
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active (has unprocessed sparks) | archived
+tags: []
+related: []            # Optional: idea files, spec IDs, session files
+---
+
+# Brainstorm: [Topic]
+
+**Date:** YYYY-MM-DD
+**Session:** [Brief description of session scope]
+
+## Session Journey
+
+[How the brainstorm evolved -- pivots, reframes, key realizations]
+
+## [Main Content Sections]
+
+[Organized by the brainstorm's natural structure -- options explored,
+analysis, trade-offs, convergence points]
+
+## Recommendation
+
+[If applicable -- the direction that emerged]
+
+## Open Questions
+
+- [Unresolved questions for further exploration]
+
+## Sparks
+
+- **[Title]** -- [one-line description]
+- **[Title]** -- [one-line description]
+```

--- a/plugins/loaf/skills/breakdown/SKILL.md
+++ b/plugins/loaf/skills/breakdown/SKILL.md
@@ -77,17 +77,24 @@ Extract: test conditions, scope, implementation notes, appetite.
 
 Break down by concern (DBA, Backend, Frontend, QA, DevOps). One concern per task. Explicit dependencies for sequential tasks.
 
-### Step 4: Interview for Priorities
+### Step 4: Decide Priorities and Granularity
 
-Ask about highest priority parts, required ordering, preferred implementation sequence.
+Own the granularity and priority decisions. Apply the Right Size Test, assign priorities
+based on dependencies and circuit breaker alignment, and do a self-review pass. Do not
+defer these decisions to the user — they trust agent judgment here.
+
+If genuinely uncertain (e.g., two equally valid orderings with different trade-offs),
+ask. Otherwise, decide and move on.
 
 ### Step 5: Draft Task List
 
 Create tasks following [task template](templates/task.md). Each task needs: clear title, priority, file hints, verification command, observable done condition.
 
-### Step 6: Present for Approval
+### Step 6: Present and Create
 
-Show tasks with priorities, dependencies, and dependency graph. **Do NOT create tasks without explicit approval.** User may adjust priorities, combine/split, add tasks, or change dependencies.
+Show the dependency graph and task summary for awareness, then create the tasks.
+Present it as "here's what I'm creating" not "which option do you prefer?" The user
+can still adjust after creation, but the default is to proceed.
 
 ### Step 7: Create Tasks
 
@@ -118,7 +125,7 @@ Set spec status to `implementing`. Announce created tasks with next steps.
 2. **Clear verification** -- how to prove it works
 3. **Observable done condition** -- not subjective
 4. **File hints** -- help session know where to look
-5. **Get approval** -- don't create without confirmation
+5. **Own the decisions** -- decide granularity and priorities, don't defer
 6. **Update spec status** -- mark as implementing
 
 ---

--- a/plugins/loaf/skills/idea/SKILL.md
+++ b/plugins/loaf/skills/idea/SKILL.md
@@ -29,7 +29,7 @@ Ideas are raw nuggets -- unprocessed, unshaped, but worth remembering. The goal 
 If `$ARGUMENTS` contains the idea, capture directly.
 
 If `$ARGUMENTS` is empty, **scan for sparks** in brainstorm documents:
-1. Search `.agents/drafts/brainstorm-*.md` for `## Sparks` sections
+1. Search `.agents/drafts/*brainstorm*.md` for `## Sparks` sections
 2. List unprocessed sparks (not marked as promoted or abandoned)
 3. Present the list and let the user pick one to promote
 4. When promoting: create idea file with `origin:` field, mark spark as `*(promoted)*` in source document
@@ -40,7 +40,7 @@ If no sparks found and no arguments, ask **at most 2-3 questions**: core idea, p
 
 Create file in `.agents/ideas/` following [idea template](templates/idea.md).
 
-**Filename:** `{YYYYMMDD}-{slug}.md`
+**Filename:** `{YYYYMMDD}-{HHMMSS}-{slug}.md`
 
 ### Step 3: Create and Announce
 

--- a/plugins/loaf/skills/idea/templates/idea.md
+++ b/plugins/loaf/skills/idea/templates/idea.md
@@ -1,13 +1,17 @@
 # Idea File Template
 
-**Location:** `.agents/ideas/{YYYYMMDD}-{slug}.md`
+**Location:** `.agents/ideas/{YYYYMMDD}-{HHMMSS}-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
 
 ```yaml
 ---
+title: "[Idea Title]"
 captured: YYYY-MM-DDTHH:MM:SSZ
 status: raw
 tags: []
-origin:              # Optional: brainstorm document this spark came from
+related: []            # Optional: spec IDs, file paths, or other idea files
+origin:                # Optional: brainstorm document this spark came from
 ---
 
 # [Idea Title]

--- a/plugins/loaf/skills/knowledge-base/SKILL.md
+++ b/plugins/loaf/skills/knowledge-base/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: knowledge-base
+description: >-
+  Provides guidance for creating, updating, and reviewing project knowledge
+  files. Covers frontmatter schema, naming conventions, staleness detection via
+  covers: field, and the review workflow. Use when creating new knowledge files,
+  updating existing ones, or when the agent needs to understand knowledge
+  management conventions. Not for retrieval or search (use QMD directly). Not
+  for architectural decisions (use ADRs). Not for agent instructions (use
+  CLAUDE.md).
+user-invocable: false
+allowed-tools: 'Read, Write, Edit, Bash, Glob, Grep'
+---
+
+# Knowledge Base
+
+Conventions and workflows for managing project knowledge files -- structured
+domain knowledge that lives in `docs/knowledge/` and persists across sessions.
+
+## Contents
+- When to Create a Knowledge File
+- Topics
+- The covers: Field
+- Review Workflow
+- What Goes Where
+- Critical Rules
+
+## When to Create a Knowledge File
+
+Create a knowledge file when information:
+
+1. **Requires context beyond the code** -- domain rules, business logic constraints,
+   cross-cutting patterns that cannot be expressed in types or docstrings
+2. **Spans multiple files or modules** -- conventions or contracts that apply across
+   the codebase, not localized to one function
+3. **Would be lost between sessions** -- insights that an agent needs repeatedly but
+   cannot derive from code alone
+4. **Serves as extended agent memory** -- roadmap context, implementation plans,
+   strategic direction that informs decisions
+
+Do NOT create knowledge files for:
+- Self-documenting code (types, docstrings, comments are sufficient)
+- One-off architectural decisions (write an ADR instead)
+- Agent behavior instructions (put those in CLAUDE.md)
+- User preferences or session pointers (those belong in MEMORY.md)
+
+## Topics
+
+| Topic | Reference | Use When |
+|-------|-----------|----------|
+| Frontmatter Schema | [frontmatter-schema.md](references/frontmatter-schema.md) | Creating or validating knowledge file frontmatter |
+| Naming Conventions | [naming-conventions.md](references/naming-conventions.md) | Deciding where to put knowledge and what to name it |
+
+| Template | Use When |
+|----------|----------|
+| [knowledge-file.md](templates/knowledge-file.md) | Creating a new knowledge file from scratch |
+
+## The covers: Field
+
+The `covers:` field is the core innovation of the knowledge management system.
+It links knowledge to code paths via glob patterns, enabling automatic staleness
+detection.
+
+### How It Works
+
+1. Author declares `covers:` globs in knowledge file frontmatter
+2. Globs resolve from the git repository root
+3. `loaf kb check` queries `git log --since={last_reviewed}` for matching files
+4. If commits exist since last review, the knowledge file is flagged as potentially stale
+
+### Good covers: Patterns
+
+```yaml
+covers:
+  - "src/pipeline/registry.py"          # Specific file
+  - "src/models/engine_*.py"            # Wildcard within directory
+  - "src/thermal/**/*.py"               # Recursive directory
+```
+
+### Patterns to Avoid
+
+```yaml
+covers:
+  - "src/**"                            # Too broad -- constant false positives
+  - "**/*.py"                           # Covers everything, means nothing
+  - "*.md"                              # Documentation changes != knowledge staleness
+```
+
+The goal is precision: cover the code paths whose changes would actually
+invalidate the knowledge. Broad globs lead to alert fatigue.
+
+### When to Omit covers:
+
+Files without `covers:` are valid knowledge files but cannot use automated
+staleness detection. Omit `covers:` when:
+
+- The knowledge is purely conceptual (no specific code paths)
+- The file covers external domain rules not tied to implementation
+- You are unsure which paths to cover (add them later when the mapping is clear)
+
+## Review Workflow
+
+### Check What Is Stale
+
+```bash
+loaf kb check
+```
+
+Shows knowledge files where covered code paths have changed since `last_reviewed`.
+
+### Validate Frontmatter
+
+```bash
+loaf kb validate
+```
+
+Checks all knowledge files for valid frontmatter: required fields present,
+correct types, valid glob patterns.
+
+### Review a File
+
+```bash
+loaf kb review <file>
+```
+
+After reading and updating a knowledge file, mark it as reviewed. This updates
+the `last_reviewed` date to today.
+
+### Overview
+
+```bash
+loaf kb status
+```
+
+Summary of all knowledge files: total count, stale count, files missing
+`covers:`, last review dates.
+
+## What Goes Where
+
+| Surface | Contains | Decision Test |
+|---------|----------|---------------|
+| **Code** (docstrings, types) | What the code does | Is it self-documenting? |
+| **Knowledge files** | Domain rules, cross-cutting context, roadmap | Requires context beyond the code? |
+| **ADRs** | Why we chose this approach | Is it an architectural decision? |
+| **CLAUDE.md** | Agent instructions, conventions | Is it about how agents should behave? |
+| **MEMORY.md** | User preferences, session pointers | Is it personal or ephemeral? |
+
+CLAUDE.md may reference knowledge files but should never duplicate their content.
+
+For the authoritative design document covering the full knowledge management
+system (QMD integration, growth loops, cross-project sharing), see
+`docs/knowledge/knowledge-management-design.md`.
+
+## Critical Rules
+
+### Always
+- Include `topics` (min 1) and `last_reviewed` in frontmatter
+- Use kebab-case filenames in `docs/knowledge/`
+- Add `covers:` globs when the knowledge maps to specific code paths
+- Run `loaf kb validate` before committing new knowledge files
+- Mark files reviewed with `loaf kb review` after updating
+
+### Never
+- Duplicate code documentation in knowledge files
+- Use date prefixes on knowledge filenames (unlike sessions or ideas)
+- Use overly broad `covers:` globs that trigger constant staleness alerts
+- Skip the `last_reviewed` field -- it is required for the lifecycle to work
+- Store knowledge files outside `docs/knowledge/` (ADRs go in `docs/decisions/`)

--- a/plugins/loaf/skills/knowledge-base/references/frontmatter-schema.md
+++ b/plugins/loaf/skills/knowledge-base/references/frontmatter-schema.md
@@ -1,0 +1,147 @@
+# Frontmatter Schema
+
+Detailed reference for knowledge file YAML frontmatter.
+
+## Contents
+- Required Fields
+- Recommended Fields
+- Optional Fields
+- Complete Example
+- Common Mistakes
+
+## Required Fields
+
+### topics
+
+- **Type:** list of strings (min 1)
+- **Purpose:** Semantic tags for routing and discovery. Agents and QMD use these
+  to find relevant knowledge files.
+
+```yaml
+topics: [engine-registry, strategy-pattern]
+```
+
+Choose tags that are specific enough to be useful for routing but general enough
+to remain stable as the codebase evolves. Prefer domain terms over implementation
+terms (e.g., `thermal-physics` over `heat-calc-module`).
+
+### last_reviewed
+
+- **Type:** string, ISO 8601 date (YYYY-MM-DD)
+- **Purpose:** Records when a human last verified the file's accuracy. Used by
+  `loaf kb check` to determine staleness.
+
+```yaml
+last_reviewed: 2026-03-14
+```
+
+Update this field only after genuinely reviewing the content -- do not bump it
+during routine edits that do not involve verification. Use `loaf kb review <file>`
+to update it properly.
+
+## Recommended Fields
+
+### covers
+
+- **Type:** list of glob strings
+- **Purpose:** Links knowledge to code paths. Globs resolve from the git
+  repository root. Enables automatic staleness detection.
+
+```yaml
+covers:
+  - "src/pipeline/registry.py"
+  - "src/models/engine_*.py"
+```
+
+**Glob resolution rules:**
+- Paths are relative to the git root (not the knowledge file location)
+- Standard glob syntax: `*` matches within a directory, `**` matches recursively
+- Patterns that match no files are silently ignored (but may indicate drift)
+
+**Precision guidelines:**
+- Cover the specific files whose changes would invalidate this knowledge
+- Avoid `src/**` or `**/*.py` -- too broad, causes alert fatigue
+- When unsure, start narrow and widen as you learn which paths matter
+
+## Optional Fields
+
+### consumers
+
+- **Type:** list of strings
+- **Purpose:** Agent routing hints. Indicates which agents or roles should be
+  aware of this knowledge.
+
+```yaml
+consumers: [backend, power-systems]
+```
+
+Values are freeform but should correspond to agent names or plugin-group names
+from `hooks.yaml`.
+
+### depends_on
+
+- **Type:** list of strings (filenames)
+- **Purpose:** Cross-references to other knowledge files. Indicates that this
+  file's content assumes or builds on another.
+
+```yaml
+depends_on: [thermal-physics.md, conductor-limits.md]
+```
+
+Use bare filenames (not paths). All knowledge files live in `docs/knowledge/`,
+so paths are implicit.
+
+### implementation_status
+
+- **Type:** enum string
+- **Valid values:** `in-progress` | `stable` | `deprecated`
+- **Default:** omit if stable (absence implies stable)
+- **Purpose:** Signals whether the knowledge reflects current, evolving, or
+  obsolete state.
+
+```yaml
+implementation_status: in-progress
+```
+
+| Value | Meaning |
+|-------|---------|
+| `in-progress` | Knowledge is being actively developed or the code it covers is in flux |
+| `stable` | Knowledge is current and verified |
+| `deprecated` | Knowledge is outdated; the domain or code has moved on |
+
+## Complete Example
+
+```yaml
+---
+topics: [engine-registry, strategy-pattern, pipeline]
+last_reviewed: 2026-03-14
+covers:
+  - "src/pipeline/registry.py"
+  - "src/models/engine_*.py"
+  - "src/pipeline/strategies/**/*.py"
+consumers: [backend, power-systems]
+depends_on: [thermal-physics.md]
+implementation_status: stable
+---
+
+# Engine Registry
+
+Domain rules for the engine registration and strategy selection system.
+
+## Key Rules
+
+- All engines must register via `EngineRegistry.register()`
+- Strategy selection is deterministic given the same input parameters
+- ...
+```
+
+## Common Mistakes
+
+| Mistake | Why It Is Wrong | Fix |
+|---------|-----------------|-----|
+| Missing `topics` | Required for routing; file is invisible to discovery | Add at least one topic |
+| `last_reviewed` in the future | Implies review that has not happened | Use today's date or earlier |
+| `covers: ["src/**"]` | Too broad; every commit triggers staleness | Narrow to specific paths |
+| `depends_on: ["docs/knowledge/foo.md"]` | Uses full path instead of filename | Use `depends_on: [foo.md]` |
+| `implementation_status: done` | Not a valid enum value | Use `stable` |
+| Topics that match code identifiers | Brittle; breaks on rename | Use domain-level terms |

--- a/plugins/loaf/skills/knowledge-base/references/naming-conventions.md
+++ b/plugins/loaf/skills/knowledge-base/references/naming-conventions.md
@@ -1,0 +1,57 @@
+# Naming Conventions
+
+Where knowledge files live, how to name them, and how they relate to other
+documentation surfaces. Based on ADR-004.
+
+## Directory Structure
+
+```
+docs/
+├── knowledge/          # Domain knowledge (cross-cutting context, rules)
+│   ├── build-system.md
+│   ├── thermal-physics.md
+│   └── knowledge-management-design.md
+└── decisions/          # Architecture Decision Records (immutable)
+    ├── ADR-001-some-decision.md
+    └── ADR-004-knowledge-naming-convention.md
+```
+
+- `docs/knowledge/` for domain knowledge files
+- `docs/decisions/` for ADRs
+- These directory names are deliberate: `knowledge` and `decisions` are
+  unambiguous, similar in length, and scan well together
+
+## Filename Rules
+
+| Rule | Example | Rationale |
+|------|---------|-----------|
+| Kebab-case | `build-system.md` | Consistent, URL-safe |
+| Descriptive | `thermal-physics.md` | Self-documenting |
+| No date prefixes | `build-system.md` | Knowledge is living; dates imply snapshots |
+| No abbreviations | `knowledge-management-design.md` | Clarity over brevity |
+
+**Contrast with other artifacts that DO use date prefixes:**
+- Sessions: `YYYYMMDD-HHMMSS-session-slug.md`
+- Ideas: `YYYYMMDD-HHMMSS-idea-slug.md`
+
+Knowledge files are living documents, not point-in-time snapshots.
+
+## CLI Abbreviation
+
+Per ADR-004, the CLI uses `kb` for ergonomics:
+
+- `loaf kb check` (not `loaf knowledge check`)
+- `loaf kb validate` (not `loaf knowledge validate`)
+
+The full word `knowledge` is for storage paths (directories, QMD collections).
+The abbreviation `kb` is for typing (CLI commands).
+
+## QMD Collection Naming
+
+When indexed by QMD:
+
+- `{repo-folder}-knowledge` for knowledge files
+- `{repo-folder}-decisions` for ADRs
+
+Example: a repo in `~/Code/gridsight-core-gds/` produces collections
+`gridsight-core-gds-knowledge` and `gridsight-core-gds-decisions`.

--- a/plugins/loaf/skills/knowledge-base/templates/knowledge-file.md
+++ b/plugins/loaf/skills/knowledge-base/templates/knowledge-file.md
@@ -1,0 +1,32 @@
+# Knowledge File Template
+
+**Location:** `docs/knowledge/{slug}.md`
+
+```yaml
+---
+topics: []                          # Required (min 1) -- semantic tags for routing
+last_reviewed: YYYY-MM-DD           # Required -- ISO 8601 date of last human review
+covers:                             # Recommended -- glob patterns from git root
+  - "path/to/covered/**/*.ts"
+consumers: []                       # Optional -- agent routing hints
+depends_on: []                      # Optional -- other knowledge file names
+implementation_status: in-progress  # Optional -- in-progress | stable | deprecated
+---
+
+# [Title]
+
+Brief description of what this knowledge covers and why it exists.
+
+## Key Rules
+
+- [Rule 1]
+- [Rule 2]
+
+## [Domain Section]
+
+[Domain-specific content organized by topic]
+
+## Cross-References
+
+- [Related knowledge file or ADR]
+```

--- a/plugins/loaf/skills/research/SKILL.md
+++ b/plugins/loaf/skills/research/SKILL.md
@@ -61,7 +61,9 @@ Always check project context first. Rate findings: **High** (official/verified),
 1. **Interview** with AskUserQuestion: what are you trying to understand? What context do you have? What decision will this inform?
 2. Check project context first (ADRs, ARCHITECTURE, sessions)
 3. Apply confidence hierarchy for external sources
-4. Synthesize following [findings template](templates/findings.md)
+4. Create findings document following [findings template](templates/findings.md)
+
+**Output file:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-research-{slug}.md`
 
 ### Brainstorming
 

--- a/plugins/loaf/skills/research/templates/findings.md
+++ b/plugins/loaf/skills/research/templates/findings.md
@@ -1,42 +1,62 @@
-# Research Findings Output Template
+# Research Findings Template
 
-```markdown
-## Research: [Topic]
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-research-{slug}.md`
+
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "Research: [Topic]"
+type: research
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active | archived
+tags: []
+related: []            # Optional: spec IDs, idea files, ADRs
+---
+
+# Research: [Topic]
 
 **Question:** [What we're trying to understand]
 
-### Summary
+## Summary
+
 [One-paragraph answer with confidence level]
 
-### Key Findings
+## Key Findings
+
 1. [Finding 1]
 2. [Finding 2]
 
-### Project Context
+## Project Context
+
 [How this relates to our existing decisions/loaf:architecture]
 
-### Options Considered
+## Options Considered
 
-#### Option A: [Name]
+### Option A: [Name]
 - **Pros:** ...
 - **Cons:** ...
 - **Best for:** ...
 
-#### Option B: [Name]
+### Option B: [Name]
 - **Pros:** ...
 - **Cons:** ...
 - **Best for:** ...
 
-### Recommendation
+## Recommendation
+
 [Which option and why, with caveats]
 
-### Sources
+## Sources
+
 - [Source 1 with confidence level]
 - [Source 2 with confidence level]
 
-### Implications
+## Implications
+
 - [What this means for our work]
 
-### Open Questions
+## Open Questions
+
 - [What's still unclear]
 ```

--- a/plugins/loaf/skills/research/templates/state-assessment.md
+++ b/plugins/loaf/skills/research/templates/state-assessment.md
@@ -1,38 +1,58 @@
-# State Assessment Output Template
+# State Assessment Template
 
-```markdown
-## Project State Assessment
+State assessments are typically presented in-conversation. If saved to a file:
 
-**Date:** YYYY-MM-DD
+**Location:** `.agents/drafts/{YYYYMMDD}-{HHMMSS}-state-assessment.md`
 
-### Current Position
+**Filename timestamp:** `date -u +"%Y%m%d-%H%M%S"`
+
+```yaml
+---
+title: "State Assessment: [YYYY-MM-DD]"
+type: state-assessment
+created: YYYY-MM-DDTHH:MM:SSZ
+status: active         # active | archived
+tags: []
+---
+
+# Project State Assessment
+
+## Current Position
+
 - [Summary of where the project stands]
 
-### Strategic Context
+## Strategic Context
+
 - **Vision:** [Brief summary]
 - **Key personas:** [Who we're building for]
 - **Current focus:** [Active specs/work]
 
-### Recent Progress
+## Recent Progress
+
 - [Key accomplishments from recent sessions]
 
-### In Flight
+## In Flight
+
 | Spec/Task | Status | Notes |
 |-----------|--------|-------|
 | SPEC-001 | implementing | [progress] |
 | SPEC-002 | approved | [next up] |
 
-### Ideas Pipeline
+## Ideas Pipeline
+
 - [Idea 1] -- raw
 - [Idea 2] -- raw
 
-### Lessons Learned (Recent)
+## Lessons Learned (Recent)
+
 - [Insights from implementation feedback]
 
-### Open Questions
+## Open Questions
+
 - [Unresolved decisions or gaps]
 
-### Recommendations
+## Recommendations
+
 1. [Actionable next step]
 2. [Actionable next step]
 ```


### PR DESCRIPTION
## Summary

- **`loaf kb` CLI** with 7 subcommands: `init`, `validate`, `check`, `status`, `review`, `import`, plus the core library (types, loader, resolve, staleness)
- **Staleness detection** via `covers:` frontmatter field + `git log` — the core innovation. Links knowledge files to code paths via globs; detects when covered code changes after the knowledge was last reviewed
- **Lifecycle hooks** — SessionStart (surfaces stale count), PostToolUse (nudges once per session when editing covered files), SessionEnd (consolidation prompt)
- **QMD soft dependency** — core commands work without QMD; `init` and `import` use it when available
- **knowledge-base reference skill** — agent guidance for creating, updating, and reviewing knowledge files
- **208 tests** across 9 suites, all passing

## Tasks

- [x] TASK-033: KB core library (types, loader, resolve, config)
- [x] TASK-034: KB validate, status, and review commands
- [x] TASK-035: Staleness detection + check command
- [x] TASK-036: Lifecycle hooks (SessionStart, PostToolUse, SessionEnd)
- [x] TASK-037: QMD soft integration + kb init
- [x] TASK-038: KB import command (stretch goal)
- [x] TASK-039: knowledge-base reference skill

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run test` passes (208 tests)
- [ ] `loaf build` succeeds across all 5 targets
- [ ] `loaf kb init` scaffolds dirs and is idempotent
- [ ] `loaf kb validate` reports errors and warnings on real knowledge files
- [ ] `loaf kb check` detects stale files with commit counts and authors
- [ ] `loaf kb check --file <path>` reverse-lookups covering knowledge files
- [ ] `loaf kb status` shows summary with stale count
- [ ] `loaf kb review <file>` updates last_reviewed date
- [ ] `loaf kb import <name>` errors helpfully when QMD not installed
- [ ] All commands support `--json` for structured output