### PR TITLE
feat: add loaf cleanup command (SPEC-012)

### DIFF
--- a/.agents/TASKS.json
+++ b/.agents/TASKS.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 53,
+  "next_id": 57,
   "tasks": {
     "TASK-001": {
       "title": "Create verification reference",
@@ -1031,6 +1031,70 @@
       "updated": "2026-03-27T23:26:23.582Z",
       "completed_at": "2026-03-27T23:26:23.581Z",
       "file": "archive/TASK-052-add-reflect-suggestions-to-shape-and-cleanup.md"
+    },
+    "TASK-053": {
+      "title": "Extract shared prompt helpers to cli/lib/prompts.ts",
+      "slug": "extract-shared-prompt-helpers-to-cli-lib-prompts-t",
+      "spec": "SPEC-012",
+      "status": "todo",
+      "priority": "P1",
+      "depends_on": [],
+      "files": [],
+      "verify": null,
+      "done": null,
+      "session": null,
+      "created": "2026-03-28T23:36:06.000Z",
+      "updated": "2026-03-28T23:36:06.000Z",
+      "completed_at": null,
+      "file": "TASK-053-extract-shared-prompt-helpers-to-cli-lib-prompts-t.md"
+    },
+    "TASK-054": {
+      "title": "Build cleanup scanner engine",
+      "slug": "build-cleanup-scanner-engine",
+      "spec": "SPEC-012",
+      "status": "todo",
+      "priority": "P1",
+      "depends_on": [],
+      "files": [],
+      "verify": null,
+      "done": null,
+      "session": null,
+      "created": "2026-03-28T23:36:09.760Z",
+      "updated": "2026-03-28T23:36:09.760Z",
+      "completed_at": null,
+      "file": "TASK-054-build-cleanup-scanner-engine.md"
+    },
+    "TASK-055": {
+      "title": "Wire loaf cleanup CLI command with interactive mode",
+      "slug": "wire-loaf-cleanup-cli-command-with-interactive-mod",
+      "spec": "SPEC-012",
+      "status": "todo",
+      "priority": "P1",
+      "depends_on": [],
+      "files": [],
+      "verify": null,
+      "done": null,
+      "session": null,
+      "created": "2026-03-28T23:36:10.956Z",
+      "updated": "2026-03-28T23:36:10.956Z",
+      "completed_at": null,
+      "file": "TASK-055-wire-loaf-cleanup-cli-command-with-interactive-mod.md"
+    },
+    "TASK-056": {
+      "title": "Update cleanup skill to reference CLI",
+      "slug": "update-cleanup-skill-to-reference-cli",
+      "spec": "SPEC-012",
+      "status": "todo",
+      "priority": "P2",
+      "depends_on": [],
+      "files": [],
+      "verify": null,
+      "done": null,
+      "session": null,
+      "created": "2026-03-28T23:36:12.093Z",
+      "updated": "2026-03-28T23:36:12.093Z",
+      "completed_at": null,
+      "file": "TASK-056-update-cleanup-skill-to-reference-cli.md"
     }
   },
   "specs": {
@@ -1177,6 +1241,15 @@
       "source": "direct",
       "created": "2026-03-27T13:32:06.000Z",
       "file": "archive/SPEC-015-workflow-hooks-changelog.md"
+    },
+    "SPEC-017": {
+      "title": "TDD Harness — spec-driven testing, eval accumulation, reviewer-to-R mapping",
+      "status": "drafting",
+      "appetite": "Medium (3-5 sessions)",
+      "requirement": null,
+      "source": "SPEC-014",
+      "created": "2026-03-28T15:45:00.000Z",
+      "file": "SPEC-017-tdd-harness.md"
     }
   }
 }

--- a/.agents/drafts/20260328-task-backend-abstraction.md
+++ b/.agents/drafts/20260328-task-backend-abstraction.md
@@ -1,0 +1,118 @@
+---
+title: "Task Backend Abstraction — .md-first filesystem, swappable backends"
+source: conversation
+created: 2026-03-28T22:00:00Z
+status: draft
+---
+
+# Task Backend Abstraction
+
+## Problem
+
+Two related problems with the current task management model:
+
+### 1. TASKS.json is a false source of truth
+
+TASKS.json and .md frontmatter can be edited independently, creating sync conflicts. The current `loaf task sync --push` overwrites .md frontmatter from TASKS.json, which:
+- Reverts direct .md edits (observed: spec status reset from `implementing` to `drafting`)
+- Strips frontmatter fields TASKS.json doesn't model (observed: `files`, `depends_on`, `verify`, `done` lost)
+- Forces an unintuitive workflow: edit .md → import → push, when editing .md should just work
+
+The .md files contain everything: structured frontmatter + rich body content. TASKS.json is a derived index that claims to be the source of truth.
+
+### 2. No backend abstraction
+
+Every CLI command and workflow skill hardcodes TASKS.json reads/writes. Users who prefer Linear for task management must maintain both systems. There's no way to swap the backend.
+
+## Desired Outcome
+
+1. **.md files are canonical.** Task/spec .md files are the source of truth for the filesystem backend. TASKS.json becomes a derived cache — generated on demand, never authoritative.
+2. **Backends are swappable.** A user can choose filesystem (.md files) or Linear (MCP-backed) as their task backend. CLI commands and skills work transparently against whichever is configured.
+
+## Shape So Far
+
+### Part 1: .md-first filesystem (the foundation)
+
+Invert the authority model. The .md frontmatter is always the source of truth for the filesystem backend.
+
+**What changes:**
+- CLI commands (`loaf task update`, `create`, etc.) write .md frontmatter directly
+- TASKS.json is rebuilt from .md files on demand (already works via `buildIndexFromFiles()`)
+- `loaf task sync --push` goes away — nothing overwrites .md
+- `loaf task sync` = rebuild index from files (what `--import` already does)
+- `next_id` derived by scanning filenames for highest `TASK-NNN` prefix
+- Unknown frontmatter fields preserved naturally (nobody overwrites them)
+
+**TASKS.json becomes a build artifact:**
+- Generated on demand for tools that want a single JSON payload (API responses, CI, web UIs)
+- Never read as authoritative by CLI commands
+- Can be gitignored or treated as a cache file
+
+**Can a web kanban board work on .md files directly?** Yes. The frontmatter has everything: `status` (columns), `priority` (lanes), `spec` (grouping), `title`, `created`, `updated`. Dragging a card = writing one frontmatter field. A lightweight server parses with `gray-matter` and renders. No JSON intermediary needed.
+
+### Part 2: Backend interface (the abstraction)
+
+```typescript
+interface TaskBackend {
+  list(filter?: TaskFilter): Promise<TaskEntry[]>
+  get(id: string): Promise<TaskEntry | null>
+  create(task: NewTask): Promise<TaskEntry>
+  update(id: string, changes: Partial<TaskEntry>): Promise<TaskEntry>
+  archive(id: string): Promise<void>
+}
+```
+
+Two implementations:
+- `FilesystemBackend` — reads/writes .md frontmatter directly (Part 1)
+- `LinearBackend` — wraps Linear MCP tool calls or API
+
+### Configuration
+
+Backend choice in `.agents/loaf.json` or similar project config:
+
+```json
+{
+  "tasks": {
+    "backend": "filesystem"
+  }
+}
+```
+
+### What Changes
+
+| Component | Current | Part 1 (.md-first) | Part 2 (abstraction) |
+|-----------|---------|---------------------|----------------------|
+| `loaf task *` commands | Direct TASKS.json | Direct .md frontmatter | `TaskBackend` interface |
+| `loaf task sync` | Bidirectional push/import | Rebuild cache from .md | N/A (backends handle their own storage) |
+| TASKS.json | Source of truth | Derived cache | Backend-specific detail |
+| `loaf spec archive` | Reads task index | Reads .md files | `TaskBackend.list()` |
+| `loaf cleanup` (SPEC-012) | Scans TASKS.json | Scans .md files | `TaskBackend.list()` |
+| `/breakdown` skill | Writes TASKS.json | Writes .md files | Backend-agnostic |
+| `/implement` skill | Reads from index | Reads .md files | Backend-agnostic |
+
+### Open Questions
+
+- Does the spec backend also need abstracting, or are specs always filesystem?
+- How does `loaf task sync` work with Linear backend? (Becomes an import/export tool between backends?)
+- What's the migration path for existing TASKS.json users? (Likely: one-time `--push` to ensure .md files are current, then stop reading TASKS.json)
+- Does LinearBackend require MCP tools at CLI level, or does it use the Linear API directly?
+- Performance: is parsing .md files on every `loaf task list` fast enough? (Likely yes at project scale — dozens of files, not thousands)
+
+### Implementation Order
+
+1. **Part 1 first** — invert to .md-first within the existing filesystem model. This fixes the immediate sync problems and is valuable standalone.
+2. **Part 2 after** — extract the `TaskBackend` interface once Part 1 stabilizes the filesystem implementation.
+3. SPEC-012's `loaf cleanup` should be built against .md files directly where possible, TASKS.json as fallback until Part 1 lands.
+
+### Dependencies
+
+- Part 1 could ship independently as a small-medium spec
+- Part 2 depends on Part 1 (the filesystem backend IS Part 1)
+- Both are orthogonal to SPEC-012 and SPEC-014
+
+## What This Is Not
+
+- Not a rewrite of task management — the CLI surface stays the same
+- Not adding new task features — just fixing the storage model
+- Not deprecating .md files — they become MORE important
+- Not removing TASKS.json — it becomes a derived cache, still useful for tooling

--- a/.agents/specs/SPEC-012-cleanup-refinement.md
+++ b/.agents/specs/SPEC-012-cleanup-refinement.md
@@ -1,17 +1,18 @@
 ---
 id: SPEC-012
-title: "Cleanup Refinement — differentiated processes + CLI"
+title: Cleanup Refinement — differentiated processes + CLI
 source: direct
-created: 2026-03-16T23:50:30Z
-status: drafting
-appetite: "Medium (3-5 days)"
+created: '2026-03-16T23:50:30.000Z'
+status: implementing
+branch: feat/cleanup-cli
+appetite: Medium (3-5 days)
 ---
 
 # SPEC-012: Cleanup Refinement
 
 ## Problem Statement
 
-The `/cleanup` skill (formerly `/review-sessions`) reviews agent artifacts and recommends actions, but it treats all artifact states the same way and relies entirely on the agent following skill instructions. There's no CLI surface for humans to run cleanup directly, no differentiated handling for completed vs stale vs cancelled work, and no guardrails against accidental data loss.
+The `/cleanup` skill already defines differentiated handling rules for every artifact type (sessions, tasks, specs, plans, drafts, councils, reports) — but those rules only execute when an agent reads the skill and follows its instructions. There's no CLI surface for humans to run cleanup directly, no way to automate or test the rules, and no guardrails against accidental data loss. The gap is CLI automation of existing policy, not defining new policy.
 
 ## Strategic Alignment
 
@@ -21,19 +22,21 @@ The `/cleanup` skill (formerly `/review-sessions`) reviews agent artifacts and r
 
 ## Solution Direction
 
-### Part 1: Differentiated Artifact Handling
+### Part 1: CLI Implementation of Existing Cleanup Rules
 
-Refine the cleanup skill with explicit processes per artifact state:
+The cleanup skill already defines these rules. The CLI implements them programmatically:
 
-| Artifact | State | Process | Preservation |
-|----------|-------|---------|-------------|
+| Artifact | State | Action | Preservation |
+|----------|-------|--------|-------------|
 | **Sessions** | Completed | Archive (move to archive/) | Full — set `archived_at`, `archived_by` |
-| **Sessions** | Stale (>7 days inactive) | Review → user decides | Never auto-delete |
+| **Sessions** | Stale (>7 days inactive) | Flag for review | Never auto-delete |
 | **Sessions** | Cancelled/abandoned | Archive with `status: cancelled` | Preserved with reason |
-| **Specs** | Complete | Archive | Full — move to archive/ |
+| **Tasks** | Done | Archive via `loaf task archive` (per-task or `--spec`) | Full — uses existing archive helpers |
+| **Tasks** | Orphaned (no spec match) | Flag for review | Never auto-delete |
+| **Specs** | Complete | Archive via `loaf spec archive` | Full — uses existing archive helpers |
 | **Specs** | Stale drafting | Flag for review | Never auto-delete |
 | **Plans** | Session archived | Delete | Ephemeral — decisions in session |
-| **Plans** | Orphaned (no session) | Delete | Ephemeral — no value without session |
+| **Plans** | Orphaned (no linked session) | Delete | Ephemeral — no value without session |
 | **Drafts** | Promoted to spec | Archive or delete (user choice) | Ask first |
 | **Drafts** | Stale (>30 days) | Flag for review | Never auto-delete |
 | **Councils** | Session summary captured | Archive | Full preservation |
@@ -41,9 +44,27 @@ Refine the cleanup skill with explicit processes per artifact state:
 
 **Core principle:** Archive, don't delete — except for truly ephemeral artifacts (plans) whose value lives entirely in session files and git history.
 
+### V1 Artifact Contract
+
+| Directory | Status | Notes |
+|-----------|--------|-------|
+| `sessions/` | **Required** | Scaffolded by `loaf init` |
+| `specs/` | **Required** | Scaffolded by `loaf init` |
+| `tasks/` | **Required** | Scaffolded by `loaf init` |
+| `ideas/` | **Required** | Scaffolded by `loaf init`. Not scanned — ideas have no lifecycle state to clean up |
+| `plans/` | Optional | Created by workflow on demand |
+| `drafts/` | Optional | Created by workflow on demand |
+| `councils/` | Optional | Created by workflow on demand |
+| `reports/` | Optional | Created by workflow on demand |
+
+- Missing optional directories → skip silently, no empty dir creation
+- Missing required directories → warn and continue (partial init or old checkout)
+- Unknown directories inside `.agents/` → ignore
+- Each archive target gets an `archive/` subdirectory created on first use
+
 ### Part 2: `loaf cleanup` CLI Command
 
-A new CLI command that automates the scanning and reporting:
+A new CLI command that automates scanning and reporting:
 
 ```
 loaf cleanup              # Scan all artifacts, show summary + recommendations
@@ -55,43 +76,47 @@ loaf cleanup --drafts     # Only review drafts
 ```
 
 The command:
-1. Scans `.agents/` directories for each artifact type
-2. Applies the differentiated rules above
-3. Shows a formatted summary table (like `loaf task status`)
+1. Scans `.agents/` directories for each artifact type (per V1 contract above)
+2. Applies the existing cleanup rules
+3. Shows a formatted summary table (like `loaf task list`)
 4. For each actionable item, prompts: Archive / Delete / Keep / Skip
 5. Performs the chosen action (move, delete, update status)
 6. Suggests `/crystallize` for sessions with extractable learnings
 
-### Part 3: Spec Completion Lifecycle
+#### CLI Interaction Contract
 
-Add `completed_at` timestamp to spec frontmatter schema. When all tasks for a spec are marked done (or the spec is manually marked complete), record when it happened. This prevents losing provenance when specs are archived.
+- **Prompts:** Reuse `askYesNo()` / `askChoice()` from `release.ts` (extract to shared `cli/lib/prompts.ts` if needed)
+- **Per-item confirmation:** Each actionable artifact is confirmed individually (not batch). Matches `loaf release` UX pattern.
+- **Delete previews:** Show first 3 lines of frontmatter before any destructive action.
+- **`--dry-run`:** Print recommendations table, exit 0, no prompts.
+- **Non-TTY (piped):** Behave like `--dry-run` — report only, no prompts. Detect via `process.stdout.isTTY`.
+- **75% circuit-breaker mode** (scanning + dry-run only) is functionally identical to `--dry-run` shipping as the only mode.
 
-Also: when a spec is marked complete on a feature branch, suggest creating a PR. The implement skill's "AFTER" flow should include branch → PR as a standard step.
+### Part 3: Skill Update
 
-### Part 4: Skill Update
-
-Update the `/cleanup` skill to reference the CLI command and the differentiated rules. The skill becomes guidance for agents on when/how to invoke `loaf cleanup`, while the CLI does the actual work.
+Update the `/cleanup` skill to reference the CLI command. The skill becomes guidance for agents on _when_ to invoke `loaf cleanup`, while the CLI does the actual work. The differentiated rules stay in the skill as the authoritative source; the CLI is the execution engine.
 
 ## Scope
 
 ### In Scope
-- Differentiated handling rules per artifact type and state
 - `loaf cleanup` CLI command with scanning, reporting, and interactive actions
-- `--dry-run` and artifact-type filters
-- Archive operations (move + set metadata)
+- `--dry-run` and artifact-type filters (`--sessions`, `--specs`, `--plans`, `--drafts`)
+- Non-TTY detection (pipe-safe output)
+- Archive operations (move + set metadata) for sessions, specs, councils, reports
 - Delete operations for ephemeral artifacts (plans)
+- Reuse existing `archiveTasks()` / `archiveSpecs()` from `migrate.ts`
+- Extract prompt helpers to shared `cli/lib/prompts.ts` if needed
 - Suggest `/crystallize` for sessions with extractable learnings
 - Update `/cleanup` skill to reference CLI
 - Register command in `cli/index.ts`
-- Add `completed_at` timestamp to spec frontmatter schema
-- Suggest PR creation when spec completes on a feature branch
-- Update implement skill "AFTER" flow to include branch → PR step
 
 ### Out of Scope
 - Automatic cleanup (always interactive or dry-run)
 - Linear integration (existing, not changing)
 - Knowledge staleness detection (SPEC-009)
 - The `/crystallize` skill itself (SPEC-011)
+- Spec `completed_at` data model changes (follow-up spec or fold into SPEC-014)
+- Branch → PR suggestions (already in implement skill's AFTER flow)
 
 ### Rabbit Holes
 - Building a TUI for cleanup — stick with sequential prompts like `loaf release`
@@ -101,8 +126,9 @@ Update the `/cleanup` skill to reference the CLI command and the differentiated 
 ### No-Gos
 - Don't auto-delete anything without user confirmation
 - Don't archive sessions without checking for extractable learnings first
-- Don't touch files outside `.agents/`
+- Cleanup **runtime actions** (archive, delete, move) only operate on `.agents/` contents — CLI registration, skill updates, and test files are normal implementation work
 - Don't require Linear for any functionality
+- Don't create empty directories for optional artifact types
 
 ## Risks
 
@@ -119,16 +145,19 @@ Update the `/cleanup` skill to reference the CLI command and the differentiated 
 
 ## Test Conditions
 
-- [ ] `loaf cleanup` scans all artifact types and shows formatted summary
-- [ ] `loaf cleanup --dry-run` shows recommendations without prompting for actions
-- [ ] `loaf cleanup --sessions` filters to sessions only
-- [ ] Completed sessions are offered for archive with correct metadata
+- [ ] `loaf cleanup` scans required + present optional directories and shows formatted summary
+- [ ] `loaf cleanup --dry-run` shows recommendations table without prompting for actions
+- [ ] `loaf cleanup --sessions` filters to sessions only (same for `--specs`, `--plans`, `--drafts`)
+- [ ] Non-TTY invocation (piped) behaves like `--dry-run`
+- [ ] Missing optional directories (plans, drafts, councils, reports) are skipped silently
+- [ ] Completed sessions are offered for archive with `archived_at` and `archived_by` metadata
 - [ ] Stale sessions (>7 days) are flagged but not auto-actioned
+- [ ] Done tasks are offered for archive via existing `archiveTasks()` helper
 - [ ] Orphaned plans (no linked session) are offered for deletion
 - [ ] Plans linked to archived sessions are offered for deletion
 - [ ] Drafts >30 days old are flagged for review
-- [ ] Archive operations set `archived_at`, `archived_by`, and move to archive/
-- [ ] Delete operations require confirmation before removing files
+- [ ] Delete operations show frontmatter preview and require confirmation
+- [ ] Archive operations move files to `archive/` subdirectory (created on first use)
 - [ ] Suggests `/crystallize` for sessions with key decisions or lessons
 
 ## Circuit Breaker

--- a/.agents/specs/SPEC-014-skill-activation-redesign.md
+++ b/.agents/specs/SPEC-014-skill-activation-redesign.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-014
-title: "Harness Redesign — functional profiles, skill activation, build cleanup"
+title: Skill Activation Redesign — foundations decomposition + agent elimination
 source: brainstorm
 created: '2026-03-24T23:30:00.000Z'
 status: drafting

--- a/.agents/specs/SPEC-016-council-advisory-redesign.md
+++ b/.agents/specs/SPEC-016-council-advisory-redesign.md
@@ -1,10 +1,10 @@
 ---
 id: SPEC-016
-title: "Council Advisory Redesign — racial composition, structured output"
+title: 'Council Advisory Redesign — dynamic specialists, structured output'
 source: direct
-created: 2026-03-27T20:50:19Z
+created: '2026-03-27T20:50:19.000Z'
 status: drafting
-appetite: "Medium (3-5 sessions)"
+appetite: Medium (3-5 sessions)
 ---
 
 # SPEC-016: Council Advisory Redesign — Racial Composition, Structured Output

--- a/.agents/specs/SPEC-017-tdd-harness.md
+++ b/.agents/specs/SPEC-017-tdd-harness.md
@@ -1,12 +1,10 @@
 ---
 id: SPEC-017
-title: "TDD Harness — spec-driven testing, eval accumulation, reviewer-to-R mapping"
+title: 'TDD Harness — spec-driven testing, eval accumulation, reviewer-to-R mapping'
 source: SPEC-014
-created: 2026-03-28T15:45:00Z
+created: '2026-03-28T15:45:00.000Z'
 status: drafting
-appetite: "Medium (3-5 sessions)"
-depends_on: [SPEC-014]
-soft_dependencies: [SPEC-016]
+appetite: Medium (3-5 sessions)
 ---
 
 # SPEC-017: TDD Harness — Spec-Driven Testing and Eval Accumulation

--- a/.agents/tasks/TASK-053-extract-shared-prompt-helpers-to-cli-lib-prompts-t.md
+++ b/.agents/tasks/TASK-053-extract-shared-prompt-helpers-to-cli-lib-prompts-t.md
@@ -1,0 +1,40 @@
+---
+id: TASK-053
+title: Extract shared prompt helpers to cli/lib/prompts.ts
+spec: SPEC-012
+status: todo
+priority: P1
+created: '2026-03-28T23:36:06.000Z'
+updated: '2026-03-28T23:36:06.000Z'
+---
+
+# TASK-053: Extract shared prompt helpers to cli/lib/prompts.ts
+
+## Description
+
+Extract `askYesNo()` and `askChoice()` from `cli/commands/release.ts` into a shared `cli/lib/prompts.ts` module. Add non-TTY detection so piped invocations skip prompts automatically.
+
+## What to do
+
+1. Create `cli/lib/prompts.ts` with:
+   - `askYesNo(question: string): Promise<boolean>` — existing logic from release.ts
+   - `askChoice<T>(question: string, options: T[], format: (t: T) => string, defaultChoice: T): Promise<T>` — generalized from release.ts's BumpType-specific version
+   - `isTTY(): boolean` — wraps `process.stdout.isTTY` check
+2. Update `cli/commands/release.ts` to import from the shared module
+3. Tests for the shared module (non-TTY returns default, TTY behavior)
+
+## Acceptance Criteria
+
+- [ ] `cli/lib/prompts.ts` exports `askYesNo`, `askChoice`, `isTTY`
+- [ ] `release.ts` imports from shared module (no duplicate implementations)
+- [ ] `isTTY()` returns false when stdout is not a TTY
+- [ ] `askYesNo()` returns false in non-TTY mode
+- [ ] `askChoice()` returns default in non-TTY mode
+- [ ] `npm run typecheck` passes
+- [ ] Existing release command still works
+
+## Verification
+
+```bash
+npm run typecheck && npm run test
+```

--- a/.agents/tasks/TASK-054-build-cleanup-scanner-engine.md
+++ b/.agents/tasks/TASK-054-build-cleanup-scanner-engine.md
@@ -1,0 +1,64 @@
+---
+id: TASK-054
+title: Build cleanup scanner engine
+spec: SPEC-012
+status: todo
+priority: P1
+created: '2026-03-28T23:36:09.760Z'
+updated: '2026-03-28T23:36:09.760Z'
+---
+
+# TASK-054: Build cleanup scanner engine
+
+## Description
+
+Build the pure-logic scanner that walks `.agents/` directories, applies the existing cleanup rules, and produces a typed list of recommendations. No I/O, no prompts — just analysis.
+
+## What to do
+
+1. Create `cli/lib/cleanup/types.ts`:
+   - `ArtifactType` enum: session, task, spec, plan, draft, council, report
+   - `RecommendedAction`: archive, delete, flag, skip
+   - `CleanupRecommendation`: `{ type, path, action, reason, metadata? }`
+   - `ScanResult`: `{ recommendations: CleanupRecommendation[], summary: ScanSummary }`
+   - `ScanOptions`: `{ filter?: ArtifactType[], agentsDir: string }`
+
+2. Create `cli/lib/cleanup/scanner.ts`:
+   - `scanArtifacts(options: ScanOptions): ScanResult`
+   - Per-artifact scanner functions implementing existing cleanup skill rules:
+     - Sessions: completed → archive, >7 days inactive → flag, cancelled → archive
+     - Tasks: done → archive (reuse `findOrphans()` for orphan detection), orphaned ref → flag
+     - Specs: complete → archive, stale drafting → flag
+     - Plans: orphaned/linked-to-archived-session → delete, >14 days stale → delete
+     - Drafts: >30 days → flag, promoted → archive-or-delete
+     - Councils: orphaned → flag, summary captured → archive
+     - Reports: processed + session archived → archive
+   - Reuse existing helpers: `getOrBuildIndex()`, `findOrphans()`, `collectFiles()`
+   - Handle missing optional directories (skip silently)
+   - Warn on missing required directories (sessions, specs, tasks)
+   - Detect `/crystallize` candidates (sessions with key decisions/lessons)
+
+3. Tests (`scanner.test.ts`):
+   - Create temp `.agents/` with fixtures for each artifact state
+   - Verify correct recommendation per rule
+   - Verify missing directories handled correctly
+   - Verify filter option works
+
+## Acceptance Criteria
+
+- [ ] Scanner returns typed recommendations for all 7 artifact types
+- [ ] Missing optional directories are skipped silently
+- [ ] Missing required directories produce a warning in results
+- [ ] Sessions with extractable learnings flagged for `/crystallize`
+- [ ] Done tasks detected via TASKS.json status
+- [ ] Orphaned tasks detected as "referenced spec doesn't exist" (not "spec is null")
+- [ ] Plans linked to archived/missing sessions recommended for deletion
+- [ ] Drafts >30 days old flagged for review
+- [ ] Filter option restricts scan to specified artifact types
+- [ ] Tests cover each artifact type's rules
+
+## Verification
+
+```bash
+npm run typecheck && npm run test
+```

--- a/.agents/tasks/TASK-055-wire-loaf-cleanup-cli-command-with-interactive-mod.md
+++ b/.agents/tasks/TASK-055-wire-loaf-cleanup-cli-command-with-interactive-mod.md
@@ -1,0 +1,67 @@
+---
+id: TASK-055
+title: Wire loaf cleanup CLI command with interactive mode
+spec: SPEC-012
+status: todo
+priority: P1
+created: '2026-03-28T23:36:10.956Z'
+updated: '2026-03-28T23:36:10.956Z'
+---
+
+# TASK-055: Wire loaf cleanup CLI command with interactive mode
+
+## Description
+
+Register the `loaf cleanup` command, wire it to the scanner engine, and implement the interactive action loop. This is the user-facing layer that consumes TASK-053 (prompts) and TASK-054 (scanner).
+
+## What to do
+
+1. Create `cli/commands/cleanup.ts`:
+   - `registerCleanupCommand(program: Command): void`
+   - Options: `--dry-run`, `--sessions`, `--specs`, `--plans`, `--drafts`
+   - Flow:
+     a. Find `.agents/` dir via `findAgentsDir()`
+     b. Run scanner with filter options → `ScanResult`
+     c. Print formatted summary table (colored, like `loaf task list`)
+     d. If `--dry-run` or non-TTY → print and exit
+     e. Otherwise, iterate actionable recommendations:
+        - Show artifact path + reason
+        - For deletes: show first 3 lines of frontmatter as preview
+        - Prompt: Archive / Delete / Keep / Skip (per-item)
+        - Execute action: `archiveTasks()`, `archiveSpecs()`, `fs.rmSync()`, etc.
+     f. Final reconciliation: save updated index
+
+2. Register in `cli/index.ts`:
+   - Import `registerCleanupCommand`
+   - Add to command registration block
+
+3. Archive operations for non-task/spec artifacts (sessions, councils, reports):
+   - These don't have existing archive helpers — implement simple move-to-archive + set `archived_at`/`archived_by` in frontmatter
+   - Create `archive/` subdirectory on first use
+
+4. Tests:
+   - `--dry-run` produces output without prompts
+   - Filter flags restrict scan scope
+   - Archive operations move files correctly
+   - Delete operations remove files
+   - Non-TTY behaves like `--dry-run`
+
+## Acceptance Criteria
+
+- [ ] `loaf cleanup` registered and accessible via CLI
+- [ ] `--dry-run` prints summary table and exits without prompts
+- [ ] `--sessions`, `--specs`, `--plans`, `--drafts` filter to specific artifact types
+- [ ] Non-TTY invocation behaves like `--dry-run`
+- [ ] Per-item confirmation with Archive / Delete / Keep / Skip choices
+- [ ] Delete operations show frontmatter preview before confirmation
+- [ ] Archive operations move to `archive/` and set metadata in frontmatter
+- [ ] Tasks/specs archived via existing `archiveTasks()` / `archiveSpecs()`
+- [ ] Sessions/councils/reports archived with `archived_at` + `archived_by`
+- [ ] Plans deleted (not archived) per spec rules
+- [ ] `/crystallize` suggestion shown for sessions with extractable learnings
+
+## Verification
+
+```bash
+npm run typecheck && npm run test && npx tsx cli/index.ts cleanup --dry-run
+```

--- a/.agents/tasks/TASK-056-update-cleanup-skill-to-reference-cli.md
+++ b/.agents/tasks/TASK-056-update-cleanup-skill-to-reference-cli.md
@@ -1,0 +1,36 @@
+---
+id: TASK-056
+title: Update cleanup skill to reference CLI
+spec: SPEC-012
+status: todo
+priority: P2
+created: '2026-03-28T23:36:12.093Z'
+updated: '2026-03-28T23:36:12.093Z'
+---
+
+# TASK-056: Update cleanup skill to reference CLI
+
+## Description
+
+Update the `/cleanup` skill to reference `loaf cleanup` as the execution engine. The skill remains the authoritative source for cleanup *policy* (when and why), while the CLI handles *execution* (scanning, prompting, archiving). The skill should explicitly own the Linear-aware checks that the CLI doesn't cover.
+
+## What to do
+
+1. Add a section near the top of SKILL.md directing agents to use `loaf cleanup` for filesystem operations
+2. Clarify the division: skill = policy + Linear checks, CLI = filesystem scanning + actions
+3. Replace manual archive instructions with `loaf cleanup` invocations where appropriate
+4. Keep the differentiated rules table as the authoritative reference
+5. Note that `loaf cleanup --dry-run` can be used for assessment before taking actions
+
+## Acceptance Criteria
+
+- [ ] Skill references `loaf cleanup` command for filesystem operations
+- [ ] Division of responsibility is clear: skill (policy + Linear) vs CLI (filesystem execution)
+- [ ] Manual archive instructions replaced with CLI equivalents
+- [ ] `loaf build` succeeds with updated skill
+
+## Verification
+
+```bash
+loaf build
+```

--- a/cli/commands/cleanup.ts
+++ b/cli/commands/cleanup.ts
@@ -1,0 +1,262 @@
+/**
+ * loaf cleanup command
+ *
+ * Scans .agents/ directories and recommends cleanup actions based on
+ * the existing cleanup skill's rules. Supports interactive mode,
+ * dry-run, artifact-type filters, and non-TTY pipe-safe output.
+ */
+
+import { Command } from "commander";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
+import { join, dirname } from "path";
+import matter from "gray-matter";
+
+import { isTTY, askYesNo } from "../lib/prompts.js";
+import { findAgentsDir, getOrBuildIndex } from "../lib/tasks/resolve.js";
+import { archiveTasks, archiveSpecs, saveIndex } from "../lib/tasks/migrate.js";
+import { scanArtifacts } from "../lib/cleanup/scanner.js";
+import type { ArtifactType, CleanupRecommendation } from "../lib/cleanup/types.js";
+
+// ANSI color helpers
+const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
+const gray = (s: string) => `\x1b[90m${s}\x1b[0m`;
+const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+
+// Display names for artifact types
+const TYPE_LABELS: Record<ArtifactType, string> = {
+  session: "SESSIONS",
+  task: "TASKS",
+  spec: "SPECS",
+  plan: "PLANS",
+  draft: "DRAFTS",
+  council: "COUNCILS",
+  report: "REPORTS",
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Format a frontmatter preview (first few fields) for delete confirmation */
+function formatPreview(fm: Record<string, unknown> | undefined): string {
+  if (!fm) return gray("  (no frontmatter)");
+  const keys = Object.keys(fm).slice(0, 3);
+  return keys
+    .map((k) => {
+      const v = fm[k];
+      const display = typeof v === "string" ? v : JSON.stringify(v);
+      return gray(`  ${k}: ${display}`);
+    })
+    .join("\n");
+}
+
+/** Archive a generic artifact (session, council, report) by moving to archive/ */
+function archiveGenericArtifact(filePath: string): void {
+  const dir = dirname(filePath);
+  const archiveDir = join(dir, "archive");
+  const filename = filePath.split("/").pop()!;
+  const destPath = join(archiveDir, filename);
+
+  mkdirSync(archiveDir, { recursive: true });
+
+  // Add archived_at and archived_by to frontmatter
+  const raw = readFileSync(filePath, "utf-8");
+  const { data, content } = matter(raw);
+  data.archived_at = new Date().toISOString();
+  data.archived_by = "loaf cleanup";
+  const updated = matter.stringify(content, data);
+  writeFileSync(filePath, updated, "utf-8");
+
+  renameSync(filePath, destPath);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function registerCleanupCommand(program: Command): void {
+  program
+    .command("cleanup")
+    .description("Scan .agents/ artifacts and recommend cleanup actions")
+    .option("--dry-run", "Show recommendations without prompting for actions")
+    .option("--sessions", "Only review sessions")
+    .option("--specs", "Only review specs")
+    .option("--plans", "Only review plans")
+    .option("--drafts", "Only review drafts")
+    .action(async (options: {
+      dryRun?: boolean;
+      sessions?: boolean;
+      specs?: boolean;
+      plans?: boolean;
+      drafts?: boolean;
+    }) => {
+      const agentsDir = findAgentsDir();
+      if (!agentsDir) {
+        console.error(`  ${red("error:")} No .agents/ directory found`);
+        process.exit(1);
+      }
+
+      console.log(`\n${bold("loaf cleanup")}\n`);
+
+      // Build filter from flags
+      const filter: ArtifactType[] | undefined = (() => {
+        const types: ArtifactType[] = [];
+        if (options.sessions) types.push("session");
+        if (options.specs) types.push("spec");
+        if (options.plans) types.push("plan");
+        if (options.drafts) types.push("draft");
+        return types.length > 0 ? types : undefined;
+      })();
+
+      // Scan
+      const result = scanArtifacts({ agentsDir, filter });
+
+      // Print warnings
+      for (const warning of result.warnings) {
+        console.log(`  ${yellow("warn:")} ${warning}`);
+      }
+      if (result.warnings.length > 0) console.log();
+
+      // Print summary table
+      for (const typeSummary of result.summary) {
+        const label = TYPE_LABELS[typeSummary.type];
+        console.log(`  ${bold(label)} ${gray(`(${typeSummary.total} total)`)}`);
+
+        const actionableRecs = result.recommendations.filter(
+          (r) => r.type === typeSummary.type && r.action !== "skip",
+        );
+
+        if (typeSummary.archive > 0) {
+          const items = actionableRecs
+            .filter((r) => r.action === "archive")
+            .map((r) => r.filename);
+          console.log(`    ${green("Ready to archive:")}  ${typeSummary.archive}  ${gray(items.join(", "))}`);
+        }
+        if (typeSummary.delete > 0) {
+          const items = actionableRecs
+            .filter((r) => r.action === "delete")
+            .map((r) => r.filename);
+          console.log(`    ${red("Ready to delete:")}   ${typeSummary.delete}  ${gray(items.join(", "))}`);
+        }
+        if (typeSummary.flag > 0) {
+          const items = actionableRecs
+            .filter((r) => r.action === "flag")
+            .map((r) => r.filename);
+          console.log(`    ${yellow("Needs review:")}      ${typeSummary.flag}  ${gray(items.join(", "))}`);
+        }
+        if (typeSummary.skip > 0) {
+          console.log(`    ${gray(`Active/current:     ${typeSummary.skip}`)}`);
+        }
+
+        console.log();
+      }
+
+      // Count actionable items
+      const actionable = result.recommendations.filter((r) => r.action !== "skip");
+
+      if (actionable.length === 0) {
+        console.log(`  ${green("✓")} Nothing to clean up.\n`);
+        return;
+      }
+
+      // Dry-run or non-TTY: stop here
+      if (options.dryRun || !isTTY()) {
+        const mode = options.dryRun ? "--dry-run" : "non-TTY";
+        console.log(`  ${cyan(`(${mode})`)} ${actionable.length} actionable item(s). Run interactively to take action.\n`);
+        return;
+      }
+
+      // ── Interactive mode ────────────────────────────────────────────────
+
+      console.log(`  ${bold("Actions")} — ${actionable.length} item(s)\n`);
+
+      const index = getOrBuildIndex(agentsDir);
+      const tasksToArchive: string[] = [];
+      const specsToArchive: string[] = [];
+      let actionsPerformed = 0;
+
+      for (const rec of actionable) {
+        // Header for each item
+        console.log(`  ${cyan("→")} ${bold(rec.filename)}`);
+        console.log(`    ${rec.reason}`);
+        if (rec.hint) console.log(`    ${yellow("hint:")} ${rec.hint}`);
+
+        if (rec.action === "archive") {
+          if (rec.type === "task") {
+            // Extract task ID from filename
+            const match = rec.filename.match(/^(TASK-\d+)/);
+            if (match) {
+              const confirmed = await askYesNo(`    Archive ${match[1]}? [y/N] `);
+              if (confirmed) {
+                tasksToArchive.push(match[1]);
+                actionsPerformed++;
+              }
+            }
+          } else if (rec.type === "spec") {
+            const match = rec.filename.match(/^(SPEC-\d+)/);
+            if (match) {
+              const confirmed = await askYesNo(`    Archive ${match[1]}? [y/N] `);
+              if (confirmed) {
+                specsToArchive.push(match[1]);
+                actionsPerformed++;
+              }
+            }
+          } else {
+            // Generic archive (session, council, report)
+            const confirmed = await askYesNo(`    Archive? [y/N] `);
+            if (confirmed && existsSync(rec.path)) {
+              archiveGenericArtifact(rec.path);
+              console.log(`    ${green("✓")} Archived`);
+              actionsPerformed++;
+            }
+          }
+        } else if (rec.action === "delete") {
+          // Show preview before delete
+          console.log(formatPreview(rec.frontmatter));
+          const confirmed = await askYesNo(`    ${red("Delete")}? [y/N] `);
+          if (confirmed && existsSync(rec.path)) {
+            rmSync(rec.path);
+            console.log(`    ${green("✓")} Deleted`);
+            actionsPerformed++;
+          }
+        } else if (rec.action === "flag") {
+          console.log(`    ${gray("(flagged for review — no automatic action)")}`);
+        }
+
+        console.log();
+      }
+
+      // Batch archive tasks and specs via existing helpers
+      if (tasksToArchive.length > 0) {
+        const results = archiveTasks(agentsDir, index, tasksToArchive);
+        for (const r of results) {
+          if (r.status === "archived") {
+            console.log(`  ${green("✓")} Archived ${r.id}`);
+          } else {
+            console.log(`  ${yellow("⚠")} Skipped ${r.id}: ${r.reason}`);
+          }
+        }
+      }
+
+      if (specsToArchive.length > 0) {
+        const results = archiveSpecs(agentsDir, index, specsToArchive);
+        for (const r of results) {
+          if (r.status === "archived") {
+            console.log(`  ${green("✓")} Archived ${r.id}`);
+          } else {
+            console.log(`  ${yellow("⚠")} Skipped ${r.id}: ${r.reason}`);
+          }
+        }
+      }
+
+      // Save index if we archived tasks/specs
+      if (tasksToArchive.length > 0 || specsToArchive.length > 0) {
+        saveIndex(join(agentsDir, "TASKS.json"), index);
+      }
+
+      console.log(`  ${green("✓")} Cleanup complete — ${actionsPerformed} action(s) performed.\n`);
+    });
+}

--- a/cli/commands/cleanup.ts
+++ b/cli/commands/cleanup.ts
@@ -1,9 +1,5 @@
 /**
- * loaf cleanup command
- *
- * Scans .agents/ directories and recommends cleanup actions based on
- * the existing cleanup skill's rules. Supports interactive mode,
- * dry-run, artifact-type filters, and non-TTY pipe-safe output.
+ * loaf cleanup — scan .agents/, recommend actions (dry-run, filters, pipe-safe).
  */
 
 import { Command } from "commander";
@@ -17,7 +13,6 @@ import { archiveTasks, archiveSpecs, saveIndex } from "../lib/tasks/migrate.js";
 import { scanArtifacts } from "../lib/cleanup/scanner.js";
 import type { ArtifactType, CleanupRecommendation } from "../lib/cleanup/types.js";
 
-// ANSI color helpers
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
@@ -25,7 +20,6 @@ const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
 const gray = (s: string) => `\x1b[90m${s}\x1b[0m`;
 const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
 
-// Display names for artifact types
 const TYPE_LABELS: Record<ArtifactType, string> = {
   session: "SESSIONS",
   task: "TASKS",
@@ -40,7 +34,6 @@ const TYPE_LABELS: Record<ArtifactType, string> = {
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Format a frontmatter preview (first few fields) for delete confirmation */
 function formatPreview(fm: Record<string, unknown> | undefined): string {
   if (!fm) return gray("  (no frontmatter)");
   const keys = Object.keys(fm).slice(0, 3);
@@ -53,11 +46,9 @@ function formatPreview(fm: Record<string, unknown> | undefined): string {
     .join("\n");
 }
 
-/**
- * Archive a generic artifact (session, council, report) by moving to archive/.
- * Writes archive metadata into the correct nested block matching the repo's
- * frontmatter conventions: session.*, council.*, report.* respectively.
- */
+const NESTED_ARCHIVE_TYPES = new Set<ArtifactType>(["session", "council", "report"]);
+
+/** Move session/council/report to archive/ and set archived metadata in frontmatter. */
 function archiveGenericArtifact(filePath: string, artifactType: ArtifactType): void {
   const dir = dirname(filePath);
   const archiveDir = join(dir, "archive");
@@ -70,11 +61,7 @@ function archiveGenericArtifact(filePath: string, artifactType: ArtifactType): v
   const raw = readFileSync(filePath, "utf-8");
   const { data, content } = matter(raw);
 
-  // Write archive metadata into the nested block that matches the artifact type
-  const blockKey = artifactType === "session" ? "session"
-    : artifactType === "council" ? "council"
-    : artifactType === "report" ? "report"
-    : null;
+  const blockKey = NESTED_ARCHIVE_TYPES.has(artifactType) ? artifactType : null;
 
   if (blockKey && data[blockKey] && typeof data[blockKey] === "object") {
     const block = data[blockKey] as Record<string, unknown>;
@@ -82,7 +69,6 @@ function archiveGenericArtifact(filePath: string, artifactType: ArtifactType): v
     block.archived_at = now;
     block.archived_by = "loaf cleanup";
   } else {
-    // Fallback for files without a nested block
     data.archived_at = now;
     data.archived_by = "loaf cleanup";
   }
@@ -121,7 +107,6 @@ export function registerCleanupCommand(program: Command): void {
 
       console.log(`\n${bold("loaf cleanup")}\n`);
 
-      // Build filter from flags
       const filter: ArtifactType[] | undefined = (() => {
         const types: ArtifactType[] = [];
         if (options.sessions) types.push("session");
@@ -131,16 +116,13 @@ export function registerCleanupCommand(program: Command): void {
         return types.length > 0 ? types : undefined;
       })();
 
-      // Scan
       const result = scanArtifacts({ agentsDir, filter });
 
-      // Print warnings
       for (const warning of result.warnings) {
         console.log(`  ${yellow("warn:")} ${warning}`);
       }
       if (result.warnings.length > 0) console.log();
 
-      // Print summary table
       for (const typeSummary of result.summary) {
         const label = TYPE_LABELS[typeSummary.type];
         console.log(`  ${bold(label)} ${gray(`(${typeSummary.total} total)`)}`);
@@ -174,7 +156,6 @@ export function registerCleanupCommand(program: Command): void {
         console.log();
       }
 
-      // Count actionable items
       const actionable = result.recommendations.filter((r) => r.action !== "skip");
 
       if (actionable.length === 0) {
@@ -182,19 +163,14 @@ export function registerCleanupCommand(program: Command): void {
         return;
       }
 
-      // Dry-run or non-TTY: stop here
       if (options.dryRun || !isTTY()) {
         const mode = options.dryRun ? "--dry-run" : "non-TTY";
         console.log(`  ${cyan(`(${mode})`)} ${actionable.length} actionable item(s). Run interactively to take action.\n`);
         return;
       }
 
-      // ── Interactive mode ────────────────────────────────────────────────
-
       console.log(`  ${bold("Actions")} — ${actionable.length} item(s)\n`);
 
-      // Defer index load until a task/spec archive is confirmed — avoid
-      // writing TASKS.json just because the user entered interactive mode.
       let index: ReturnType<typeof getOrBuildIndex> | null = null;
       const getIndex = () => {
         if (!index) index = getOrBuildIndex(agentsDir);
@@ -205,14 +181,12 @@ export function registerCleanupCommand(program: Command): void {
       let actionsPerformed = 0;
 
       for (const rec of actionable) {
-        // Header for each item
         console.log(`  ${cyan("→")} ${bold(rec.filename)}`);
         console.log(`    ${rec.reason}`);
         if (rec.hint) console.log(`    ${yellow("hint:")} ${rec.hint}`);
 
         if (rec.action === "archive") {
           if (rec.type === "task") {
-            // Extract task ID from filename
             const match = rec.filename.match(/^(TASK-\d+)/);
             if (match) {
               const confirmed = await askYesNo(`    Archive ${match[1]}? [y/N] `);
@@ -231,7 +205,6 @@ export function registerCleanupCommand(program: Command): void {
               }
             }
           } else {
-            // Generic archive (session, council, report)
             const confirmed = await askYesNo(`    Archive? [y/N] `);
             if (confirmed && existsSync(rec.path)) {
               archiveGenericArtifact(rec.path, rec.type);
@@ -240,7 +213,6 @@ export function registerCleanupCommand(program: Command): void {
             }
           }
         } else if (rec.action === "delete") {
-          // Show preview before delete
           console.log(formatPreview(rec.frontmatter));
           const confirmed = await askYesNo(`    ${red("Delete")}? [y/N] `);
           if (confirmed && existsSync(rec.path)) {
@@ -255,7 +227,6 @@ export function registerCleanupCommand(program: Command): void {
         console.log();
       }
 
-      // Batch archive tasks and specs via existing helpers
       if (tasksToArchive.length > 0) {
         const idx = getIndex();
         const results = archiveTasks(agentsDir, idx, tasksToArchive);
@@ -280,7 +251,6 @@ export function registerCleanupCommand(program: Command): void {
         }
       }
 
-      // Save index only if we actually loaded and used it
       if (index) {
         saveIndex(join(agentsDir, "TASKS.json"), index);
       }

--- a/cli/commands/cleanup.ts
+++ b/cli/commands/cleanup.ts
@@ -193,7 +193,13 @@ export function registerCleanupCommand(program: Command): void {
 
       console.log(`  ${bold("Actions")} — ${actionable.length} item(s)\n`);
 
-      const index = getOrBuildIndex(agentsDir);
+      // Defer index load until a task/spec archive is confirmed — avoid
+      // writing TASKS.json just because the user entered interactive mode.
+      let index: ReturnType<typeof getOrBuildIndex> | null = null;
+      const getIndex = () => {
+        if (!index) index = getOrBuildIndex(agentsDir);
+        return index;
+      };
       const tasksToArchive: string[] = [];
       const specsToArchive: string[] = [];
       let actionsPerformed = 0;
@@ -251,7 +257,8 @@ export function registerCleanupCommand(program: Command): void {
 
       // Batch archive tasks and specs via existing helpers
       if (tasksToArchive.length > 0) {
-        const results = archiveTasks(agentsDir, index, tasksToArchive);
+        const idx = getIndex();
+        const results = archiveTasks(agentsDir, idx, tasksToArchive);
         for (const r of results) {
           if (r.status === "archived") {
             console.log(`  ${green("✓")} Archived ${r.id}`);
@@ -262,7 +269,8 @@ export function registerCleanupCommand(program: Command): void {
       }
 
       if (specsToArchive.length > 0) {
-        const results = archiveSpecs(agentsDir, index, specsToArchive);
+        const idx = getIndex();
+        const results = archiveSpecs(agentsDir, idx, specsToArchive);
         for (const r of results) {
           if (r.status === "archived") {
             console.log(`  ${green("✓")} Archived ${r.id}`);
@@ -272,8 +280,8 @@ export function registerCleanupCommand(program: Command): void {
         }
       }
 
-      // Save index if we archived tasks/specs
-      if (tasksToArchive.length > 0 || specsToArchive.length > 0) {
+      // Save index only if we actually loaded and used it
+      if (index) {
         saveIndex(join(agentsDir, "TASKS.json"), index);
       }
 

--- a/cli/commands/cleanup.ts
+++ b/cli/commands/cleanup.ts
@@ -53,8 +53,12 @@ function formatPreview(fm: Record<string, unknown> | undefined): string {
     .join("\n");
 }
 
-/** Archive a generic artifact (session, council, report) by moving to archive/ */
-function archiveGenericArtifact(filePath: string): void {
+/**
+ * Archive a generic artifact (session, council, report) by moving to archive/.
+ * Writes archive metadata into the correct nested block matching the repo's
+ * frontmatter conventions: session.*, council.*, report.* respectively.
+ */
+function archiveGenericArtifact(filePath: string, artifactType: ArtifactType): void {
   const dir = dirname(filePath);
   const archiveDir = join(dir, "archive");
   const filename = filePath.split("/").pop()!;
@@ -62,11 +66,27 @@ function archiveGenericArtifact(filePath: string): void {
 
   mkdirSync(archiveDir, { recursive: true });
 
-  // Add archived_at and archived_by to frontmatter
+  const now = new Date().toISOString();
   const raw = readFileSync(filePath, "utf-8");
   const { data, content } = matter(raw);
-  data.archived_at = new Date().toISOString();
-  data.archived_by = "loaf cleanup";
+
+  // Write archive metadata into the nested block that matches the artifact type
+  const blockKey = artifactType === "session" ? "session"
+    : artifactType === "council" ? "council"
+    : artifactType === "report" ? "report"
+    : null;
+
+  if (blockKey && data[blockKey] && typeof data[blockKey] === "object") {
+    const block = data[blockKey] as Record<string, unknown>;
+    block.status = "archived";
+    block.archived_at = now;
+    block.archived_by = "loaf cleanup";
+  } else {
+    // Fallback for files without a nested block
+    data.archived_at = now;
+    data.archived_by = "loaf cleanup";
+  }
+
   const updated = matter.stringify(content, data);
   writeFileSync(filePath, updated, "utf-8");
 
@@ -208,7 +228,7 @@ export function registerCleanupCommand(program: Command): void {
             // Generic archive (session, council, report)
             const confirmed = await askYesNo(`    Archive? [y/N] `);
             if (confirmed && existsSync(rec.path)) {
-              archiveGenericArtifact(rec.path);
+              archiveGenericArtifact(rec.path, rec.type);
               console.log(`    ${green("✓")} Archived`);
               actionsPerformed++;
             }

--- a/cli/commands/release.ts
+++ b/cli/commands/release.ts
@@ -19,6 +19,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { createInterface } from "readline";
 
+import { askYesNo } from "../lib/prompts.js";
 import { getLastTag, getCommitsSince, suggestBump } from "../lib/release/commits.js";
 import type { ParsedCommit } from "../lib/release/commits.js";
 import {
@@ -45,32 +46,6 @@ const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
-
-function askYesNo(question: string): Promise<boolean> {
-  if (!process.stdin.isTTY) {
-    return Promise.resolve(false);
-  }
-
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  return new Promise((resolve) => {
-    let resolved = false;
-    rl.on("close", () => {
-      if (!resolved) {
-        resolved = true;
-        resolve(false);
-      }
-    });
-    rl.question(question, (answer) => {
-      resolved = true;
-      rl.close();
-      resolve(answer.trim().toLowerCase().startsWith("y"));
-    });
-  });
-}
 
 async function askChoice(
   question: string,

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -11,6 +11,7 @@ import { registerSpecCommand } from "./commands/spec.js";
 import { registerKbCommand } from "./commands/kb.js";
 import { registerSetupCommand } from "./commands/setup.js";
 import { registerVersionCommand } from "./commands/version.js";
+import { registerCleanupCommand } from "./commands/cleanup.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -40,6 +41,7 @@ registerSpecCommand(program);
 registerKbCommand(program);
 registerSetupCommand(program);
 registerVersionCommand(program);
+registerCleanupCommand(program);
 
 // Show help when no subcommand is given (exit 0, not error)
 if (process.argv.length <= 2) {

--- a/cli/lib/cleanup/scanner.test.ts
+++ b/cli/lib/cleanup/scanner.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Cleanup Scanner Tests
+ *
+ * Tests the scanner engine against temp .agents/ fixtures.
+ * Each test creates a minimal directory structure with specific artifact states.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import { scanArtifacts } from "./scanner.js";
+import type { ArtifactType, CleanupRecommendation } from "./types.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+let tempDir: string;
+
+function agentsDir(): string {
+  return join(tempDir, ".agents");
+}
+
+function setupDir(...subpaths: string[]): string {
+  const dir = join(agentsDir(), ...subpaths);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeArtifact(subdir: string, filename: string, frontmatter: Record<string, unknown>, body = ""): void {
+  const dir = setupDir(subdir);
+  const lines = Object.entries(frontmatter).map(([k, v]) => `${k}: ${JSON.stringify(v)}`);
+  const content = `---\n${lines.join("\n")}\n---\n\n${body}`;
+  writeFileSync(join(dir, filename), content, "utf-8");
+}
+
+/** Write a minimal TASKS.json */
+function writeIndex(tasks: Record<string, unknown> = {}, specs: Record<string, unknown> = {}): void {
+  const index = { version: 1, next_id: 100, tasks, specs };
+  writeFileSync(join(agentsDir(), "TASKS.json"), JSON.stringify(index, null, 2), "utf-8");
+}
+
+function findRec(recs: CleanupRecommendation[], filename: string): CleanupRecommendation | undefined {
+  return recs.find((r) => r.filename === filename);
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "loaf-cleanup-test-"));
+  // Create required directories
+  setupDir("sessions");
+  setupDir("tasks");
+  setupDir("specs");
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sessions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("sessions", () => {
+  it("recommends archive for completed sessions", () => {
+    writeArtifact("sessions", "SESSION-001.md", { status: "completed", created: "2026-03-01" });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "SESSION-001.md");
+    expect(rec?.action).toBe("archive");
+  });
+
+  it("hints at /crystallize for sessions with learnings", () => {
+    writeArtifact("sessions", "SESSION-002.md", { status: "completed", created: "2026-03-01" }, "## Key Decisions\n- Did a thing");
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "SESSION-002.md");
+    expect(rec?.action).toBe("archive");
+    expect(rec?.hint).toContain("crystallize");
+  });
+
+  it("flags stale sessions (>7 days inactive)", () => {
+    const staleDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    writeArtifact("sessions", "SESSION-003.md", { status: "active", updated: staleDate });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "SESSION-003.md");
+    expect(rec?.action).toBe("flag");
+    expect(rec?.reason).toContain("inactive");
+  });
+
+  it("skips active sessions", () => {
+    writeArtifact("sessions", "SESSION-004.md", { status: "active", updated: new Date().toISOString() });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "SESSION-004.md");
+    expect(rec?.action).toBe("skip");
+  });
+
+  it("archives cancelled sessions", () => {
+    writeArtifact("sessions", "SESSION-005.md", { status: "cancelled", created: "2026-03-01" });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "SESSION-005.md");
+    expect(rec?.action).toBe("archive");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tasks
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("tasks", () => {
+  it("recommends archive for done tasks", () => {
+    writeIndex(
+      {
+        "TASK-001": {
+          title: "Done task", slug: "done", spec: null, status: "done",
+          priority: "P1", depends_on: [], files: [], verify: null, done: null,
+          session: null, created: "2026-03-01", updated: "2026-03-01",
+          completed_at: "2026-03-10", file: "TASK-001-done.md",
+        },
+      },
+      {},
+    );
+    writeArtifact("tasks", "TASK-001-done.md", { id: "TASK-001", title: "Done task", status: "done" });
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "TASK-001-done.md");
+    expect(rec?.action).toBe("archive");
+  });
+
+  it("flags tasks referencing missing specs (orphaned ref)", () => {
+    writeIndex(
+      {
+        "TASK-002": {
+          title: "Orphan ref", slug: "orphan", spec: "SPEC-099", status: "todo",
+          priority: "P2", depends_on: [], files: [], verify: null, done: null,
+          session: null, created: "2026-03-01", updated: "2026-03-01",
+          completed_at: null, file: "TASK-002-orphan.md",
+        },
+      },
+      {},
+    );
+    writeArtifact("tasks", "TASK-002-orphan.md", { id: "TASK-002", title: "Orphan ref", spec: "SPEC-099" });
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "TASK-002-orphan.md");
+    expect(rec?.action).toBe("flag");
+    expect(rec?.reason).toContain("SPEC-099");
+  });
+
+  it("does NOT flag tasks with spec: null (valid ad-hoc tasks)", () => {
+    writeIndex(
+      {
+        "TASK-003": {
+          title: "Ad-hoc", slug: "adhoc", spec: null, status: "todo",
+          priority: "P2", depends_on: [], files: [], verify: null, done: null,
+          session: null, created: "2026-03-01", updated: "2026-03-01",
+          completed_at: null, file: "TASK-003-adhoc.md",
+        },
+      },
+      {},
+    );
+    writeArtifact("tasks", "TASK-003-adhoc.md", { id: "TASK-003", title: "Ad-hoc" });
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "TASK-003-adhoc.md");
+    expect(rec?.action).toBe("skip");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Specs
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("specs", () => {
+  it("recommends archive for complete specs", () => {
+    writeIndex(
+      {},
+      {
+        "SPEC-001": {
+          title: "Done spec", status: "complete", appetite: null,
+          requirement: null, source: null, created: "2026-03-01",
+          file: "SPEC-001-done.md",
+        },
+      },
+    );
+    writeArtifact("specs", "SPEC-001-done.md", { id: "SPEC-001", title: "Done spec", status: "complete" });
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "SPEC-001-done.md");
+    expect(rec?.action).toBe("archive");
+  });
+
+  it("flags stale drafting specs (>14 days)", () => {
+    const staleDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
+    writeIndex(
+      {},
+      {
+        "SPEC-002": {
+          title: "Stale spec", status: "drafting", appetite: null,
+          requirement: null, source: null, created: staleDate,
+          file: "SPEC-002-stale.md",
+        },
+      },
+    );
+    writeArtifact("specs", "SPEC-002-stale.md", { id: "SPEC-002", title: "Stale spec", status: "drafting" });
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "SPEC-002-stale.md");
+    expect(rec?.action).toBe("flag");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plans
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("plans", () => {
+  it("recommends delete for orphaned plans (no session link)", () => {
+    writeArtifact("plans", "plan-001.md", { title: "Orphan plan", created: "2026-03-01" });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "plan-001.md");
+    expect(rec?.action).toBe("delete");
+    expect(rec?.reason).toContain("no linked session");
+  });
+
+  it("recommends delete for plans linked to completed sessions", () => {
+    writeArtifact("sessions", "SESSION-010.md", { status: "completed", created: "2026-03-01" });
+    writeArtifact("plans", "plan-002.md", { session: "SESSION-010.md", created: "2026-03-01" });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "plan-002.md");
+    expect(rec?.action).toBe("delete");
+  });
+
+  it("skips plans linked to active sessions", () => {
+    writeArtifact("sessions", "SESSION-011.md", { status: "active", updated: new Date().toISOString() });
+    writeArtifact("plans", "plan-003.md", { session: "SESSION-011.md", updated: new Date().toISOString() });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "plan-003.md");
+    expect(rec?.action).toBe("skip");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Drafts
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("drafts", () => {
+  it("flags stale drafts (>30 days)", () => {
+    const staleDate = new Date(Date.now() - 35 * 24 * 60 * 60 * 1000).toISOString();
+    writeArtifact("drafts", "draft-001.md", { title: "Old draft", created: staleDate });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "draft-001.md");
+    expect(rec?.action).toBe("flag");
+    expect(rec?.reason).toContain("days old");
+  });
+
+  it("notes sparks section in stale drafts", () => {
+    const staleDate = new Date(Date.now() - 35 * 24 * 60 * 60 * 1000).toISOString();
+    writeArtifact("drafts", "draft-002.md", { title: "Sparky draft", created: staleDate }, "## Sparks\n- Great idea");
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "draft-002.md");
+    expect(rec?.hint).toContain("Sparks");
+  });
+
+  it("skips recent drafts", () => {
+    writeArtifact("drafts", "draft-003.md", { title: "Fresh draft", created: new Date().toISOString() });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "draft-003.md");
+    expect(rec?.action).toBe("skip");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Missing Directories
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("directory handling", () => {
+  it("warns about missing required directories", () => {
+    // Remove the sessions dir we created in beforeEach
+    rmSync(join(agentsDir(), "sessions"), { recursive: true });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    expect(result.warnings).toContain("Required directory missing: sessions/");
+  });
+
+  it("skips missing optional directories silently", () => {
+    writeIndex();
+    // plans/ doesn't exist — should produce no warnings
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    expect(result.warnings.filter((w) => w.includes("plans"))).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Filter
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("filter option", () => {
+  it("restricts scan to specified artifact types", () => {
+    writeArtifact("sessions", "SESSION-001.md", { status: "completed", created: "2026-03-01" });
+    writeArtifact("drafts", "draft-001.md", { title: "Draft", created: new Date().toISOString() });
+    writeIndex();
+
+    const result = scanArtifacts({ agentsDir: agentsDir(), filter: ["session"] });
+    const types = new Set(result.recommendations.map((r) => r.type));
+    expect(types.has("session")).toBe(true);
+    expect(types.has("draft")).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Summary
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("summary", () => {
+  it("produces correct counts per artifact type", () => {
+    writeArtifact("sessions", "SESSION-001.md", { status: "completed", created: "2026-03-01" });
+    writeArtifact("sessions", "SESSION-002.md", { status: "active", updated: new Date().toISOString() });
+    writeIndex();
+
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const sessionSummary = result.summary.find((s) => s.type === "session");
+    expect(sessionSummary?.total).toBe(2);
+    expect(sessionSummary?.archive).toBe(1);
+    expect(sessionSummary?.skip).toBe(1);
+  });
+});

--- a/cli/lib/cleanup/scanner.test.ts
+++ b/cli/lib/cleanup/scanner.test.ts
@@ -346,6 +346,21 @@ describe("councils", () => {
     expect(rec?.action).toBe("skip");
   });
 
+  it("reads dates from orchestration schema (council.timestamp + council.session)", () => {
+    const staleDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
+    writeSession("20260301-session.md", { status: "active", last_updated: new Date().toISOString() });
+    writeNestedArtifact("councils", "council-005.md", "council", {
+      topic: "Orchestration format",
+      timestamp: staleDate,
+      session: "20260301-session",
+    });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "council-005.md");
+    expect(rec?.action).toBe("archive");
+    expect(rec?.reason).toContain("days old");
+  });
+
   it("recommends archive for old councils with valid linked session", () => {
     const staleDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
     writeSession("20260301-session.md", { status: "active", last_updated: new Date().toISOString() });
@@ -390,6 +405,18 @@ describe("reports", () => {
     const rec = findRec(result.recommendations, "report-002.md");
     expect(rec?.action).toBe("archive");
     expect(rec?.reason).toContain("prerequisites met");
+  });
+
+  it("flags processed reports missing session_reference", () => {
+    writeNestedArtifact("reports", "report-004.md", "report", {
+      status: "processed",
+      processed_at: "2026-03-01T00:00:00Z",
+    });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "report-004.md");
+    expect(rec?.action).toBe("flag");
+    expect(rec?.reason).toContain("missing session_reference");
   });
 
   it("skips processed reports when linked session is not yet archived", () => {

--- a/cli/lib/cleanup/scanner.test.ts
+++ b/cli/lib/cleanup/scanner.test.ts
@@ -1,10 +1,3 @@
-/**
- * Cleanup Scanner Tests
- *
- * Tests the scanner engine against temp .agents/ fixtures.
- * Each test creates a minimal directory structure with specific artifact states.
- */
-
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync } from "fs";
 import { join } from "path";
@@ -64,7 +57,6 @@ function findRec(recs: CleanupRecommendation[], filename: string): CleanupRecomm
 
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "loaf-cleanup-test-"));
-  // Create required directories
   setupDir("sessions");
   setupDir("tasks");
   setupDir("specs");

--- a/cli/lib/cleanup/scanner.test.ts
+++ b/cli/lib/cleanup/scanner.test.ts
@@ -306,7 +306,7 @@ describe("drafts", () => {
     );
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "brainstorm-loaf-cli.md");
-    expect(rec?.action).toBe("flag");
+    expect(rec?.action).toBe("delete");
     expect(rec?.reason).toContain("promoted to spec");
   });
 

--- a/cli/lib/cleanup/scanner.test.ts
+++ b/cli/lib/cleanup/scanner.test.ts
@@ -348,7 +348,7 @@ describe("councils", () => {
 
   it("reads dates from orchestration schema (council.timestamp + council.session)", () => {
     const staleDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
-    writeSession("20260301-session.md", { status: "active", last_updated: new Date().toISOString() });
+    writeSession("20260301-session.md", { status: "complete", last_updated: new Date().toISOString() });
     writeNestedArtifact("councils", "council-005.md", "council", {
       topic: "Orchestration format",
       timestamp: staleDate,
@@ -358,12 +358,12 @@ describe("councils", () => {
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "council-005.md");
     expect(rec?.action).toBe("archive");
-    expect(rec?.reason).toContain("days old");
+    expect(rec?.reason).toContain("session completed");
   });
 
-  it("recommends archive for old councils with decision recorded and valid session", () => {
+  it("recommends archive for old councils with decision and completed session", () => {
     const staleDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
-    writeSession("20260301-session.md", { status: "active", last_updated: new Date().toISOString() });
+    writeSession("20260301-session.md", { status: "completed", last_updated: new Date().toISOString() });
     writeNestedArtifact("councils", "council-004.md", "council", {
       topic: "Old council",
       created: staleDate,
@@ -375,9 +375,24 @@ describe("councils", () => {
     expect(rec?.action).toBe("archive");
   });
 
-  it("flags old councils without decision recorded", () => {
+  it("flags old councils with decision but active session", () => {
     const staleDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
     writeSession("20260301-session.md", { status: "active", last_updated: new Date().toISOString() });
+    writeNestedArtifact("councils", "council-007.md", "council", {
+      topic: "Decision made but session open",
+      created: staleDate,
+      session_reference: ".agents/sessions/20260301-session.md",
+    }, "## Decision\n\nApproved option A.\n");
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "council-007.md");
+    expect(rec?.action).toBe("flag");
+    expect(rec?.reason).toContain("linked session not yet completed");
+  });
+
+  it("flags old councils without decision recorded", () => {
+    const staleDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
+    writeSession("20260301-session.md", { status: "complete", last_updated: new Date().toISOString() });
     writeNestedArtifact("councils", "council-006.md", "council", {
       topic: "Undecided council",
       created: staleDate,

--- a/cli/lib/cleanup/scanner.test.ts
+++ b/cli/lib/cleanup/scanner.test.ts
@@ -292,6 +292,24 @@ describe("drafts", () => {
     expect(rec?.hint).toContain("Sparks");
   });
 
+  it("flags drafts promoted to a spec", () => {
+    writeArtifact("drafts", "brainstorm-loaf-cli.md", { title: "Brainstorm", created: new Date().toISOString() });
+    writeIndex(
+      {},
+      {
+        "SPEC-009": {
+          title: "Knowledge Management", status: "complete", appetite: null,
+          requirement: null, source: ".agents/drafts/brainstorm-loaf-cli.md",
+          created: "2026-03-01", file: "archive/SPEC-009-knowledge.md",
+        },
+      },
+    );
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "brainstorm-loaf-cli.md");
+    expect(rec?.action).toBe("flag");
+    expect(rec?.reason).toContain("promoted to spec");
+  });
+
   it("skips recent drafts", () => {
     writeArtifact("drafts", "draft-003.md", { title: "Fresh draft", created: new Date().toISOString() });
     writeIndex();

--- a/cli/lib/cleanup/scanner.test.ts
+++ b/cli/lib/cleanup/scanner.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -33,6 +33,18 @@ function writeArtifact(subdir: string, filename: string, frontmatter: Record<str
   const dir = setupDir(subdir);
   const lines = Object.entries(frontmatter).map(([k, v]) => `${k}: ${JSON.stringify(v)}`);
   const content = `---\n${lines.join("\n")}\n---\n\n${body}`;
+  writeFileSync(join(dir, filename), content, "utf-8");
+}
+
+/** Write a session file with the nested session: block format used in this repo */
+function writeSession(filename: string, sessionFields: Record<string, unknown>, body = ""): void {
+  const dir = setupDir("sessions");
+  // Build nested YAML manually for the session: block
+  let yaml = "session:\n";
+  for (const [k, v] of Object.entries(sessionFields)) {
+    yaml += `  ${k}: ${JSON.stringify(v)}\n`;
+  }
+  const content = `---\n${yaml}---\n\n${body}`;
   writeFileSync(join(dir, filename), content, "utf-8");
 }
 
@@ -63,8 +75,8 @@ afterEach(() => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("sessions", () => {
-  it("recommends archive for completed sessions", () => {
-    writeArtifact("sessions", "SESSION-001.md", { status: "completed", created: "2026-03-01" });
+  it("recommends archive for completed sessions (nested session.status)", () => {
+    writeSession("SESSION-001.md", { status: "completed", created: "2026-03-01" });
     writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "SESSION-001.md");
@@ -72,7 +84,7 @@ describe("sessions", () => {
   });
 
   it("hints at /crystallize for sessions with learnings", () => {
-    writeArtifact("sessions", "SESSION-002.md", { status: "completed", created: "2026-03-01" }, "## Key Decisions\n- Did a thing");
+    writeSession("SESSION-002.md", { status: "completed", created: "2026-03-01" }, "## Key Decisions\n- Did a thing");
     writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "SESSION-002.md");
@@ -82,7 +94,7 @@ describe("sessions", () => {
 
   it("flags stale sessions (>7 days inactive)", () => {
     const staleDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
-    writeArtifact("sessions", "SESSION-003.md", { status: "active", updated: staleDate });
+    writeSession("SESSION-003.md", { status: "active", last_updated: staleDate });
     writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "SESSION-003.md");
@@ -91,7 +103,7 @@ describe("sessions", () => {
   });
 
   it("skips active sessions", () => {
-    writeArtifact("sessions", "SESSION-004.md", { status: "active", updated: new Date().toISOString() });
+    writeSession("SESSION-004.md", { status: "active", last_updated: new Date().toISOString() });
     writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "SESSION-004.md");
@@ -99,7 +111,7 @@ describe("sessions", () => {
   });
 
   it("archives cancelled sessions", () => {
-    writeArtifact("sessions", "SESSION-005.md", { status: "cancelled", created: "2026-03-01" });
+    writeSession("SESSION-005.md", { status: "cancelled", created: "2026-03-01" });
     writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "SESSION-005.md");
@@ -224,20 +236,30 @@ describe("plans", () => {
   });
 
   it("recommends delete for plans linked to completed sessions", () => {
-    writeArtifact("sessions", "SESSION-010.md", { status: "completed", created: "2026-03-01" });
-    writeArtifact("plans", "plan-002.md", { session: "SESSION-010.md", created: "2026-03-01" });
+    writeSession("20260327-163059-spec-015-workflow-hooks.md", { status: "complete", created: "2026-03-01" });
+    writeArtifact("plans", "plan-002.md", { session: "20260327-163059-spec-015", created: "2026-03-01" });
     writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "plan-002.md");
     expect(rec?.action).toBe("delete");
   });
 
-  it("skips plans linked to active sessions", () => {
-    writeArtifact("sessions", "SESSION-011.md", { status: "active", updated: new Date().toISOString() });
-    writeArtifact("plans", "plan-003.md", { session: "SESSION-011.md", updated: new Date().toISOString() });
+  it("matches session refs by stem (ID prefix without full filename)", () => {
+    writeSession("20260327-181352-task-020.md", { status: "active", last_updated: new Date().toISOString() });
+    // Plan uses the ID stem, not the full filename
+    writeArtifact("plans", "plan-003.md", { session: "20260327-181352-task-020", updated: new Date().toISOString() });
     writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "plan-003.md");
+    expect(rec?.action).toBe("skip");
+  });
+
+  it("also matches session refs by full filename", () => {
+    writeSession("SESSION-011.md", { status: "active", last_updated: new Date().toISOString() });
+    writeArtifact("plans", "plan-004.md", { session: "SESSION-011.md", updated: new Date().toISOString() });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "plan-004.md");
     expect(rec?.action).toBe("skip");
   });
 });
@@ -276,6 +298,37 @@ describe("drafts", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Reports
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("reports", () => {
+  it("reads nested report.archived_at and skips already-archived reports", () => {
+    // Write report with nested report: block (matching the template)
+    const dir = setupDir("reports");
+    const content = `---\nreport:\n  status: "processed"\n  archived_at: "2026-03-01T00:00:00Z"\n  archived_by: "agent-pm"\n---\n\n# Report`;
+    writeFileSync(join(dir, "report-001.md"), content, "utf-8");
+    writeIndex();
+
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "report-001.md");
+    expect(rec?.action).toBe("skip");
+    expect(rec?.reason).toContain("archived");
+  });
+
+  it("recommends archive for processed reports without archived_at", () => {
+    const dir = setupDir("reports");
+    const content = `---\nreport:\n  status: "processed"\n  processed_at: "2026-03-01T00:00:00Z"\n---\n\n# Report`;
+    writeFileSync(join(dir, "report-002.md"), content, "utf-8");
+    writeIndex();
+
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "report-002.md");
+    expect(rec?.action).toBe("archive");
+    expect(rec?.reason).toContain("processed");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Missing Directories
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -294,6 +347,14 @@ describe("directory handling", () => {
     const result = scanArtifacts({ agentsDir: agentsDir() });
     expect(result.warnings.filter((w) => w.includes("plans"))).toHaveLength(0);
   });
+
+  it("does not write TASKS.json when it is missing (read-only scan)", () => {
+    // Don't call writeIndex() — scanner should not create TASKS.json
+    const indexPath = join(agentsDir(), "TASKS.json");
+    expect(existsSync(indexPath)).toBe(false);
+    scanArtifacts({ agentsDir: agentsDir() });
+    expect(existsSync(indexPath)).toBe(false);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -302,7 +363,7 @@ describe("directory handling", () => {
 
 describe("filter option", () => {
   it("restricts scan to specified artifact types", () => {
-    writeArtifact("sessions", "SESSION-001.md", { status: "completed", created: "2026-03-01" });
+    writeSession("SESSION-001.md", { status: "completed", created: "2026-03-01" });
     writeArtifact("drafts", "draft-001.md", { title: "Draft", created: new Date().toISOString() });
     writeIndex();
 
@@ -319,8 +380,8 @@ describe("filter option", () => {
 
 describe("summary", () => {
   it("produces correct counts per artifact type", () => {
-    writeArtifact("sessions", "SESSION-001.md", { status: "completed", created: "2026-03-01" });
-    writeArtifact("sessions", "SESSION-002.md", { status: "active", updated: new Date().toISOString() });
+    writeSession("SESSION-001.md", { status: "completed", created: "2026-03-01" });
+    writeSession("SESSION-002.md", { status: "active", last_updated: new Date().toISOString() });
     writeIndex();
 
     const result = scanArtifacts({ agentsDir: agentsDir() });

--- a/cli/lib/cleanup/scanner.test.ts
+++ b/cli/lib/cleanup/scanner.test.ts
@@ -324,7 +324,7 @@ describe("councils", () => {
     writeNestedArtifact("councils", "council-002.md", "council", {
       topic: "Missing session",
       created: new Date().toISOString(),
-      session_reference: "20260101-000000-nonexistent.md",
+      session_reference: ".agents/sessions/20260101-000000-nonexistent.md",
     });
     writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });
@@ -333,17 +333,31 @@ describe("councils", () => {
     expect(rec?.reason).toContain("Orphaned");
   });
 
-  it("skips recent councils with valid session", () => {
+  it("skips recent councils with valid session (normalizes .agents/sessions/ prefix)", () => {
     writeSession("20260327-181352-task-020.md", { status: "active", last_updated: new Date().toISOString() });
     writeNestedArtifact("councils", "council-003.md", "council", {
       topic: "Active council",
       created: new Date().toISOString(),
-      session_reference: "20260327-181352-task-020.md",
+      session_reference: ".agents/sessions/20260327-181352-task-020.md",
     });
     writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "council-003.md");
     expect(rec?.action).toBe("skip");
+  });
+
+  it("recommends archive for old councils with valid linked session", () => {
+    const staleDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
+    writeSession("20260301-session.md", { status: "active", last_updated: new Date().toISOString() });
+    writeNestedArtifact("councils", "council-004.md", "council", {
+      topic: "Old council",
+      created: staleDate,
+      session_reference: ".agents/sessions/20260301-session.md",
+    });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "council-004.md");
+    expect(rec?.action).toBe("archive");
   });
 });
 
@@ -369,7 +383,7 @@ describe("reports", () => {
     writeNestedArtifact("reports", "report-002.md", "report", {
       status: "processed",
       processed_at: "2026-03-01T00:00:00Z",
-      session_reference: "20260301-session.md",
+      session_reference: ".agents/sessions/20260301-session.md",
     });
     writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });
@@ -383,7 +397,7 @@ describe("reports", () => {
     writeNestedArtifact("reports", "report-003.md", "report", {
       status: "processed",
       processed_at: "2026-03-01T00:00:00Z",
-      session_reference: "20260327-active-session.md",
+      session_reference: ".agents/sessions/20260327-active-session.md",
     });
     writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });

--- a/cli/lib/cleanup/scanner.test.ts
+++ b/cli/lib/cleanup/scanner.test.ts
@@ -36,16 +36,20 @@ function writeArtifact(subdir: string, filename: string, frontmatter: Record<str
   writeFileSync(join(dir, filename), content, "utf-8");
 }
 
-/** Write a session file with the nested session: block format used in this repo */
-function writeSession(filename: string, sessionFields: Record<string, unknown>, body = ""): void {
-  const dir = setupDir("sessions");
-  // Build nested YAML manually for the session: block
-  let yaml = "session:\n";
-  for (const [k, v] of Object.entries(sessionFields)) {
+/** Write a file with a nested YAML block (e.g., session:, council:, report:) */
+function writeNestedArtifact(subdir: string, filename: string, blockName: string, fields: Record<string, unknown>, body = ""): void {
+  const dir = setupDir(subdir);
+  let yaml = `${blockName}:\n`;
+  for (const [k, v] of Object.entries(fields)) {
     yaml += `  ${k}: ${JSON.stringify(v)}\n`;
   }
   const content = `---\n${yaml}---\n\n${body}`;
   writeFileSync(join(dir, filename), content, "utf-8");
+}
+
+/** Write a session file with the nested session: block format used in this repo */
+function writeSession(filename: string, sessionFields: Record<string, unknown>, body = ""): void {
+  writeNestedArtifact("sessions", filename, "session", sessionFields, body);
 }
 
 /** Write a minimal TASKS.json */
@@ -301,30 +305,91 @@ describe("drafts", () => {
 // Reports
 // ─────────────────────────────────────────────────────────────────────────────
 
+describe("councils", () => {
+  it("reads dates from nested council.created", () => {
+    const staleDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
+    writeNestedArtifact("councils", "council-001.md", "council", {
+      topic: "Architecture decision",
+      created: staleDate,
+      status: "in_progress",
+    });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "council-001.md");
+    expect(rec?.action).toBe("flag");
+    expect(rec?.reason).toContain("Stale");
+  });
+
+  it("flags orphaned councils with missing session reference", () => {
+    writeNestedArtifact("councils", "council-002.md", "council", {
+      topic: "Missing session",
+      created: new Date().toISOString(),
+      session_reference: "20260101-000000-nonexistent.md",
+    });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "council-002.md");
+    expect(rec?.action).toBe("flag");
+    expect(rec?.reason).toContain("Orphaned");
+  });
+
+  it("skips recent councils with valid session", () => {
+    writeSession("20260327-181352-task-020.md", { status: "active", last_updated: new Date().toISOString() });
+    writeNestedArtifact("councils", "council-003.md", "council", {
+      topic: "Active council",
+      created: new Date().toISOString(),
+      session_reference: "20260327-181352-task-020.md",
+    });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "council-003.md");
+    expect(rec?.action).toBe("skip");
+  });
+});
+
 describe("reports", () => {
   it("reads nested report.archived_at and skips already-archived reports", () => {
-    // Write report with nested report: block (matching the template)
-    const dir = setupDir("reports");
-    const content = `---\nreport:\n  status: "processed"\n  archived_at: "2026-03-01T00:00:00Z"\n  archived_by: "agent-pm"\n---\n\n# Report`;
-    writeFileSync(join(dir, "report-001.md"), content, "utf-8");
+    writeNestedArtifact("reports", "report-001.md", "report", {
+      status: "processed",
+      archived_at: "2026-03-01T00:00:00Z",
+      archived_by: "agent-pm",
+    });
     writeIndex();
-
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "report-001.md");
     expect(rec?.action).toBe("skip");
     expect(rec?.reason).toContain("archived");
   });
 
-  it("recommends archive for processed reports without archived_at", () => {
-    const dir = setupDir("reports");
-    const content = `---\nreport:\n  status: "processed"\n  processed_at: "2026-03-01T00:00:00Z"\n---\n\n# Report`;
-    writeFileSync(join(dir, "report-002.md"), content, "utf-8");
-    writeIndex();
+  it("recommends archive for processed reports when session is archived", () => {
+    // Create an archived session
+    const archiveDir = setupDir("sessions", "archive");
+    writeFileSync(join(archiveDir, "20260301-session.md"), "---\nsession:\n  status: archived\n---\n", "utf-8");
 
+    writeNestedArtifact("reports", "report-002.md", "report", {
+      status: "processed",
+      processed_at: "2026-03-01T00:00:00Z",
+      session_reference: "20260301-session.md",
+    });
+    writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "report-002.md");
     expect(rec?.action).toBe("archive");
-    expect(rec?.reason).toContain("processed");
+    expect(rec?.reason).toContain("prerequisites met");
+  });
+
+  it("skips processed reports when linked session is not yet archived", () => {
+    writeSession("20260327-active-session.md", { status: "active", last_updated: new Date().toISOString() });
+    writeNestedArtifact("reports", "report-003.md", "report", {
+      status: "processed",
+      processed_at: "2026-03-01T00:00:00Z",
+      session_reference: "20260327-active-session.md",
+    });
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "report-003.md");
+    expect(rec?.action).toBe("skip");
+    expect(rec?.reason).toContain("not yet archived");
   });
 });
 

--- a/cli/lib/cleanup/scanner.test.ts
+++ b/cli/lib/cleanup/scanner.test.ts
@@ -353,7 +353,7 @@ describe("councils", () => {
       topic: "Orchestration format",
       timestamp: staleDate,
       session: "20260301-session",
-    });
+    }, "## Decision\n\nUse option B.\n");
     writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "council-005.md");
@@ -361,18 +361,33 @@ describe("councils", () => {
     expect(rec?.reason).toContain("days old");
   });
 
-  it("recommends archive for old councils with valid linked session", () => {
+  it("recommends archive for old councils with decision recorded and valid session", () => {
     const staleDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
     writeSession("20260301-session.md", { status: "active", last_updated: new Date().toISOString() });
     writeNestedArtifact("councils", "council-004.md", "council", {
       topic: "Old council",
       created: staleDate,
       session_reference: ".agents/sessions/20260301-session.md",
-    });
+    }, "## Decision\n\nApproved option A.\n");
     writeIndex();
     const result = scanArtifacts({ agentsDir: agentsDir() });
     const rec = findRec(result.recommendations, "council-004.md");
     expect(rec?.action).toBe("archive");
+  });
+
+  it("flags old councils without decision recorded", () => {
+    const staleDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
+    writeSession("20260301-session.md", { status: "active", last_updated: new Date().toISOString() });
+    writeNestedArtifact("councils", "council-006.md", "council", {
+      topic: "Undecided council",
+      created: staleDate,
+      session_reference: ".agents/sessions/20260301-session.md",
+    }, "## Decision\n\n[To be filled after user approval]\n");
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "council-006.md");
+    expect(rec?.action).toBe("flag");
+    expect(rec?.reason).toContain("decision not yet recorded");
   });
 });
 
@@ -417,6 +432,21 @@ describe("reports", () => {
     const rec = findRec(result.recommendations, "report-004.md");
     expect(rec?.action).toBe("flag");
     expect(rec?.reason).toContain("missing session_reference");
+  });
+
+  it("flags old unprocessed reports instead of archiving them", () => {
+    const staleDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
+    writeNestedArtifact("reports", "report-005.md", "report", {
+      status: "pending",
+    });
+    // Need to write with a stale date — use flat frontmatter for created
+    const dir = setupDir("reports");
+    writeFileSync(join(dir, "report-005.md"), `---\nreport:\n  status: "pending"\ncreated: ${JSON.stringify(staleDate)}\n---\n`, "utf-8");
+    writeIndex();
+    const result = scanArtifacts({ agentsDir: agentsDir() });
+    const rec = findRec(result.recommendations, "report-005.md");
+    expect(rec?.action).toBe("flag");
+    expect(rec?.reason).toContain("not yet processed");
   });
 
   it("skips processed reports when linked session is not yet archived", () => {

--- a/cli/lib/cleanup/scanner.ts
+++ b/cli/lib/cleanup/scanner.ts
@@ -465,10 +465,12 @@ function scanCouncils(agentsDir: string): CleanupRecommendation[] {
   for (const file of files) {
     const fm = file.frontmatter;
 
-    // Council template nests metadata under `council:` block
+    // Two council schemas exist:
+    //   council-session template: council.created, council.session_reference
+    //   orchestration reference:  council.timestamp, council.session
     const councilBlock = fm.council as Record<string, unknown> | undefined;
-    const councilDate = councilBlock?.created as string | undefined;
-    const sessionRef = councilBlock?.session_reference as string | undefined;
+    const councilDate = (councilBlock?.created || councilBlock?.timestamp) as string | undefined;
+    const sessionRef = (councilBlock?.session_reference || councilBlock?.session) as string | undefined;
     const days = daysSince(councilDate || lastActivity(fm));
 
     // Check for orphaned councils (no linked session or missing session)
@@ -560,8 +562,17 @@ function scanReports(agentsDir: string): CleanupRecommendation[] {
         frontmatter: fm,
       });
     } else if (reportStatus === "processed" || processedAt) {
-      // Archive prerequisite: linked session must be archived first
-      if (sessionRef && !sessionIsArchived(normalizeSessionRef(sessionRef))) {
+      // Archive prerequisites: session_reference required, and that session must be archived
+      if (!sessionRef) {
+        recs.push({
+          type: "report",
+          path: file.path,
+          filename: file.filename,
+          action: "flag",
+          reason: "Report is processed but missing session_reference — repair metadata",
+          frontmatter: fm,
+        });
+      } else if (!sessionIsArchived(normalizeSessionRef(sessionRef))) {
         recs.push({
           type: "report",
           path: file.path,

--- a/cli/lib/cleanup/scanner.ts
+++ b/cli/lib/cleanup/scanner.ts
@@ -9,8 +9,8 @@ import { existsSync, readFileSync, readdirSync, statSync } from "fs";
 import { join, basename } from "path";
 import matter from "gray-matter";
 
-import { getOrBuildIndex } from "../tasks/resolve.js";
-import { findOrphans } from "../tasks/migrate.js";
+import { findAgentsDir } from "../tasks/resolve.js";
+import { loadIndex, buildIndexFromFiles, findOrphans } from "../tasks/migrate.js";
 import type { TaskIndex } from "../tasks/types.js";
 import type {
   ArtifactType,
@@ -62,9 +62,23 @@ function daysSince(dateStr: string | undefined): number | null {
   return Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60 * 24));
 }
 
-/** Get the most recent date from frontmatter (updated > created) */
+/** Get the most recent date from frontmatter (supports nested session.last_updated) */
 function lastActivity(fm: Record<string, unknown>): string | undefined {
+  // Session files use nested session.last_updated / session.created
+  const sessionBlock = fm.session as Record<string, unknown> | undefined;
+  if (sessionBlock && typeof sessionBlock === "object") {
+    return (sessionBlock.last_updated as string) || (sessionBlock.created as string) || undefined;
+  }
   return (fm.updated as string) || (fm.created as string) || undefined;
+}
+
+/** Extract status from frontmatter, supporting nested session.status */
+function getStatus(fm: Record<string, unknown>): string {
+  const sessionBlock = fm.session as Record<string, unknown> | undefined;
+  if (sessionBlock && typeof sessionBlock === "object" && sessionBlock.status) {
+    return String(sessionBlock.status).toLowerCase();
+  }
+  return String(fm.status || "").toLowerCase();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -78,7 +92,7 @@ function scanSessions(agentsDir: string): CleanupRecommendation[] {
 
   for (const file of files) {
     const fm = file.frontmatter;
-    const status = String(fm.status || "").toLowerCase();
+    const status = getStatus(fm);
 
     // Check for extractable learnings
     const hasLearnings =
@@ -275,10 +289,13 @@ function scanPlans(agentsDir: string): CleanupRecommendation[] {
   const files = readMdFiles(dir);
   const recs: CleanupRecommendation[] = [];
 
-  // Build a set of active session filenames for cross-referencing
+  // Build sets of session IDs (stem without .md) for cross-referencing.
+  // Plan frontmatter stores session IDs (e.g., "20260327-163059-spec-015"),
+  // while session files are named like "20260327-163059-spec-015-workflow-hooks.md".
+  // Match by checking if any session filename starts with the plan's session ref.
   const sessionsDir = join(agentsDir, "sessions");
-  const activeSessions = new Set<string>();
-  const archivedSessions = new Set<string>();
+  const activeSessionFiles: string[] = [];
+  const archivedSessionFiles: string[] = [];
 
   if (existsSync(sessionsDir)) {
     for (const name of readdirSync(sessionsDir)) {
@@ -286,11 +303,11 @@ function scanPlans(agentsDir: string): CleanupRecommendation[] {
       try {
         const raw = readFileSync(join(sessionsDir, name), "utf-8");
         const { data } = matter(raw);
-        const status = String(data.status || "").toLowerCase();
-        if (status === "completed" || status === "complete" || status === "cancelled") {
-          archivedSessions.add(name);
+        const status = getStatus(data);
+        if (status === "completed" || status === "complete" || status === "cancelled" || status === "archived") {
+          archivedSessionFiles.push(name);
         } else {
-          activeSessions.add(name);
+          activeSessionFiles.push(name);
         }
       } catch {
         // Skip unreadable
@@ -303,10 +320,20 @@ function scanPlans(agentsDir: string): CleanupRecommendation[] {
   if (existsSync(sessionArchive)) {
     try {
       for (const name of readdirSync(sessionArchive)) {
-        if (name.endsWith(".md")) archivedSessions.add(name);
+        if (name.endsWith(".md")) archivedSessionFiles.push(name);
       }
     } catch { /* skip */ }
   }
+
+  // Match a session reference against session filenames.
+  // Refs can be filenames ("SESSION-001.md") or ID stems ("20260327-163059-spec-015").
+  const matchesSession = (ref: string, files: string[]): boolean => {
+    // Direct filename match
+    if (files.includes(ref)) return true;
+    // Stem match: ref is a prefix of a filename (without .md)
+    const stem = ref.replace(/\.md$/, "");
+    return files.some((f) => f.startsWith(stem));
+  };
 
   for (const file of files) {
     const fm = file.frontmatter;
@@ -322,7 +349,7 @@ function scanPlans(agentsDir: string): CleanupRecommendation[] {
         reason: "Orphaned plan — no linked session",
         frontmatter: fm,
       });
-    } else if (archivedSessions.has(sessionRef)) {
+    } else if (matchesSession(sessionRef, archivedSessionFiles)) {
       recs.push({
         type: "plan",
         path: file.path,
@@ -331,7 +358,7 @@ function scanPlans(agentsDir: string): CleanupRecommendation[] {
         reason: "Linked session is archived/completed",
         frontmatter: fm,
       });
-    } else if (!activeSessions.has(sessionRef)) {
+    } else if (!matchesSession(sessionRef, activeSessionFiles)) {
       recs.push({
         type: "plan",
         path: file.path,
@@ -444,14 +471,28 @@ function scanReports(agentsDir: string): CleanupRecommendation[] {
   for (const file of files) {
     const fm = file.frontmatter;
 
-    if (fm.archived_at) {
-      // Already has archive metadata — skip
+    // Report template nests metadata under `report:` block
+    const reportBlock = fm.report as Record<string, unknown> | undefined;
+    const archivedAt = reportBlock?.archived_at || fm.archived_at;
+    const reportStatus = reportBlock?.status as string | undefined;
+    const processedAt = reportBlock?.processed_at as string | undefined;
+
+    if (archivedAt) {
       recs.push({
         type: "report",
         path: file.path,
         filename: file.filename,
         action: "skip",
-        reason: "Already processed",
+        reason: "Already archived",
+        frontmatter: fm,
+      });
+    } else if (reportStatus === "processed" || processedAt) {
+      recs.push({
+        type: "report",
+        path: file.path,
+        filename: file.filename,
+        action: "archive",
+        reason: "Report is processed — ready for archive",
         frontmatter: fm,
       });
     } else {
@@ -504,8 +545,9 @@ export function scanArtifacts(options: ScanOptions): ScanResult {
     }
   }
 
-  // Load task index (needed for task and spec scanning)
-  const index = getOrBuildIndex(agentsDir);
+  // Load task index read-only (never write TASKS.json during scan)
+  const indexPath = join(agentsDir, "TASKS.json");
+  const index = loadIndex(indexPath) ?? buildIndexFromFiles(agentsDir);
 
   // Run per-type scanners
   const shouldScan = (type: ArtifactType) => !filter || filter.includes(type);

--- a/cli/lib/cleanup/scanner.ts
+++ b/cli/lib/cleanup/scanner.ts
@@ -541,6 +541,7 @@ function scanCouncils(agentsDir: string): CleanupRecommendation[] {
           filename: file.filename,
           action: "archive",
           reason: `Council is ${days} days old — decision recorded, session completed`,
+          hint: "Verify the linked session summary captures the council outcome before archiving",
           frontmatter: fm,
         });
       } else {

--- a/cli/lib/cleanup/scanner.ts
+++ b/cli/lib/cleanup/scanner.ts
@@ -484,15 +484,18 @@ function scanCouncils(agentsDir: string): CleanupRecommendation[] {
         frontmatter: fm,
       });
     } else if (days !== null && days > 14) {
-      // If the council has a valid linked session, it's archive-ready (outcome captured).
-      // Without a session link, just flag for review.
-      if (sessionRef && matchesAnySession(normalizeSessionRef(sessionRef))) {
+      // Archive only if council has a Decision/outcome recorded.
+      // The council file itself is the source — check for ## Decision content.
+      const hasDecision = file.raw.includes("## Decision") &&
+        !file.raw.match(/## Decision\s*\n\s*\n\s*(\[To be filled|$)/);
+
+      if (hasDecision && sessionRef && matchesAnySession(normalizeSessionRef(sessionRef))) {
         recs.push({
           type: "council",
           path: file.path,
           filename: file.filename,
           action: "archive",
-          reason: `Council is ${days} days old with linked session — ready for archive`,
+          reason: `Council is ${days} days old with decision recorded — ready for archive`,
           frontmatter: fm,
         });
       } else {
@@ -501,7 +504,9 @@ function scanCouncils(agentsDir: string): CleanupRecommendation[] {
           path: file.path,
           filename: file.filename,
           action: "flag",
-          reason: `Stale council — ${days} days old, no linked session`,
+          reason: hasDecision
+            ? `Stale council — ${days} days old, no linked session`
+            : `Stale council — ${days} days old, decision not yet recorded`,
           frontmatter: fm,
         });
       }
@@ -592,14 +597,16 @@ function scanReports(agentsDir: string): CleanupRecommendation[] {
         });
       }
     } else {
+      // Unprocessed reports: flag if stale, skip if recent.
+      // No age-based archive — reports must be processed first.
       const days = daysSince(lastActivity(fm));
       if (days !== null && days > 14) {
         recs.push({
           type: "report",
           path: file.path,
           filename: file.filename,
-          action: "archive",
-          reason: `Report is ${days} days old — ready for archive`,
+          action: "flag",
+          reason: `Report is ${days} days old but not yet processed`,
           frontmatter: fm,
         });
       } else {

--- a/cli/lib/cleanup/scanner.ts
+++ b/cli/lib/cleanup/scanner.ts
@@ -443,14 +443,25 @@ function scanCouncils(agentsDir: string): CleanupRecommendation[] {
   const files = readMdFiles(dir);
   const recs: CleanupRecommendation[] = [];
 
-  // Build session lookup for orphan detection
+  // Build session lookup for orphan detection and archive-readiness
   const sessionsDir = join(agentsDir, "sessions");
   const allSessionFiles: string[] = [];
+  const completedSessionFiles: string[] = [];
+
   for (const subdir of [sessionsDir, join(sessionsDir, "archive")]) {
     if (existsSync(subdir)) {
       try {
         for (const name of readdirSync(subdir)) {
-          if (name.endsWith(".md")) allSessionFiles.push(name);
+          if (!name.endsWith(".md")) continue;
+          allSessionFiles.push(name);
+          try {
+            const raw = readFileSync(join(subdir, name), "utf-8");
+            const { data } = matter(raw);
+            const status = getStatus(data);
+            if (["completed", "complete", "archived", "cancelled"].includes(status)) {
+              completedSessionFiles.push(name);
+            }
+          } catch { /* skip */ }
         }
       } catch { /* skip */ }
     }
@@ -460,6 +471,12 @@ function scanCouncils(agentsDir: string): CleanupRecommendation[] {
     if (allSessionFiles.includes(ref)) return true;
     const stem = ref.replace(/\.md$/, "");
     return allSessionFiles.some((f) => f.startsWith(stem));
+  };
+
+  const sessionIsCompleted = (ref: string): boolean => {
+    if (completedSessionFiles.includes(ref)) return true;
+    const stem = ref.replace(/\.md$/, "");
+    return completedSessionFiles.some((f) => f.startsWith(stem));
   };
 
   for (const file of files) {
@@ -489,24 +506,31 @@ function scanCouncils(agentsDir: string): CleanupRecommendation[] {
       const hasDecision = file.raw.includes("## Decision") &&
         !file.raw.match(/## Decision\s*\n\s*\n\s*(\[To be filled|$)/);
 
-      if (hasDecision && sessionRef && matchesAnySession(normalizeSessionRef(sessionRef))) {
+      // Archive requires: decision recorded AND linked session completed/archived
+      // (policy: "session summary captured → archive")
+      const normalizedRef = sessionRef ? normalizeSessionRef(sessionRef) : null;
+      const sessionDone = normalizedRef && sessionIsCompleted(normalizedRef);
+
+      if (hasDecision && sessionDone) {
         recs.push({
           type: "council",
           path: file.path,
           filename: file.filename,
           action: "archive",
-          reason: `Council is ${days} days old with decision recorded — ready for archive`,
+          reason: `Council is ${days} days old — decision recorded, session completed`,
           frontmatter: fm,
         });
       } else {
+        const reasons: string[] = [];
+        if (!hasDecision) reasons.push("decision not yet recorded");
+        if (!sessionRef) reasons.push("no linked session");
+        else if (!sessionDone) reasons.push("linked session not yet completed");
         recs.push({
           type: "council",
           path: file.path,
           filename: file.filename,
           action: "flag",
-          reason: hasDecision
-            ? `Stale council — ${days} days old, no linked session`
-            : `Stale council — ${days} days old, decision not yet recorded`,
+          reason: `Stale council — ${days} days old, ${reasons.join(", ")}`,
           frontmatter: fm,
         });
       }

--- a/cli/lib/cleanup/scanner.ts
+++ b/cli/lib/cleanup/scanner.ts
@@ -403,16 +403,39 @@ function scanPlans(agentsDir: string): CleanupRecommendation[] {
   return recs;
 }
 
-function scanDrafts(agentsDir: string): CleanupRecommendation[] {
+function scanDrafts(agentsDir: string, index: TaskIndex): CleanupRecommendation[] {
   const dir = join(agentsDir, "drafts");
   const files = readMdFiles(dir);
   const recs: CleanupRecommendation[] = [];
+
+  // Build set of draft references from spec source fields.
+  // Specs record source as full path (".agents/drafts/FILE.md") or keyword ("brainstorm", "direct").
+  const promotedDrafts = new Set<string>();
+  for (const entry of Object.values(index.specs)) {
+    if (entry.source && entry.source.includes("/drafts/")) {
+      // Extract bare filename from path
+      const filename = entry.source.replace(/^.*\/drafts\//, "");
+      promotedDrafts.add(filename);
+    }
+  }
 
   for (const file of files) {
     const fm = file.frontmatter;
     const days = daysSince(lastActivity(fm) || fm.created as string);
 
-    if (days !== null && days > 30) {
+    // Check if this draft has been promoted to a spec
+    if (promotedDrafts.has(file.filename)) {
+      const hasSparks = file.raw.includes("## Sparks");
+      recs.push({
+        type: "draft",
+        path: file.path,
+        filename: file.filename,
+        action: "flag",
+        reason: "Draft promoted to spec — served its purpose",
+        hint: hasSparks ? "Contains ## Sparks section — review before deletion" : "Can be archived or deleted",
+        frontmatter: fm,
+      });
+    } else if (days !== null && days > 30) {
       const hasSparks = file.raw.includes("## Sparks");
       recs.push({
         type: "draft",
@@ -683,7 +706,7 @@ export function scanArtifacts(options: ScanOptions): ScanResult {
   if (shouldScan("task")) recommendations.push(...scanTasks(agentsDir, index));
   if (shouldScan("spec")) recommendations.push(...scanSpecs(agentsDir, index));
   if (shouldScan("plan")) recommendations.push(...scanPlans(agentsDir));
-  if (shouldScan("draft")) recommendations.push(...scanDrafts(agentsDir));
+  if (shouldScan("draft")) recommendations.push(...scanDrafts(agentsDir, index));
   if (shouldScan("council")) recommendations.push(...scanCouncils(agentsDir));
   if (shouldScan("report")) recommendations.push(...scanReports(agentsDir));
 

--- a/cli/lib/cleanup/scanner.ts
+++ b/cli/lib/cleanup/scanner.ts
@@ -435,11 +435,45 @@ function scanCouncils(agentsDir: string): CleanupRecommendation[] {
   const files = readMdFiles(dir);
   const recs: CleanupRecommendation[] = [];
 
+  // Build session lookup for orphan detection
+  const sessionsDir = join(agentsDir, "sessions");
+  const allSessionFiles: string[] = [];
+  for (const subdir of [sessionsDir, join(sessionsDir, "archive")]) {
+    if (existsSync(subdir)) {
+      try {
+        for (const name of readdirSync(subdir)) {
+          if (name.endsWith(".md")) allSessionFiles.push(name);
+        }
+      } catch { /* skip */ }
+    }
+  }
+
+  const matchesAnySession = (ref: string): boolean => {
+    if (allSessionFiles.includes(ref)) return true;
+    const stem = ref.replace(/\.md$/, "");
+    return allSessionFiles.some((f) => f.startsWith(stem));
+  };
+
   for (const file of files) {
     const fm = file.frontmatter;
-    const days = daysSince(lastActivity(fm));
 
-    if (days !== null && days > 14) {
+    // Council template nests metadata under `council:` block
+    const councilBlock = fm.council as Record<string, unknown> | undefined;
+    const councilDate = councilBlock?.created as string | undefined;
+    const sessionRef = councilBlock?.session_reference as string | undefined;
+    const days = daysSince(councilDate || lastActivity(fm));
+
+    // Check for orphaned councils (no linked session or missing session)
+    if (sessionRef && !matchesAnySession(sessionRef)) {
+      recs.push({
+        type: "council",
+        path: file.path,
+        filename: file.filename,
+        action: "flag",
+        reason: `Orphaned council — linked session "${sessionRef}" not found`,
+        frontmatter: fm,
+      });
+    } else if (days !== null && days > 14) {
       recs.push({
         type: "council",
         path: file.path,
@@ -468,6 +502,23 @@ function scanReports(agentsDir: string): CleanupRecommendation[] {
   const files = readMdFiles(dir);
   const recs: CleanupRecommendation[] = [];
 
+  // Build set of archived session files for prerequisite check
+  const sessionArchiveDir = join(agentsDir, "sessions", "archive");
+  const archivedSessionFiles: string[] = [];
+  if (existsSync(sessionArchiveDir)) {
+    try {
+      for (const name of readdirSync(sessionArchiveDir)) {
+        if (name.endsWith(".md")) archivedSessionFiles.push(name);
+      }
+    } catch { /* skip */ }
+  }
+
+  const sessionIsArchived = (ref: string): boolean => {
+    if (archivedSessionFiles.includes(ref)) return true;
+    const stem = ref.replace(/\.md$/, "");
+    return archivedSessionFiles.some((f) => f.startsWith(stem));
+  };
+
   for (const file of files) {
     const fm = file.frontmatter;
 
@@ -476,6 +527,7 @@ function scanReports(agentsDir: string): CleanupRecommendation[] {
     const archivedAt = reportBlock?.archived_at || fm.archived_at;
     const reportStatus = reportBlock?.status as string | undefined;
     const processedAt = reportBlock?.processed_at as string | undefined;
+    const sessionRef = reportBlock?.session_reference as string | undefined;
 
     if (archivedAt) {
       recs.push({
@@ -487,14 +539,26 @@ function scanReports(agentsDir: string): CleanupRecommendation[] {
         frontmatter: fm,
       });
     } else if (reportStatus === "processed" || processedAt) {
-      recs.push({
-        type: "report",
-        path: file.path,
-        filename: file.filename,
-        action: "archive",
-        reason: "Report is processed — ready for archive",
-        frontmatter: fm,
-      });
+      // Archive prerequisite: linked session must be archived first
+      if (sessionRef && !sessionIsArchived(sessionRef)) {
+        recs.push({
+          type: "report",
+          path: file.path,
+          filename: file.filename,
+          action: "skip",
+          reason: "Report is processed but linked session is not yet archived",
+          frontmatter: fm,
+        });
+      } else {
+        recs.push({
+          type: "report",
+          path: file.path,
+          filename: file.filename,
+          action: "archive",
+          reason: "Report is processed and prerequisites met — ready for archive",
+          frontmatter: fm,
+        });
+      }
     } else {
       const days = daysSince(lastActivity(fm));
       if (days !== null && days > 14) {

--- a/cli/lib/cleanup/scanner.ts
+++ b/cli/lib/cleanup/scanner.ts
@@ -62,6 +62,14 @@ function daysSince(dateStr: string | undefined): number | null {
   return Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60 * 24));
 }
 
+/**
+ * Normalize a session reference to a bare filename.
+ * Templates store paths like ".agents/sessions/FILE.md" — strip the prefix.
+ */
+function normalizeSessionRef(ref: string): string {
+  return ref.replace(/^\.agents\/sessions\/(archive\/)?/, "");
+}
+
 /** Get the most recent date from frontmatter (supports nested session.last_updated) */
 function lastActivity(fm: Record<string, unknown>): string | undefined {
   // Session files use nested session.last_updated / session.created
@@ -464,7 +472,7 @@ function scanCouncils(agentsDir: string): CleanupRecommendation[] {
     const days = daysSince(councilDate || lastActivity(fm));
 
     // Check for orphaned councils (no linked session or missing session)
-    if (sessionRef && !matchesAnySession(sessionRef)) {
+    if (sessionRef && !matchesAnySession(normalizeSessionRef(sessionRef))) {
       recs.push({
         type: "council",
         path: file.path,
@@ -474,14 +482,27 @@ function scanCouncils(agentsDir: string): CleanupRecommendation[] {
         frontmatter: fm,
       });
     } else if (days !== null && days > 14) {
-      recs.push({
-        type: "council",
-        path: file.path,
-        filename: file.filename,
-        action: "flag",
-        reason: `Stale council — ${days} days old`,
-        frontmatter: fm,
-      });
+      // If the council has a valid linked session, it's archive-ready (outcome captured).
+      // Without a session link, just flag for review.
+      if (sessionRef && matchesAnySession(normalizeSessionRef(sessionRef))) {
+        recs.push({
+          type: "council",
+          path: file.path,
+          filename: file.filename,
+          action: "archive",
+          reason: `Council is ${days} days old with linked session — ready for archive`,
+          frontmatter: fm,
+        });
+      } else {
+        recs.push({
+          type: "council",
+          path: file.path,
+          filename: file.filename,
+          action: "flag",
+          reason: `Stale council — ${days} days old, no linked session`,
+          frontmatter: fm,
+        });
+      }
     } else {
       recs.push({
         type: "council",
@@ -540,7 +561,7 @@ function scanReports(agentsDir: string): CleanupRecommendation[] {
       });
     } else if (reportStatus === "processed" || processedAt) {
       // Archive prerequisite: linked session must be archived first
-      if (sessionRef && !sessionIsArchived(sessionRef)) {
+      if (sessionRef && !sessionIsArchived(normalizeSessionRef(sessionRef))) {
         recs.push({
           type: "report",
           path: file.path,

--- a/cli/lib/cleanup/scanner.ts
+++ b/cli/lib/cleanup/scanner.ts
@@ -430,9 +430,9 @@ function scanDrafts(agentsDir: string, index: TaskIndex): CleanupRecommendation[
         type: "draft",
         path: file.path,
         filename: file.filename,
-        action: "flag",
+        action: "delete",
         reason: "Draft promoted to spec — served its purpose",
-        hint: hasSparks ? "Contains ## Sparks section — review before deletion" : "Can be archived or deleted",
+        hint: hasSparks ? "Contains ## Sparks section — review before deletion" : undefined,
         frontmatter: fm,
       });
     } else if (days !== null && days > 30) {

--- a/cli/lib/cleanup/scanner.ts
+++ b/cli/lib/cleanup/scanner.ts
@@ -1,15 +1,11 @@
 /**
- * Cleanup Scanner Engine
- *
- * Walks .agents/ directories and produces typed recommendations based on
- * the cleanup skill's existing rules. Pure logic — no I/O prompts.
+ * Walks .agents/ and produces cleanup recommendations (no prompts).
  */
 
 import { existsSync, readFileSync, readdirSync, statSync } from "fs";
-import { join, basename } from "path";
+import { join } from "path";
 import matter from "gray-matter";
 
-import { findAgentsDir } from "../tasks/resolve.js";
 import { loadIndex, buildIndexFromFiles, findOrphans } from "../tasks/migrate.js";
 import type { TaskIndex } from "../tasks/types.js";
 import type {
@@ -32,23 +28,24 @@ function readMdFiles(dir: string): Array<{ path: string; filename: string; front
 
   const results: Array<{ path: string; filename: string; frontmatter: Record<string, unknown>; raw: string }> = [];
 
+  let entries: string[];
   try {
-    const entries = readdirSync(dir);
-    for (const name of entries) {
-      if (name === "archive" || !name.endsWith(".md")) continue;
-      const filePath = join(dir, name);
-      try {
-        const stat = statSync(filePath);
-        if (!stat.isFile()) continue;
-        const raw = readFileSync(filePath, "utf-8");
-        const { data } = matter(raw);
-        results.push({ path: filePath, filename: name, frontmatter: data, raw });
-      } catch {
-        // Can't read file — skip
-      }
-    }
+    entries = readdirSync(dir);
   } catch {
-    // Can't read directory — skip
+    return results;
+  }
+
+  for (const name of entries) {
+    if (name === "archive" || !name.endsWith(".md")) continue;
+    const filePath = join(dir, name);
+    try {
+      if (!statSync(filePath).isFile()) continue;
+      const raw = readFileSync(filePath, "utf-8");
+      const { data } = matter(raw);
+      results.push({ path: filePath, filename: name, frontmatter: data, raw });
+    } catch {
+      continue;
+    }
   }
 
   return results;
@@ -70,9 +67,8 @@ function normalizeSessionRef(ref: string): string {
   return ref.replace(/^\.agents\/sessions\/(archive\/)?/, "");
 }
 
-/** Get the most recent date from frontmatter (supports nested session.last_updated) */
+/** Most recent activity date from frontmatter (nested `session.*` or top-level). */
 function lastActivity(fm: Record<string, unknown>): string | undefined {
-  // Session files use nested session.last_updated / session.created
   const sessionBlock = fm.session as Record<string, unknown> | undefined;
   if (sessionBlock && typeof sessionBlock === "object") {
     return (sessionBlock.last_updated as string) || (sessionBlock.created as string) || undefined;
@@ -102,7 +98,6 @@ function scanSessions(agentsDir: string): CleanupRecommendation[] {
     const fm = file.frontmatter;
     const status = getStatus(fm);
 
-    // Check for extractable learnings
     const hasLearnings =
       file.raw.includes("## Key Decisions") ||
       file.raw.includes("## Lessons Learned") ||
@@ -170,11 +165,9 @@ function scanSessions(agentsDir: string): CleanupRecommendation[] {
 function scanTasks(agentsDir: string, index: TaskIndex): CleanupRecommendation[] {
   const recs: CleanupRecommendation[] = [];
 
-  // Known spec IDs for orphan detection
   const knownSpecIds = new Set(Object.keys(index.specs));
 
   for (const [id, entry] of Object.entries(index.tasks)) {
-    // Skip already-archived tasks
     if (entry.file.startsWith("archive/")) continue;
 
     const filePath = join(agentsDir, "tasks", entry.file);
@@ -189,7 +182,6 @@ function scanTasks(agentsDir: string, index: TaskIndex): CleanupRecommendation[]
         frontmatter: { id, title: entry.title, status: entry.status, spec: entry.spec },
       });
     } else if (entry.spec && !knownSpecIds.has(entry.spec)) {
-      // Orphaned: references a spec that doesn't exist
       recs.push({
         type: "task",
         path: filePath,
@@ -210,7 +202,6 @@ function scanTasks(agentsDir: string, index: TaskIndex): CleanupRecommendation[]
     }
   }
 
-  // Also check for filesystem orphans (files not in index)
   const orphans = findOrphans(agentsDir, index);
   for (const orphan of orphans.tasks) {
     recs.push({
@@ -276,7 +267,6 @@ function scanSpecs(agentsDir: string, index: TaskIndex): CleanupRecommendation[]
     }
   }
 
-  // Check for filesystem orphans
   const orphans = findOrphans(agentsDir, index);
   for (const orphan of orphans.specs) {
     recs.push({
@@ -297,10 +287,6 @@ function scanPlans(agentsDir: string): CleanupRecommendation[] {
   const files = readMdFiles(dir);
   const recs: CleanupRecommendation[] = [];
 
-  // Build sets of session IDs (stem without .md) for cross-referencing.
-  // Plan frontmatter stores session IDs (e.g., "20260327-163059-spec-015"),
-  // while session files are named like "20260327-163059-spec-015-workflow-hooks.md".
-  // Match by checking if any session filename starts with the plan's session ref.
   const sessionsDir = join(agentsDir, "sessions");
   const activeSessionFiles: string[] = [];
   const archivedSessionFiles: string[] = [];
@@ -318,27 +304,24 @@ function scanPlans(agentsDir: string): CleanupRecommendation[] {
           activeSessionFiles.push(name);
         }
       } catch {
-        // Skip unreadable
+        continue;
       }
     }
   }
 
-  // Also check archive/ for sessions
   const sessionArchive = join(sessionsDir, "archive");
   if (existsSync(sessionArchive)) {
     try {
       for (const name of readdirSync(sessionArchive)) {
         if (name.endsWith(".md")) archivedSessionFiles.push(name);
       }
-    } catch { /* skip */ }
+    } catch {
+      /* skip */
+    }
   }
 
-  // Match a session reference against session filenames.
-  // Refs can be filenames ("SESSION-001.md") or ID stems ("20260327-163059-spec-015").
   const matchesSession = (ref: string, files: string[]): boolean => {
-    // Direct filename match
     if (files.includes(ref)) return true;
-    // Stem match: ref is a prefix of a filename (without .md)
     const stem = ref.replace(/\.md$/, "");
     return files.some((f) => f.startsWith(stem));
   };
@@ -348,7 +331,6 @@ function scanPlans(agentsDir: string): CleanupRecommendation[] {
     const sessionRef = fm.session as string | undefined;
 
     if (!sessionRef) {
-      // No session link — orphaned
       recs.push({
         type: "plan",
         path: file.path,
@@ -376,7 +358,6 @@ function scanPlans(agentsDir: string): CleanupRecommendation[] {
         frontmatter: fm,
       });
     } else {
-      // Check staleness
       const days = daysSince(lastActivity(fm));
       if (days !== null && days > 14) {
         recs.push({
@@ -408,12 +389,9 @@ function scanDrafts(agentsDir: string, index: TaskIndex): CleanupRecommendation[
   const files = readMdFiles(dir);
   const recs: CleanupRecommendation[] = [];
 
-  // Build set of draft references from spec source fields.
-  // Specs record source as full path (".agents/drafts/FILE.md") or keyword ("brainstorm", "direct").
   const promotedDrafts = new Set<string>();
   for (const entry of Object.values(index.specs)) {
     if (entry.source && entry.source.includes("/drafts/")) {
-      // Extract bare filename from path
       const filename = entry.source.replace(/^.*\/drafts\//, "");
       promotedDrafts.add(filename);
     }
@@ -423,7 +401,6 @@ function scanDrafts(agentsDir: string, index: TaskIndex): CleanupRecommendation[
     const fm = file.frontmatter;
     const days = daysSince(lastActivity(fm) || fm.created as string);
 
-    // Check if this draft has been promoted to a spec
     if (promotedDrafts.has(file.filename)) {
       const hasSparks = file.raw.includes("## Sparks");
       recs.push({
@@ -466,7 +443,6 @@ function scanCouncils(agentsDir: string): CleanupRecommendation[] {
   const files = readMdFiles(dir);
   const recs: CleanupRecommendation[] = [];
 
-  // Build session lookup for orphan detection and archive-readiness
   const sessionsDir = join(agentsDir, "sessions");
   const allSessionFiles: string[] = [];
   const completedSessionFiles: string[] = [];
@@ -505,15 +481,11 @@ function scanCouncils(agentsDir: string): CleanupRecommendation[] {
   for (const file of files) {
     const fm = file.frontmatter;
 
-    // Two council schemas exist:
-    //   council-session template: council.created, council.session_reference
-    //   orchestration reference:  council.timestamp, council.session
     const councilBlock = fm.council as Record<string, unknown> | undefined;
     const councilDate = (councilBlock?.created || councilBlock?.timestamp) as string | undefined;
     const sessionRef = (councilBlock?.session_reference || councilBlock?.session) as string | undefined;
     const days = daysSince(councilDate || lastActivity(fm));
 
-    // Check for orphaned councils (no linked session or missing session)
     if (sessionRef && !matchesAnySession(normalizeSessionRef(sessionRef))) {
       recs.push({
         type: "council",
@@ -524,13 +496,9 @@ function scanCouncils(agentsDir: string): CleanupRecommendation[] {
         frontmatter: fm,
       });
     } else if (days !== null && days > 14) {
-      // Archive only if council has a Decision/outcome recorded.
-      // The council file itself is the source — check for ## Decision content.
       const hasDecision = file.raw.includes("## Decision") &&
         !file.raw.match(/## Decision\s*\n\s*\n\s*(\[To be filled|$)/);
 
-      // Archive requires: decision recorded AND linked session completed/archived
-      // (policy: "session summary captured → archive")
       const normalizedRef = sessionRef ? normalizeSessionRef(sessionRef) : null;
       const sessionDone = normalizedRef && sessionIsCompleted(normalizedRef);
 
@@ -578,7 +546,6 @@ function scanReports(agentsDir: string): CleanupRecommendation[] {
   const files = readMdFiles(dir);
   const recs: CleanupRecommendation[] = [];
 
-  // Build set of archived session files for prerequisite check
   const sessionArchiveDir = join(agentsDir, "sessions", "archive");
   const archivedSessionFiles: string[] = [];
   if (existsSync(sessionArchiveDir)) {
@@ -598,7 +565,6 @@ function scanReports(agentsDir: string): CleanupRecommendation[] {
   for (const file of files) {
     const fm = file.frontmatter;
 
-    // Report template nests metadata under `report:` block
     const reportBlock = fm.report as Record<string, unknown> | undefined;
     const archivedAt = reportBlock?.archived_at || fm.archived_at;
     const reportStatus = reportBlock?.status as string | undefined;
@@ -615,7 +581,6 @@ function scanReports(agentsDir: string): CleanupRecommendation[] {
         frontmatter: fm,
       });
     } else if (reportStatus === "processed" || processedAt) {
-      // Archive prerequisites: session_reference required, and that session must be archived
       if (!sessionRef) {
         recs.push({
           type: "report",
@@ -645,8 +610,6 @@ function scanReports(agentsDir: string): CleanupRecommendation[] {
         });
       }
     } else {
-      // Unprocessed reports: flag if stale, skip if recent.
-      // No age-based archive — reports must be processed first.
       const days = daysSince(lastActivity(fm));
       if (days !== null && days > 14) {
         recs.push({
@@ -677,13 +640,11 @@ function scanReports(agentsDir: string): CleanupRecommendation[] {
 // Main Scanner
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Scan .agents/ artifacts and produce cleanup recommendations */
 export function scanArtifacts(options: ScanOptions): ScanResult {
   const { agentsDir, filter } = options;
   const recommendations: CleanupRecommendation[] = [];
   const warnings: string[] = [];
 
-  // Check directory existence per V1 contract
   for (const dir of ARTIFACT_DIRS) {
     if (filter && !filter.includes(dir.type)) continue;
 
@@ -692,15 +653,12 @@ export function scanArtifacts(options: ScanOptions): ScanResult {
       if (dir.required) {
         warnings.push(`Required directory missing: ${dir.dirname}/`);
       }
-      // Optional dirs: skip silently
     }
   }
 
-  // Load task index read-only (never write TASKS.json during scan)
   const indexPath = join(agentsDir, "TASKS.json");
   const index = loadIndex(indexPath) ?? buildIndexFromFiles(agentsDir);
 
-  // Run per-type scanners
   const shouldScan = (type: ArtifactType) => !filter || filter.includes(type);
 
   if (shouldScan("session")) recommendations.push(...scanSessions(agentsDir));
@@ -711,7 +669,6 @@ export function scanArtifacts(options: ScanOptions): ScanResult {
   if (shouldScan("council")) recommendations.push(...scanCouncils(agentsDir));
   if (shouldScan("report")) recommendations.push(...scanReports(agentsDir));
 
-  // Build summary
   const summary: TypeSummary[] = ARTIFACT_TYPES
     .filter((t) => shouldScan(t))
     .map((type) => {

--- a/cli/lib/cleanup/scanner.ts
+++ b/cli/lib/cleanup/scanner.ts
@@ -1,0 +1,538 @@
+/**
+ * Cleanup Scanner Engine
+ *
+ * Walks .agents/ directories and produces typed recommendations based on
+ * the cleanup skill's existing rules. Pure logic — no I/O prompts.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { join, basename } from "path";
+import matter from "gray-matter";
+
+import { getOrBuildIndex } from "../tasks/resolve.js";
+import { findOrphans } from "../tasks/migrate.js";
+import type { TaskIndex } from "../tasks/types.js";
+import type {
+  ArtifactType,
+  CleanupRecommendation,
+  ScanResult,
+  ScanOptions,
+  TypeSummary,
+  ArtifactDirectory,
+} from "./types.js";
+import { ARTIFACT_DIRS, ARTIFACT_TYPES } from "./types.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Read .md files from a directory (non-recursive, excludes archive/) */
+function readMdFiles(dir: string): Array<{ path: string; filename: string; frontmatter: Record<string, unknown>; raw: string }> {
+  if (!existsSync(dir)) return [];
+
+  const results: Array<{ path: string; filename: string; frontmatter: Record<string, unknown>; raw: string }> = [];
+
+  try {
+    const entries = readdirSync(dir);
+    for (const name of entries) {
+      if (name === "archive" || !name.endsWith(".md")) continue;
+      const filePath = join(dir, name);
+      try {
+        const stat = statSync(filePath);
+        if (!stat.isFile()) continue;
+        const raw = readFileSync(filePath, "utf-8");
+        const { data } = matter(raw);
+        results.push({ path: filePath, filename: name, frontmatter: data, raw });
+      } catch {
+        // Can't read file — skip
+      }
+    }
+  } catch {
+    // Can't read directory — skip
+  }
+
+  return results;
+}
+
+/** Days since a date string (ISO 8601 or similar) */
+function daysSince(dateStr: string | undefined): number | null {
+  if (!dateStr) return null;
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return null;
+  return Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+/** Get the most recent date from frontmatter (updated > created) */
+function lastActivity(fm: Record<string, unknown>): string | undefined {
+  return (fm.updated as string) || (fm.created as string) || undefined;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-Artifact Scanners
+// ─────────────────────────────────────────────────────────────────────────────
+
+function scanSessions(agentsDir: string): CleanupRecommendation[] {
+  const dir = join(agentsDir, "sessions");
+  const files = readMdFiles(dir);
+  const recs: CleanupRecommendation[] = [];
+
+  for (const file of files) {
+    const fm = file.frontmatter;
+    const status = String(fm.status || "").toLowerCase();
+
+    // Check for extractable learnings
+    const hasLearnings =
+      file.raw.includes("## Key Decisions") ||
+      file.raw.includes("## Lessons Learned") ||
+      file.raw.includes("lessons_learned") ||
+      (fm.traceability && typeof fm.traceability === "object" &&
+        "decisions" in (fm.traceability as Record<string, unknown>));
+
+    if (status === "completed" || status === "complete") {
+      if (hasLearnings) {
+        recs.push({
+          type: "session",
+          path: file.path,
+          filename: file.filename,
+          action: "archive",
+          reason: "Completed session with extractable learnings",
+          hint: "Consider running /crystallize before archiving",
+          frontmatter: fm,
+        });
+      } else {
+        recs.push({
+          type: "session",
+          path: file.path,
+          filename: file.filename,
+          action: "archive",
+          reason: "Completed session",
+          frontmatter: fm,
+        });
+      }
+    } else if (status === "cancelled" || status === "abandoned") {
+      recs.push({
+        type: "session",
+        path: file.path,
+        filename: file.filename,
+        action: "archive",
+        reason: `Session ${status} — archive with status preserved`,
+        frontmatter: fm,
+      });
+    } else {
+      const days = daysSince(lastActivity(fm));
+      if (days !== null && days > 7) {
+        recs.push({
+          type: "session",
+          path: file.path,
+          filename: file.filename,
+          action: "flag",
+          reason: `Stale session — inactive for ${days} days`,
+          frontmatter: fm,
+        });
+      } else {
+        recs.push({
+          type: "session",
+          path: file.path,
+          filename: file.filename,
+          action: "skip",
+          reason: "Active session",
+          frontmatter: fm,
+        });
+      }
+    }
+  }
+
+  return recs;
+}
+
+function scanTasks(agentsDir: string, index: TaskIndex): CleanupRecommendation[] {
+  const recs: CleanupRecommendation[] = [];
+
+  // Known spec IDs for orphan detection
+  const knownSpecIds = new Set(Object.keys(index.specs));
+
+  for (const [id, entry] of Object.entries(index.tasks)) {
+    // Skip already-archived tasks
+    if (entry.file.startsWith("archive/")) continue;
+
+    const filePath = join(agentsDir, "tasks", entry.file);
+
+    if (entry.status === "done") {
+      recs.push({
+        type: "task",
+        path: filePath,
+        filename: entry.file,
+        action: "archive",
+        reason: `Task ${id} is done`,
+        frontmatter: { id, title: entry.title, status: entry.status, spec: entry.spec },
+      });
+    } else if (entry.spec && !knownSpecIds.has(entry.spec)) {
+      // Orphaned: references a spec that doesn't exist
+      recs.push({
+        type: "task",
+        path: filePath,
+        filename: entry.file,
+        action: "flag",
+        reason: `Task ${id} references missing spec ${entry.spec}`,
+        frontmatter: { id, title: entry.title, status: entry.status, spec: entry.spec },
+      });
+    } else {
+      recs.push({
+        type: "task",
+        path: filePath,
+        filename: entry.file,
+        action: "skip",
+        reason: `Task ${id} is ${entry.status}`,
+        frontmatter: { id, title: entry.title, status: entry.status },
+      });
+    }
+  }
+
+  // Also check for filesystem orphans (files not in index)
+  const orphans = findOrphans(agentsDir, index);
+  for (const orphan of orphans.tasks) {
+    recs.push({
+      type: "task",
+      path: join(agentsDir, "tasks", orphan.entry.file),
+      filename: orphan.entry.file,
+      action: "flag",
+      reason: `Task ${orphan.id} exists on disk but not in index — run loaf task sync --import`,
+      frontmatter: { id: orphan.id, title: orphan.entry.title },
+    });
+  }
+
+  return recs;
+}
+
+function scanSpecs(agentsDir: string, index: TaskIndex): CleanupRecommendation[] {
+  const recs: CleanupRecommendation[] = [];
+
+  for (const [id, entry] of Object.entries(index.specs)) {
+    if (entry.file.startsWith("archive/")) continue;
+
+    const filePath = join(agentsDir, "specs", entry.file);
+
+    if (entry.status === "complete") {
+      recs.push({
+        type: "spec",
+        path: filePath,
+        filename: entry.file,
+        action: "archive",
+        reason: `Spec ${id} is complete`,
+        frontmatter: { id, title: entry.title, status: entry.status },
+      });
+    } else if (entry.status === "drafting") {
+      const days = daysSince(entry.created);
+      if (days !== null && days > 14) {
+        recs.push({
+          type: "spec",
+          path: filePath,
+          filename: entry.file,
+          action: "flag",
+          reason: `Spec ${id} has been drafting for ${days} days`,
+          frontmatter: { id, title: entry.title, status: entry.status },
+        });
+      } else {
+        recs.push({
+          type: "spec",
+          path: filePath,
+          filename: entry.file,
+          action: "skip",
+          reason: `Spec ${id} is ${entry.status}`,
+          frontmatter: { id, title: entry.title, status: entry.status },
+        });
+      }
+    } else {
+      recs.push({
+        type: "spec",
+        path: filePath,
+        filename: entry.file,
+        action: "skip",
+        reason: `Spec ${id} is ${entry.status}`,
+        frontmatter: { id, title: entry.title, status: entry.status },
+      });
+    }
+  }
+
+  // Check for filesystem orphans
+  const orphans = findOrphans(agentsDir, index);
+  for (const orphan of orphans.specs) {
+    recs.push({
+      type: "spec",
+      path: join(agentsDir, "specs", orphan.entry.file),
+      filename: orphan.entry.file,
+      action: "flag",
+      reason: `Spec ${orphan.id} exists on disk but not in index — run loaf task sync --import`,
+      frontmatter: { id: orphan.id, title: orphan.entry.title },
+    });
+  }
+
+  return recs;
+}
+
+function scanPlans(agentsDir: string): CleanupRecommendation[] {
+  const dir = join(agentsDir, "plans");
+  const files = readMdFiles(dir);
+  const recs: CleanupRecommendation[] = [];
+
+  // Build a set of active session filenames for cross-referencing
+  const sessionsDir = join(agentsDir, "sessions");
+  const activeSessions = new Set<string>();
+  const archivedSessions = new Set<string>();
+
+  if (existsSync(sessionsDir)) {
+    for (const name of readdirSync(sessionsDir)) {
+      if (name === "archive" || !name.endsWith(".md")) continue;
+      try {
+        const raw = readFileSync(join(sessionsDir, name), "utf-8");
+        const { data } = matter(raw);
+        const status = String(data.status || "").toLowerCase();
+        if (status === "completed" || status === "complete" || status === "cancelled") {
+          archivedSessions.add(name);
+        } else {
+          activeSessions.add(name);
+        }
+      } catch {
+        // Skip unreadable
+      }
+    }
+  }
+
+  // Also check archive/ for sessions
+  const sessionArchive = join(sessionsDir, "archive");
+  if (existsSync(sessionArchive)) {
+    try {
+      for (const name of readdirSync(sessionArchive)) {
+        if (name.endsWith(".md")) archivedSessions.add(name);
+      }
+    } catch { /* skip */ }
+  }
+
+  for (const file of files) {
+    const fm = file.frontmatter;
+    const sessionRef = fm.session as string | undefined;
+
+    if (!sessionRef) {
+      // No session link — orphaned
+      recs.push({
+        type: "plan",
+        path: file.path,
+        filename: file.filename,
+        action: "delete",
+        reason: "Orphaned plan — no linked session",
+        frontmatter: fm,
+      });
+    } else if (archivedSessions.has(sessionRef)) {
+      recs.push({
+        type: "plan",
+        path: file.path,
+        filename: file.filename,
+        action: "delete",
+        reason: "Linked session is archived/completed",
+        frontmatter: fm,
+      });
+    } else if (!activeSessions.has(sessionRef)) {
+      recs.push({
+        type: "plan",
+        path: file.path,
+        filename: file.filename,
+        action: "delete",
+        reason: `Linked session "${sessionRef}" not found`,
+        frontmatter: fm,
+      });
+    } else {
+      // Check staleness
+      const days = daysSince(lastActivity(fm));
+      if (days !== null && days > 14) {
+        recs.push({
+          type: "plan",
+          path: file.path,
+          filename: file.filename,
+          action: "delete",
+          reason: `Stale plan — inactive for ${days} days with active session`,
+          frontmatter: fm,
+        });
+      } else {
+        recs.push({
+          type: "plan",
+          path: file.path,
+          filename: file.filename,
+          action: "skip",
+          reason: "Plan linked to active session",
+          frontmatter: fm,
+        });
+      }
+    }
+  }
+
+  return recs;
+}
+
+function scanDrafts(agentsDir: string): CleanupRecommendation[] {
+  const dir = join(agentsDir, "drafts");
+  const files = readMdFiles(dir);
+  const recs: CleanupRecommendation[] = [];
+
+  for (const file of files) {
+    const fm = file.frontmatter;
+    const days = daysSince(lastActivity(fm) || fm.created as string);
+
+    if (days !== null && days > 30) {
+      const hasSparks = file.raw.includes("## Sparks");
+      recs.push({
+        type: "draft",
+        path: file.path,
+        filename: file.filename,
+        action: "flag",
+        reason: `Stale draft — ${days} days old`,
+        hint: hasSparks ? "Contains ## Sparks section — review before deletion" : undefined,
+        frontmatter: fm,
+      });
+    } else {
+      recs.push({
+        type: "draft",
+        path: file.path,
+        filename: file.filename,
+        action: "skip",
+        reason: "Recent draft",
+        frontmatter: fm,
+      });
+    }
+  }
+
+  return recs;
+}
+
+function scanCouncils(agentsDir: string): CleanupRecommendation[] {
+  const dir = join(agentsDir, "councils");
+  const files = readMdFiles(dir);
+  const recs: CleanupRecommendation[] = [];
+
+  for (const file of files) {
+    const fm = file.frontmatter;
+    const days = daysSince(lastActivity(fm));
+
+    if (days !== null && days > 14) {
+      recs.push({
+        type: "council",
+        path: file.path,
+        filename: file.filename,
+        action: "flag",
+        reason: `Stale council — ${days} days old`,
+        frontmatter: fm,
+      });
+    } else {
+      recs.push({
+        type: "council",
+        path: file.path,
+        filename: file.filename,
+        action: "skip",
+        reason: "Recent council",
+        frontmatter: fm,
+      });
+    }
+  }
+
+  return recs;
+}
+
+function scanReports(agentsDir: string): CleanupRecommendation[] {
+  const dir = join(agentsDir, "reports");
+  const files = readMdFiles(dir);
+  const recs: CleanupRecommendation[] = [];
+
+  for (const file of files) {
+    const fm = file.frontmatter;
+
+    if (fm.archived_at) {
+      // Already has archive metadata — skip
+      recs.push({
+        type: "report",
+        path: file.path,
+        filename: file.filename,
+        action: "skip",
+        reason: "Already processed",
+        frontmatter: fm,
+      });
+    } else {
+      const days = daysSince(lastActivity(fm));
+      if (days !== null && days > 14) {
+        recs.push({
+          type: "report",
+          path: file.path,
+          filename: file.filename,
+          action: "archive",
+          reason: `Report is ${days} days old — ready for archive`,
+          frontmatter: fm,
+        });
+      } else {
+        recs.push({
+          type: "report",
+          path: file.path,
+          filename: file.filename,
+          action: "skip",
+          reason: "Recent report",
+          frontmatter: fm,
+        });
+      }
+    }
+  }
+
+  return recs;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main Scanner
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Scan .agents/ artifacts and produce cleanup recommendations */
+export function scanArtifacts(options: ScanOptions): ScanResult {
+  const { agentsDir, filter } = options;
+  const recommendations: CleanupRecommendation[] = [];
+  const warnings: string[] = [];
+
+  // Check directory existence per V1 contract
+  for (const dir of ARTIFACT_DIRS) {
+    if (filter && !filter.includes(dir.type)) continue;
+
+    const fullPath = join(agentsDir, dir.dirname);
+    if (!existsSync(fullPath)) {
+      if (dir.required) {
+        warnings.push(`Required directory missing: ${dir.dirname}/`);
+      }
+      // Optional dirs: skip silently
+    }
+  }
+
+  // Load task index (needed for task and spec scanning)
+  const index = getOrBuildIndex(agentsDir);
+
+  // Run per-type scanners
+  const shouldScan = (type: ArtifactType) => !filter || filter.includes(type);
+
+  if (shouldScan("session")) recommendations.push(...scanSessions(agentsDir));
+  if (shouldScan("task")) recommendations.push(...scanTasks(agentsDir, index));
+  if (shouldScan("spec")) recommendations.push(...scanSpecs(agentsDir, index));
+  if (shouldScan("plan")) recommendations.push(...scanPlans(agentsDir));
+  if (shouldScan("draft")) recommendations.push(...scanDrafts(agentsDir));
+  if (shouldScan("council")) recommendations.push(...scanCouncils(agentsDir));
+  if (shouldScan("report")) recommendations.push(...scanReports(agentsDir));
+
+  // Build summary
+  const summary: TypeSummary[] = ARTIFACT_TYPES
+    .filter((t) => shouldScan(t))
+    .map((type) => {
+      const typeRecs = recommendations.filter((r) => r.type === type);
+      return {
+        type,
+        total: typeRecs.length,
+        archive: typeRecs.filter((r) => r.action === "archive").length,
+        delete: typeRecs.filter((r) => r.action === "delete").length,
+        flag: typeRecs.filter((r) => r.action === "flag").length,
+        skip: typeRecs.filter((r) => r.action === "skip").length,
+      };
+    })
+    .filter((s) => s.total > 0);
+
+  return { recommendations, summary, warnings };
+}

--- a/cli/lib/cleanup/types.ts
+++ b/cli/lib/cleanup/types.ts
@@ -1,12 +1,7 @@
 /**
- * Cleanup Scanner Types
- *
- * Type definitions for the cleanup scanning engine. The scanner walks
- * .agents/ directories and produces typed recommendations based on
- * the existing cleanup skill's rules.
+ * Types for the cleanup scanner.
  */
 
-/** Artifact types that the cleanup scanner recognizes */
 export type ArtifactType =
   | "session"
   | "task"
@@ -16,7 +11,6 @@ export type ArtifactType =
   | "council"
   | "report";
 
-/** All artifact types, ordered for display */
 export const ARTIFACT_TYPES: ArtifactType[] = [
   "session",
   "task",
@@ -27,28 +21,18 @@ export const ARTIFACT_TYPES: ArtifactType[] = [
   "report",
 ];
 
-/** Actions the scanner can recommend */
 export type RecommendedAction = "archive" | "delete" | "flag" | "skip";
 
-/** A single cleanup recommendation for one artifact */
 export interface CleanupRecommendation {
-  /** Which artifact type this is */
   type: ArtifactType;
-  /** Absolute path to the artifact file */
   path: string;
-  /** Filename for display */
   filename: string;
-  /** What the scanner recommends */
   action: RecommendedAction;
-  /** Human-readable reason for the recommendation */
   reason: string;
-  /** Optional hint for the user (e.g., "run /crystallize first") */
   hint?: string;
-  /** Frontmatter data for previews */
   frontmatter?: Record<string, unknown>;
 }
 
-/** Per-type summary counts */
 export interface TypeSummary {
   type: ArtifactType;
   total: number;
@@ -58,29 +42,23 @@ export interface TypeSummary {
   skip: number;
 }
 
-/** Full scan result */
 export interface ScanResult {
   recommendations: CleanupRecommendation[];
   summary: TypeSummary[];
   warnings: string[];
 }
 
-/** Options for the scanner */
 export interface ScanOptions {
-  /** Path to .agents/ directory */
   agentsDir: string;
-  /** Filter to specific artifact types (scan all if omitted) */
   filter?: ArtifactType[];
 }
 
-/** Directory metadata for the V1 artifact contract */
 export interface ArtifactDirectory {
   type: ArtifactType;
   dirname: string;
   required: boolean;
 }
 
-/** V1 artifact directory contract */
 export const ARTIFACT_DIRS: ArtifactDirectory[] = [
   { type: "session", dirname: "sessions", required: true },
   { type: "task", dirname: "tasks", required: true },

--- a/cli/lib/cleanup/types.ts
+++ b/cli/lib/cleanup/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Cleanup Scanner Types
+ *
+ * Type definitions for the cleanup scanning engine. The scanner walks
+ * .agents/ directories and produces typed recommendations based on
+ * the existing cleanup skill's rules.
+ */
+
+/** Artifact types that the cleanup scanner recognizes */
+export type ArtifactType =
+  | "session"
+  | "task"
+  | "spec"
+  | "plan"
+  | "draft"
+  | "council"
+  | "report";
+
+/** All artifact types, ordered for display */
+export const ARTIFACT_TYPES: ArtifactType[] = [
+  "session",
+  "task",
+  "spec",
+  "plan",
+  "draft",
+  "council",
+  "report",
+];
+
+/** Actions the scanner can recommend */
+export type RecommendedAction = "archive" | "delete" | "flag" | "skip";
+
+/** A single cleanup recommendation for one artifact */
+export interface CleanupRecommendation {
+  /** Which artifact type this is */
+  type: ArtifactType;
+  /** Absolute path to the artifact file */
+  path: string;
+  /** Filename for display */
+  filename: string;
+  /** What the scanner recommends */
+  action: RecommendedAction;
+  /** Human-readable reason for the recommendation */
+  reason: string;
+  /** Optional hint for the user (e.g., "run /crystallize first") */
+  hint?: string;
+  /** Frontmatter data for previews */
+  frontmatter?: Record<string, unknown>;
+}
+
+/** Per-type summary counts */
+export interface TypeSummary {
+  type: ArtifactType;
+  total: number;
+  archive: number;
+  delete: number;
+  flag: number;
+  skip: number;
+}
+
+/** Full scan result */
+export interface ScanResult {
+  recommendations: CleanupRecommendation[];
+  summary: TypeSummary[];
+  warnings: string[];
+}
+
+/** Options for the scanner */
+export interface ScanOptions {
+  /** Path to .agents/ directory */
+  agentsDir: string;
+  /** Filter to specific artifact types (scan all if omitted) */
+  filter?: ArtifactType[];
+}
+
+/** Directory metadata for the V1 artifact contract */
+export interface ArtifactDirectory {
+  type: ArtifactType;
+  dirname: string;
+  required: boolean;
+}
+
+/** V1 artifact directory contract */
+export const ARTIFACT_DIRS: ArtifactDirectory[] = [
+  { type: "session", dirname: "sessions", required: true },
+  { type: "task", dirname: "tasks", required: true },
+  { type: "spec", dirname: "specs", required: true },
+  { type: "plan", dirname: "plans", required: false },
+  { type: "draft", dirname: "drafts", required: false },
+  { type: "council", dirname: "councils", required: false },
+  { type: "report", dirname: "reports", required: false },
+];

--- a/cli/lib/prompts.test.ts
+++ b/cli/lib/prompts.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Prompt Helpers Tests
+ *
+ * Tests for the shared CLI prompt utilities. Focuses on non-TTY behavior
+ * since interactive TTY prompts can't be reliably tested in CI.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isTTY, askYesNo, askChoice } from "./prompts.js";
+
+describe("isTTY", () => {
+  it("returns a boolean", () => {
+    expect(typeof isTTY()).toBe("boolean");
+  });
+});
+
+describe("askYesNo", () => {
+  it("returns false when stdin is not a TTY (CI/piped)", async () => {
+    // In test environments, stdin.isTTY is typically undefined/false
+    const result = await askYesNo("Test? [y/N] ");
+    expect(result).toBe(false);
+  });
+});
+
+describe("askChoice", () => {
+  it("returns defaultChoice when stdin is not a TTY", async () => {
+    const options = ["alpha", "beta", "gamma"];
+    const format = (opt: string, i: number) => `  ${i + 1}. ${opt}`;
+    const result = await askChoice("Choose: ", options, format, "beta");
+    expect(result).toBe("beta");
+  });
+
+  it("works with non-string types", async () => {
+    const options = [1, 2, 3];
+    const format = (opt: number, i: number) => `  ${i + 1}. Option ${opt}`;
+    const result = await askChoice("Choose: ", options, format, 2);
+    expect(result).toBe(2);
+  });
+});

--- a/cli/lib/prompts.ts
+++ b/cli/lib/prompts.ts
@@ -8,11 +8,13 @@
 import { createInterface } from "readline";
 
 /**
- * Check if stdout is a TTY (interactive terminal).
- * Returns false when output is piped or in CI environments.
+ * Check if both stdin and stdout are TTYs (interactive terminal).
+ * Returns false when either is piped or redirected — this matters because
+ * askYesNo/askChoice key off stdin.isTTY while the CLI dry-run check
+ * uses this function. Both must agree to enter interactive mode.
  */
 export function isTTY(): boolean {
-  return !!process.stdout.isTTY;
+  return !!process.stdin.isTTY && !!process.stdout.isTTY;
 }
 
 /**

--- a/cli/lib/prompts.ts
+++ b/cli/lib/prompts.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared CLI Prompt Helpers
+ *
+ * Reusable prompt utilities for interactive CLI commands.
+ * All helpers are TTY-safe: they return defaults when stdin is not a terminal.
+ */
+
+import { createInterface } from "readline";
+
+/**
+ * Check if stdout is a TTY (interactive terminal).
+ * Returns false when output is piped or in CI environments.
+ */
+export function isTTY(): boolean {
+  return !!process.stdout.isTTY;
+}
+
+/**
+ * Ask a yes/no question. Returns false if non-TTY.
+ */
+export function askYesNo(question: string): Promise<boolean> {
+  if (!process.stdin.isTTY) {
+    return Promise.resolve(false);
+  }
+
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    let resolved = false;
+    rl.on("close", () => {
+      if (!resolved) {
+        resolved = true;
+        resolve(false);
+      }
+    });
+    rl.question(question, (answer) => {
+      resolved = true;
+      rl.close();
+      resolve(answer.trim().toLowerCase().startsWith("y"));
+    });
+  });
+}
+
+/**
+ * Ask the user to choose from a numbered list of options.
+ * Returns defaultChoice if non-TTY or invalid input.
+ *
+ * @param question - Prompt text (e.g., "  Choose [1/2/3]: ")
+ * @param options - Array of options to choose from
+ * @param format - Function to format each option for display (called before prompting)
+ * @param defaultChoice - Fallback for non-TTY or invalid input
+ */
+export function askChoice<T>(
+  question: string,
+  options: T[],
+  format: (option: T, index: number) => string,
+  defaultChoice: T,
+): Promise<T> {
+  if (!process.stdin.isTTY) {
+    return Promise.resolve(defaultChoice);
+  }
+
+  // Print formatted options before prompting
+  for (let i = 0; i < options.length; i++) {
+    console.log(format(options[i], i));
+  }
+
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    let resolved = false;
+    rl.on("close", () => {
+      if (!resolved) {
+        resolved = true;
+        resolve(defaultChoice);
+      }
+    });
+    rl.question(question, (answer) => {
+      resolved = true;
+      rl.close();
+      const num = parseInt(answer.trim(), 10);
+      if (num >= 1 && num <= options.length) {
+        resolve(options[num - 1]);
+      } else {
+        resolve(defaultChoice);
+      }
+    });
+  });
+}

--- a/config/hooks.yaml
+++ b/config/hooks.yaml
@@ -69,9 +69,9 @@ hooks:
       skill: foundations
       script: hooks/pre-tool/workflow-pre-push.sh
       matcher: "Bash"
-      blocking: false
+      blocking: true
       timeout: 5000
-      description: Advisory push reminders (branch naming, uncommitted files, force-push safety)
+      description: Block git push without explicit user approval
 
     # Orchestration - Commit and Linear integration
     - id: validate-commit

--- a/config/hooks.yaml
+++ b/config/hooks.yaml
@@ -69,9 +69,9 @@ hooks:
       skill: foundations
       script: hooks/pre-tool/workflow-pre-push.sh
       matcher: "Bash"
-      blocking: true
+      blocking: false
       timeout: 5000
-      description: Block git push without explicit user approval
+      description: Advisory reminders before git push (confirmation via Claude Code permissions)
 
     # Orchestration - Commit and Linear integration
     - id: validate-commit

--- a/content/hooks/pre-tool/workflow-pre-push.sh
+++ b/content/hooks/pre-tool/workflow-pre-push.sh
@@ -58,5 +58,6 @@ if [[ "$TARGET_BRANCH" == "main" || "$TARGET_BRANCH" == "master" ]] && $FORCE_PU
   echo "WARNING: Force-pushing to $TARGET_BRANCH. This rewrites shared history." >&2
 fi
 
-# Non-blocking - always exit 0
-exit 0
+# Blocking - require explicit user approval for all pushes
+echo "BLOCKED: git push requires explicit user approval." >&2
+exit 2

--- a/content/hooks/pre-tool/workflow-pre-push.sh
+++ b/content/hooks/pre-tool/workflow-pre-push.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-# Hook: Pre-Push Advisory (INFORMATIONAL)
+# Hook: Pre-Push Gate (BLOCKING)
 # PreToolUse hook - reads JSON from stdin per Claude Code hooks API
 #
-# Triggers on git push commands
-# Shows branch naming and safety reminders (non-blocking)
+# Blocks git push commands until user explicitly approves
 
 set -euo pipefail
 
@@ -26,11 +25,10 @@ else
 fi
 COMMAND=$(parse_command "$INPUT")
 
-# Only match git push
-case "$COMMAND" in
-  *"git push"*) ;;
-  *) exit 0 ;;
-esac
+# Match git push as a command, not as substring in arguments (e.g. commit messages)
+if ! echo "$COMMAND" | grep -qE '(^|[;&|]\s*)git\s+push'; then
+  exit 0
+fi
 
 # Detect force-push flags
 FORCE_PUSH=false

--- a/content/hooks/pre-tool/workflow-pre-push.sh
+++ b/content/hooks/pre-tool/workflow-pre-push.sh
@@ -56,6 +56,5 @@ if [[ "$TARGET_BRANCH" == "main" || "$TARGET_BRANCH" == "master" ]] && $FORCE_PU
   echo "WARNING: Force-pushing to $TARGET_BRANCH. This rewrites shared history." >&2
 fi
 
-# Blocking - require explicit user approval for all pushes
-echo "BLOCKED: git push requires explicit user approval." >&2
-exit 2
+# Advisory — remind user to confirm, but let Claude Code's permission system handle approval
+exit 0

--- a/content/skills/cleanup/SKILL.md
+++ b/content/skills/cleanup/SKILL.md
@@ -11,6 +11,25 @@ description: >-
 
 Review ALL agent artifacts in `.agents/` and provide hygiene recommendations.
 
+## CLI Command
+
+Use `loaf cleanup` for filesystem scanning and actions. The CLI is the execution engine; this skill defines the policy and adds Linear-aware checks the CLI cannot perform.
+
+```bash
+loaf cleanup              # Scan all artifacts, show summary + interactive actions
+loaf cleanup --dry-run    # Show recommendations without prompting
+loaf cleanup --sessions   # Only review sessions
+loaf cleanup --specs      # Only review specs
+loaf cleanup --plans      # Only review plans
+loaf cleanup --drafts     # Only review drafts
+```
+
+**Division of responsibility:**
+- **CLI (`loaf cleanup`):** Filesystem scanning, archive/delete operations, non-TTY reporting
+- **This skill (agent context):** Linear status checks, extraction recommendations, cross-referencing external systems
+
+When running as an agent, use `loaf cleanup --dry-run` first to assess, then take actions interactively or via the CLI.
+
 ## Contents
 - Sessions
 - Tasks

--- a/dist/codex/skills/cleanup/SKILL.md
+++ b/dist/codex/skills/cleanup/SKILL.md
@@ -13,6 +13,25 @@ version: 2.0.0-dev.4
 
 Review ALL agent artifacts in `.agents/` and provide hygiene recommendations.
 
+## CLI Command
+
+Use `loaf cleanup` for filesystem scanning and actions. The CLI is the execution engine; this skill defines the policy and adds Linear-aware checks the CLI cannot perform.
+
+```bash
+loaf cleanup              # Scan all artifacts, show summary + interactive actions
+loaf cleanup --dry-run    # Show recommendations without prompting
+loaf cleanup --sessions   # Only review sessions
+loaf cleanup --specs      # Only review specs
+loaf cleanup --plans      # Only review plans
+loaf cleanup --drafts     # Only review drafts
+```
+
+**Division of responsibility:**
+- **CLI (`loaf cleanup`):** Filesystem scanning, archive/delete operations, non-TTY reporting
+- **This skill (agent context):** Linear status checks, extraction recommendations, cross-referencing external systems
+
+When running as an agent, use `loaf cleanup --dry-run` first to assess, then take actions interactively or via the CLI.
+
 ## Contents
 - Sessions
 - Tasks

--- a/dist/cursor/hooks/pre-tool/workflow-pre-push.sh
+++ b/dist/cursor/hooks/pre-tool/workflow-pre-push.sh
@@ -58,5 +58,6 @@ if [[ "$TARGET_BRANCH" == "main" || "$TARGET_BRANCH" == "master" ]] && $FORCE_PU
   echo "WARNING: Force-pushing to $TARGET_BRANCH. This rewrites shared history." >&2
 fi
 
-# Non-blocking - always exit 0
-exit 0
+# Blocking - require explicit user approval for all pushes
+echo "BLOCKED: git push requires explicit user approval." >&2
+exit 2

--- a/dist/cursor/hooks/pre-tool/workflow-pre-push.sh
+++ b/dist/cursor/hooks/pre-tool/workflow-pre-push.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-# Hook: Pre-Push Advisory (INFORMATIONAL)
+# Hook: Pre-Push Gate (BLOCKING)
 # PreToolUse hook - reads JSON from stdin per Claude Code hooks API
 #
-# Triggers on git push commands
-# Shows branch naming and safety reminders (non-blocking)
+# Blocks git push commands until user explicitly approves
 
 set -euo pipefail
 
@@ -26,11 +25,10 @@ else
 fi
 COMMAND=$(parse_command "$INPUT")
 
-# Only match git push
-case "$COMMAND" in
-  *"git push"*) ;;
-  *) exit 0 ;;
-esac
+# Match git push as a command, not as substring in arguments (e.g. commit messages)
+if ! echo "$COMMAND" | grep -qE '(^|[;&|]\s*)git\s+push'; then
+  exit 0
+fi
 
 # Detect force-push flags
 FORCE_PUSH=false

--- a/dist/cursor/hooks/pre-tool/workflow-pre-push.sh
+++ b/dist/cursor/hooks/pre-tool/workflow-pre-push.sh
@@ -56,6 +56,5 @@ if [[ "$TARGET_BRANCH" == "main" || "$TARGET_BRANCH" == "master" ]] && $FORCE_PU
   echo "WARNING: Force-pushing to $TARGET_BRANCH. This rewrites shared history." >&2
 fi
 
-# Blocking - require explicit user approval for all pushes
-echo "BLOCKED: git push requires explicit user approval." >&2
-exit 2
+# Advisory — remind user to confirm, but let Claude Code's permission system handle approval
+exit 0

--- a/dist/cursor/skills/cleanup/SKILL.md
+++ b/dist/cursor/skills/cleanup/SKILL.md
@@ -13,6 +13,25 @@ version: 2.0.0-dev.4
 
 Review ALL agent artifacts in `.agents/` and provide hygiene recommendations.
 
+## CLI Command
+
+Use `loaf cleanup` for filesystem scanning and actions. The CLI is the execution engine; this skill defines the policy and adds Linear-aware checks the CLI cannot perform.
+
+```bash
+loaf cleanup              # Scan all artifacts, show summary + interactive actions
+loaf cleanup --dry-run    # Show recommendations without prompting
+loaf cleanup --sessions   # Only review sessions
+loaf cleanup --specs      # Only review specs
+loaf cleanup --plans      # Only review plans
+loaf cleanup --drafts     # Only review drafts
+```
+
+**Division of responsibility:**
+- **CLI (`loaf cleanup`):** Filesystem scanning, archive/delete operations, non-TTY reporting
+- **This skill (agent context):** Linear status checks, extraction recommendations, cross-referencing external systems
+
+When running as an agent, use `loaf cleanup --dry-run` first to assess, then take actions interactively or via the CLI.
+
 ## Contents
 - Sessions
 - Tasks

--- a/dist/gemini/skills/cleanup/SKILL.md
+++ b/dist/gemini/skills/cleanup/SKILL.md
@@ -13,6 +13,25 @@ version: 2.0.0-dev.4
 
 Review ALL agent artifacts in `.agents/` and provide hygiene recommendations.
 
+## CLI Command
+
+Use `loaf cleanup` for filesystem scanning and actions. The CLI is the execution engine; this skill defines the policy and adds Linear-aware checks the CLI cannot perform.
+
+```bash
+loaf cleanup              # Scan all artifacts, show summary + interactive actions
+loaf cleanup --dry-run    # Show recommendations without prompting
+loaf cleanup --sessions   # Only review sessions
+loaf cleanup --specs      # Only review specs
+loaf cleanup --plans      # Only review plans
+loaf cleanup --drafts     # Only review drafts
+```
+
+**Division of responsibility:**
+- **CLI (`loaf cleanup`):** Filesystem scanning, archive/delete operations, non-TTY reporting
+- **This skill (agent context):** Linear status checks, extraction recommendations, cross-referencing external systems
+
+When running as an agent, use `loaf cleanup --dry-run` first to assess, then take actions interactively or via the CLI.
+
 ## Contents
 - Sessions
 - Tasks

--- a/dist/opencode/commands/cleanup.md
+++ b/dist/opencode/commands/cleanup.md
@@ -14,6 +14,25 @@ version: 2.0.0-dev.4
 
 Review ALL agent artifacts in `.agents/` and provide hygiene recommendations.
 
+## CLI Command
+
+Use `loaf cleanup` for filesystem scanning and actions. The CLI is the execution engine; this skill defines the policy and adds Linear-aware checks the CLI cannot perform.
+
+```bash
+loaf cleanup              # Scan all artifacts, show summary + interactive actions
+loaf cleanup --dry-run    # Show recommendations without prompting
+loaf cleanup --sessions   # Only review sessions
+loaf cleanup --specs      # Only review specs
+loaf cleanup --plans      # Only review plans
+loaf cleanup --drafts     # Only review drafts
+```
+
+**Division of responsibility:**
+- **CLI (`loaf cleanup`):** Filesystem scanning, archive/delete operations, non-TTY reporting
+- **This skill (agent context):** Linear status checks, extraction recommendations, cross-referencing external systems
+
+When running as an agent, use `loaf cleanup --dry-run` first to assess, then take actions interactively or via the CLI.
+
 ## Contents
 - Sessions
 - Tasks

--- a/dist/opencode/plugins/hooks/pre-tool/workflow-pre-push.sh
+++ b/dist/opencode/plugins/hooks/pre-tool/workflow-pre-push.sh
@@ -58,5 +58,6 @@ if [[ "$TARGET_BRANCH" == "main" || "$TARGET_BRANCH" == "master" ]] && $FORCE_PU
   echo "WARNING: Force-pushing to $TARGET_BRANCH. This rewrites shared history." >&2
 fi
 
-# Non-blocking - always exit 0
-exit 0
+# Blocking - require explicit user approval for all pushes
+echo "BLOCKED: git push requires explicit user approval." >&2
+exit 2

--- a/dist/opencode/plugins/hooks/pre-tool/workflow-pre-push.sh
+++ b/dist/opencode/plugins/hooks/pre-tool/workflow-pre-push.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-# Hook: Pre-Push Advisory (INFORMATIONAL)
+# Hook: Pre-Push Gate (BLOCKING)
 # PreToolUse hook - reads JSON from stdin per Claude Code hooks API
 #
-# Triggers on git push commands
-# Shows branch naming and safety reminders (non-blocking)
+# Blocks git push commands until user explicitly approves
 
 set -euo pipefail
 
@@ -26,11 +25,10 @@ else
 fi
 COMMAND=$(parse_command "$INPUT")
 
-# Only match git push
-case "$COMMAND" in
-  *"git push"*) ;;
-  *) exit 0 ;;
-esac
+# Match git push as a command, not as substring in arguments (e.g. commit messages)
+if ! echo "$COMMAND" | grep -qE '(^|[;&|]\s*)git\s+push'; then
+  exit 0
+fi
 
 # Detect force-push flags
 FORCE_PUSH=false

--- a/dist/opencode/plugins/hooks/pre-tool/workflow-pre-push.sh
+++ b/dist/opencode/plugins/hooks/pre-tool/workflow-pre-push.sh
@@ -56,6 +56,5 @@ if [[ "$TARGET_BRANCH" == "main" || "$TARGET_BRANCH" == "master" ]] && $FORCE_PU
   echo "WARNING: Force-pushing to $TARGET_BRANCH. This rewrites shared history." >&2
 fi
 
-# Blocking - require explicit user approval for all pushes
-echo "BLOCKED: git push requires explicit user approval." >&2
-exit 2
+# Advisory — remind user to confirm, but let Claude Code's permission system handle approval
+exit 0

--- a/dist/opencode/skills/cleanup/SKILL.md
+++ b/dist/opencode/skills/cleanup/SKILL.md
@@ -12,6 +12,25 @@ description: >-
 
 Review ALL agent artifacts in `.agents/` and provide hygiene recommendations.
 
+## CLI Command
+
+Use `loaf cleanup` for filesystem scanning and actions. The CLI is the execution engine; this skill defines the policy and adds Linear-aware checks the CLI cannot perform.
+
+```bash
+loaf cleanup              # Scan all artifacts, show summary + interactive actions
+loaf cleanup --dry-run    # Show recommendations without prompting
+loaf cleanup --sessions   # Only review sessions
+loaf cleanup --specs      # Only review specs
+loaf cleanup --plans      # Only review plans
+loaf cleanup --drafts     # Only review drafts
+```
+
+**Division of responsibility:**
+- **CLI (`loaf cleanup`):** Filesystem scanning, archive/delete operations, non-TTY reporting
+- **This skill (agent context):** Linear status checks, extraction recommendations, cross-referencing external systems
+
+When running as an agent, use `loaf cleanup --dry-run` first to assess, then take actions interactively or via the CLI.
+
 ## Contents
 - Sessions
 - Tasks

--- a/plugins/loaf/.claude-plugin/plugin.json
+++ b/plugins/loaf/.claude-plugin/plugin.json
@@ -156,7 +156,7 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/workflow-pre-push.sh",
             "timeout": 5000,
-            "description": "Block git push without explicit user approval"
+            "description": "Advisory reminders before git push (confirmation via Claude Code permissions)"
           },
           {
             "type": "command",

--- a/plugins/loaf/.claude-plugin/plugin.json
+++ b/plugins/loaf/.claude-plugin/plugin.json
@@ -156,7 +156,7 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/workflow-pre-push.sh",
             "timeout": 5000,
-            "description": "Advisory push reminders (branch naming, uncommitted files, force-push safety)"
+            "description": "Block git push without explicit user approval"
           },
           {
             "type": "command",

--- a/plugins/loaf/hooks/workflow-pre-push.sh
+++ b/plugins/loaf/hooks/workflow-pre-push.sh
@@ -58,5 +58,6 @@ if [[ "$TARGET_BRANCH" == "main" || "$TARGET_BRANCH" == "master" ]] && $FORCE_PU
   echo "WARNING: Force-pushing to $TARGET_BRANCH. This rewrites shared history." >&2
 fi
 
-# Non-blocking - always exit 0
-exit 0
+# Blocking - require explicit user approval for all pushes
+echo "BLOCKED: git push requires explicit user approval." >&2
+exit 2

--- a/plugins/loaf/hooks/workflow-pre-push.sh
+++ b/plugins/loaf/hooks/workflow-pre-push.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-# Hook: Pre-Push Advisory (INFORMATIONAL)
+# Hook: Pre-Push Gate (BLOCKING)
 # PreToolUse hook - reads JSON from stdin per Claude Code hooks API
 #
-# Triggers on git push commands
-# Shows branch naming and safety reminders (non-blocking)
+# Blocks git push commands until user explicitly approves
 
 set -euo pipefail
 
@@ -26,11 +25,10 @@ else
 fi
 COMMAND=$(parse_command "$INPUT")
 
-# Only match git push
-case "$COMMAND" in
-  *"git push"*) ;;
-  *) exit 0 ;;
-esac
+# Match git push as a command, not as substring in arguments (e.g. commit messages)
+if ! echo "$COMMAND" | grep -qE '(^|[;&|]\s*)git\s+push'; then
+  exit 0
+fi
 
 # Detect force-push flags
 FORCE_PUSH=false

--- a/plugins/loaf/hooks/workflow-pre-push.sh
+++ b/plugins/loaf/hooks/workflow-pre-push.sh
@@ -56,6 +56,5 @@ if [[ "$TARGET_BRANCH" == "main" || "$TARGET_BRANCH" == "master" ]] && $FORCE_PU
   echo "WARNING: Force-pushing to $TARGET_BRANCH. This rewrites shared history." >&2
 fi
 
-# Blocking - require explicit user approval for all pushes
-echo "BLOCKED: git push requires explicit user approval." >&2
-exit 2
+# Advisory — remind user to confirm, but let Claude Code's permission system handle approval
+exit 0

--- a/plugins/loaf/skills/cleanup/SKILL.md
+++ b/plugins/loaf/skills/cleanup/SKILL.md
@@ -12,6 +12,25 @@ description: >-
 
 Review ALL agent artifacts in `.agents/` and provide hygiene recommendations.
 
+## CLI Command
+
+Use `loaf cleanup` for filesystem scanning and actions. The CLI is the execution engine; this skill defines the policy and adds Linear-aware checks the CLI cannot perform.
+
+```bash
+loaf cleanup              # Scan all artifacts, show summary + interactive actions
+loaf cleanup --dry-run    # Show recommendations without prompting
+loaf cleanup --sessions   # Only review sessions
+loaf cleanup --specs      # Only review specs
+loaf cleanup --plans      # Only review plans
+loaf cleanup --drafts     # Only review drafts
+```
+
+**Division of responsibility:**
+- **CLI (`loaf cleanup`):** Filesystem scanning, archive/delete operations, non-TTY reporting
+- **This skill (agent context):** Linear status checks, extraction recommendations, cross-referencing external systems
+
+When running as an agent, use `loaf cleanup --dry-run` first to assess, then take actions interactively or via the CLI.
+
 ## Contents
 - Sessions
 - Tasks


### PR DESCRIPTION
## Summary

- Add `loaf cleanup` CLI command that scans `.agents/` directories and recommends cleanup actions based on the existing cleanup skill's rules
- Extract shared prompt helpers (`askYesNo`, `askChoice`, `isTTY`) to `cli/lib/prompts.ts`
- Build pure-logic scanner engine covering all 7 artifact types with 35 tests
- Support `--dry-run`, `--sessions`/`--specs`/`--plans`/`--drafts` filters, non-TTY pipe-safe output
- Update cleanup skill to reference CLI as the execution engine

### Scanner rules implemented
- **Sessions:** nested `session.*` frontmatter, completed → archive, stale → flag, `/crystallize` hints
- **Tasks:** done → archive, orphaned spec refs → flag (null spec is valid)
- **Specs:** complete → archive, stale drafting → flag
- **Plans:** orphan/completed-session → delete, session ID stem matching, `.agents/sessions/` path normalization
- **Drafts:** promoted-to-spec → delete (cross-references spec `source` field), stale → flag, sparks hints
- **Councils:** dual schema support (`created`/`session_reference` + `timestamp`/`session`), decision + session-completed gate, session summary verification hint
- **Reports:** nested `report.*` block, session-archived prerequisite, missing `session_reference` flagged, no age-based archive for unprocessed reports

### Also included
- Spec tightening (2 review rounds) and task breakdown (TASK-053 through TASK-056)
- Task backend abstraction draft (`.agents/drafts/20260328-task-backend-abstraction.md`)

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run test` passes (290 tests, 35 new)
- [ ] `loaf cleanup --dry-run` runs end-to-end
- [ ] `loaf cleanup --sessions` filters correctly
- [ ] `loaf build` succeeds with updated skill
- [ ] Non-TTY invocation (piped) behaves like `--dry-run`