### PR TITLE
feat: add /reflect workflow suggestions

### DIFF
--- a/.agents/TASKS.json
+++ b/.agents/TASKS.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 50,
+  "next_id": 53,
   "tasks": {
     "TASK-001": {
       "title": "Create verification reference",
@@ -979,6 +979,58 @@
       "updated": "2026-03-27T16:45:24.486Z",
       "completed_at": "2026-03-27T16:45:24.485Z",
       "file": "archive/TASK-049-hook-registration-build-integration-docs.md"
+    },
+    "TASK-050": {
+      "title": "Fix stale paths in /reflect SKILL.md",
+      "slug": "fix-stale-paths-in-reflect-skill-md",
+      "spec": "SPEC-011",
+      "status": "done",
+      "priority": "P1",
+      "depends_on": [],
+      "files": [],
+      "verify": null,
+      "done": null,
+      "session": null,
+      "created": "2026-03-27T23:19:02.500Z",
+      "updated": "2026-03-27T23:26:22.598Z",
+      "completed_at": "2026-03-27T23:26:22.597Z",
+      "file": "TASK-050-fix-stale-paths-in-reflect-skill-md.md"
+    },
+    "TASK-051": {
+      "title": "Add /reflect suggestion to /implement AFTER phase",
+      "slug": "add-reflect-suggestion-to-implement-after-phase",
+      "spec": "SPEC-011",
+      "status": "done",
+      "priority": "P1",
+      "depends_on": [
+        "TASK-050"
+      ],
+      "files": [],
+      "verify": null,
+      "done": null,
+      "session": null,
+      "created": "2026-03-27T23:19:05.410Z",
+      "updated": "2026-03-27T23:26:23.114Z",
+      "completed_at": "2026-03-27T23:26:23.114Z",
+      "file": "TASK-051-add-reflect-suggestion-to-implement-after-phase.md"
+    },
+    "TASK-052": {
+      "title": "Add /reflect suggestions to /shape and /cleanup",
+      "slug": "add-reflect-suggestions-to-shape-and-cleanup",
+      "spec": "SPEC-011",
+      "status": "done",
+      "priority": "P2",
+      "depends_on": [
+        "TASK-050"
+      ],
+      "files": [],
+      "verify": null,
+      "done": null,
+      "session": null,
+      "created": "2026-03-27T23:19:09.457Z",
+      "updated": "2026-03-27T23:26:23.582Z",
+      "completed_at": "2026-03-27T23:26:23.581Z",
+      "file": "TASK-052-add-reflect-suggestions-to-shape-and-cleanup.md"
     }
   },
   "specs": {

--- a/.agents/tasks/TASK-050-fix-stale-paths-in-reflect-skill-md.md
+++ b/.agents/tasks/TASK-050-fix-stale-paths-in-reflect-skill-md.md
@@ -1,0 +1,34 @@
+---
+id: TASK-050
+title: Fix stale paths in /reflect SKILL.md
+spec: SPEC-011
+status: done
+priority: P1
+created: '2026-03-27T23:19:02.500Z'
+updated: '2026-03-27T23:26:22.598Z'
+completed_at: '2026-03-27T23:26:22.597Z'
+---
+
+# TASK-050: Fix stale paths in /reflect SKILL.md
+
+## Description
+
+Fix stale file paths in `/reflect` SKILL.md. Line 49 references `docs/specs/SPEC-*.md` but specs live at `.agents/specs/`. Verify all other paths (session paths, template links, strategic doc paths) are accurate.
+
+**Files:** `content/skills/reflect/SKILL.md`
+
+## Acceptance Criteria
+
+- [ ] `docs/specs/SPEC-*.md` on line 49 changed to `.agents/specs/SPEC-*.md`
+- [ ] Session path (`.agents/sessions/`) confirmed correct
+- [ ] Template link (`templates/update-proposal.md`) confirmed resolving
+- [ ] Strategic doc paths (VISION.md, STRATEGY.md, ARCHITECTURE.md) confirmed accurate
+- [ ] `loaf build` succeeds
+
+## Verification
+
+```bash
+loaf build
+grep -c 'docs/specs/' content/skills/reflect/SKILL.md  # should be 0
+grep -c '.agents/specs/' content/skills/reflect/SKILL.md  # should be >= 1
+```

--- a/.agents/tasks/TASK-051-add-reflect-suggestion-to-implement-after-phase.md
+++ b/.agents/tasks/TASK-051-add-reflect-suggestion-to-implement-after-phase.md
@@ -1,0 +1,45 @@
+---
+id: TASK-051
+title: Add /reflect suggestion to /implement AFTER phase
+spec: SPEC-011
+status: done
+priority: P1
+created: '2026-03-27T23:19:05.410Z'
+updated: '2026-03-27T23:26:23.114Z'
+depends_on:
+  - TASK-050
+completed_at: '2026-03-27T23:26:23.114Z'
+---
+
+# TASK-051: Add /reflect suggestion to /implement AFTER phase
+
+## Description
+
+Add a conditional `/reflect` suggestion as step 8 in the AFTER (Completion) block of `/implement` SKILL.md, after "Commit housekeeping to main."
+
+**Detection signals** (any triggers the suggestion):
+- Session body `## Key Decisions` has content (not `*(none yet)*` or empty) — **primary**
+- Session frontmatter `traceability.decisions` has entries (ADRs were created)
+- Linked spec (`session.spec`) has `## Lessons Learned` with content
+- Session has `session.spec` set (linked to meaningful work)
+
+**Suggestion text:** "This session produced key decisions. Consider running /reflect to update strategic docs."
+
+Silent when no detection signals are present.
+
+**Files:** `content/skills/implement/SKILL.md`
+
+## Acceptance Criteria
+
+- [ ] Step 8 added to AFTER block with conditional `/reflect` suggestion
+- [ ] Detection signals documented clearly
+- [ ] Suggestion is advisory only (never blocking)
+- [ ] Silent when no signals present
+- [ ] `loaf build` succeeds
+
+## Verification
+
+```bash
+loaf build
+grep -c 'Consider running /reflect' content/skills/implement/SKILL.md  # should be >= 1
+```

--- a/.agents/tasks/TASK-052-add-reflect-suggestions-to-shape-and-cleanup.md
+++ b/.agents/tasks/TASK-052-add-reflect-suggestions-to-shape-and-cleanup.md
@@ -1,0 +1,43 @@
+---
+id: TASK-052
+title: Add /reflect suggestions to /shape and /cleanup
+spec: SPEC-011
+status: done
+priority: P2
+created: '2026-03-27T23:19:09.457Z'
+updated: '2026-03-27T23:26:23.582Z'
+depends_on:
+  - TASK-050
+completed_at: '2026-03-27T23:26:23.581Z'
+---
+
+# TASK-052: Add /reflect suggestions to /shape and /cleanup
+
+## Description
+
+Add `/reflect` suggestions to two skills:
+
+**Shape:** Add Step 9 after "Create Spec File" — conditionally suggest `/reflect` when the shaping session produced key decisions. Signals: `## Key Decisions` has content (primary), `traceability.decisions` has entries. No spec-lessons signal (spec was just created). Suggestion: "This shaping session produced key decisions. Consider running /reflect to update strategic docs."
+
+**Cleanup:** In section "C. Check for Extraction Needs" (lines 48-52 within Sessions section), add `/reflect` as the recommended action for sessions with `decisions`. In section "D. Present Per Session" (lines 54-56), add "Extract & Archive → suggest `/reflect` before archiving" for sessions with extractable learnings. Note: cleanup SKILL.md was recently updated with a new Tasks section (section 2) — Sessions section is still section 1.
+
+**Files:** `content/skills/shape/SKILL.md`, `content/skills/cleanup/SKILL.md`
+
+**Circuit breaker:** At 75%, ship shape only and skip cleanup.
+
+## Acceptance Criteria
+
+- [ ] `/shape` Step 9 suggests `/reflect` after spec creation when decisions exist
+- [ ] `/shape` stays silent when no decisions to extract
+- [ ] `/cleanup` section C mentions `/reflect` as extraction mechanism
+- [ ] `/cleanup` section D recommends `/reflect` before archiving sessions with learnings
+- [ ] Suggestions are advisory only (never blocking)
+- [ ] `loaf build` succeeds
+
+## Verification
+
+```bash
+loaf build
+grep -c 'reflect' content/skills/shape/SKILL.md     # should be >= 3 (existing + new)
+grep -c 'reflect' content/skills/cleanup/SKILL.md    # should be >= 1
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Advisory `/reflect` suggestion in `/implement` AFTER phase when session has extractable learnings (SPEC-011)
+- Post-implementation reflection flag in `/shape` Step 9 for sessions with strategic tensions (SPEC-011)
+- `/reflect` recommendation in `/cleanup` extraction checks before archiving decision-rich sessions (SPEC-011)
+
+### Fixed
+- Stale `docs/specs/` paths in `/reflect`, `/shape`, and spec template — now `.agents/specs/`
+
 ## [2.0.0-dev.4] - 2026-03-27
 
 ### Added

--- a/content/skills/cleanup/SKILL.md
+++ b/content/skills/cleanup/SKILL.md
@@ -48,12 +48,13 @@ For EACH session file in `.agents/sessions/` and `.agents/sessions/archive/`:
 ### C. Check for Extraction Needs
 - [ ] Contains `lessons_learned`? → Extract to relevant docs
 - [ ] Contains unrecorded `decisions`? → Suggest ADR creation
+- [ ] `## Key Decisions` has content or `traceability.decisions` has entries? → Suggest running `/reflect` before archiving
 - [ ] Contains `remaining_work`/`next_steps`/`technical_debt`? → Check if tracked
 - [ ] CHANGELOG draft present but not integrated? → Flag for integration
 
 ### D. Present Per Session
 Summary (2-3 lines), issues found, extraction recommendations.
-Recommendation: **Extract & Archive** / **Archive** / **Keep**
+Recommendation: **Extract & Archive** (suggest `/reflect` first) / **Archive** / **Keep**
 
 ---
 

--- a/content/skills/implement/SKILL.md
+++ b/content/skills/implement/SKILL.md
@@ -181,6 +181,11 @@ After creating session AND plan files:
 5. `loaf task update TASK-XXX --status done`
 6. Update session file (status: complete, `archived_at`, `archived_by`)
 7. Commit housekeeping to main: `chore: close TASK-XXX session`
+8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
+   - `## Key Decisions` has content (not `*(none yet)*` or empty)
+   - `traceability.decisions` has entries (ADRs were recorded)
+   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
+   If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
 

--- a/content/skills/implement/SKILL.md
+++ b/content/skills/implement/SKILL.md
@@ -184,7 +184,6 @@ After creating session AND plan files:
 8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
-   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---

--- a/content/skills/reflect/SKILL.md
+++ b/content/skills/reflect/SKILL.md
@@ -46,7 +46,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`docs/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
 2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/content/skills/shape/SKILL.md
+++ b/content/skills/shape/SKILL.md
@@ -88,7 +88,7 @@ After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file sta
 
 ### Step 9: Flag for Post-Implementation Reflection
 
-If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/reflect` should be run after implementation ships. Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
+If shaping surfaced strategic tensions (noted in the spec's "Strategic Alignment" section per the Strategic Tensions guidelines below), remind the user: *"This spec has strategic tensions. After implementation ships, run `/reflect` to update strategic docs."* Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/content/skills/shape/SKILL.md
+++ b/content/skills/shape/SKILL.md
@@ -54,7 +54,7 @@ Read in order: VISION.md, STRATEGY.md, ARCHITECTURE.md, existing specs.
 | Does this advance our vision? | VISION.md |
 | Does this serve our target personas? | STRATEGY.md |
 | Does this fit our technical constraints? | ARCHITECTURE.md |
-| Does this conflict with existing work? | docs/specs/ |
+| Does this conflict with existing work? | .agents/specs/ |
 
 If misaligned: surface the tension, adjust idea, or note for `/reflect` later.
 
@@ -72,7 +72,7 @@ Create spec following [spec template](templates/spec.md).
 ### Step 6: Generate Spec ID
 
 ```bash
-ls docs/specs/SPEC-*.md docs/specs/archive/SPEC-*.md 2>/dev/null | \
+ls .agents/specs/SPEC-*.md .agents/specs/archive/SPEC-*.md 2>/dev/null | \
   grep -oE 'SPEC-[0-9]+' | sort -t- -k2 -n | tail -1 | awk -F- '{print $2 + 1}'
 ```
 
@@ -84,7 +84,11 @@ Present full spec. **Do NOT create spec file without explicit approval.** User m
 
 ### Step 8: Create Spec File
 
-After approval: create `docs/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+
+### Step 9: Flag for Post-Implementation Reflection
+
+If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/reflect` should be run after implementation ships. Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/content/skills/shape/templates/spec.md
+++ b/content/skills/shape/templates/spec.md
@@ -1,6 +1,6 @@
 # Spec Template
 
-**Location:** `docs/specs/SPEC-{id}-{slug}.md`
+**Location:** `.agents/specs/SPEC-{id}-{slug}.md`
 
 ```yaml
 ---

--- a/dist/codex/skills/cleanup/SKILL.md
+++ b/dist/codex/skills/cleanup/SKILL.md
@@ -50,12 +50,13 @@ For EACH session file in `.agents/sessions/` and `.agents/sessions/archive/`:
 ### C. Check for Extraction Needs
 - [ ] Contains `lessons_learned`? → Extract to relevant docs
 - [ ] Contains unrecorded `decisions`? → Suggest ADR creation
+- [ ] `## Key Decisions` has content or `traceability.decisions` has entries? → Suggest running `/reflect` before archiving
 - [ ] Contains `remaining_work`/`next_steps`/`technical_debt`? → Check if tracked
 - [ ] CHANGELOG draft present but not integrated? → Flag for integration
 
 ### D. Present Per Session
 Summary (2-3 lines), issues found, extraction recommendations.
-Recommendation: **Extract & Archive** / **Archive** / **Keep**
+Recommendation: **Extract & Archive** (suggest `/reflect` first) / **Archive** / **Keep**
 
 ---
 

--- a/dist/codex/skills/implement/SKILL.md
+++ b/dist/codex/skills/implement/SKILL.md
@@ -183,6 +183,11 @@ After creating session AND plan files:
 5. `loaf task update TASK-XXX --status done`
 6. Update session file (status: complete, `archived_at`, `archived_by`)
 7. Commit housekeeping to main: `chore: close TASK-XXX session`
+8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
+   - `## Key Decisions` has content (not `*(none yet)*` or empty)
+   - `traceability.decisions` has entries (ADRs were recorded)
+   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
+   If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
 

--- a/dist/codex/skills/implement/SKILL.md
+++ b/dist/codex/skills/implement/SKILL.md
@@ -186,7 +186,6 @@ After creating session AND plan files:
 8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
-   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---

--- a/dist/codex/skills/reflect/SKILL.md
+++ b/dist/codex/skills/reflect/SKILL.md
@@ -47,7 +47,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`docs/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
 2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/codex/skills/shape/SKILL.md
+++ b/dist/codex/skills/shape/SKILL.md
@@ -56,7 +56,7 @@ Read in order: VISION.md, STRATEGY.md, ARCHITECTURE.md, existing specs.
 | Does this advance our vision? | VISION.md |
 | Does this serve our target personas? | STRATEGY.md |
 | Does this fit our technical constraints? | ARCHITECTURE.md |
-| Does this conflict with existing work? | docs/specs/ |
+| Does this conflict with existing work? | .agents/specs/ |
 
 If misaligned: surface the tension, adjust idea, or note for `/reflect` later.
 
@@ -74,7 +74,7 @@ Create spec following [spec template](templates/spec.md).
 ### Step 6: Generate Spec ID
 
 ```bash
-ls docs/specs/SPEC-*.md docs/specs/archive/SPEC-*.md 2>/dev/null | \
+ls .agents/specs/SPEC-*.md .agents/specs/archive/SPEC-*.md 2>/dev/null | \
   grep -oE 'SPEC-[0-9]+' | sort -t- -k2 -n | tail -1 | awk -F- '{print $2 + 1}'
 ```
 
@@ -86,7 +86,11 @@ Present full spec. **Do NOT create spec file without explicit approval.** User m
 
 ### Step 8: Create Spec File
 
-After approval: create `docs/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+
+### Step 9: Flag for Post-Implementation Reflection
+
+If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/reflect` should be run after implementation ships. Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/dist/codex/skills/shape/SKILL.md
+++ b/dist/codex/skills/shape/SKILL.md
@@ -90,7 +90,7 @@ After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file sta
 
 ### Step 9: Flag for Post-Implementation Reflection
 
-If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/reflect` should be run after implementation ships. Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
+If shaping surfaced strategic tensions (noted in the spec's "Strategic Alignment" section per the Strategic Tensions guidelines below), remind the user: *"This spec has strategic tensions. After implementation ships, run `/reflect` to update strategic docs."* Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/dist/codex/skills/shape/templates/spec.md
+++ b/dist/codex/skills/shape/templates/spec.md
@@ -1,6 +1,6 @@
 # Spec Template
 
-**Location:** `docs/specs/SPEC-{id}-{slug}.md`
+**Location:** `.agents/specs/SPEC-{id}-{slug}.md`
 
 ```yaml
 ---

--- a/dist/cursor/skills/cleanup/SKILL.md
+++ b/dist/cursor/skills/cleanup/SKILL.md
@@ -50,12 +50,13 @@ For EACH session file in `.agents/sessions/` and `.agents/sessions/archive/`:
 ### C. Check for Extraction Needs
 - [ ] Contains `lessons_learned`? → Extract to relevant docs
 - [ ] Contains unrecorded `decisions`? → Suggest ADR creation
+- [ ] `## Key Decisions` has content or `traceability.decisions` has entries? → Suggest running `/reflect` before archiving
 - [ ] Contains `remaining_work`/`next_steps`/`technical_debt`? → Check if tracked
 - [ ] CHANGELOG draft present but not integrated? → Flag for integration
 
 ### D. Present Per Session
 Summary (2-3 lines), issues found, extraction recommendations.
-Recommendation: **Extract & Archive** / **Archive** / **Keep**
+Recommendation: **Extract & Archive** (suggest `/reflect` first) / **Archive** / **Keep**
 
 ---
 

--- a/dist/cursor/skills/implement/SKILL.md
+++ b/dist/cursor/skills/implement/SKILL.md
@@ -183,6 +183,11 @@ After creating session AND plan files:
 5. `loaf task update TASK-XXX --status done`
 6. Update session file (status: complete, `archived_at`, `archived_by`)
 7. Commit housekeeping to main: `chore: close TASK-XXX session`
+8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
+   - `## Key Decisions` has content (not `*(none yet)*` or empty)
+   - `traceability.decisions` has entries (ADRs were recorded)
+   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
+   If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
 

--- a/dist/cursor/skills/implement/SKILL.md
+++ b/dist/cursor/skills/implement/SKILL.md
@@ -186,7 +186,6 @@ After creating session AND plan files:
 8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
-   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---

--- a/dist/cursor/skills/reflect/SKILL.md
+++ b/dist/cursor/skills/reflect/SKILL.md
@@ -47,7 +47,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`docs/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
 2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/cursor/skills/shape/SKILL.md
+++ b/dist/cursor/skills/shape/SKILL.md
@@ -56,7 +56,7 @@ Read in order: VISION.md, STRATEGY.md, ARCHITECTURE.md, existing specs.
 | Does this advance our vision? | VISION.md |
 | Does this serve our target personas? | STRATEGY.md |
 | Does this fit our technical constraints? | ARCHITECTURE.md |
-| Does this conflict with existing work? | docs/specs/ |
+| Does this conflict with existing work? | .agents/specs/ |
 
 If misaligned: surface the tension, adjust idea, or note for `/reflect` later.
 
@@ -74,7 +74,7 @@ Create spec following [spec template](templates/spec.md).
 ### Step 6: Generate Spec ID
 
 ```bash
-ls docs/specs/SPEC-*.md docs/specs/archive/SPEC-*.md 2>/dev/null | \
+ls .agents/specs/SPEC-*.md .agents/specs/archive/SPEC-*.md 2>/dev/null | \
   grep -oE 'SPEC-[0-9]+' | sort -t- -k2 -n | tail -1 | awk -F- '{print $2 + 1}'
 ```
 
@@ -86,7 +86,11 @@ Present full spec. **Do NOT create spec file without explicit approval.** User m
 
 ### Step 8: Create Spec File
 
-After approval: create `docs/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+
+### Step 9: Flag for Post-Implementation Reflection
+
+If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/reflect` should be run after implementation ships. Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/dist/cursor/skills/shape/SKILL.md
+++ b/dist/cursor/skills/shape/SKILL.md
@@ -90,7 +90,7 @@ After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file sta
 
 ### Step 9: Flag for Post-Implementation Reflection
 
-If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/reflect` should be run after implementation ships. Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
+If shaping surfaced strategic tensions (noted in the spec's "Strategic Alignment" section per the Strategic Tensions guidelines below), remind the user: *"This spec has strategic tensions. After implementation ships, run `/reflect` to update strategic docs."* Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/dist/cursor/skills/shape/templates/spec.md
+++ b/dist/cursor/skills/shape/templates/spec.md
@@ -1,6 +1,6 @@
 # Spec Template
 
-**Location:** `docs/specs/SPEC-{id}-{slug}.md`
+**Location:** `.agents/specs/SPEC-{id}-{slug}.md`
 
 ```yaml
 ---

--- a/dist/gemini/skills/cleanup/SKILL.md
+++ b/dist/gemini/skills/cleanup/SKILL.md
@@ -50,12 +50,13 @@ For EACH session file in `.agents/sessions/` and `.agents/sessions/archive/`:
 ### C. Check for Extraction Needs
 - [ ] Contains `lessons_learned`? → Extract to relevant docs
 - [ ] Contains unrecorded `decisions`? → Suggest ADR creation
+- [ ] `## Key Decisions` has content or `traceability.decisions` has entries? → Suggest running `/reflect` before archiving
 - [ ] Contains `remaining_work`/`next_steps`/`technical_debt`? → Check if tracked
 - [ ] CHANGELOG draft present but not integrated? → Flag for integration
 
 ### D. Present Per Session
 Summary (2-3 lines), issues found, extraction recommendations.
-Recommendation: **Extract & Archive** / **Archive** / **Keep**
+Recommendation: **Extract & Archive** (suggest `/reflect` first) / **Archive** / **Keep**
 
 ---
 

--- a/dist/gemini/skills/implement/SKILL.md
+++ b/dist/gemini/skills/implement/SKILL.md
@@ -183,6 +183,11 @@ After creating session AND plan files:
 5. `loaf task update TASK-XXX --status done`
 6. Update session file (status: complete, `archived_at`, `archived_by`)
 7. Commit housekeeping to main: `chore: close TASK-XXX session`
+8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
+   - `## Key Decisions` has content (not `*(none yet)*` or empty)
+   - `traceability.decisions` has entries (ADRs were recorded)
+   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
+   If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
 

--- a/dist/gemini/skills/implement/SKILL.md
+++ b/dist/gemini/skills/implement/SKILL.md
@@ -186,7 +186,6 @@ After creating session AND plan files:
 8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
-   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---

--- a/dist/gemini/skills/reflect/SKILL.md
+++ b/dist/gemini/skills/reflect/SKILL.md
@@ -47,7 +47,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`docs/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
 2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/gemini/skills/shape/SKILL.md
+++ b/dist/gemini/skills/shape/SKILL.md
@@ -56,7 +56,7 @@ Read in order: VISION.md, STRATEGY.md, ARCHITECTURE.md, existing specs.
 | Does this advance our vision? | VISION.md |
 | Does this serve our target personas? | STRATEGY.md |
 | Does this fit our technical constraints? | ARCHITECTURE.md |
-| Does this conflict with existing work? | docs/specs/ |
+| Does this conflict with existing work? | .agents/specs/ |
 
 If misaligned: surface the tension, adjust idea, or note for `/reflect` later.
 
@@ -74,7 +74,7 @@ Create spec following [spec template](templates/spec.md).
 ### Step 6: Generate Spec ID
 
 ```bash
-ls docs/specs/SPEC-*.md docs/specs/archive/SPEC-*.md 2>/dev/null | \
+ls .agents/specs/SPEC-*.md .agents/specs/archive/SPEC-*.md 2>/dev/null | \
   grep -oE 'SPEC-[0-9]+' | sort -t- -k2 -n | tail -1 | awk -F- '{print $2 + 1}'
 ```
 
@@ -86,7 +86,11 @@ Present full spec. **Do NOT create spec file without explicit approval.** User m
 
 ### Step 8: Create Spec File
 
-After approval: create `docs/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+
+### Step 9: Flag for Post-Implementation Reflection
+
+If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/reflect` should be run after implementation ships. Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/dist/gemini/skills/shape/SKILL.md
+++ b/dist/gemini/skills/shape/SKILL.md
@@ -90,7 +90,7 @@ After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file sta
 
 ### Step 9: Flag for Post-Implementation Reflection
 
-If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/reflect` should be run after implementation ships. Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
+If shaping surfaced strategic tensions (noted in the spec's "Strategic Alignment" section per the Strategic Tensions guidelines below), remind the user: *"This spec has strategic tensions. After implementation ships, run `/reflect` to update strategic docs."* Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/dist/gemini/skills/shape/templates/spec.md
+++ b/dist/gemini/skills/shape/templates/spec.md
@@ -1,6 +1,6 @@
 # Spec Template
 
-**Location:** `docs/specs/SPEC-{id}-{slug}.md`
+**Location:** `.agents/specs/SPEC-{id}-{slug}.md`
 
 ```yaml
 ---

--- a/dist/opencode/commands/cleanup.md
+++ b/dist/opencode/commands/cleanup.md
@@ -51,12 +51,13 @@ For EACH session file in `.agents/sessions/` and `.agents/sessions/archive/`:
 ### C. Check for Extraction Needs
 - [ ] Contains `lessons_learned`? → Extract to relevant docs
 - [ ] Contains unrecorded `decisions`? → Suggest ADR creation
+- [ ] `## Key Decisions` has content or `traceability.decisions` has entries? → Suggest running `/reflect` before archiving
 - [ ] Contains `remaining_work`/`next_steps`/`technical_debt`? → Check if tracked
 - [ ] CHANGELOG draft present but not integrated? → Flag for integration
 
 ### D. Present Per Session
 Summary (2-3 lines), issues found, extraction recommendations.
-Recommendation: **Extract & Archive** / **Archive** / **Keep**
+Recommendation: **Extract & Archive** (suggest `/reflect` first) / **Archive** / **Keep**
 
 ---
 

--- a/dist/opencode/commands/implement.md
+++ b/dist/opencode/commands/implement.md
@@ -184,6 +184,11 @@ After creating session AND plan files:
 5. `loaf task update TASK-XXX --status done`
 6. Update session file (status: complete, `archived_at`, `archived_by`)
 7. Commit housekeeping to main: `chore: close TASK-XXX session`
+8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
+   - `## Key Decisions` has content (not `*(none yet)*` or empty)
+   - `traceability.decisions` has entries (ADRs were recorded)
+   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
+   If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
 

--- a/dist/opencode/commands/implement.md
+++ b/dist/opencode/commands/implement.md
@@ -187,7 +187,6 @@ After creating session AND plan files:
 8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
-   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---

--- a/dist/opencode/commands/reflect.md
+++ b/dist/opencode/commands/reflect.md
@@ -48,7 +48,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`docs/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
 2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/opencode/commands/shape.md
+++ b/dist/opencode/commands/shape.md
@@ -57,7 +57,7 @@ Read in order: VISION.md, STRATEGY.md, ARCHITECTURE.md, existing specs.
 | Does this advance our vision? | VISION.md |
 | Does this serve our target personas? | STRATEGY.md |
 | Does this fit our technical constraints? | ARCHITECTURE.md |
-| Does this conflict with existing work? | docs/specs/ |
+| Does this conflict with existing work? | .agents/specs/ |
 
 If misaligned: surface the tension, adjust idea, or note for `/reflect` later.
 
@@ -75,7 +75,7 @@ Create spec following [spec template](../skills/shape/templates/spec.md).
 ### Step 6: Generate Spec ID
 
 ```bash
-ls docs/specs/SPEC-*.md docs/specs/archive/SPEC-*.md 2>/dev/null | \
+ls .agents/specs/SPEC-*.md .agents/specs/archive/SPEC-*.md 2>/dev/null | \
   grep -oE 'SPEC-[0-9]+' | sort -t- -k2 -n | tail -1 | awk -F- '{print $2 + 1}'
 ```
 
@@ -87,7 +87,11 @@ Present full spec. **Do NOT create spec file without explicit approval.** User m
 
 ### Step 8: Create Spec File
 
-After approval: create `docs/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+
+### Step 9: Flag for Post-Implementation Reflection
+
+If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/reflect` should be run after implementation ships. Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/dist/opencode/commands/shape.md
+++ b/dist/opencode/commands/shape.md
@@ -91,7 +91,7 @@ After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file sta
 
 ### Step 9: Flag for Post-Implementation Reflection
 
-If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/reflect` should be run after implementation ships. Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
+If shaping surfaced strategic tensions (noted in the spec's "Strategic Alignment" section per the Strategic Tensions guidelines below), remind the user: *"This spec has strategic tensions. After implementation ships, run `/reflect` to update strategic docs."* Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/dist/opencode/skills/cleanup/SKILL.md
+++ b/dist/opencode/skills/cleanup/SKILL.md
@@ -49,12 +49,13 @@ For EACH session file in `.agents/sessions/` and `.agents/sessions/archive/`:
 ### C. Check for Extraction Needs
 - [ ] Contains `lessons_learned`? → Extract to relevant docs
 - [ ] Contains unrecorded `decisions`? → Suggest ADR creation
+- [ ] `## Key Decisions` has content or `traceability.decisions` has entries? → Suggest running `/reflect` before archiving
 - [ ] Contains `remaining_work`/`next_steps`/`technical_debt`? → Check if tracked
 - [ ] CHANGELOG draft present but not integrated? → Flag for integration
 
 ### D. Present Per Session
 Summary (2-3 lines), issues found, extraction recommendations.
-Recommendation: **Extract & Archive** / **Archive** / **Keep**
+Recommendation: **Extract & Archive** (suggest `/reflect` first) / **Archive** / **Keep**
 
 ---
 

--- a/dist/opencode/skills/implement/SKILL.md
+++ b/dist/opencode/skills/implement/SKILL.md
@@ -185,7 +185,6 @@ After creating session AND plan files:
 8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
-   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---

--- a/dist/opencode/skills/implement/SKILL.md
+++ b/dist/opencode/skills/implement/SKILL.md
@@ -182,6 +182,11 @@ After creating session AND plan files:
 5. `loaf task update TASK-XXX --status done`
 6. Update session file (status: complete, `archived_at`, `archived_by`)
 7. Commit housekeeping to main: `chore: close TASK-XXX session`
+8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
+   - `## Key Decisions` has content (not `*(none yet)*` or empty)
+   - `traceability.decisions` has entries (ADRs were recorded)
+   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
+   If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
 

--- a/dist/opencode/skills/reflect/SKILL.md
+++ b/dist/opencode/skills/reflect/SKILL.md
@@ -46,7 +46,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`docs/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
 2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/opencode/skills/shape/SKILL.md
+++ b/dist/opencode/skills/shape/SKILL.md
@@ -55,7 +55,7 @@ Read in order: VISION.md, STRATEGY.md, ARCHITECTURE.md, existing specs.
 | Does this advance our vision? | VISION.md |
 | Does this serve our target personas? | STRATEGY.md |
 | Does this fit our technical constraints? | ARCHITECTURE.md |
-| Does this conflict with existing work? | docs/specs/ |
+| Does this conflict with existing work? | .agents/specs/ |
 
 If misaligned: surface the tension, adjust idea, or note for `/reflect` later.
 
@@ -73,7 +73,7 @@ Create spec following [spec template](templates/spec.md).
 ### Step 6: Generate Spec ID
 
 ```bash
-ls docs/specs/SPEC-*.md docs/specs/archive/SPEC-*.md 2>/dev/null | \
+ls .agents/specs/SPEC-*.md .agents/specs/archive/SPEC-*.md 2>/dev/null | \
   grep -oE 'SPEC-[0-9]+' | sort -t- -k2 -n | tail -1 | awk -F- '{print $2 + 1}'
 ```
 
@@ -85,7 +85,11 @@ Present full spec. **Do NOT create spec file without explicit approval.** User m
 
 ### Step 8: Create Spec File
 
-After approval: create `docs/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+
+### Step 9: Flag for Post-Implementation Reflection
+
+If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/reflect` should be run after implementation ships. Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/dist/opencode/skills/shape/SKILL.md
+++ b/dist/opencode/skills/shape/SKILL.md
@@ -89,7 +89,7 @@ After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file sta
 
 ### Step 9: Flag for Post-Implementation Reflection
 
-If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/reflect` should be run after implementation ships. Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
+If shaping surfaced strategic tensions (noted in the spec's "Strategic Alignment" section per the Strategic Tensions guidelines below), remind the user: *"This spec has strategic tensions. After implementation ships, run `/reflect` to update strategic docs."* Don't suggest running `/reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/dist/opencode/skills/shape/templates/spec.md
+++ b/dist/opencode/skills/shape/templates/spec.md
@@ -1,6 +1,6 @@
 # Spec Template
 
-**Location:** `docs/specs/SPEC-{id}-{slug}.md`
+**Location:** `.agents/specs/SPEC-{id}-{slug}.md`
 
 ```yaml
 ---

--- a/plugins/loaf/skills/cleanup/SKILL.md
+++ b/plugins/loaf/skills/cleanup/SKILL.md
@@ -49,12 +49,13 @@ For EACH session file in `.agents/sessions/` and `.agents/sessions/archive/`:
 ### C. Check for Extraction Needs
 - [ ] Contains `lessons_learned`? → Extract to relevant docs
 - [ ] Contains unrecorded `decisions`? → Suggest ADR creation
+- [ ] `## Key Decisions` has content or `traceability.decisions` has entries? → Suggest running `/loaf:reflect` before archiving
 - [ ] Contains `remaining_work`/`next_steps`/`technical_debt`? → Check if tracked
 - [ ] CHANGELOG draft present but not integrated? → Flag for integration
 
 ### D. Present Per Session
 Summary (2-3 lines), issues found, extraction recommendations.
-Recommendation: **Extract & Archive** / **Archive** / **Keep**
+Recommendation: **Extract & Archive** (suggest `/loaf:reflect` first) / **Archive** / **Keep**
 
 ---
 

--- a/plugins/loaf/skills/implement/SKILL.md
+++ b/plugins/loaf/skills/implement/SKILL.md
@@ -183,6 +183,11 @@ After creating session AND plan files:
 5. `loaf task update TASK-XXX --status done`
 6. Update session file (status: complete, `archived_at`, `archived_by`)
 7. Commit housekeeping to main: `chore: close TASK-XXX session`
+8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
+   - `## Key Decisions` has content (not `*(none yet)*` or empty)
+   - `traceability.decisions` has entries (ADRs were recorded)
+   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
+   If any signal is present, suggest: *"This session produced key decisions. Consider running `/loaf:reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
 

--- a/plugins/loaf/skills/implement/SKILL.md
+++ b/plugins/loaf/skills/implement/SKILL.md
@@ -186,7 +186,6 @@ After creating session AND plan files:
 8. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
-   - Linked spec (via `session.spec`) has a `## Lessons Learned` section with content
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/loaf:reflect` to update strategic docs."* If none are present, stay silent.
 
 ---

--- a/plugins/loaf/skills/reflect/SKILL.md
+++ b/plugins/loaf/skills/reflect/SKILL.md
@@ -47,7 +47,7 @@ After completing work, `/loaf:reflect` extracts learnings and proposes updates t
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`docs/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
 2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/plugins/loaf/skills/shape/SKILL.md
+++ b/plugins/loaf/skills/shape/SKILL.md
@@ -90,7 +90,7 @@ After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file sta
 
 ### Step 9: Flag for Post-Implementation Reflection
 
-If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/loaf:reflect` should be run after implementation ships. Don't suggest running `/loaf:reflect` now — strategy updates come from shipped work, not planning.
+If shaping surfaced strategic tensions (noted in the spec's "Strategic Alignment" section per the Strategic Tensions guidelines below), remind the user: *"This spec has strategic tensions. After implementation ships, run `/loaf:reflect` to update strategic docs."* Don't suggest running `/loaf:reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/plugins/loaf/skills/shape/SKILL.md
+++ b/plugins/loaf/skills/shape/SKILL.md
@@ -56,7 +56,7 @@ Read in order: VISION.md, STRATEGY.md, ARCHITECTURE.md, existing specs.
 | Does this advance our vision? | VISION.md |
 | Does this serve our target personas? | STRATEGY.md |
 | Does this fit our technical constraints? | ARCHITECTURE.md |
-| Does this conflict with existing work? | docs/specs/ |
+| Does this conflict with existing work? | .agents/specs/ |
 
 If misaligned: surface the tension, adjust idea, or note for `/loaf:reflect` later.
 
@@ -74,7 +74,7 @@ Create spec following [spec template](templates/spec.md).
 ### Step 6: Generate Spec ID
 
 ```bash
-ls docs/specs/SPEC-*.md docs/specs/archive/SPEC-*.md 2>/dev/null | \
+ls .agents/specs/SPEC-*.md .agents/specs/archive/SPEC-*.md 2>/dev/null | \
   grep -oE 'SPEC-[0-9]+' | sort -t- -k2 -n | tail -1 | awk -F- '{print $2 + 1}'
 ```
 
@@ -86,7 +86,11 @@ Present full spec. **Do NOT create spec file without explicit approval.** User m
 
 ### Step 8: Create Spec File
 
-After approval: create `docs/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+After approval: create `.agents/specs/SPEC-{id}-{slug}.md`, update idea file status if applicable.
+
+### Step 9: Flag for Post-Implementation Reflection
+
+If the shaping session surfaced strategic tensions or key decisions (`## Key Decisions` has content, `traceability.decisions` has entries), note in the spec's "Strategic Alignment" section that `/loaf:reflect` should be run after implementation ships. Don't suggest running `/loaf:reflect` now — strategy updates come from shipped work, not planning.
 
 ---
 

--- a/plugins/loaf/skills/shape/templates/spec.md
+++ b/plugins/loaf/skills/shape/templates/spec.md
@@ -1,6 +1,6 @@
 # Spec Template
 
-**Location:** `docs/specs/SPEC-{id}-{slug}.md`
+**Location:** `.agents/specs/SPEC-{id}-{slug}.md`
 
 ```yaml
 ---


### PR DESCRIPTION
## Summary
- `/implement` AFTER phase suggests `/reflect` when session has key decisions, ADRs, or linked spec with lessons learned
- `/shape` Step 9 flags strategic tensions for post-implementation reflection (respects reflect's "after shipping" contract)
- `/cleanup` extraction checks recommend `/reflect` before archiving decision-rich sessions
- Fixes stale `docs/specs/` → `.agents/specs/` paths in reflect, shape, and spec template

## Test plan
- [ ] `/implement` suggests `/reflect` after completing a spec when session has key decisions
- [ ] `/implement` stays silent when session has no extractable learnings
- [ ] `/shape` flags decisions for post-implementation reflection (does not suggest immediate `/reflect`)
- [ ] `/cleanup` flags sessions with learnings as "Extract & Archive (suggest `/reflect` first)"
- [ ] `/reflect` SKILL.md references `.agents/specs/` paths
- [ ] `loaf build` succeeds across all targets