### PR TITLE
feat: /release skill and non-interactive loaf release flags

### DIFF
--- a/.agents/drafts/20260330-idea-dry-run-all-commands.md
+++ b/.agents/drafts/20260330-idea-dry-run-all-commands.md
@@ -1,0 +1,31 @@
+---
+type: idea
+created: '2026-03-30'
+status: captured
+---
+
+# Idea: `--dry-run` for All Mutating CLI Commands
+
+## Nugget
+
+Every `loaf` command that creates, modifies, or deletes files should support `--dry-run` to preview planned changes without executing them. Currently only `release` and `cleanup` have it.
+
+## What It Would Do
+
+Add `--dry-run` to: `build`, `install`, `init`, `setup`, `task`, `spec`. Each would output what it plans to do (files to write, dirs to create, copies to make) without actually doing it.
+
+## Why
+
+Discovered during `/release` skill development — the principle that destructive commands should be previewable applies uniformly. `install` is the highest-value addition since it writes into external config directories (`~/.config/`), where surprises are most costly.
+
+## Priority Order
+
+1. `install` — touches external dirs, highest risk of surprise
+2. `build` — regenerable output, but useful for debugging target issues
+3. `task` / `spec` — lower risk (writes to `.agents/`), but consistency matters
+4. `init` / `setup` — one-time commands, lowest urgency
+
+## Open Questions
+
+- Should `--dry-run` output be machine-readable (JSON) for piping, or just human-readable?
+- Should `build --dry-run` show a diff of what would change in existing output files?

--- a/.agents/drafts/20260330-idea-dry-run-all-commands.md
+++ b/.agents/drafts/20260330-idea-dry-run-all-commands.md
@@ -4,7 +4,7 @@ created: '2026-03-30'
 status: captured
 ---
 
-# Idea: `--dry-run` for All Mutating CLI Commands
+# Idea: CLI Robustness — `--dry-run` for All Commands + Error Handling Hardening
 
 ## Nugget
 
@@ -24,6 +24,21 @@ Discovered during `/release` skill development — the principle that destructiv
 2. `build` — regenerable output, but useful for debugging target issues
 3. `task` / `spec` — lower risk (writes to `.agents/`), but consistency matters
 4. `init` / `setup` — one-time commands, lowest urgency
+
+## Error Handling Hardening
+
+Discovered during SPEC-019 PR review — pre-existing patterns in the release pipeline where bare `catch {}` blocks hide real failures. Should be fixed alongside `--dry-run` since it's the same files and the same "CLI robustness" theme.
+
+**By severity:**
+
+1. `prepareVersionUpdates` silently skips files it can't update — can produce inconsistent versions across `package.json` and `pyproject.toml` with no warning (`cli/lib/release/version.ts`)
+2. `getCommitsSince` returns `[]` on git failure — "No unreleased changes" instead of an error (`cli/lib/release/commits.ts`)
+3. `getLastTag` returns `null` on git failure — falls through to "all commits in history" (`cli/lib/release/commits.ts`)
+4. `detectVersionFiles` silently skips unreadable files — wrong version source without warning (`cli/lib/release/version.ts`)
+5. `scanIncompleteTasks` nested bare catches — incomplete task warning silently skipped (`cli/commands/release.ts`)
+6. Editor failure catch hides the actual error message (`cli/commands/release.ts`)
+
+**Pattern to apply:** Distinguish "expected failure" (git exit code, file not found) from "unexpected failure" (ENOENT for git binary, EACCES, spawn failures) — propagate the latter. Already applied in `refResolves` during SPEC-019 as the reference pattern.
 
 ## Open Questions
 

--- a/.agents/drafts/20260330-idea-merge-command.md
+++ b/.agents/drafts/20260330-idea-merge-command.md
@@ -1,7 +1,8 @@
 ---
 type: idea
 created: '2026-03-30'
-status: captured
+status: superseded
+superseded_by: SPEC-019
 ---
 
 # Idea: `/merge` Slash Command

--- a/.agents/specs/SPEC-019-release-skill.md
+++ b/.agents/specs/SPEC-019-release-skill.md
@@ -1,0 +1,93 @@
+---
+id: SPEC-019
+title: Release Skill — orchestrated merge ritual with CLI-backed versioning
+source: idea/20260330-idea-merge-command
+created: '2026-03-30T15:20:00.000Z'
+status: drafting
+appetite: Small (1–2 sessions)
+branch: feat/release-skill
+---
+
+# SPEC-019: Release Skill
+
+## Problem Statement
+
+The merge ritual is scattered across manual steps, advisory hooks, and skill documentation with no single coordination point:
+
+1. **Version bump timing is wrong**: SPEC-014's version bump happened post-merge in a separate commit, creating a stale-version window on main. The bump must be on the feature branch so the squash commit carries it.
+
+2. **`[Unreleased]` section lost**: Manual changelog editing converted `[Unreleased]` to a versioned header without adding a fresh one back. `loaf release`'s `insertIntoChangelog` does this correctly, but it wasn't used.
+
+3. **Documentation staleness unchecked**: After major features (e.g., replacing 8 agents with 3 profiles), README and ARCHITECTURE.md may reference removed concepts. Nothing in the merge flow flags this.
+
+4. **No enforcement, only reminders**: The `workflow-pre-merge` hook is a non-blocking prompt. The `workflow-post-merge` hook emits an informational checklist. The implement skill's AFTER section documents the flow but doesn't enforce ordering.
+
+## Solution Direction
+
+### Part 1: Enhance `loaf release` CLI with non-interactive flags
+
+Add flags to `cli/commands/release.ts` so the skill can drive versioning mechanically:
+
+| Flag | Purpose |
+|------|---------|
+| `--bump <type>` | Skip interactive bump choice. Values: `prerelease`, `release`, `major`, `minor`, `patch` |
+| `--no-tag` | Skip git tag creation |
+| `--no-gh` | Skip GitHub release draft |
+
+When `--bump` is provided, skip `askChoice`. Non-TTY already defaults bump choice and skips the editor. Combined with `--no-tag --no-gh`, this gives the skill a clean version+changelog+build+commit pipeline without release artifacts.
+
+**What stays the same**: All library code (`version.ts`, `changelog.ts`, `commits.ts`), the full interactive flow (no flags), `--dry-run`.
+
+### Part 2: Create `/release` skill
+
+A user-invocable skill (`/loaf:release`) that orchestrates the full merge ritual in 7 steps:
+
+1. **Detect context** — Current branch, associated PR (auto-detect via `gh pr view` or accept argument)
+2. **Pre-flight checks** (BLOCKING) — `npm run typecheck`, `npm run test`, `npx loaf build`
+3. **Documentation freshness** — Check README.md, ARCHITECTURE.md, docs/ for stale references using branch diff
+4. **Housekeeping verification** — Spec archived, tasks archived, session updated (verify only, offer to fix)
+5. **Version bump + changelog** — Call `loaf release --bump <type> --no-tag --no-gh` on the feature branch
+6. **Squash merge** — Draft clean body, confirm with user, execute `gh pr merge --squash`
+7. **Post-merge cleanup** — Pull main, delete branch, suggest `/reflect`
+
+**Separation of concerns:**
+- CLI handles: version detection, semver calculation, changelog generation/insertion, version file updates, build, commit
+- Skill handles: pre-flight, docs freshness, housekeeping, merge orchestration, cleanup
+
+## Scope
+
+### In Scope
+
+- Add `--bump`, `--no-tag`, `--no-gh` flags to `loaf release`
+- Create `content/skills/release/SKILL.md` with 7-step orchestration prompt
+- Create `content/skills/release/SKILL.claude-code.yaml` sidecar
+- Update cross-references in implement, git-workflow, and post-merge instructions
+- Fix missing `[Unreleased]` section in CHANGELOG.md
+
+### Out of Scope
+
+- Replacing `loaf release` CLI — it stays for terminal-only workflows
+- Modifying existing hooks — they stay as safety nets for manual merges
+- Changing the semver library code
+- Non-Claude Code targets (the skill is Claude Code-only; CLI flags benefit everyone)
+
+### Rabbit Holes
+
+- Don't build a "smart" diff analyzer for documentation freshness — just flag files that changed and let the user review
+- Don't try to auto-generate the squash body — draft it, but the user must review
+- Don't add `--yes` auto-confirm flag — force the user to confirm in the terminal too (the skill handles confirmation conversationally)
+
+## Dependencies
+
+| Dependency | Type | Notes |
+|---|---|---|
+| SPEC-014 | Hard (resolved) | Profile model and skill conventions are in place |
+
+## Test Conditions
+
+- [ ] `loaf release --bump prerelease --no-tag --no-gh --dry-run` shows correct preview without tag/gh steps
+- [ ] `loaf release --bump prerelease --no-tag --no-gh` executes version+changelog+build+commit only (no tag, no GH release)
+- [ ] `loaf release --dry-run` (no new flags) behaves identically to before
+- [ ] `npx loaf build` produces `plugins/loaf/skills/release/SKILL.md` in output
+- [ ] `/loaf:release` appears in Claude Code skill list
+- [ ] CHANGELOG.md has `[Unreleased]` section after version bump

--- a/.agents/specs/SPEC-019-release-skill.md
+++ b/.agents/specs/SPEC-019-release-skill.md
@@ -3,7 +3,7 @@ id: SPEC-019
 title: Release Skill — orchestrated merge ritual with CLI-backed versioning
 source: idea/20260330-idea-merge-command
 created: '2026-03-30T15:20:00.000Z'
-status: drafting
+status: complete
 appetite: Small (1–2 sessions)
 branch: feat/release-skill
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `/release` skill — orchestrates squash merge ritual: pre-flight, docs freshness, housekeeping, version bump, merge, cleanup (SPEC-019)
+- `loaf release --bump <type>` — skip interactive bump prompt for non-interactive use
+- `loaf release --base <ref>` — scope commits to a branch instead of last tag
+- `loaf release --no-tag` — skip git tag creation (implies `--no-gh`)
+- Release library test suite: version, changelog, commits, options, and command integration tests
+
+### Changed
+- Option validation and skip-flag logic extracted to `cli/lib/release/options.ts`
+
 ## [2.0.0-dev.6] - 2026-03-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-dev.7] - 2026-03-30
+
 ### Added
 - `/release` skill — orchestrates squash merge ritual: pre-flight, docs freshness, housekeeping, version bump, merge, cleanup (SPEC-019)
+- `/ship` alias for `/release` — ergonomic "ship it" invocation
 - `loaf release --bump <type>` — skip interactive bump prompt for non-interactive use
 - `loaf release --base <ref>` — scope commits to a branch instead of last tag
 - `loaf release --no-tag` — skip git tag creation (implies `--no-gh`)
+- `loaf release --yes` — skip confirmation prompt for non-interactive use
 - Release library test suite: version, changelog, commits, options, and command integration tests
 
 ### Changed
 - Option validation and skip-flag logic extracted to `cli/lib/release/options.ts`
+- `/release` skill detects curated changelog entries under `[Unreleased]` and preserves them instead of regenerating from commits
 
 ## [2.0.0-dev.6] - 2026-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [2.0.0-dev.6] - 2026-03-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,44 +2,45 @@
 
 > "Why have just a slice when you can get the whole loaf?"
 
-Loaf is an opinionated agentic framework (*An Opinionated Agentic Framework*) that transforms how you work with AI coding assistants. Instead of ad-hoc prompting, Loaf provides a **complete pipeline from idea to implementation to learning**—with full traceability at every step.
+Loaf is an opinionated agentic framework that gives AI coding assistants structured knowledge, enforced tool boundaries, and a complete pipeline from idea to implementation to learning. Write your skills once, deploy to Claude Code, OpenCode, Cursor, Codex, and Gemini.
 
-## Philosophy
+## Why Loaf?
 
-**Spec-first development**: Ideas are shaped into bounded specs before any code is written. No more scope creep or undefined requirements.
+**Portable knowledge** — 29 skills covering workflows, engineering standards, and language expertise. Build once, deploy to five AI coding tools without rewriting anything.
 
-**Multi-agent delegation**: A PM agent orchestrates work, specialized agents implement. The orchestrator never touches code directly—it plans, coordinates, and verifies.
+**Spec-first pipeline** — Ideas are shaped into bounded specs before any code is written. Every change flows: Idea → Spec → Tasks → Code → Learnings. Nothing gets lost.
 
-**Full traceability**: Every piece of work flows through: Idea → Spec → Tasks → Code → Learnings. Nothing gets lost.
+**Profile-based agents** — Three functional profiles defined by tool access, not job titles. A Smith with `python-development` skills becomes a backend engineer; the same Smith with `infrastructure-management` becomes a DevOps engineer. Skills determine what an agent knows; the profile determines what it can touch.
 
-**Session continuity**: Work survives context loss, compaction, and `/clear`. Pick up exactly where you left off.
+**Session continuity** — Work survives context loss, compaction, and `/clear`. Pick up exactly where you left off with full traceability.
 
-## The Command Pipeline
+**Hooks as quality gates** — Pre-tool hooks block secrets in commits. Post-tool hooks run linters, type checkers, and security scans. Language-aware and automatic.
+
+## The Pipeline
 
 Loaf's commands form a three-phase workflow that mirrors how good software gets built:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                    PHASE 1: SHAPE                           │
+│                      PHASE 1: SHAPE                         │
 │                                                             │
-│   /idea  →  /brainstorm  →  /shape  →  Bounded Spec         │
-│   (capture) (explore)       (define)                        │
+│   /idea  →  /brainstorm  →  /shape  →  Bounded Spec        │
+│                                                             │
 └─────────────────────────────────────────────────────────────┘
                               ↓
 ┌─────────────────────────────────────────────────────────────┐
-│                    PHASE 2: BUILD                           │
+│                      PHASE 2: BUILD                         │
 │                                                             │
 │   /breakdown  →  /implement                                 │
-│   (decompose)    (single task or multi-task orchestration)  │
 │                                                             │
-│   Optional: /council-session for complex decisions          │
+│   /resume-session after context loss                        │
 └─────────────────────────────────────────────────────────────┘
                               ↓
 ┌─────────────────────────────────────────────────────────────┐
-│                    PHASE 3: LEARN                           │
+│                      PHASE 3: LEARN                         │
 │                                                             │
-│   /review-sessions  →  /reflect  →  Updated Strategy        │
-│   (outcomes)           (learnings)                          │
+│   /cleanup  →  /reflect  →  Updated Strategy                │
+│                                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -47,8 +48,8 @@ Loaf's commands form a three-phase workflow that mirrors how good software gets 
 
 Transform raw ideas into implementable specs with clear boundaries.
 
-| Command | Purpose |
-|---------|---------|
+| Command | What It Does |
+|---------|--------------|
 | `/idea` | Quick capture of rough ideas into `.agents/ideas/` |
 | `/brainstorm` | Deep exploration of a problem space |
 | `/shape` | Rigorous shaping into bounded spec (what's IN and OUT) |
@@ -58,102 +59,107 @@ Transform raw ideas into implementable specs with clear boundaries.
 
 Decompose specs into atomic tasks and execute with specialized agents.
 
-| Command | Purpose |
-|---------|---------|
+| Command | What It Does |
+|---------|--------------|
 | `/breakdown` | Split spec into agent-sized atomic tasks |
-| `/implement` | Start single-task work or multi-task orchestration with dependency tracking |
-| `/council-session` | Convene agents for multi-perspective decisions |
-| `/resume` | Continue after context loss or new conversation |
+| `/implement` | Execute tasks with orchestrated agent delegation |
+| `/release` (`/ship`) | Orchestrate the merge ritual: pre-flight, docs check, version bump, squash merge, cleanup |
+| `/resume-session` | Continue after context loss or new conversation |
 
 ### Phase 3: Learn
 
 Integrate outcomes into strategic knowledge.
 
-| Command | Purpose |
-|---------|---------|
-| `/review-sessions` | Review completed sessions, identify patterns |
-| `/reflect` | Integrate learnings into STRATEGY.md |
-| `/reference-session` | Reuse patterns from prior sessions |
+| Command | What It Does |
+|---------|--------------|
+| `/cleanup` | Review completed sessions, archive artifacts |
+| `/reflect` | Integrate learnings into strategic documents |
+| `/reference-session` | Import decisions from prior sessions |
 
-## Key Concepts
+## Profiles
 
-**Shape Up Methodology**: Inspired by Basecamp's Shape Up. Specs define appetite (how much effort), boundaries (what's out), and rabbit holes (known risks). Work is shaped, not just specified.
+Loaf uses three functional profiles defined by mechanically enforced tool boundaries — not role titles, not domain labels. What an agent *can do* is fixed by its profile. What it *knows* comes from skills loaded at spawn time.
 
-**Strict Delegation**: The PM agent plans and coordinates but never writes code. All implementation is delegated to specialized agents: `backend-dev`, `frontend-dev`, `dba`, `qa`, `devops`, `design`.
+| Profile | Role | Tool Access | What It Does |
+|---------|------|-------------|--------------|
+| **Smith** | Implementer | Full write | Forges code, tests, config, and docs. Speciality determined by skills. |
+| **Sentinel** | Reviewer | Read-only | Watches, guards, and verifies. Cannot modify what it reviews — by design. |
+| **Ranger** | Researcher | Read + web | Scouts far, gathers intelligence, reports structured findings. |
 
-**Sessions as State Machines**: Every `/implement` creates a session file in `.agents/sessions/`. Sessions track: spec → tasks → agent assignments → outcomes. They survive `/clear`, compaction, and context switches.
-
-**Hooks as Quality Gates**: Pre-tool hooks can block dangerous actions (secrets in commits). Post-tool hooks run linters, type checkers, security scans. Language-aware and automatic.
-
-## Agents
-
-**Orchestrator:**
-
-| Agent | Use For |
-|-------|---------|
-| `pm` | Orchestrating work, managing sessions, delegating to specialists |
-
-**Implementation Agents** (write code):
-
-| Agent | Use For |
-|-------|---------|
-| `backend-dev` | Python, Ruby/Rails, Go, or TypeScript services |
-| `frontend-dev` | React, Next.js, UI components |
-| `devops` | Docker, Kubernetes, CI/CD |
-
-**Advisory Agents** (expertise in councils, delegate implementation):
-
-| Agent | Use For |
-|-------|---------|
-| `dba` | Schema design, migrations, queries |
-| `qa` | Testing, code review, security |
-| `design` | UI/UX, accessibility |
-| `power-systems` | Grid design, power electronics |
+The main session is the **Warden** — it coordinates and delegates but never implements directly. See [SOUL.md](SOUL.md) for the full fellowship identity.
 
 ## Skills
 
-Domain knowledge that agents draw from:
+### Workflow
 
-| Skill | Coverage |
-|-------|----------|
-| `orchestration` | Sessions, councils, Linear integration, Shape Up |
-| `foundations` | Code style, docs, security, commits |
-| `python-development` | FastAPI, Pydantic, pytest, async |
-| `typescript-development` | TypeScript, React, Next.js, type safety |
-| `ruby-development` | Rails 8, Hotwire, Minitest, DHH philosophy |
+Skills you invoke directly to drive work forward.
+
+| Skill | Activates When |
+|-------|----------------|
+| `implement` | Starting task or spec implementation |
+| `breakdown` | Decomposing specs into atomic tasks |
+| `shape` | Shaping ideas into bounded specs |
+| `brainstorm` | Deep exploration of a problem space |
+| `research` | Investigating questions, comparing options |
+| `strategy` | Discovering or updating strategic direction |
+| `architecture` | Creating Architecture Decision Records |
+| `reflect` | Integrating learnings into strategic docs |
+| `cleanup` | Reviewing and archiving agent artifacts |
+| `reference-session` | Importing decisions from past sessions |
+| `resume-session` | Continuing after context loss |
+| `bootstrap` | Bootstrapping new or existing projects |
+| `idea` | Quick capture of ideas for later evaluation |
+
+### Orchestration & Knowledge
+
+Background skills that activate automatically during agent coordination and project management.
+
+| Skill | Activates When |
+|-------|----------------|
+| `orchestration` | Managing sessions, delegating agents, Linear integration |
+| `council-session` | Multi-perspective deliberation during complex decisions |
+| `knowledge-base` | Managing project knowledge files |
+
+### Engineering Standards
+
+Background knowledge that activates automatically to enforce quality.
+
+| Skill | Activates When |
+|-------|----------------|
+| `foundations` | Writing code — style, naming, TDD, verification, code review |
+| `git-workflow` | Branching, commits, PRs, squash merges |
+| `debugging` | Diagnosing failures, tracking hypotheses, flaky tests |
+| `security-compliance` | Threat modeling, secrets management, compliance checks |
+| `documentation-standards` | ADRs, API docs, changelogs, Mermaid diagrams |
+
+### Language & Domain
+
+Domain expertise that loads based on project context.
+
+| Skill | Activates When |
+|-------|----------------|
+| `typescript-development` | TypeScript, React, Next.js, Tailwind, Vitest |
+| `python-development` | FastAPI, Pydantic, pytest, async patterns |
+| `ruby-development` | Rails 8, Hotwire, Minitest |
 | `go-development` | Go services, concurrency, testing |
-| `database-design` | Schema design, migrations, optimization |
-| `infrastructure-management` | Docker, K8s, Terraform |
-| `interface-design` | Accessibility, design systems |
-| `power-systems-modeling` | Grid design, power electronics |
+| `interface-design` | UI/UX, accessibility (WCAG 2.1), design systems |
+| `database-design` | Schema design, migrations, query optimization |
+| `infrastructure-management` | Docker, Kubernetes, CI/CD, Terraform |
+| `power-systems-modeling` | Thermal rating models, conductor physics |
 
 ## Multi-Target Support
 
-Loaf is built once and deployed to multiple AI coding tools:
+Build once, deploy everywhere. Skills are the universal layer; profiles and hooks adapt per target.
 
-| Target | Features | Status |
-|--------|----------|--------|
-| Claude Code | Full (agents, skills, hooks, MCP, LSP) | Primary |
-| OpenCode | Full (agents, skills, commands, hooks) | Full support |
-| Cursor | Agents, skills, hooks | Full support |
-| Codex | Skills only | Partial |
-| Gemini | Skills only | Partial |
+| Target | Profiles | Skills | Hooks | MCP | Status |
+|--------|:--------:|:------:|:-----:|:---:|--------|
+| Claude Code | ✓ | ✓ | ✓ | ✓ | Primary |
+| OpenCode | ✓ | ✓ | ✓ | — | Full support |
+| Cursor | ✓ | ✓ | ✓ | — | Full support |
+| Codex | — | ✓ | — | — | Skills only |
+| Gemini | — | ✓ | — | — | Skills only |
 
-## Integrations
-
-*Claude Code only.*
-
-**MCP Servers:**
-
-- **Serena** - Code intelligence and semantic search
-- **Sequential Thinking** - Structured reasoning
-- **Linear** - Issue tracking and project management
-
-**LSP Servers:**
-
-- **gopls**, **pyright**, **typescript-language-server**, **solargraph**
-
-## Installation
+## Getting Started
 
 ### Claude Code
 
@@ -161,7 +167,7 @@ Loaf is built once and deployed to multiple AI coding tools:
 /plugin marketplace add levifig/loaf
 ```
 
-Updates happen automatically via plugin marketplace.
+Updates happen automatically via plugin marketplace. Commands are scoped under `loaf:` (e.g., `/loaf:implement`).
 
 ### OpenCode, Cursor, Codex, Gemini
 
@@ -169,17 +175,7 @@ Updates happen automatically via plugin marketplace.
 curl -fsSL https://raw.githubusercontent.com/levifig/loaf/main/install.sh | bash
 ```
 
-The installer detects installed tools, lets you select targets, and downloads pre-built distributions.
-
-**Update:**
-
-```bash
-# Interactive
-curl -fsSL https://raw.githubusercontent.com/levifig/loaf/main/install.sh | bash
-
-# Unattended (CI, scripts)
-curl -fsSL https://raw.githubusercontent.com/levifig/loaf/main/install.sh | bash -s -- --upgrade
-```
+The installer detects installed tools, lets you select targets, and downloads pre-built distributions. Re-run with `--upgrade` to update.
 
 **Install locations:**
 
@@ -190,17 +186,13 @@ curl -fsSL https://raw.githubusercontent.com/levifig/loaf/main/install.sh | bash
 | Codex | `$CODEX_HOME/skills/` or `~/.codex/skills/` |
 | Gemini | `~/.gemini/skills/` |
 
-## Plugin Scoping
+## Integrations
 
 *Claude Code only.*
 
-Commands and agents are scoped to avoid conflicts:
+**MCP Servers:** Serena (code intelligence), Sequential Thinking (structured reasoning), Linear (issue tracking)
 
-```bash
-/loaf:implement          # Start implementation session
-/loaf:council-session    # Run a council deliberation
-@loaf:backend-dev        # Reference an agent
-```
+**LSP Servers:** gopls, pyright, typescript-language-server, solargraph
 
 ## Development
 
@@ -212,6 +204,13 @@ npm run build
 ```
 
 See [AGENTS.md](.agents/AGENTS.md) for development guidelines.
+
+```bash
+npm run typecheck    # Type check
+npm run test         # Run tests
+loaf build           # Build all targets (after initial npm run build)
+loaf install --to all  # Install to detected tools
+```
 
 **Testing locally:**
 

--- a/cli/commands/release.test.ts
+++ b/cli/commands/release.test.ts
@@ -120,6 +120,24 @@ describe("--no-tag implies --no-gh", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// --yes flag wiring
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("--yes flag", () => {
+  it("is accepted as a valid option", () => {
+    // --yes with --dry-run: dry-run exits before confirmation, so --yes has
+    // no visible effect, but the flag must parse without error
+    const result = runRelease("--yes", "--dry-run");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("short form -y is accepted", () => {
+    const result = runRelease("-y", "--dry-run");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Regression guards
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/cli/commands/release.test.ts
+++ b/cli/commands/release.test.ts
@@ -3,22 +3,36 @@
  *
  * Tests that the `loaf release` command correctly wires option parsing
  * to the underlying helpers. These are subprocess tests that invoke the
- * built CLI binary, so they verify the full Commander → handler → helper
- * chain, not just the helpers in isolation.
+ * CLI, so they verify the full Commander → handler → helper chain,
+ * not just the helpers in isolation.
  *
- * Requires: `npm run build:cli` to have been run (tests use dist-cli/index.js).
+ * The CLI is built from source in beforeAll, so these tests always
+ * exercise current code regardless of dist-cli/ state.
+ *
  * All tests use --dry-run, so no files or git state are modified.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { execFileSync } from "child_process";
 import { join } from "path";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Helpers
+// Setup — build the CLI from source before running integration tests
 // ─────────────────────────────────────────────────────────────────────────────
 
 const CLI_PATH = join(process.cwd(), "dist-cli", "index.js");
+
+beforeAll(() => {
+  execFileSync("npm", ["run", "build:cli"], {
+    cwd: process.cwd(),
+    stdio: "ignore",
+    timeout: 30_000,
+  });
+}, 30_000);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
 
 interface RunResult {
   stdout: string;

--- a/cli/commands/release.test.ts
+++ b/cli/commands/release.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Release Command Integration Tests
+ *
+ * Tests that the `loaf release` command correctly wires option parsing
+ * to the underlying helpers. These are subprocess tests that invoke the
+ * built CLI binary, so they verify the full Commander → handler → helper
+ * chain, not just the helpers in isolation.
+ *
+ * Requires: `npm run build:cli` to have been run (tests use dist-cli/index.js).
+ * All tests use --dry-run, so no files or git state are modified.
+ */
+
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "child_process";
+import { join } from "path";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CLI_PATH = join(process.cwd(), "dist-cli", "index.js");
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Run the release command with given args. Never throws — captures exit code. */
+function runRelease(...args: string[]): RunResult {
+  try {
+    const stdout = execFileSync("node", [CLI_PATH, "release", ...args], {
+      cwd: process.cwd(),
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 15_000,
+    });
+    return { stdout, stderr: "", exitCode: 0 };
+  } catch (error: unknown) {
+    const err = error as { stdout?: string; stderr?: string; status?: number };
+    return {
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+      exitCode: err.status ?? 1,
+    };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// --bump validation wiring
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("--bump flag", () => {
+  it("rejects invalid bump type with exit code 1", () => {
+    const result = runRelease("--bump", "bogus", "--dry-run");
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Invalid bump type "bogus"');
+  });
+
+  it("accepts valid bump type and skips interactive prompt", () => {
+    const result = runRelease("--bump", "prerelease", "--dry-run");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("via --bump flag");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// --base validation wiring
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("--base flag", () => {
+  it("rejects nonexistent ref with exit code 1", () => {
+    const result = runRelease("--base", "definitely-not-a-ref", "--dry-run");
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("does not exist or is not reachable");
+  });
+
+  it("accepts valid ref and scopes commits", () => {
+    // HEAD..HEAD = 0 commits, but the ref validation should pass
+    const result = runRelease("--base", "HEAD", "--dry-run");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("via --base flag");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// --no-tag / --no-gh wiring
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("--no-tag implies --no-gh", () => {
+  it("shows both tag and gh as skipped when only --no-tag is passed", () => {
+    const result = runRelease("--no-tag", "--dry-run");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("--no-tag — skipped");
+    expect(result.stdout).toContain("--no-gh — skipped");
+  });
+
+  it("skips only gh when only --no-gh is passed", () => {
+    const result = runRelease("--no-gh", "--dry-run");
+    expect(result.exitCode).toBe(0);
+    // Tag step should NOT be skipped
+    expect(result.stdout).not.toContain("--no-tag — skipped");
+    // GH step should be skipped
+    expect(result.stdout).toContain("--no-gh — skipped");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Regression guards
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("existing behavior preserved", () => {
+  it("--dry-run alone exits 0 without modifying anything", () => {
+    const result = runRelease("--dry-run");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("No changes made");
+  });
+});

--- a/cli/commands/release.ts
+++ b/cli/commands/release.ts
@@ -171,6 +171,7 @@ export function registerReleaseCommand(program: Command): void {
     .option("--base <ref>", "Use commits since <ref> instead of last tag (e.g. main)")
     .option("--no-tag", "Skip git tag creation")
     .option("--no-gh", "Skip GitHub release draft")
+    .option("-y, --yes", "Skip confirmation prompt (for non-interactive use)")
     .action(async (options: ReleaseOptions) => {
       const cwd = process.cwd();
 
@@ -387,11 +388,13 @@ export function registerReleaseCommand(program: Command): void {
         process.exit(0);
       }
 
-      // Confirmation
-      const confirmed = await askYesNo(`  Proceed with release ${bold(tagName)}? [y/N] `);
-      if (!confirmed) {
-        console.log(`\n  ${gray("Release cancelled.")}\n`);
-        process.exit(0);
+      // Confirmation (--yes skips the prompt for non-interactive use)
+      if (!options.yes) {
+        const confirmed = await askYesNo(`  Proceed with release ${bold(tagName)}? [y/N] `);
+        if (!confirmed) {
+          console.log(`\n  ${gray("Release cancelled.")}\n`);
+          process.exit(0);
+        }
       }
 
       console.log();
@@ -426,7 +429,7 @@ export function registerReleaseCommand(program: Command): void {
           if (inserted) {
             changelogContent = inserted;
           } else {
-            // No [Unreleased] marker — append after header
+            // No [Unreleased] marker — append at end of file
             changelogContent = existing + "\n" + changelogSection + "\n";
           }
         } else {

--- a/cli/commands/release.ts
+++ b/cli/commands/release.ts
@@ -34,6 +34,12 @@ import {
   insertIntoChangelog,
   createChangelog,
 } from "../lib/release/changelog.js";
+import {
+  validateBumpType,
+  validateBaseRef,
+  normalizeSkipFlags,
+} from "../lib/release/options.js";
+import type { ReleaseOptions } from "../lib/release/options.js";
 
 // ANSI color helpers
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
@@ -161,7 +167,11 @@ export function registerReleaseCommand(program: Command): void {
     .command("release")
     .description("Create a new release with changelog, version bump, and tag")
     .option("--dry-run", "Preview release without making changes")
-    .action(async (options: { dryRun?: boolean }) => {
+    .option("--bump <type>", "Skip interactive bump choice (prerelease, release, major, minor, patch)")
+    .option("--base <ref>", "Use commits since <ref> instead of last tag (e.g. main)")
+    .option("--no-tag", "Skip git tag creation")
+    .option("--no-gh", "Skip GitHub release draft")
+    .action(async (options: ReleaseOptions) => {
       const cwd = process.cwd();
 
       console.log(`\n${bold("loaf release")}\n`);
@@ -177,11 +187,27 @@ export function registerReleaseCommand(program: Command): void {
 
       process.stdout.write(`  ${cyan("Analyzing")}...\n\n`);
 
-      const lastTag = getLastTag(cwd);
-      const commits = getCommitsSince(cwd, lastTag);
+      const baseRef = options.base ?? getLastTag(cwd);
 
-      console.log(`  Last tag: ${lastTag ? bold(lastTag) : gray("(none)")}`);
-      console.log(`  Commits since tag: ${bold(String(commits.length))}`);
+      // Validate --base ref exists before proceeding
+      if (options.base) {
+        try {
+          validateBaseRef(cwd, options.base);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error(`  ${red("error:")} ${message}`);
+          process.exit(1);
+        }
+      }
+
+      const commits = getCommitsSince(cwd, baseRef);
+
+      if (options.base) {
+        console.log(`  Base ref: ${bold(options.base)} (via --base flag)`);
+      } else {
+        console.log(`  Last tag: ${baseRef ? bold(baseRef) : gray("(none)")}`);
+      }
+      console.log(`  Commits since ${options.base ? "base" : "tag"}: ${bold(String(commits.length))}`);
       console.log();
 
       if (commits.length === 0) {
@@ -219,7 +245,19 @@ export function registerReleaseCommand(program: Command): void {
       let bump: BumpType;
       let newVersion: string | null;
 
-      if (isPrerelease) {
+      // Validate --bump flag if provided
+      if (options.bump) {
+        try {
+          bump = validateBumpType(options.bump);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error(`  ${red("error:")} ${message}`);
+          process.exit(1);
+        }
+        newVersion = bumpVersion(currentVersion, bump);
+        console.log(`  Bump type: ${bold(bump)} (via --bump flag)`);
+        console.log();
+      } else if (isPrerelease) {
         // On a pre-release version — default to bumping the prerelease counter
         // Show available options
         console.log(`  ${bold("Current pre-release:")} ${currentVersion}`);
@@ -316,6 +354,9 @@ export function registerReleaseCommand(program: Command): void {
       console.log(`  New version: ${bold(newVersion)}`);
       console.log();
 
+      // Determine which steps are enabled
+      const { skipTag, skipGh } = normalizeSkipFlags(options);
+
       // Action list
       console.log(`  ${bold("Actions:")}`);
       let actionNum = 1;
@@ -323,8 +364,14 @@ export function registerReleaseCommand(program: Command): void {
       console.log(`    ${actionNum++}. Update CHANGELOG.md`);
       console.log(`    ${actionNum++}. Run loaf build`);
       console.log(`    ${actionNum++}. Commit release artifacts`);
-      console.log(`    ${actionNum++}. Create git tag ${tagName}`);
-      if (ghAvailable) {
+      if (skipTag) {
+        console.log(`    ${gray(`${actionNum++}. Create git tag ${tagName} (--no-tag — skipped)`)}`);
+      } else {
+        console.log(`    ${actionNum++}. Create git tag ${tagName}`);
+      }
+      if (skipGh) {
+        console.log(`    ${gray(`${actionNum++}. Create GitHub release draft (--no-gh — skipped)`)}`);
+      } else if (ghAvailable) {
         console.log(`    ${actionNum++}. Create GitHub release draft (gh available)`);
       } else {
         console.log(`    ${gray(`${actionNum++}. Create GitHub release draft (gh not available — skipped)`)}`);
@@ -423,20 +470,26 @@ export function registerReleaseCommand(program: Command): void {
       }
 
       // Step 5: Create git tag
-      try {
-        execFileSync("git", ["tag", "-a", tagName, "-m", `Release ${newVersion}`], {
-          cwd,
-          stdio: ["ignore", "pipe", "ignore"],
-        });
-        console.log(`    ${green("\u2713")} Created tag ${tagName}`);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error(`    ${red("\u2717")} Failed to create tag: ${message}`);
-        process.exit(1);
+      if (skipTag) {
+        console.log(`    ${gray("-")} Git tag skipped (--no-tag)`);
+      } else {
+        try {
+          execFileSync("git", ["tag", "-a", tagName, "-m", `Release ${newVersion}`], {
+            cwd,
+            stdio: ["ignore", "pipe", "ignore"],
+          });
+          console.log(`    ${green("\u2713")} Created tag ${tagName}`);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error(`    ${red("\u2717")} Failed to create tag: ${message}`);
+          process.exit(1);
+        }
       }
 
       // Step 6: Create GitHub release draft
-      if (ghAvailable) {
+      if (skipGh) {
+        console.log(`    ${gray("-")} GitHub release skipped (--no-gh)`);
+      } else if (ghAvailable) {
         try {
           execFileSync(
             "gh",

--- a/cli/commands/release.ts
+++ b/cli/commands/release.ts
@@ -203,7 +203,10 @@ export function registerReleaseCommand(program: Command): void {
       const commits = getCommitsSince(cwd, baseRef);
 
       if (options.base) {
-        console.log(`  Base ref: ${bold(options.base)} (via --base flag)`);
+        const baseRefLabel = baseRef === options.base
+          ? `${bold(options.base)} (via --base flag)`
+          : `${bold(options.base)} (resolved to ${bold(baseRef!)} via --base flag)`;
+        console.log(`  Base ref: ${baseRefLabel}`);
       } else {
         console.log(`  Last tag: ${baseRef ? bold(baseRef) : gray("(none)")}`);
       }

--- a/cli/commands/release.ts
+++ b/cli/commands/release.ts
@@ -187,12 +187,12 @@ export function registerReleaseCommand(program: Command): void {
 
       process.stdout.write(`  ${cyan("Analyzing")}...\n\n`);
 
-      const baseRef = options.base ?? getLastTag(cwd);
+      let baseRef = options.base ?? getLastTag(cwd);
 
-      // Validate --base ref exists before proceeding
+      // Validate --base ref exists before proceeding (may resolve to origin/<ref>)
       if (options.base) {
         try {
-          validateBaseRef(cwd, options.base);
+          baseRef = validateBaseRef(cwd, options.base);
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           console.error(`  ${red("error:")} ${message}`);

--- a/cli/lib/release/changelog.test.ts
+++ b/cli/lib/release/changelog.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Release Changelog Tests
+ *
+ * Tests for changelog generation and insertion into existing CHANGELOG.md files.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { ParsedCommit } from "./commits.js";
+import {
+  groupBySection,
+  generateChangelogSection,
+  insertIntoChangelog,
+  createChangelog,
+} from "./changelog.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeCommit(
+  overrides: Partial<ParsedCommit> & { hash: string; message: string },
+): ParsedCommit {
+  return {
+    type: "feat",
+    breaking: false,
+    section: "Added",
+    raw: `feat: ${overrides.message}`,
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// groupBySection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("groupBySection", () => {
+  it("groups commits by section", () => {
+    const commits = [
+      makeCommit({ hash: "abc", message: "add feature", section: "Added" }),
+      makeCommit({ hash: "def", message: "fix bug", section: "Fixed" }),
+      makeCommit({ hash: "ghi", message: "add another", section: "Added" }),
+    ];
+
+    const groups = groupBySection(commits);
+    expect(groups.get("Added")).toHaveLength(2);
+    expect(groups.get("Fixed")).toHaveLength(1);
+  });
+
+  it("filters out null-section commits", () => {
+    const commits = [
+      makeCommit({ hash: "abc", message: "add feature", section: "Added" }),
+      makeCommit({ hash: "def", message: "chore stuff", section: null }),
+    ];
+
+    const groups = groupBySection(commits);
+    expect(groups.size).toBe(1);
+    expect(groups.has("Added")).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// generateChangelogSection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("generateChangelogSection", () => {
+  it("generates a versioned section with grouped entries", () => {
+    const commits = [
+      makeCommit({ hash: "abc", message: "new feature", section: "Added" }),
+      makeCommit({ hash: "def", message: "fix crash", section: "Fixed" }),
+    ];
+
+    const section = generateChangelogSection("2.0.0-dev.7", "2026-03-30", commits);
+
+    expect(section).toContain("## [2.0.0-dev.7] - 2026-03-30");
+    expect(section).toContain("### Added");
+    expect(section).toContain("- New feature (abc)");
+    expect(section).toContain("### Fixed");
+    expect(section).toContain("- Fix crash (def)");
+  });
+
+  it("omits sections with no commits", () => {
+    const commits = [
+      makeCommit({ hash: "abc", message: "fix only", section: "Fixed" }),
+    ];
+
+    const section = generateChangelogSection("1.0.1", "2026-03-30", commits);
+    expect(section).not.toContain("### Added");
+    expect(section).toContain("### Fixed");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// insertIntoChangelog
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("insertIntoChangelog", () => {
+  it("inserts below [Unreleased] and preserves it", () => {
+    const existing = [
+      "# Changelog",
+      "",
+      "## [Unreleased]",
+      "",
+      "## [1.0.0] - 2026-01-01",
+      "",
+      "### Added",
+      "- Initial release",
+    ].join("\n");
+
+    const newSection = "## [1.1.0] - 2026-03-30\n\n### Added\n- New feature (abc)";
+    const result = insertIntoChangelog(existing, newSection);
+
+    expect(result).not.toBeNull();
+    // [Unreleased] is preserved at the top
+    expect(result).toContain("## [Unreleased]");
+    // New section appears between [Unreleased] and old version
+    const lines = result!.split("\n");
+    const unreleasedIdx = lines.findIndex((l) => l.includes("[Unreleased]"));
+    const newSectionIdx = lines.findIndex((l) => l.includes("[1.1.0]"));
+    const oldSectionIdx = lines.findIndex((l) => l.includes("[1.0.0]"));
+    expect(unreleasedIdx).toBeLessThan(newSectionIdx);
+    expect(newSectionIdx).toBeLessThan(oldSectionIdx);
+  });
+
+  it("returns null when no [Unreleased] marker exists", () => {
+    const existing = "# Changelog\n\n## [1.0.0] - 2026-01-01\n\n### Added\n- Initial";
+    const result = insertIntoChangelog(existing, "## [1.1.0] - 2026-03-30");
+    expect(result).toBeNull();
+  });
+
+  it("is case-insensitive for [Unreleased]", () => {
+    const existing = "# Changelog\n\n## [unreleased]\n\n## [1.0.0] - 2026-01-01";
+    const result = insertIntoChangelog(existing, "## [1.1.0] - 2026-03-30");
+    expect(result).not.toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createChangelog
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("createChangelog", () => {
+  it("creates a new changelog with [Unreleased] section", () => {
+    const section = "## [1.0.0] - 2026-03-30\n\n### Added\n- First feature";
+    const result = createChangelog(section);
+
+    expect(result).toContain("# Changelog");
+    expect(result).toContain("## [Unreleased]");
+    expect(result).toContain("## [1.0.0] - 2026-03-30");
+  });
+});

--- a/cli/lib/release/commits.test.ts
+++ b/cli/lib/release/commits.test.ts
@@ -1,16 +1,175 @@
 /**
  * Release Commits Tests
  *
- * Tests for conventional commit parsing, bump suggestion,
- * and the commit gathering functions used by `loaf release`.
+ * Tests for conventional commit parsing, section mapping, breaking change
+ * detection, and bump suggestion.
  */
 
 import { describe, it, expect } from "vitest";
-import { suggestBump } from "./commits.js";
+import { parseCommit, suggestBump } from "./commits.js";
 import type { ParsedCommit } from "./commits.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Test helpers
+// parseCommit — conventional commit regex + section mapping
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("parseCommit", () => {
+  describe("standard types", () => {
+    it("parses feat into Added section", () => {
+      const result = parseCommit("abc", "feat: add login page", "");
+      expect(result).toMatchObject({
+        type: "feat",
+        message: "add login page",
+        breaking: false,
+        section: "Added",
+      });
+    });
+
+    it("parses fix into Fixed section", () => {
+      const result = parseCommit("abc", "fix: null pointer in auth", "");
+      expect(result).toMatchObject({
+        type: "fix",
+        message: "null pointer in auth",
+        section: "Fixed",
+      });
+    });
+
+    it("parses refactor into Changed section", () => {
+      const result = parseCommit("abc", "refactor: extract helper", "");
+      expect(result).toMatchObject({ type: "refactor", section: "Changed" });
+    });
+
+    it("parses perf into Changed section", () => {
+      const result = parseCommit("abc", "perf: optimize query", "");
+      expect(result).toMatchObject({ type: "perf", section: "Changed" });
+    });
+  });
+
+  describe("filtered types (null section)", () => {
+    it.each(["docs", "chore", "ci", "test", "build", "style"])(
+      "parses %s into null section (filtered from changelog)",
+      (type) => {
+        const result = parseCommit("abc", `${type}: some work`, "");
+        expect(result.section).toBeNull();
+      },
+    );
+  });
+
+  describe("unknown types", () => {
+    it("maps unknown type to Other section", () => {
+      const result = parseCommit("abc", "wip: experiment", "");
+      expect(result).toMatchObject({ type: "wip", section: "Other" });
+    });
+  });
+
+  describe("scope handling", () => {
+    it("ignores scope parentheses in parsing", () => {
+      const result = parseCommit("abc", "fix(core): something", "");
+      expect(result).toMatchObject({
+        type: "fix",
+        message: "something",
+        section: "Fixed",
+      });
+    });
+
+    it("handles multi-word scope", () => {
+      const result = parseCommit("abc", "feat(auth-service): add SSO", "");
+      expect(result).toMatchObject({
+        type: "feat",
+        message: "add SSO",
+        section: "Added",
+      });
+    });
+  });
+
+  describe("breaking changes", () => {
+    it("detects bang syntax", () => {
+      const result = parseCommit("abc", "feat!: drop legacy API", "");
+      expect(result).toMatchObject({
+        breaking: true,
+        section: "Breaking Changes",
+      });
+    });
+
+    it("detects bang with scope", () => {
+      const result = parseCommit("abc", "fix(auth)!: remove v1 tokens", "");
+      expect(result).toMatchObject({
+        breaking: true,
+        section: "Breaking Changes",
+      });
+    });
+
+    it("detects BREAKING CHANGE in body", () => {
+      const result = parseCommit(
+        "abc",
+        "feat: new auth system",
+        "BREAKING CHANGE: removed v1 token support",
+      );
+      expect(result).toMatchObject({
+        breaking: true,
+        section: "Breaking Changes",
+      });
+    });
+
+    it("detects BREAKING-CHANGE in body (hyphenated)", () => {
+      const result = parseCommit(
+        "abc",
+        "feat: new auth",
+        "BREAKING-CHANGE: removed old API",
+      );
+      expect(result.breaking).toBe(true);
+    });
+
+    it("body breaking overrides section even for fix type", () => {
+      const result = parseCommit(
+        "abc",
+        "fix: remove deprecated endpoint",
+        "BREAKING CHANGE: /v1 no longer available",
+      );
+      expect(result.section).toBe("Breaking Changes");
+    });
+  });
+
+  describe("non-conventional commits", () => {
+    it("handles merge commits", () => {
+      const result = parseCommit("abc", "Merge pull request #42", "");
+      expect(result).toMatchObject({
+        type: "",
+        message: "Merge pull request #42",
+        section: "Other",
+      });
+    });
+
+    it("handles plain messages", () => {
+      const result = parseCommit("abc", "update readme", "");
+      expect(result).toMatchObject({
+        type: "",
+        section: "Other",
+      });
+    });
+
+    it("detects breaking in body of non-conventional commit", () => {
+      const result = parseCommit(
+        "abc",
+        "big refactor",
+        "BREAKING CHANGE: everything changed",
+      );
+      expect(result.breaking).toBe(true);
+      expect(result.section).toBe("Breaking Changes");
+    });
+  });
+
+  describe("preserves raw subject and hash", () => {
+    it("stores original subject as raw", () => {
+      const result = parseCommit("abc123", "feat: new thing", "");
+      expect(result.raw).toBe("feat: new thing");
+      expect(result.hash).toBe("abc123");
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// suggestBump
 // ─────────────────────────────────────────────────────────────────────────────
 
 function makeCommit(
@@ -25,14 +184,10 @@ function makeCommit(
   };
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// suggestBump
-// ─────────────────────────────────────────────────────────────────────────────
-
 describe("suggestBump", () => {
   it("suggests major when breaking changes present", () => {
     const commits = [
-      makeCommit({ hash: "a", message: "breaking thing", breaking: true, section: "Breaking Changes" }),
+      makeCommit({ hash: "a", message: "breaking", breaking: true, section: "Breaking Changes" }),
       makeCommit({ hash: "b", message: "normal feat", section: "Added" }),
     ];
     expect(suggestBump(commits)).toBe("major");
@@ -48,15 +203,14 @@ describe("suggestBump", () => {
 
   it("suggests patch when only fixes present", () => {
     const commits = [
-      makeCommit({ hash: "a", message: "fix bug", type: "fix", section: "Fixed" }),
-      makeCommit({ hash: "b", message: "another fix", type: "fix", section: "Fixed" }),
+      makeCommit({ hash: "a", message: "fix", type: "fix", section: "Fixed" }),
     ];
     expect(suggestBump(commits)).toBe("patch");
   });
 
-  it("suggests patch for empty-ish commits (no features, no breaking)", () => {
+  it("suggests patch for filtered-only commits", () => {
     const commits = [
-      makeCommit({ hash: "a", message: "misc", type: "chore", section: null }),
+      makeCommit({ hash: "a", message: "chore", type: "chore", section: null }),
     ];
     expect(suggestBump(commits)).toBe("patch");
   });

--- a/cli/lib/release/commits.test.ts
+++ b/cli/lib/release/commits.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Release Commits Tests
+ *
+ * Tests for conventional commit parsing, bump suggestion,
+ * and the commit gathering functions used by `loaf release`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { suggestBump } from "./commits.js";
+import type { ParsedCommit } from "./commits.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeCommit(
+  overrides: Partial<ParsedCommit> & { hash: string; message: string },
+): ParsedCommit {
+  return {
+    type: "feat",
+    breaking: false,
+    section: "Added",
+    raw: `feat: ${overrides.message}`,
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// suggestBump
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("suggestBump", () => {
+  it("suggests major when breaking changes present", () => {
+    const commits = [
+      makeCommit({ hash: "a", message: "breaking thing", breaking: true, section: "Breaking Changes" }),
+      makeCommit({ hash: "b", message: "normal feat", section: "Added" }),
+    ];
+    expect(suggestBump(commits)).toBe("major");
+  });
+
+  it("suggests minor when features present (no breaking)", () => {
+    const commits = [
+      makeCommit({ hash: "a", message: "new feature", section: "Added" }),
+      makeCommit({ hash: "b", message: "fix bug", section: "Fixed" }),
+    ];
+    expect(suggestBump(commits)).toBe("minor");
+  });
+
+  it("suggests patch when only fixes present", () => {
+    const commits = [
+      makeCommit({ hash: "a", message: "fix bug", type: "fix", section: "Fixed" }),
+      makeCommit({ hash: "b", message: "another fix", type: "fix", section: "Fixed" }),
+    ];
+    expect(suggestBump(commits)).toBe("patch");
+  });
+
+  it("suggests patch for empty-ish commits (no features, no breaking)", () => {
+    const commits = [
+      makeCommit({ hash: "a", message: "misc", type: "chore", section: null }),
+    ];
+    expect(suggestBump(commits)).toBe("patch");
+  });
+});

--- a/cli/lib/release/commits.ts
+++ b/cli/lib/release/commits.ts
@@ -1,8 +1,9 @@
 /**
  * Conventional Commit Parser
  *
- * Shells out to git to get commits since the last tag, then parses them
- * into typed structures for changelog generation and version bumping.
+ * Shells out to git to get commits since a given ref (tag or branch),
+ * then parses them into typed structures for changelog generation and
+ * version bumping.
  */
 
 import { execFileSync } from "child_process";
@@ -102,7 +103,8 @@ export function getCommitsSince(
   return commits;
 }
 
-function parseCommit(hash: string, subject: string, body: string): ParsedCommit {
+/** Parse a single commit's subject and body into a typed structure. */
+export function parseCommit(hash: string, subject: string, body: string): ParsedCommit {
   const match = subject.match(CONVENTIONAL_RE);
 
   if (!match) {

--- a/cli/lib/release/options.test.ts
+++ b/cli/lib/release/options.test.ts
@@ -47,8 +47,20 @@ describe("validateBumpType", () => {
 describe("validateBaseRef", () => {
   const cwd = process.cwd();
 
-  it("accepts HEAD as a valid ref", () => {
-    expect(() => validateBaseRef(cwd, "HEAD")).not.toThrow();
+  it("returns the ref when it resolves directly", () => {
+    expect(validateBaseRef(cwd, "HEAD")).toBe("HEAD");
+  });
+
+  it("falls back to origin/<ref> when local ref is missing", () => {
+    // origin/main exists in any clone, even without a local main branch
+    const result = validateBaseRef(cwd, "main");
+    // Should resolve to either "main" (local exists) or "origin/main" (fallback)
+    expect(result).toMatch(/^(origin\/)?main$/);
+  });
+
+  it("does not double-prefix refs that already contain a slash", () => {
+    // origin/main should resolve directly, not try origin/origin/main
+    expect(validateBaseRef(cwd, "origin/main")).toBe("origin/main");
   });
 
   it("rejects a nonexistent ref", () => {
@@ -63,9 +75,9 @@ describe("validateBaseRef", () => {
     );
   });
 
-  it("error message suggests fetching", () => {
+  it("error message mentions both attempted refs", () => {
     expect(() => validateBaseRef(cwd, "missing-branch")).toThrow(
-      /git fetch origin missing-branch/,
+      /Tried "missing-branch" and "origin\/missing-branch"/,
     );
   });
 });

--- a/cli/lib/release/options.test.ts
+++ b/cli/lib/release/options.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Release Options Tests
+ *
+ * Tests for CLI option validation and normalization used by `loaf release`.
+ * Covers --bump validation, --base ref validation, and --no-tag/--no-gh
+ * flag interaction.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  validateBumpType,
+  validateBaseRef,
+  normalizeSkipFlags,
+} from "./options.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validateBumpType
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("validateBumpType", () => {
+  it.each(["major", "minor", "patch", "prerelease", "release"])(
+    "accepts valid bump type: %s",
+    (type) => {
+      expect(validateBumpType(type)).toBe(type);
+    },
+  );
+
+  it("rejects invalid bump type", () => {
+    expect(() => validateBumpType("bogus")).toThrow(
+      /Invalid bump type "bogus"/,
+    );
+  });
+
+  it("rejects empty string", () => {
+    expect(() => validateBumpType("")).toThrow(/Invalid bump type/);
+  });
+
+  it("error message lists valid options", () => {
+    expect(() => validateBumpType("nope")).toThrow(/major, minor, patch, prerelease, release/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validateBaseRef (integration — uses the real git repo we're running in)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("validateBaseRef", () => {
+  const cwd = process.cwd();
+
+  it("accepts HEAD as a valid ref", () => {
+    expect(() => validateBaseRef(cwd, "HEAD")).not.toThrow();
+  });
+
+  it("rejects a nonexistent ref", () => {
+    expect(() => validateBaseRef(cwd, "definitely-not-a-ref-xyz")).toThrow(
+      /does not exist or is not reachable/,
+    );
+  });
+
+  it("error message includes the bad ref name", () => {
+    expect(() => validateBaseRef(cwd, "no-such-branch")).toThrow(
+      /no-such-branch/,
+    );
+  });
+
+  it("error message suggests fetching", () => {
+    expect(() => validateBaseRef(cwd, "missing-branch")).toThrow(
+      /git fetch origin missing-branch/,
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// normalizeSkipFlags
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("normalizeSkipFlags", () => {
+  it("defaults to skipping nothing", () => {
+    const { skipTag, skipGh } = normalizeSkipFlags({});
+    expect(skipTag).toBe(false);
+    expect(skipGh).toBe(false);
+  });
+
+  it("--no-tag sets skipTag", () => {
+    const { skipTag } = normalizeSkipFlags({ tag: false });
+    expect(skipTag).toBe(true);
+  });
+
+  it("--no-gh sets skipGh", () => {
+    const { skipGh } = normalizeSkipFlags({ gh: false });
+    expect(skipGh).toBe(true);
+  });
+
+  it("--no-tag implies --no-gh", () => {
+    const { skipTag, skipGh } = normalizeSkipFlags({ tag: false });
+    expect(skipTag).toBe(true);
+    expect(skipGh).toBe(true);
+  });
+
+  it("--no-tag implies --no-gh even when gh is explicitly true", () => {
+    // Commander won't produce this, but the logic should be robust
+    const { skipTag, skipGh } = normalizeSkipFlags({ tag: false, gh: true });
+    expect(skipTag).toBe(true);
+    expect(skipGh).toBe(true);
+  });
+
+  it("explicit --no-gh without --no-tag only skips gh", () => {
+    const { skipTag, skipGh } = normalizeSkipFlags({ gh: false });
+    expect(skipTag).toBe(false);
+    expect(skipGh).toBe(true);
+  });
+
+  it("undefined tag/gh (no flags passed) skips nothing", () => {
+    const { skipTag, skipGh } = normalizeSkipFlags({ dryRun: true });
+    expect(skipTag).toBe(false);
+    expect(skipGh).toBe(false);
+  });
+});

--- a/cli/lib/release/options.test.ts
+++ b/cli/lib/release/options.test.ts
@@ -80,6 +80,12 @@ describe("validateBaseRef", () => {
       /Tried "missing-branch" and "origin\/missing-branch"/,
     );
   });
+
+  it("does not claim an origin/origin fallback for refs with a slash", () => {
+    expect(() => validateBaseRef(cwd, "missing/branch")).toThrow(
+      /Tried "missing\/branch"\. If this is a remote branch, run: git fetch origin missing\/branch/,
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/cli/lib/release/options.ts
+++ b/cli/lib/release/options.ts
@@ -46,20 +46,40 @@ export function validateBumpType(value: string): BumpType {
 
 /**
  * Validate that a git ref exists and resolves to a commit.
- * Throws with a descriptive message if the ref is invalid.
+ * Returns the resolved ref name — which may differ from the input
+ * if the literal ref doesn't exist but `origin/<ref>` does.
+ *
+ * This handles the common case where a clone has `origin/main` but
+ * no local `main` branch.
  */
-export function validateBaseRef(cwd: string, ref: string): void {
+export function validateBaseRef(cwd: string, ref: string): string {
+  // Try the literal ref first
+  if (refResolves(cwd, ref)) return ref;
+
+  // Fall back to origin/<ref> if the ref doesn't contain a slash
+  // (i.e., don't try origin/origin/main)
+  if (!ref.includes("/")) {
+    const remoteRef = `origin/${ref}`;
+    if (refResolves(cwd, remoteRef)) return remoteRef;
+  }
+
+  throw new Error(
+    `Base ref "${ref}" does not exist or is not reachable. ` +
+    `Tried "${ref}" and "origin/${ref}". ` +
+    `If this is a remote branch, run: git fetch origin ${ref}`,
+  );
+}
+
+function refResolves(cwd: string, ref: string): boolean {
   try {
     execFileSync("git", ["rev-parse", "--verify", `${ref}^{commit}`], {
       cwd,
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
     });
+    return true;
   } catch {
-    throw new Error(
-      `Base ref "${ref}" does not exist or is not reachable. ` +
-      `If this is a remote branch, run: git fetch origin ${ref}`,
-    );
+    return false;
   }
 }
 

--- a/cli/lib/release/options.ts
+++ b/cli/lib/release/options.ts
@@ -1,7 +1,7 @@
 /**
  * Release Option Validation & Normalization
  *
- * Pure functions for validating and normalizing CLI options
+ * Validation and normalization helpers for CLI options
  * used by the `loaf release` command. Extracted for testability.
  */
 
@@ -18,6 +18,7 @@ export interface ReleaseOptions {
   base?: string;
   tag?: boolean;
   gh?: boolean;
+  yes?: boolean;
 }
 
 export interface NormalizedFlags {
@@ -79,8 +80,13 @@ function refResolves(cwd: string, ref: string): boolean {
       stdio: ["ignore", "pipe", "ignore"],
     });
     return true;
-  } catch {
-    return false;
+  } catch (error: unknown) {
+    // Expected: git ran but the ref was invalid (non-zero exit code).
+    // Unexpected: git not found, permission denied, etc. — propagate.
+    if (error && typeof error === "object" && "status" in error) {
+      return false;
+    }
+    throw error;
   }
 }
 

--- a/cli/lib/release/options.ts
+++ b/cli/lib/release/options.ts
@@ -53,21 +53,22 @@ export function validateBumpType(value: string): BumpType {
  * no local `main` branch.
  */
 export function validateBaseRef(cwd: string, ref: string): string {
-  // Try the literal ref first
-  if (refResolves(cwd, ref)) return ref;
+  const attemptedRefs = getCandidateRefs(ref);
 
-  // Fall back to origin/<ref> if the ref doesn't contain a slash
-  // (i.e., don't try origin/origin/main)
-  if (!ref.includes("/")) {
-    const remoteRef = `origin/${ref}`;
-    if (refResolves(cwd, remoteRef)) return remoteRef;
+  for (const candidate of attemptedRefs) {
+    if (refResolves(cwd, candidate)) return candidate;
   }
 
   throw new Error(
     `Base ref "${ref}" does not exist or is not reachable. ` +
-    `Tried "${ref}" and "origin/${ref}". ` +
+    `Tried ${attemptedRefs.map((candidate) => `"${candidate}"`).join(" and ")}. ` +
     `If this is a remote branch, run: git fetch origin ${ref}`,
   );
+}
+
+function getCandidateRefs(ref: string): string[] {
+  if (ref.includes("/")) return [ref];
+  return [ref, `origin/${ref}`];
 }
 
 function refResolves(cwd: string, ref: string): boolean {

--- a/cli/lib/release/options.ts
+++ b/cli/lib/release/options.ts
@@ -1,0 +1,80 @@
+/**
+ * Release Option Validation & Normalization
+ *
+ * Pure functions for validating and normalizing CLI options
+ * used by the `loaf release` command. Extracted for testability.
+ */
+
+import { execFileSync } from "child_process";
+import type { BumpType } from "./version.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ReleaseOptions {
+  dryRun?: boolean;
+  bump?: string;
+  base?: string;
+  tag?: boolean;
+  gh?: boolean;
+}
+
+export interface NormalizedFlags {
+  skipTag: boolean;
+  skipGh: boolean;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+const VALID_BUMPS: BumpType[] = ["major", "minor", "patch", "prerelease", "release"];
+
+/**
+ * Validate a --bump value. Returns the validated BumpType or throws
+ * with a descriptive message.
+ */
+export function validateBumpType(value: string): BumpType {
+  if (!VALID_BUMPS.includes(value as BumpType)) {
+    throw new Error(
+      `Invalid bump type "${value}". Must be one of: ${VALID_BUMPS.join(", ")}`,
+    );
+  }
+  return value as BumpType;
+}
+
+/**
+ * Validate that a git ref exists and resolves to a commit.
+ * Throws with a descriptive message if the ref is invalid.
+ */
+export function validateBaseRef(cwd: string, ref: string): void {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", `${ref}^{commit}`], {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    throw new Error(
+      `Base ref "${ref}" does not exist or is not reachable. ` +
+      `If this is a remote branch, run: git fetch origin ${ref}`,
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Normalization
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Normalize skip flags from CLI options.
+ *
+ * --no-tag implies --no-gh because `gh release create` auto-creates
+ * missing tags on GitHub, which would defeat the purpose of --no-tag.
+ */
+export function normalizeSkipFlags(options: ReleaseOptions): NormalizedFlags {
+  const skipTag = options.tag === false;
+  const skipGh = options.gh === false || skipTag;
+  return { skipTag, skipGh };
+}

--- a/cli/lib/release/version.test.ts
+++ b/cli/lib/release/version.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Release Version Tests
+ *
+ * Tests for semver parsing, bumping, and version file detection.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseSemVer, formatSemVer, bumpVersion } from "./version.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseSemVer
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("parseSemVer", () => {
+  it("parses a stable version", () => {
+    expect(parseSemVer("2.0.0")).toEqual({ major: 2, minor: 0, patch: 0 });
+  });
+
+  it("parses a pre-release version", () => {
+    expect(parseSemVer("2.0.0-dev.6")).toEqual({
+      major: 2,
+      minor: 0,
+      patch: 0,
+      prerelease: "dev.6",
+    });
+  });
+
+  it("parses a pre-release with no numeric suffix", () => {
+    expect(parseSemVer("1.0.0-alpha")).toEqual({
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: "alpha",
+    });
+  });
+
+  it("returns null for invalid versions", () => {
+    expect(parseSemVer("not-a-version")).toBeNull();
+    expect(parseSemVer("1.2")).toBeNull();
+    expect(parseSemVer("1.2.3-")).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// formatSemVer
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("formatSemVer", () => {
+  it("formats a stable version", () => {
+    expect(formatSemVer({ major: 2, minor: 1, patch: 0 })).toBe("2.1.0");
+  });
+
+  it("formats a pre-release version", () => {
+    expect(
+      formatSemVer({ major: 2, minor: 0, patch: 0, prerelease: "dev.6" }),
+    ).toBe("2.0.0-dev.6");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// bumpVersion
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("bumpVersion", () => {
+  describe("stable versions", () => {
+    it("bumps major", () => {
+      expect(bumpVersion("1.2.3", "major")).toBe("2.0.0");
+    });
+
+    it("bumps minor", () => {
+      expect(bumpVersion("1.2.3", "minor")).toBe("1.3.0");
+    });
+
+    it("bumps patch", () => {
+      expect(bumpVersion("1.2.3", "patch")).toBe("1.2.4");
+    });
+
+    it("returns null for prerelease bump on stable", () => {
+      expect(bumpVersion("1.2.3", "prerelease")).toBeNull();
+    });
+
+    it("returns null for release bump on stable", () => {
+      expect(bumpVersion("1.2.3", "release")).toBeNull();
+    });
+  });
+
+  describe("pre-release versions", () => {
+    it("increments dev counter", () => {
+      expect(bumpVersion("2.0.0-dev.6", "prerelease")).toBe("2.0.0-dev.7");
+    });
+
+    it("promotes to stable release", () => {
+      expect(bumpVersion("2.0.0-dev.6", "release")).toBe("2.0.0");
+    });
+
+    it("bumps major from pre-release", () => {
+      expect(bumpVersion("2.0.0-dev.6", "major")).toBe("3.0.0");
+    });
+
+    it("bumps minor from pre-release", () => {
+      expect(bumpVersion("2.0.0-dev.6", "minor")).toBe("2.1.0");
+    });
+
+    it("appends .1 to prerelease without numeric suffix", () => {
+      expect(bumpVersion("1.0.0-alpha", "prerelease")).toBe("1.0.0-alpha.1");
+    });
+
+    it("increments existing numeric suffix", () => {
+      expect(bumpVersion("1.0.0-alpha.3", "prerelease")).toBe("1.0.0-alpha.4");
+    });
+  });
+});

--- a/cli/lib/release/version.test.ts
+++ b/cli/lib/release/version.test.ts
@@ -108,5 +108,19 @@ describe("bumpVersion", () => {
     it("increments existing numeric suffix", () => {
       expect(bumpVersion("1.0.0-alpha.3", "prerelease")).toBe("1.0.0-alpha.4");
     });
+
+    it("appends .1 to non-numeric suffix segment", () => {
+      expect(bumpVersion("1.0.0-alpha.beta", "prerelease")).toBe("1.0.0-alpha.beta.1");
+    });
+  });
+
+  describe("invalid input", () => {
+    it("returns null for unparseable version", () => {
+      expect(bumpVersion("garbage", "major")).toBeNull();
+    });
+
+    it("returns null for incomplete version", () => {
+      expect(bumpVersion("1.2", "patch")).toBeNull();
+    });
   });
 });

--- a/content/hooks/instructions/post-merge.md
+++ b/content/hooks/instructions/post-merge.md
@@ -1,3 +1,5 @@
+**Note:** If you used `/release`, these steps were already handled by the skill. This checklist is for manual merges.
+
 # Pre-Merge Checklist
 
 Complete these steps on the feature branch before creating the PR.

--- a/content/skills/git-workflow/SKILL.md
+++ b/content/skills/git-workflow/SKILL.md
@@ -19,3 +19,4 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, pre-PR/pre-push/post-merge hooks |
+| Release ritual | `/release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |

--- a/content/skills/git-workflow/references/commits.md
+++ b/content/skills/git-workflow/references/commits.md
@@ -168,6 +168,7 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a concise summary of the branch's work (2-4 lines)
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
+- The `/release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
 
 ## Critical Rules
 

--- a/content/skills/implement/SKILL.md
+++ b/content/skills/implement/SKILL.md
@@ -188,7 +188,7 @@ After creating session AND plan files:
    - Update session file (status: complete, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After merge lands on main: switch to main, pull, delete merged branch.
+5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)

--- a/content/skills/release/SKILL.claude-code.yaml
+++ b/content/skills/release/SKILL.claude-code.yaml
@@ -1,0 +1,2 @@
+# Claude Code skill configuration
+argument-hint: "[PR number or URL]"

--- a/content/skills/release/SKILL.md
+++ b/content/skills/release/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: release
+description: >-
+  Orchestrates the full release ritual for squash-merging a feature branch:
+  pre-flight checks, documentation freshness review, housekeeping verification,
+  version bump and changelog via `loaf release` CLI, squash merge with clean
+  body, and post-merge cleanup. Use when the user says "release this", "merge
+  this PR", "ready to merge", or "ship it." Enforces correct ordering so the
+  squash commit on the target branch carries the new version. Not for creating
+  PRs (use implement) or strategic reflection (use reflect).
+---
+
+# Release
+
+Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+
+## Contents
+- Context Detection
+- Step 1: Pre-Flight Checks
+- Step 2: Documentation Freshness
+- Step 3: Housekeeping Verification
+- Step 4: Version Bump + Changelog
+- Step 5: Squash Merge
+- Step 6: Post-Merge Cleanup
+- Guardrails
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Context Detection
+
+Before anything, detect where we are:
+
+1. **Get current branch and repo default branch:**
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
+3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
+4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName
+   ```
+5. If no PR exists for this branch, STOP — suggest creating one first.
+6. **Save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
+7. Confirm the PR identity with the user before proceeding: show PR title, number, branch, and target base.
+
+---
+
+## Step 1: Pre-Flight Checks (BLOCKING)
+
+Run these and **BLOCK on any failure** — do not offer to skip.
+
+### Detect project type
+
+Inspect the repo to determine available checks:
+- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
+- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config
+- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
+- **Go** (`go.mod`): `go vet`, `go test`
+
+### Run checks
+
+Run whichever checks the project supports. Examples for a Node project:
+1. `npm run typecheck` (if the script exists)
+2. `npm run test` (if the script exists)
+3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
+
+For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
+
+**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
+
+On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
+
+---
+
+## Step 2: Documentation Freshness
+
+Check whether documentation is stale relative to the branch's changes:
+
+1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
+2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
+3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
+4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
+
+Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
+
+---
+
+## Step 3: Housekeeping Verification
+
+**Verify** that implementation housekeeping was done. Do NOT do it — that's the implement skill's job. Each check produces pass/fail:
+
+1. **Spec archived**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`.
+2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived.
+3. **CHANGELOG updated**: Verify `CHANGELOG.md` has entries under `[Unreleased]`.
+4. **Session file**: If a session file exists, check that its status reflects completion.
+
+On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`, `loaf spec archive`). The user decides. Do NOT silently fix or silently skip.
+
+---
+
+## Step 4: Version Bump + Changelog (on feature branch)
+
+This step uses the `loaf release` CLI for all mechanical versioning work.
+
+### Preview
+
+Run `loaf release --base <baseRefName> --dry-run` to show:
+- Current version and suggested bump type
+- Generated changelog section from **this branch's commits only** (not everything since the last tag)
+- Which version files will be updated
+
+The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered. Without it, `loaf release` uses the last git tag as the base, which would pull in unrelated already-merged commits.
+
+Present the preview to the user. They may:
+- Accept the suggested bump type
+- Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
+- Edit the changelog content (note: without `$EDITOR` set, editing happens conversationally)
+
+### Execute
+
+Once confirmed, run:
+```bash
+loaf release --base <baseRefName> --bump <type> --no-tag --no-gh
+```
+
+This will:
+1. Bump version in all detected files (package.json, pyproject.toml, etc.)
+2. Generate and insert changelog section from branch commits (preserving `[Unreleased]`)
+3. Run `loaf build` to rebuild all targets with new version
+4. Commit: `release: vX.Y.Z`
+
+After the commit, push to the feature branch (**with user confirmation**).
+
+### Why these flags?
+
+- `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
+- `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
+- `--no-gh` — GitHub release drafts belong to stable releases
+
+The `/release` skill bumps version so the squash commit carries it. Tagging happens later via `loaf release` (without these flags) when cutting a stable release.
+
+---
+
+## Step 5: Squash Merge
+
+1. **Draft a clean squash body**: Read the branch's commit history and PR description. Write a 2–4 sentence summary focusing on *what shipped and why* — not individual commits.
+2. **Present the draft** to the user for review. They may edit it.
+3. **Execute** (after user confirms):
+   ```bash
+   gh pr merge <N> --squash --body "$(cat <<'EOF'
+   <body>
+   EOF
+   )"
+   ```
+4. Let GitHub default the title (`PR title (#N)`).
+5. **NEVER** use `--auto` or the automatic squash description that dumps all commits.
+
+---
+
+## Step 6: Post-Merge Cleanup
+
+After successful merge:
+
+1. Switch to the base branch and pull:
+   ```bash
+   git checkout <baseRefName> && git pull --rebase
+   ```
+2. Delete the merged feature branch locally and remotely:
+   ```bash
+   git branch -d <branch>
+   git push origin --delete <branch>
+   ```
+3. **Suggest `/reflect`** if the session has extractable learnings:
+   - Check session file for `## Key Decisions` with content
+   - Check `traceability.decisions` for ADR entries
+   - If signal present: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."*
+   - If none: stay silent.
+
+---
+
+## Guardrails
+
+1. **BLOCK on pre-flight failure** — do not offer to skip
+2. **User confirms** every destructive action (version bump commit, push, merge, branch deletion)
+3. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
+4. **Clean squash body** — never use the auto-generated commit dump
+5. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
+6. **Detect-first** — auto-detect PR from branch before asking for a number
+7. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
+8. **Never push without confirmation** — even after successful version bump
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks. They remain as safety nets for manual merges:
+
+| Hook | When `/release` Runs |
+|------|---------------------|
+| `workflow-pre-merge` (prompt) | Fires on `gh pr merge`. Redundant — body already crafted. Harmless. |
+| `workflow-post-merge` (bash) | Fires after merge. Outputs checklist the skill already handled. Informational. |
+| `validate-push` (bash) | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
+
+Do not modify, disable, or skip these hooks.
+
+---
+
+## Related Skills
+
+- **implement** — Does the work and housekeeping; `/release` handles the merge afterward
+- **reflect** — Suggested post-merge if session has learnings
+- **git-workflow** — Conventions this skill enforces
+- **cleanup** — Handles artifact hygiene; `/release` verifies it was done

--- a/content/skills/release/SKILL.md
+++ b/content/skills/release/SKILL.md
@@ -106,40 +106,62 @@ On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`
 
 ## Step 4: Version Bump + Changelog (on feature branch)
 
-This step uses the `loaf release` CLI for all mechanical versioning work.
+This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
 
-### Preview
+### Check for existing changelog entries
 
-Run `loaf release --base <baseRefName> --dry-run` to show:
-- Current version and suggested bump type
-- Generated changelog section from **this branch's commits only** (not everything since the last tag)
-- Which version files will be updated
+Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
 
-The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered. Without it, `loaf release` uses the last git tag as the base, which would pull in unrelated already-merged commits.
+- **If curated entries exist** → Use the **Curated path** (preserve them)
+- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
 
-Present the preview to the user. They may:
-- Accept the suggested bump type
-- Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-- Edit the changelog content (note: without `$EDITOR` set, editing happens conversationally)
+### Curated path (preferred when entries exist)
 
-### Execute
+The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
 
-Once the user confirms, run:
-```bash
-loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
-```
+1. Run `loaf release --base <baseRefName> --dry-run` to get the **suggested bump type** and **current version**
+2. Present the bump suggestion to the user. They may accept or override.
+3. Once confirmed, perform the version bump manually:
+   - Bump version in `package.json` (or other version files)
+   - Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it)
+   - Add a fresh empty `## [Unreleased]` section above it
+   - Run the project's build command (e.g., `npm run build` or `loaf build`)
+   - Commit: `release: vX.Y.Z`
 
-This will:
-1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-2. Generate and insert changelog section from branch commits (preserving `[Unreleased]`)
-3. Run `loaf build` to rebuild all targets with new version
-4. Commit: `release: vX.Y.Z`
+### Generated path (when no entries exist)
 
-After the commit, push to the feature branch (**with user confirmation**).
+When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+
+1. Run `loaf release --base <baseRefName> --dry-run` to preview:
+   - Current version and suggested bump type
+   - Generated changelog section from **this branch's commits only**
+   - Which version files will be updated
+
+   The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered.
+
+2. Present the preview to the user. They may:
+   - Accept the suggested bump type
+   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
+   - Edit the changelog content conversationally
+
+3. Once the user confirms, run:
+   ```bash
+   loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
+   ```
+
+   This will:
+   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
+   2. Generate and insert changelog section from branch commits (adding fresh `[Unreleased]`)
+   3. Run `loaf build` to rebuild all targets with new version
+   4. Commit: `release: vX.Y.Z`
+
+### After either path
+
+Push to the feature branch (**with user confirmation**).
 
 ### Why these flags?
 
-- `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
+- `--base <baseRefName>` — Scopes changelog and bump suggestion to this PR's work, not everything since the last tag
 - `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
 - `--no-gh` — GitHub release drafts belong to stable releases
 - `--yes` — Skip the CLI confirmation prompt (the skill already confirmed with the user conversationally)

--- a/content/skills/release/SKILL.md
+++ b/content/skills/release/SKILL.md
@@ -211,12 +211,13 @@ After successful merge:
 
 1. **BLOCK on pre-flight failure** — do not offer to skip
 2. **User confirms** every destructive action (version bump commit, push, merge, branch deletion)
-3. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
-4. **Clean squash body** — never use the auto-generated commit dump
-5. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
-6. **Detect-first** — auto-detect PR from branch before asking for a number
-7. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
-8. **Never push without confirmation** — even after successful version bump
+3. **Use `AskUserQuestion` (or equivalent)** for all confirmation gates — push, merge, branch deletion. Provides structured choices instead of inline text questions. If not available, fall back to inline confirmation.
+4. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
+5. **Clean squash body** — never use the auto-generated commit dump
+6. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
+7. **Detect-first** — auto-detect PR from branch before asking for a number
+8. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
+9. **Never push without confirmation** — even after successful version bump
 
 ---
 

--- a/content/skills/release/SKILL.md
+++ b/content/skills/release/SKILL.md
@@ -97,7 +97,7 @@ Present findings to the user. They decide whether to fix now or note for later. 
 
 1. **Spec archived**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`.
 2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived.
-3. **CHANGELOG updated**: Verify `CHANGELOG.md` has entries under `[Unreleased]`.
+3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
 4. **Session file**: If a session file exists, check that its status reflects completion.
 
 On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`, `loaf spec archive`). The user decides. Do NOT silently fix or silently skip.
@@ -124,9 +124,9 @@ Present the preview to the user. They may:
 
 ### Execute
 
-Once confirmed, run:
+Once the user confirms, run:
 ```bash
-loaf release --base <baseRefName> --bump <type> --no-tag --no-gh
+loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
 ```
 
 This will:
@@ -142,6 +142,7 @@ After the commit, push to the feature branch (**with user confirmation**).
 - `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
 - `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
 - `--no-gh` — GitHub release drafts belong to stable releases
+- `--yes` — Skip the CLI confirmation prompt (the skill already confirmed with the user conversationally)
 
 The `/release` skill bumps version so the squash commit carries it. Tagging happens later via `loaf release` (without these flags) when cutting a stable release.
 

--- a/content/skills/ship/SKILL.claude-code.yaml
+++ b/content/skills/ship/SKILL.claude-code.yaml
@@ -1,0 +1,2 @@
+# Claude Code skill configuration — alias for /release
+argument-hint: "[PR number or URL]"

--- a/content/skills/ship/SKILL.md
+++ b/content/skills/ship/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: ship
+description: >-
+  Alias for /release. Orchestrates the full release ritual for squash-merging
+  a feature branch. Use when the user says "ship it", "let's ship", or "ship
+  this PR." See release skill for full documentation.
+---
+
+# Ship
+
+This is an alias for `/release`. Follow the release skill's full process.
+
+**Input:** $ARGUMENTS
+
+Load and execute the `/release` skill with the same arguments. All steps, guardrails, and conventions from the release skill apply.

--- a/dist/codex/skills/architecture/SKILL.md
+++ b/dist/codex/skills/architecture/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Use when making technical decisions or when the user asks "should we use X or
   Y?" Produces ADRs and updates to ARCHITECTURE.md. Not for strategic direction
   (use strategy) or multi-perspective deliberation (use council-session).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Architecture

--- a/dist/codex/skills/bootstrap/SKILL.md
+++ b/dist/codex/skills/bootstrap/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   shaping features into specs -- use /shape. Not for brainstorming ideas -- use
   /brainstorm. Not for mechanical scaffolding -- use `loaf setup` first, then
   /bootstrap.
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Bootstrap

--- a/dist/codex/skills/brainstorm/SKILL.md
+++ b/dist/codex/skills/brainstorm/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   documents with sparks (speculative byproducts) that can later be promoted to
   ideas via /idea. Not for capturing a single quick idea (use idea) or shaping
   into a bounded spec (use shape).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Brainstorm

--- a/dist/codex/skills/breakdown/SKILL.md
+++ b/dist/codex/skills/breakdown/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   the user asks "break this down" or "create tasks for this spec." Produces task
   files with estimates, dependencies, and acceptance criteria. Not for shaping
   ideas into specs (use shape) or implementing tasks (use implement).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Breakdown

--- a/dist/codex/skills/cleanup/SKILL.md
+++ b/dist/codex/skills/cleanup/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   recommendations, archives completed work, and ensures extracted knowledge is
   preserved. Not for reflecting on learnings (use reflect) or managing knowledge
   files (use knowledge-base).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Cleanup

--- a/dist/codex/skills/council-session/SKILL.md
+++ b/dist/codex/skills/council-session/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   research) or architectural decisions that don't need multi-agent deliberation
   (use architecture). Produces structured council reports with per-specialist
   analysis and synthesized recommendations.
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Council Deliberation Session

--- a/dist/codex/skills/database-design/SKILL.md
+++ b/dist/codex/skills/database-design/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   optimizing queries, or evaluating denormalization. Not for ORM usage in
   application code (use the relevant language skill) or infrastructure
   provisioning (use infrastructure-management).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Database Skill

--- a/dist/codex/skills/debugging/SKILL.md
+++ b/dist/codex/skills/debugging/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   during investigation, or fixing flaky or intermittent tests. Not for writing
   new tests (use foundations TDD reference) or security vulnerability analysis
   (use security-compliance).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Debugging

--- a/dist/codex/skills/documentation-standards/SKILL.md
+++ b/dist/codex/skills/documentation-standards/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   APIs, maintaining changelogs, reviewing documentation quality, or creating
   architectural diagrams. Not for code comments (use foundations) or README
   files (project-specific).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Documentation Standards

--- a/dist/codex/skills/foundations/SKILL.md
+++ b/dist/codex/skills/foundations/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   quality, running verification checks, or setting up review processes. Not for
   git workflow (use git-workflow), debugging (use debugging), security (use
   security-compliance), or documentation (use documentation-standards).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Code Standards

--- a/dist/codex/skills/git-workflow/SKILL.md
+++ b/dist/codex/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   merge workflow. Use when creating branches, writing commit messages, creating
   or merging pull requests, or managing git history. Not for code style (use
   foundations) or CI/CD pipelines (use infrastructure-management).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Git Workflow

--- a/dist/codex/skills/git-workflow/SKILL.md
+++ b/dist/codex/skills/git-workflow/SKILL.md
@@ -20,3 +20,4 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, pre-PR/pre-push/post-merge hooks |
+| Release ritual | `/release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |

--- a/dist/codex/skills/git-workflow/references/commits.md
+++ b/dist/codex/skills/git-workflow/references/commits.md
@@ -168,6 +168,7 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a concise summary of the branch's work (2-4 lines)
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
+- The `/release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
 
 ## Critical Rules
 

--- a/dist/codex/skills/go-development/SKILL.md
+++ b/dist/codex/skills/go-development/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   error handling, and testing. Use when writing Go services, CLIs, or libraries.
   Not for database schema design (use database-design) or infrastructure
   orchestration (use infrastructure-management).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Go Skill

--- a/dist/codex/skills/idea/SKILL.md
+++ b/dist/codex/skills/idea/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   brainstorm documents for unprocessed sparks to promote. Produces idea files
   with context and evaluation criteria. Not for deep exploration (use
   brainstorm) or shaping into specs (use shape).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Idea

--- a/dist/codex/skills/implement/SKILL.md
+++ b/dist/codex/skills/implement/SKILL.md
@@ -189,7 +189,7 @@ After creating session AND plan files:
    - Update session file (status: complete, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After merge lands on main: switch to main, pull, delete merged branch.
+5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)

--- a/dist/codex/skills/implement/SKILL.md
+++ b/dist/codex/skills/implement/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   execution. Use when the user asks "implement this" or "start working on
   TASK-XXX." Produces session files, plans, and coordinated agent output. Not
   for shaping work (use shape) or breaking down specs (use breakdown).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Implement

--- a/dist/codex/skills/infrastructure-management/SKILL.md
+++ b/dist/codex/skills/infrastructure-management/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   CI/CD, or managing deployment infrastructure. Not for application code (use
   the relevant language skill), database schema design (use database-design), or
   security audits (use security-compliance).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Infrastructure

--- a/dist/codex/skills/interface-design/SKILL.md
+++ b/dist/codex/skills/interface-design/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   decisions, evaluating layouts, or ensuring accessibility compliance. Not for
   writing frontend code (use typescript-development) or API design (use
   documentation-standards).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Design Principles

--- a/dist/codex/skills/knowledge-base/SKILL.md
+++ b/dist/codex/skills/knowledge-base/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   management conventions. Not for retrieval or search (use QMD directly). Not
   for architectural decisions (use ADRs). Not for agent instructions (use
   CLAUDE.md).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Knowledge Base

--- a/dist/codex/skills/orchestration/SKILL.md
+++ b/dist/codex/skills/orchestration/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   delegating to agents, or coordinating cross-cutting work. Produces session
   files and coordinated agent output. Not for single-task implementation (use
   implement) or research without delegation (use research).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # PM Orchestration

--- a/dist/codex/skills/power-systems-modeling/SKILL.md
+++ b/dist/codex/skills/power-systems-modeling/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   thermal calculations, validating conductor parameters, or working with sag and
   resistance formulas. Not for general infrastructure (use
   infrastructure-management) or application architecture (use architecture).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Power Systems Reference

--- a/dist/codex/skills/python-development/SKILL.md
+++ b/dist/codex/skills/python-development/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   data models, or tests. Not for database schema design (use database-design),
   infrastructure or deployment (use infrastructure-management), or frontend code
   (use typescript-development).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Python Development

--- a/dist/codex/skills/reference-session/SKILL.md
+++ b/dist/codex/skills/reference-session/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   context summary with key decisions and outcomes from referenced sessions. Not
   for resuming active work (use resume-session) or general research (use
   research).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Reference Session

--- a/dist/codex/skills/reflect/SKILL.md
+++ b/dist/codex/skills/reflect/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Produces updates to VISION.md, STRATEGY.md, and ARCHITECTURE.md based on
   proven implementation. Not for pre-implementation strategy (use strategy) or
   architecture decisions (use architecture).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Reflect

--- a/dist/codex/skills/release/SKILL.md
+++ b/dist/codex/skills/release/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: release
+description: >-
+  Orchestrates the full release ritual for squash-merging a feature branch:
+  pre-flight checks, documentation freshness review, housekeeping verification,
+  version bump and changelog via `loaf release` CLI, squash merge with clean
+  body, and post-merge cleanup. Use when the user says "release this", "merge
+  this PR", "ready to merge", or "ship it." Enforces correct ordering so the
+  squash commit on the target branch carries the new version. Not for creating
+  PRs (use implement) or strategic reflection (use reflect).
+version: 2.0.0-dev.6
+---
+
+# Release
+
+Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+
+## Contents
+- Context Detection
+- Step 1: Pre-Flight Checks
+- Step 2: Documentation Freshness
+- Step 3: Housekeeping Verification
+- Step 4: Version Bump + Changelog
+- Step 5: Squash Merge
+- Step 6: Post-Merge Cleanup
+- Guardrails
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Context Detection
+
+Before anything, detect where we are:
+
+1. **Get current branch and repo default branch:**
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
+3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
+4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName
+   ```
+5. If no PR exists for this branch, STOP — suggest creating one first.
+6. **Save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
+7. Confirm the PR identity with the user before proceeding: show PR title, number, branch, and target base.
+
+---
+
+## Step 1: Pre-Flight Checks (BLOCKING)
+
+Run these and **BLOCK on any failure** — do not offer to skip.
+
+### Detect project type
+
+Inspect the repo to determine available checks:
+- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
+- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config
+- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
+- **Go** (`go.mod`): `go vet`, `go test`
+
+### Run checks
+
+Run whichever checks the project supports. Examples for a Node project:
+1. `npm run typecheck` (if the script exists)
+2. `npm run test` (if the script exists)
+3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
+
+For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
+
+**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
+
+On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
+
+---
+
+## Step 2: Documentation Freshness
+
+Check whether documentation is stale relative to the branch's changes:
+
+1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
+2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
+3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
+4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
+
+Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
+
+---
+
+## Step 3: Housekeeping Verification
+
+**Verify** that implementation housekeeping was done. Do NOT do it — that's the implement skill's job. Each check produces pass/fail:
+
+1. **Spec archived**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`.
+2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived.
+3. **CHANGELOG updated**: Verify `CHANGELOG.md` has entries under `[Unreleased]`.
+4. **Session file**: If a session file exists, check that its status reflects completion.
+
+On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`, `loaf spec archive`). The user decides. Do NOT silently fix or silently skip.
+
+---
+
+## Step 4: Version Bump + Changelog (on feature branch)
+
+This step uses the `loaf release` CLI for all mechanical versioning work.
+
+### Preview
+
+Run `loaf release --base <baseRefName> --dry-run` to show:
+- Current version and suggested bump type
+- Generated changelog section from **this branch's commits only** (not everything since the last tag)
+- Which version files will be updated
+
+The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered. Without it, `loaf release` uses the last git tag as the base, which would pull in unrelated already-merged commits.
+
+Present the preview to the user. They may:
+- Accept the suggested bump type
+- Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
+- Edit the changelog content (note: without `$EDITOR` set, editing happens conversationally)
+
+### Execute
+
+Once confirmed, run:
+```bash
+loaf release --base <baseRefName> --bump <type> --no-tag --no-gh
+```
+
+This will:
+1. Bump version in all detected files (package.json, pyproject.toml, etc.)
+2. Generate and insert changelog section from branch commits (preserving `[Unreleased]`)
+3. Run `loaf build` to rebuild all targets with new version
+4. Commit: `release: vX.Y.Z`
+
+After the commit, push to the feature branch (**with user confirmation**).
+
+### Why these flags?
+
+- `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
+- `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
+- `--no-gh` — GitHub release drafts belong to stable releases
+
+The `/release` skill bumps version so the squash commit carries it. Tagging happens later via `loaf release` (without these flags) when cutting a stable release.
+
+---
+
+## Step 5: Squash Merge
+
+1. **Draft a clean squash body**: Read the branch's commit history and PR description. Write a 2–4 sentence summary focusing on *what shipped and why* — not individual commits.
+2. **Present the draft** to the user for review. They may edit it.
+3. **Execute** (after user confirms):
+   ```bash
+   gh pr merge <N> --squash --body "$(cat <<'EOF'
+   <body>
+   EOF
+   )"
+   ```
+4. Let GitHub default the title (`PR title (#N)`).
+5. **NEVER** use `--auto` or the automatic squash description that dumps all commits.
+
+---
+
+## Step 6: Post-Merge Cleanup
+
+After successful merge:
+
+1. Switch to the base branch and pull:
+   ```bash
+   git checkout <baseRefName> && git pull --rebase
+   ```
+2. Delete the merged feature branch locally and remotely:
+   ```bash
+   git branch -d <branch>
+   git push origin --delete <branch>
+   ```
+3. **Suggest `/reflect`** if the session has extractable learnings:
+   - Check session file for `## Key Decisions` with content
+   - Check `traceability.decisions` for ADR entries
+   - If signal present: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."*
+   - If none: stay silent.
+
+---
+
+## Guardrails
+
+1. **BLOCK on pre-flight failure** — do not offer to skip
+2. **User confirms** every destructive action (version bump commit, push, merge, branch deletion)
+3. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
+4. **Clean squash body** — never use the auto-generated commit dump
+5. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
+6. **Detect-first** — auto-detect PR from branch before asking for a number
+7. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
+8. **Never push without confirmation** — even after successful version bump
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks. They remain as safety nets for manual merges:
+
+| Hook | When `/release` Runs |
+|------|---------------------|
+| `workflow-pre-merge` (prompt) | Fires on `gh pr merge`. Redundant — body already crafted. Harmless. |
+| `workflow-post-merge` (bash) | Fires after merge. Outputs checklist the skill already handled. Informational. |
+| `validate-push` (bash) | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
+
+Do not modify, disable, or skip these hooks.
+
+---
+
+## Related Skills
+
+- **implement** — Does the work and housekeeping; `/release` handles the merge afterward
+- **reflect** — Suggested post-merge if session has learnings
+- **git-workflow** — Conventions this skill enforces
+- **cleanup** — Handles artifact hygiene; `/release` verifies it was done

--- a/dist/codex/skills/release/SKILL.md
+++ b/dist/codex/skills/release/SKILL.md
@@ -98,7 +98,7 @@ Present findings to the user. They decide whether to fix now or note for later. 
 
 1. **Spec archived**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`.
 2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived.
-3. **CHANGELOG updated**: Verify `CHANGELOG.md` has entries under `[Unreleased]`.
+3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
 4. **Session file**: If a session file exists, check that its status reflects completion.
 
 On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`, `loaf spec archive`). The user decides. Do NOT silently fix or silently skip.
@@ -125,9 +125,9 @@ Present the preview to the user. They may:
 
 ### Execute
 
-Once confirmed, run:
+Once the user confirms, run:
 ```bash
-loaf release --base <baseRefName> --bump <type> --no-tag --no-gh
+loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
 ```
 
 This will:
@@ -143,6 +143,7 @@ After the commit, push to the feature branch (**with user confirmation**).
 - `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
 - `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
 - `--no-gh` — GitHub release drafts belong to stable releases
+- `--yes` — Skip the CLI confirmation prompt (the skill already confirmed with the user conversationally)
 
 The `/release` skill bumps version so the squash commit carries it. Tagging happens later via `loaf release` (without these flags) when cutting a stable release.
 

--- a/dist/codex/skills/release/SKILL.md
+++ b/dist/codex/skills/release/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   this PR", "ready to merge", or "ship it." Enforces correct ordering so the
   squash commit on the target branch carries the new version. Not for creating
   PRs (use implement) or strategic reflection (use reflect).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Release
@@ -212,12 +212,13 @@ After successful merge:
 
 1. **BLOCK on pre-flight failure** — do not offer to skip
 2. **User confirms** every destructive action (version bump commit, push, merge, branch deletion)
-3. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
-4. **Clean squash body** — never use the auto-generated commit dump
-5. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
-6. **Detect-first** — auto-detect PR from branch before asking for a number
-7. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
-8. **Never push without confirmation** — even after successful version bump
+3. **Use `AskUserQuestion` (or equivalent)** for all confirmation gates — push, merge, branch deletion. Provides structured choices instead of inline text questions. If not available, fall back to inline confirmation.
+4. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
+5. **Clean squash body** — never use the auto-generated commit dump
+6. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
+7. **Detect-first** — auto-detect PR from branch before asking for a number
+8. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
+9. **Never push without confirmation** — even after successful version bump
 
 ---
 

--- a/dist/codex/skills/release/SKILL.md
+++ b/dist/codex/skills/release/SKILL.md
@@ -107,40 +107,62 @@ On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`
 
 ## Step 4: Version Bump + Changelog (on feature branch)
 
-This step uses the `loaf release` CLI for all mechanical versioning work.
+This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
 
-### Preview
+### Check for existing changelog entries
 
-Run `loaf release --base <baseRefName> --dry-run` to show:
-- Current version and suggested bump type
-- Generated changelog section from **this branch's commits only** (not everything since the last tag)
-- Which version files will be updated
+Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
 
-The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered. Without it, `loaf release` uses the last git tag as the base, which would pull in unrelated already-merged commits.
+- **If curated entries exist** → Use the **Curated path** (preserve them)
+- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
 
-Present the preview to the user. They may:
-- Accept the suggested bump type
-- Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-- Edit the changelog content (note: without `$EDITOR` set, editing happens conversationally)
+### Curated path (preferred when entries exist)
 
-### Execute
+The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
 
-Once the user confirms, run:
-```bash
-loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
-```
+1. Run `loaf release --base <baseRefName> --dry-run` to get the **suggested bump type** and **current version**
+2. Present the bump suggestion to the user. They may accept or override.
+3. Once confirmed, perform the version bump manually:
+   - Bump version in `package.json` (or other version files)
+   - Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it)
+   - Add a fresh empty `## [Unreleased]` section above it
+   - Run the project's build command (e.g., `npm run build` or `loaf build`)
+   - Commit: `release: vX.Y.Z`
 
-This will:
-1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-2. Generate and insert changelog section from branch commits (preserving `[Unreleased]`)
-3. Run `loaf build` to rebuild all targets with new version
-4. Commit: `release: vX.Y.Z`
+### Generated path (when no entries exist)
 
-After the commit, push to the feature branch (**with user confirmation**).
+When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+
+1. Run `loaf release --base <baseRefName> --dry-run` to preview:
+   - Current version and suggested bump type
+   - Generated changelog section from **this branch's commits only**
+   - Which version files will be updated
+
+   The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered.
+
+2. Present the preview to the user. They may:
+   - Accept the suggested bump type
+   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
+   - Edit the changelog content conversationally
+
+3. Once the user confirms, run:
+   ```bash
+   loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
+   ```
+
+   This will:
+   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
+   2. Generate and insert changelog section from branch commits (adding fresh `[Unreleased]`)
+   3. Run `loaf build` to rebuild all targets with new version
+   4. Commit: `release: vX.Y.Z`
+
+### After either path
+
+Push to the feature branch (**with user confirmation**).
 
 ### Why these flags?
 
-- `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
+- `--base <baseRefName>` — Scopes changelog and bump suggestion to this PR's work, not everything since the last tag
 - `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
 - `--no-gh` — GitHub release drafts belong to stable releases
 - `--yes` — Skip the CLI confirmation prompt (the skill already confirmed with the user conversationally)

--- a/dist/codex/skills/research/SKILL.md
+++ b/dist/codex/skills/research/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Produces state assessments, research findings with ranked options, or vision
   change proposals. Not for multi-agent deliberation (use council-session) or
   implementing changes (use implement).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Research

--- a/dist/codex/skills/resume-session/SKILL.md
+++ b/dist/codex/skills/resume-session/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   asks "resume that session" or "pick up where we left off." Produces an updated
   session file with synced state and next steps. Not for referencing past
   decisions (use reference-session) or starting new work (use implement).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Resume Session

--- a/dist/codex/skills/ruby-development/SKILL.md
+++ b/dist/codex/skills/ruby-development/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   following Rails-specific patterns. Not for database schema decisions (use
   database-design) or frontend-only work outside Hotwire (use
   typescript-development).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Ruby Development

--- a/dist/codex/skills/security-compliance/SKILL.md
+++ b/dist/codex/skills/security-compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   secrets or credentials, performing threat analysis, or running compliance
   audits. Not for debugging (use debugging) or general code review (use
   foundations).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Security & Compliance

--- a/dist/codex/skills/shape/SKILL.md
+++ b/dist/codex/skills/shape/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   definition to bound into a spec. Produces spec files with scope, acceptance
   criteria, and test conditions. Not for breaking specs into tasks (use
   breakdown) or brainstorming without constraints (use brainstorm).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Shape

--- a/dist/codex/skills/ship/SKILL.md
+++ b/dist/codex/skills/ship/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: ship
+description: >-
+  Alias for /release. Orchestrates the full release ritual for squash-merging a
+  feature branch. Use when the user says "ship it", "let's ship", or "ship this
+  PR." See release skill for full documentation.
+version: 2.0.0-dev.6
+---
+
+# Ship
+
+This is an alias for `/release`. Follow the release skill's full process.
+
+**Input:** $ARGUMENTS
+
+Load and execute the `/release` skill with the same arguments. All steps, guardrails, and conventions from the release skill apply.

--- a/dist/codex/skills/ship/SKILL.md
+++ b/dist/codex/skills/ship/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Alias for /release. Orchestrates the full release ritual for squash-merging a
   feature branch. Use when the user says "ship it", "let's ship", or "ship this
   PR." See release skill for full documentation.
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Ship

--- a/dist/codex/skills/strategy/SKILL.md
+++ b/dist/codex/skills/strategy/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   strategic direction." Produces or updates STRATEGY.md with personas, market
   landscape, and problem space. Not for technical architecture (use
   architecture) or reflecting on shipped work (use reflect).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Strategy

--- a/dist/codex/skills/typescript-development/SKILL.md
+++ b/dist/codex/skills/typescript-development/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   applications, React components, or Node.js services. Not for UI/UX design
   decisions (use interface-design), database schema design (use
   database-design), or backend Python services (use python-development).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # TypeScript Development

--- a/dist/cursor/agents/background-runner.md
+++ b/dist/cursor/agents/background-runner.md
@@ -167,4 +167,4 @@ Background Agent ID: bg-20260123-143000-auth-security
 4. Update `.agents/sessions/20260123-140000-auth-feature.md` frontmatter
 
 ---
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7

--- a/dist/cursor/agents/context-archiver.md
+++ b/dist/cursor/agents/context-archiver.md
@@ -191,4 +191,4 @@ Before completing:
 - [ ] Memory name follows convention: `session-<slug>-decisions.md`
 
 ---
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7

--- a/dist/cursor/agents/implementer.md
+++ b/dist/cursor/agents/implementer.md
@@ -37,4 +37,4 @@ Example: `Borin — auth API implementation`
 - Do not orchestrate other agents — that is the Warden's role.
 
 ---
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7

--- a/dist/cursor/agents/researcher.md
+++ b/dist/cursor/agents/researcher.md
@@ -34,4 +34,4 @@ Example: `Haldan — OAuth provider comparison`
 - Do not orchestrate other agents — that is the Warden's role.
 
 ---
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7

--- a/dist/cursor/agents/reviewer.md
+++ b/dist/cursor/agents/reviewer.md
@@ -34,4 +34,4 @@ Example: `Elendir — session refactor review`
 - Do not orchestrate other agents — that is the Warden's role.
 
 ---
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7

--- a/dist/cursor/hooks/instructions/post-merge.md
+++ b/dist/cursor/hooks/instructions/post-merge.md
@@ -1,3 +1,5 @@
+**Note:** If you used `/release`, these steps were already handled by the skill. This checklist is for manual merges.
+
 # Pre-Merge Checklist
 
 Complete these steps on the feature branch before creating the PR.

--- a/dist/cursor/skills/architecture/SKILL.md
+++ b/dist/cursor/skills/architecture/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Use when making technical decisions or when the user asks "should we use X or
   Y?" Produces ADRs and updates to ARCHITECTURE.md. Not for strategic direction
   (use strategy) or multi-perspective deliberation (use council-session).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Architecture

--- a/dist/cursor/skills/bootstrap/SKILL.md
+++ b/dist/cursor/skills/bootstrap/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   shaping features into specs -- use /shape. Not for brainstorming ideas -- use
   /brainstorm. Not for mechanical scaffolding -- use `loaf setup` first, then
   /bootstrap.
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Bootstrap

--- a/dist/cursor/skills/brainstorm/SKILL.md
+++ b/dist/cursor/skills/brainstorm/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   documents with sparks (speculative byproducts) that can later be promoted to
   ideas via /idea. Not for capturing a single quick idea (use idea) or shaping
   into a bounded spec (use shape).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Brainstorm

--- a/dist/cursor/skills/breakdown/SKILL.md
+++ b/dist/cursor/skills/breakdown/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   the user asks "break this down" or "create tasks for this spec." Produces task
   files with estimates, dependencies, and acceptance criteria. Not for shaping
   ideas into specs (use shape) or implementing tasks (use implement).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Breakdown

--- a/dist/cursor/skills/cleanup/SKILL.md
+++ b/dist/cursor/skills/cleanup/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   recommendations, archives completed work, and ensures extracted knowledge is
   preserved. Not for reflecting on learnings (use reflect) or managing knowledge
   files (use knowledge-base).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Cleanup

--- a/dist/cursor/skills/council-session/SKILL.md
+++ b/dist/cursor/skills/council-session/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   research) or architectural decisions that don't need multi-agent deliberation
   (use architecture). Produces structured council reports with per-specialist
   analysis and synthesized recommendations.
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Council Deliberation Session

--- a/dist/cursor/skills/database-design/SKILL.md
+++ b/dist/cursor/skills/database-design/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   optimizing queries, or evaluating denormalization. Not for ORM usage in
   application code (use the relevant language skill) or infrastructure
   provisioning (use infrastructure-management).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Database Skill

--- a/dist/cursor/skills/debugging/SKILL.md
+++ b/dist/cursor/skills/debugging/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   during investigation, or fixing flaky or intermittent tests. Not for writing
   new tests (use foundations TDD reference) or security vulnerability analysis
   (use security-compliance).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Debugging

--- a/dist/cursor/skills/documentation-standards/SKILL.md
+++ b/dist/cursor/skills/documentation-standards/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   APIs, maintaining changelogs, reviewing documentation quality, or creating
   architectural diagrams. Not for code comments (use foundations) or README
   files (project-specific).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Documentation Standards

--- a/dist/cursor/skills/foundations/SKILL.md
+++ b/dist/cursor/skills/foundations/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   quality, running verification checks, or setting up review processes. Not for
   git workflow (use git-workflow), debugging (use debugging), security (use
   security-compliance), or documentation (use documentation-standards).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Code Standards

--- a/dist/cursor/skills/git-workflow/SKILL.md
+++ b/dist/cursor/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   merge workflow. Use when creating branches, writing commit messages, creating
   or merging pull requests, or managing git history. Not for code style (use
   foundations) or CI/CD pipelines (use infrastructure-management).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Git Workflow

--- a/dist/cursor/skills/git-workflow/SKILL.md
+++ b/dist/cursor/skills/git-workflow/SKILL.md
@@ -20,3 +20,4 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, pre-PR/pre-push/post-merge hooks |
+| Release ritual | `/release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |

--- a/dist/cursor/skills/git-workflow/references/commits.md
+++ b/dist/cursor/skills/git-workflow/references/commits.md
@@ -168,6 +168,7 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a concise summary of the branch's work (2-4 lines)
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
+- The `/release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
 
 ## Critical Rules
 

--- a/dist/cursor/skills/go-development/SKILL.md
+++ b/dist/cursor/skills/go-development/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   error handling, and testing. Use when writing Go services, CLIs, or libraries.
   Not for database schema design (use database-design) or infrastructure
   orchestration (use infrastructure-management).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Go Skill

--- a/dist/cursor/skills/idea/SKILL.md
+++ b/dist/cursor/skills/idea/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   brainstorm documents for unprocessed sparks to promote. Produces idea files
   with context and evaluation criteria. Not for deep exploration (use
   brainstorm) or shaping into specs (use shape).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Idea

--- a/dist/cursor/skills/implement/SKILL.md
+++ b/dist/cursor/skills/implement/SKILL.md
@@ -189,7 +189,7 @@ After creating session AND plan files:
    - Update session file (status: complete, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After merge lands on main: switch to main, pull, delete merged branch.
+5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)

--- a/dist/cursor/skills/implement/SKILL.md
+++ b/dist/cursor/skills/implement/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   execution. Use when the user asks "implement this" or "start working on
   TASK-XXX." Produces session files, plans, and coordinated agent output. Not
   for shaping work (use shape) or breaking down specs (use breakdown).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Implement

--- a/dist/cursor/skills/infrastructure-management/SKILL.md
+++ b/dist/cursor/skills/infrastructure-management/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   CI/CD, or managing deployment infrastructure. Not for application code (use
   the relevant language skill), database schema design (use database-design), or
   security audits (use security-compliance).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Infrastructure

--- a/dist/cursor/skills/interface-design/SKILL.md
+++ b/dist/cursor/skills/interface-design/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   decisions, evaluating layouts, or ensuring accessibility compliance. Not for
   writing frontend code (use typescript-development) or API design (use
   documentation-standards).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Design Principles

--- a/dist/cursor/skills/knowledge-base/SKILL.md
+++ b/dist/cursor/skills/knowledge-base/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   management conventions. Not for retrieval or search (use QMD directly). Not
   for architectural decisions (use ADRs). Not for agent instructions (use
   CLAUDE.md).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Knowledge Base

--- a/dist/cursor/skills/orchestration/SKILL.md
+++ b/dist/cursor/skills/orchestration/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   delegating to agents, or coordinating cross-cutting work. Produces session
   files and coordinated agent output. Not for single-task implementation (use
   implement) or research without delegation (use research).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # PM Orchestration

--- a/dist/cursor/skills/power-systems-modeling/SKILL.md
+++ b/dist/cursor/skills/power-systems-modeling/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   thermal calculations, validating conductor parameters, or working with sag and
   resistance formulas. Not for general infrastructure (use
   infrastructure-management) or application architecture (use architecture).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Power Systems Reference

--- a/dist/cursor/skills/python-development/SKILL.md
+++ b/dist/cursor/skills/python-development/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   data models, or tests. Not for database schema design (use database-design),
   infrastructure or deployment (use infrastructure-management), or frontend code
   (use typescript-development).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Python Development

--- a/dist/cursor/skills/reference-session/SKILL.md
+++ b/dist/cursor/skills/reference-session/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   context summary with key decisions and outcomes from referenced sessions. Not
   for resuming active work (use resume-session) or general research (use
   research).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Reference Session

--- a/dist/cursor/skills/reflect/SKILL.md
+++ b/dist/cursor/skills/reflect/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Produces updates to VISION.md, STRATEGY.md, and ARCHITECTURE.md based on
   proven implementation. Not for pre-implementation strategy (use strategy) or
   architecture decisions (use architecture).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Reflect

--- a/dist/cursor/skills/release/SKILL.md
+++ b/dist/cursor/skills/release/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: release
+description: >-
+  Orchestrates the full release ritual for squash-merging a feature branch:
+  pre-flight checks, documentation freshness review, housekeeping verification,
+  version bump and changelog via `loaf release` CLI, squash merge with clean
+  body, and post-merge cleanup. Use when the user says "release this", "merge
+  this PR", "ready to merge", or "ship it." Enforces correct ordering so the
+  squash commit on the target branch carries the new version. Not for creating
+  PRs (use implement) or strategic reflection (use reflect).
+version: 2.0.0-dev.6
+---
+
+# Release
+
+Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+
+## Contents
+- Context Detection
+- Step 1: Pre-Flight Checks
+- Step 2: Documentation Freshness
+- Step 3: Housekeeping Verification
+- Step 4: Version Bump + Changelog
+- Step 5: Squash Merge
+- Step 6: Post-Merge Cleanup
+- Guardrails
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Context Detection
+
+Before anything, detect where we are:
+
+1. **Get current branch and repo default branch:**
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
+3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
+4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName
+   ```
+5. If no PR exists for this branch, STOP — suggest creating one first.
+6. **Save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
+7. Confirm the PR identity with the user before proceeding: show PR title, number, branch, and target base.
+
+---
+
+## Step 1: Pre-Flight Checks (BLOCKING)
+
+Run these and **BLOCK on any failure** — do not offer to skip.
+
+### Detect project type
+
+Inspect the repo to determine available checks:
+- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
+- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config
+- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
+- **Go** (`go.mod`): `go vet`, `go test`
+
+### Run checks
+
+Run whichever checks the project supports. Examples for a Node project:
+1. `npm run typecheck` (if the script exists)
+2. `npm run test` (if the script exists)
+3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
+
+For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
+
+**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
+
+On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
+
+---
+
+## Step 2: Documentation Freshness
+
+Check whether documentation is stale relative to the branch's changes:
+
+1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
+2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
+3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
+4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
+
+Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
+
+---
+
+## Step 3: Housekeeping Verification
+
+**Verify** that implementation housekeeping was done. Do NOT do it — that's the implement skill's job. Each check produces pass/fail:
+
+1. **Spec archived**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`.
+2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived.
+3. **CHANGELOG updated**: Verify `CHANGELOG.md` has entries under `[Unreleased]`.
+4. **Session file**: If a session file exists, check that its status reflects completion.
+
+On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`, `loaf spec archive`). The user decides. Do NOT silently fix or silently skip.
+
+---
+
+## Step 4: Version Bump + Changelog (on feature branch)
+
+This step uses the `loaf release` CLI for all mechanical versioning work.
+
+### Preview
+
+Run `loaf release --base <baseRefName> --dry-run` to show:
+- Current version and suggested bump type
+- Generated changelog section from **this branch's commits only** (not everything since the last tag)
+- Which version files will be updated
+
+The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered. Without it, `loaf release` uses the last git tag as the base, which would pull in unrelated already-merged commits.
+
+Present the preview to the user. They may:
+- Accept the suggested bump type
+- Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
+- Edit the changelog content (note: without `$EDITOR` set, editing happens conversationally)
+
+### Execute
+
+Once confirmed, run:
+```bash
+loaf release --base <baseRefName> --bump <type> --no-tag --no-gh
+```
+
+This will:
+1. Bump version in all detected files (package.json, pyproject.toml, etc.)
+2. Generate and insert changelog section from branch commits (preserving `[Unreleased]`)
+3. Run `loaf build` to rebuild all targets with new version
+4. Commit: `release: vX.Y.Z`
+
+After the commit, push to the feature branch (**with user confirmation**).
+
+### Why these flags?
+
+- `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
+- `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
+- `--no-gh` — GitHub release drafts belong to stable releases
+
+The `/release` skill bumps version so the squash commit carries it. Tagging happens later via `loaf release` (without these flags) when cutting a stable release.
+
+---
+
+## Step 5: Squash Merge
+
+1. **Draft a clean squash body**: Read the branch's commit history and PR description. Write a 2–4 sentence summary focusing on *what shipped and why* — not individual commits.
+2. **Present the draft** to the user for review. They may edit it.
+3. **Execute** (after user confirms):
+   ```bash
+   gh pr merge <N> --squash --body "$(cat <<'EOF'
+   <body>
+   EOF
+   )"
+   ```
+4. Let GitHub default the title (`PR title (#N)`).
+5. **NEVER** use `--auto` or the automatic squash description that dumps all commits.
+
+---
+
+## Step 6: Post-Merge Cleanup
+
+After successful merge:
+
+1. Switch to the base branch and pull:
+   ```bash
+   git checkout <baseRefName> && git pull --rebase
+   ```
+2. Delete the merged feature branch locally and remotely:
+   ```bash
+   git branch -d <branch>
+   git push origin --delete <branch>
+   ```
+3. **Suggest `/reflect`** if the session has extractable learnings:
+   - Check session file for `## Key Decisions` with content
+   - Check `traceability.decisions` for ADR entries
+   - If signal present: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."*
+   - If none: stay silent.
+
+---
+
+## Guardrails
+
+1. **BLOCK on pre-flight failure** — do not offer to skip
+2. **User confirms** every destructive action (version bump commit, push, merge, branch deletion)
+3. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
+4. **Clean squash body** — never use the auto-generated commit dump
+5. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
+6. **Detect-first** — auto-detect PR from branch before asking for a number
+7. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
+8. **Never push without confirmation** — even after successful version bump
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks. They remain as safety nets for manual merges:
+
+| Hook | When `/release` Runs |
+|------|---------------------|
+| `workflow-pre-merge` (prompt) | Fires on `gh pr merge`. Redundant — body already crafted. Harmless. |
+| `workflow-post-merge` (bash) | Fires after merge. Outputs checklist the skill already handled. Informational. |
+| `validate-push` (bash) | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
+
+Do not modify, disable, or skip these hooks.
+
+---
+
+## Related Skills
+
+- **implement** — Does the work and housekeeping; `/release` handles the merge afterward
+- **reflect** — Suggested post-merge if session has learnings
+- **git-workflow** — Conventions this skill enforces
+- **cleanup** — Handles artifact hygiene; `/release` verifies it was done

--- a/dist/cursor/skills/release/SKILL.md
+++ b/dist/cursor/skills/release/SKILL.md
@@ -98,7 +98,7 @@ Present findings to the user. They decide whether to fix now or note for later. 
 
 1. **Spec archived**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`.
 2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived.
-3. **CHANGELOG updated**: Verify `CHANGELOG.md` has entries under `[Unreleased]`.
+3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
 4. **Session file**: If a session file exists, check that its status reflects completion.
 
 On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`, `loaf spec archive`). The user decides. Do NOT silently fix or silently skip.
@@ -125,9 +125,9 @@ Present the preview to the user. They may:
 
 ### Execute
 
-Once confirmed, run:
+Once the user confirms, run:
 ```bash
-loaf release --base <baseRefName> --bump <type> --no-tag --no-gh
+loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
 ```
 
 This will:
@@ -143,6 +143,7 @@ After the commit, push to the feature branch (**with user confirmation**).
 - `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
 - `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
 - `--no-gh` — GitHub release drafts belong to stable releases
+- `--yes` — Skip the CLI confirmation prompt (the skill already confirmed with the user conversationally)
 
 The `/release` skill bumps version so the squash commit carries it. Tagging happens later via `loaf release` (without these flags) when cutting a stable release.
 

--- a/dist/cursor/skills/release/SKILL.md
+++ b/dist/cursor/skills/release/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   this PR", "ready to merge", or "ship it." Enforces correct ordering so the
   squash commit on the target branch carries the new version. Not for creating
   PRs (use implement) or strategic reflection (use reflect).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Release
@@ -212,12 +212,13 @@ After successful merge:
 
 1. **BLOCK on pre-flight failure** — do not offer to skip
 2. **User confirms** every destructive action (version bump commit, push, merge, branch deletion)
-3. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
-4. **Clean squash body** — never use the auto-generated commit dump
-5. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
-6. **Detect-first** — auto-detect PR from branch before asking for a number
-7. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
-8. **Never push without confirmation** — even after successful version bump
+3. **Use `AskUserQuestion` (or equivalent)** for all confirmation gates — push, merge, branch deletion. Provides structured choices instead of inline text questions. If not available, fall back to inline confirmation.
+4. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
+5. **Clean squash body** — never use the auto-generated commit dump
+6. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
+7. **Detect-first** — auto-detect PR from branch before asking for a number
+8. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
+9. **Never push without confirmation** — even after successful version bump
 
 ---
 

--- a/dist/cursor/skills/release/SKILL.md
+++ b/dist/cursor/skills/release/SKILL.md
@@ -107,40 +107,62 @@ On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`
 
 ## Step 4: Version Bump + Changelog (on feature branch)
 
-This step uses the `loaf release` CLI for all mechanical versioning work.
+This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
 
-### Preview
+### Check for existing changelog entries
 
-Run `loaf release --base <baseRefName> --dry-run` to show:
-- Current version and suggested bump type
-- Generated changelog section from **this branch's commits only** (not everything since the last tag)
-- Which version files will be updated
+Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
 
-The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered. Without it, `loaf release` uses the last git tag as the base, which would pull in unrelated already-merged commits.
+- **If curated entries exist** → Use the **Curated path** (preserve them)
+- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
 
-Present the preview to the user. They may:
-- Accept the suggested bump type
-- Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-- Edit the changelog content (note: without `$EDITOR` set, editing happens conversationally)
+### Curated path (preferred when entries exist)
 
-### Execute
+The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
 
-Once the user confirms, run:
-```bash
-loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
-```
+1. Run `loaf release --base <baseRefName> --dry-run` to get the **suggested bump type** and **current version**
+2. Present the bump suggestion to the user. They may accept or override.
+3. Once confirmed, perform the version bump manually:
+   - Bump version in `package.json` (or other version files)
+   - Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it)
+   - Add a fresh empty `## [Unreleased]` section above it
+   - Run the project's build command (e.g., `npm run build` or `loaf build`)
+   - Commit: `release: vX.Y.Z`
 
-This will:
-1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-2. Generate and insert changelog section from branch commits (preserving `[Unreleased]`)
-3. Run `loaf build` to rebuild all targets with new version
-4. Commit: `release: vX.Y.Z`
+### Generated path (when no entries exist)
 
-After the commit, push to the feature branch (**with user confirmation**).
+When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+
+1. Run `loaf release --base <baseRefName> --dry-run` to preview:
+   - Current version and suggested bump type
+   - Generated changelog section from **this branch's commits only**
+   - Which version files will be updated
+
+   The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered.
+
+2. Present the preview to the user. They may:
+   - Accept the suggested bump type
+   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
+   - Edit the changelog content conversationally
+
+3. Once the user confirms, run:
+   ```bash
+   loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
+   ```
+
+   This will:
+   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
+   2. Generate and insert changelog section from branch commits (adding fresh `[Unreleased]`)
+   3. Run `loaf build` to rebuild all targets with new version
+   4. Commit: `release: vX.Y.Z`
+
+### After either path
+
+Push to the feature branch (**with user confirmation**).
 
 ### Why these flags?
 
-- `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
+- `--base <baseRefName>` — Scopes changelog and bump suggestion to this PR's work, not everything since the last tag
 - `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
 - `--no-gh` — GitHub release drafts belong to stable releases
 - `--yes` — Skip the CLI confirmation prompt (the skill already confirmed with the user conversationally)

--- a/dist/cursor/skills/research/SKILL.md
+++ b/dist/cursor/skills/research/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Produces state assessments, research findings with ranked options, or vision
   change proposals. Not for multi-agent deliberation (use council-session) or
   implementing changes (use implement).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Research

--- a/dist/cursor/skills/resume-session/SKILL.md
+++ b/dist/cursor/skills/resume-session/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   asks "resume that session" or "pick up where we left off." Produces an updated
   session file with synced state and next steps. Not for referencing past
   decisions (use reference-session) or starting new work (use implement).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Resume Session

--- a/dist/cursor/skills/ruby-development/SKILL.md
+++ b/dist/cursor/skills/ruby-development/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   following Rails-specific patterns. Not for database schema decisions (use
   database-design) or frontend-only work outside Hotwire (use
   typescript-development).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Ruby Development

--- a/dist/cursor/skills/security-compliance/SKILL.md
+++ b/dist/cursor/skills/security-compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   secrets or credentials, performing threat analysis, or running compliance
   audits. Not for debugging (use debugging) or general code review (use
   foundations).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Security & Compliance

--- a/dist/cursor/skills/shape/SKILL.md
+++ b/dist/cursor/skills/shape/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   definition to bound into a spec. Produces spec files with scope, acceptance
   criteria, and test conditions. Not for breaking specs into tasks (use
   breakdown) or brainstorming without constraints (use brainstorm).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Shape

--- a/dist/cursor/skills/ship/SKILL.md
+++ b/dist/cursor/skills/ship/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: ship
+description: >-
+  Alias for /release. Orchestrates the full release ritual for squash-merging a
+  feature branch. Use when the user says "ship it", "let's ship", or "ship this
+  PR." See release skill for full documentation.
+version: 2.0.0-dev.6
+---
+
+# Ship
+
+This is an alias for `/release`. Follow the release skill's full process.
+
+**Input:** $ARGUMENTS
+
+Load and execute the `/release` skill with the same arguments. All steps, guardrails, and conventions from the release skill apply.

--- a/dist/cursor/skills/ship/SKILL.md
+++ b/dist/cursor/skills/ship/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Alias for /release. Orchestrates the full release ritual for squash-merging a
   feature branch. Use when the user says "ship it", "let's ship", or "ship this
   PR." See release skill for full documentation.
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Ship

--- a/dist/cursor/skills/strategy/SKILL.md
+++ b/dist/cursor/skills/strategy/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   strategic direction." Produces or updates STRATEGY.md with personas, market
   landscape, and problem space. Not for technical architecture (use
   architecture) or reflecting on shipped work (use reflect).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Strategy

--- a/dist/cursor/skills/typescript-development/SKILL.md
+++ b/dist/cursor/skills/typescript-development/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   applications, React components, or Node.js services. Not for UI/UX design
   decisions (use interface-design), database schema design (use
   database-design), or backend Python services (use python-development).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # TypeScript Development

--- a/dist/gemini/skills/architecture/SKILL.md
+++ b/dist/gemini/skills/architecture/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Use when making technical decisions or when the user asks "should we use X or
   Y?" Produces ADRs and updates to ARCHITECTURE.md. Not for strategic direction
   (use strategy) or multi-perspective deliberation (use council-session).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Architecture

--- a/dist/gemini/skills/bootstrap/SKILL.md
+++ b/dist/gemini/skills/bootstrap/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   shaping features into specs -- use /shape. Not for brainstorming ideas -- use
   /brainstorm. Not for mechanical scaffolding -- use `loaf setup` first, then
   /bootstrap.
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Bootstrap

--- a/dist/gemini/skills/brainstorm/SKILL.md
+++ b/dist/gemini/skills/brainstorm/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   documents with sparks (speculative byproducts) that can later be promoted to
   ideas via /idea. Not for capturing a single quick idea (use idea) or shaping
   into a bounded spec (use shape).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Brainstorm

--- a/dist/gemini/skills/breakdown/SKILL.md
+++ b/dist/gemini/skills/breakdown/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   the user asks "break this down" or "create tasks for this spec." Produces task
   files with estimates, dependencies, and acceptance criteria. Not for shaping
   ideas into specs (use shape) or implementing tasks (use implement).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Breakdown

--- a/dist/gemini/skills/cleanup/SKILL.md
+++ b/dist/gemini/skills/cleanup/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   recommendations, archives completed work, and ensures extracted knowledge is
   preserved. Not for reflecting on learnings (use reflect) or managing knowledge
   files (use knowledge-base).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Cleanup

--- a/dist/gemini/skills/council-session/SKILL.md
+++ b/dist/gemini/skills/council-session/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   research) or architectural decisions that don't need multi-agent deliberation
   (use architecture). Produces structured council reports with per-specialist
   analysis and synthesized recommendations.
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Council Deliberation Session

--- a/dist/gemini/skills/database-design/SKILL.md
+++ b/dist/gemini/skills/database-design/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   optimizing queries, or evaluating denormalization. Not for ORM usage in
   application code (use the relevant language skill) or infrastructure
   provisioning (use infrastructure-management).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Database Skill

--- a/dist/gemini/skills/debugging/SKILL.md
+++ b/dist/gemini/skills/debugging/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   during investigation, or fixing flaky or intermittent tests. Not for writing
   new tests (use foundations TDD reference) or security vulnerability analysis
   (use security-compliance).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Debugging

--- a/dist/gemini/skills/documentation-standards/SKILL.md
+++ b/dist/gemini/skills/documentation-standards/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   APIs, maintaining changelogs, reviewing documentation quality, or creating
   architectural diagrams. Not for code comments (use foundations) or README
   files (project-specific).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Documentation Standards

--- a/dist/gemini/skills/foundations/SKILL.md
+++ b/dist/gemini/skills/foundations/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   quality, running verification checks, or setting up review processes. Not for
   git workflow (use git-workflow), debugging (use debugging), security (use
   security-compliance), or documentation (use documentation-standards).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Code Standards

--- a/dist/gemini/skills/git-workflow/SKILL.md
+++ b/dist/gemini/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   merge workflow. Use when creating branches, writing commit messages, creating
   or merging pull requests, or managing git history. Not for code style (use
   foundations) or CI/CD pipelines (use infrastructure-management).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Git Workflow

--- a/dist/gemini/skills/git-workflow/SKILL.md
+++ b/dist/gemini/skills/git-workflow/SKILL.md
@@ -20,3 +20,4 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, pre-PR/pre-push/post-merge hooks |
+| Release ritual | `/release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |

--- a/dist/gemini/skills/git-workflow/references/commits.md
+++ b/dist/gemini/skills/git-workflow/references/commits.md
@@ -168,6 +168,7 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a concise summary of the branch's work (2-4 lines)
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
+- The `/release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
 
 ## Critical Rules
 

--- a/dist/gemini/skills/go-development/SKILL.md
+++ b/dist/gemini/skills/go-development/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   error handling, and testing. Use when writing Go services, CLIs, or libraries.
   Not for database schema design (use database-design) or infrastructure
   orchestration (use infrastructure-management).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Go Skill

--- a/dist/gemini/skills/idea/SKILL.md
+++ b/dist/gemini/skills/idea/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   brainstorm documents for unprocessed sparks to promote. Produces idea files
   with context and evaluation criteria. Not for deep exploration (use
   brainstorm) or shaping into specs (use shape).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Idea

--- a/dist/gemini/skills/implement/SKILL.md
+++ b/dist/gemini/skills/implement/SKILL.md
@@ -189,7 +189,7 @@ After creating session AND plan files:
    - Update session file (status: complete, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After merge lands on main: switch to main, pull, delete merged branch.
+5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)

--- a/dist/gemini/skills/implement/SKILL.md
+++ b/dist/gemini/skills/implement/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   execution. Use when the user asks "implement this" or "start working on
   TASK-XXX." Produces session files, plans, and coordinated agent output. Not
   for shaping work (use shape) or breaking down specs (use breakdown).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Implement

--- a/dist/gemini/skills/infrastructure-management/SKILL.md
+++ b/dist/gemini/skills/infrastructure-management/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   CI/CD, or managing deployment infrastructure. Not for application code (use
   the relevant language skill), database schema design (use database-design), or
   security audits (use security-compliance).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Infrastructure

--- a/dist/gemini/skills/interface-design/SKILL.md
+++ b/dist/gemini/skills/interface-design/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   decisions, evaluating layouts, or ensuring accessibility compliance. Not for
   writing frontend code (use typescript-development) or API design (use
   documentation-standards).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Design Principles

--- a/dist/gemini/skills/knowledge-base/SKILL.md
+++ b/dist/gemini/skills/knowledge-base/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   management conventions. Not for retrieval or search (use QMD directly). Not
   for architectural decisions (use ADRs). Not for agent instructions (use
   CLAUDE.md).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Knowledge Base

--- a/dist/gemini/skills/orchestration/SKILL.md
+++ b/dist/gemini/skills/orchestration/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   delegating to agents, or coordinating cross-cutting work. Produces session
   files and coordinated agent output. Not for single-task implementation (use
   implement) or research without delegation (use research).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # PM Orchestration

--- a/dist/gemini/skills/power-systems-modeling/SKILL.md
+++ b/dist/gemini/skills/power-systems-modeling/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   thermal calculations, validating conductor parameters, or working with sag and
   resistance formulas. Not for general infrastructure (use
   infrastructure-management) or application architecture (use architecture).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Power Systems Reference

--- a/dist/gemini/skills/python-development/SKILL.md
+++ b/dist/gemini/skills/python-development/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   data models, or tests. Not for database schema design (use database-design),
   infrastructure or deployment (use infrastructure-management), or frontend code
   (use typescript-development).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Python Development

--- a/dist/gemini/skills/reference-session/SKILL.md
+++ b/dist/gemini/skills/reference-session/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   context summary with key decisions and outcomes from referenced sessions. Not
   for resuming active work (use resume-session) or general research (use
   research).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Reference Session

--- a/dist/gemini/skills/reflect/SKILL.md
+++ b/dist/gemini/skills/reflect/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Produces updates to VISION.md, STRATEGY.md, and ARCHITECTURE.md based on
   proven implementation. Not for pre-implementation strategy (use strategy) or
   architecture decisions (use architecture).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Reflect

--- a/dist/gemini/skills/release/SKILL.md
+++ b/dist/gemini/skills/release/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: release
+description: >-
+  Orchestrates the full release ritual for squash-merging a feature branch:
+  pre-flight checks, documentation freshness review, housekeeping verification,
+  version bump and changelog via `loaf release` CLI, squash merge with clean
+  body, and post-merge cleanup. Use when the user says "release this", "merge
+  this PR", "ready to merge", or "ship it." Enforces correct ordering so the
+  squash commit on the target branch carries the new version. Not for creating
+  PRs (use implement) or strategic reflection (use reflect).
+version: 2.0.0-dev.6
+---
+
+# Release
+
+Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+
+## Contents
+- Context Detection
+- Step 1: Pre-Flight Checks
+- Step 2: Documentation Freshness
+- Step 3: Housekeeping Verification
+- Step 4: Version Bump + Changelog
+- Step 5: Squash Merge
+- Step 6: Post-Merge Cleanup
+- Guardrails
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Context Detection
+
+Before anything, detect where we are:
+
+1. **Get current branch and repo default branch:**
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
+3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
+4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName
+   ```
+5. If no PR exists for this branch, STOP — suggest creating one first.
+6. **Save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
+7. Confirm the PR identity with the user before proceeding: show PR title, number, branch, and target base.
+
+---
+
+## Step 1: Pre-Flight Checks (BLOCKING)
+
+Run these and **BLOCK on any failure** — do not offer to skip.
+
+### Detect project type
+
+Inspect the repo to determine available checks:
+- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
+- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config
+- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
+- **Go** (`go.mod`): `go vet`, `go test`
+
+### Run checks
+
+Run whichever checks the project supports. Examples for a Node project:
+1. `npm run typecheck` (if the script exists)
+2. `npm run test` (if the script exists)
+3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
+
+For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
+
+**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
+
+On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
+
+---
+
+## Step 2: Documentation Freshness
+
+Check whether documentation is stale relative to the branch's changes:
+
+1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
+2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
+3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
+4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
+
+Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
+
+---
+
+## Step 3: Housekeeping Verification
+
+**Verify** that implementation housekeeping was done. Do NOT do it — that's the implement skill's job. Each check produces pass/fail:
+
+1. **Spec archived**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`.
+2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived.
+3. **CHANGELOG updated**: Verify `CHANGELOG.md` has entries under `[Unreleased]`.
+4. **Session file**: If a session file exists, check that its status reflects completion.
+
+On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`, `loaf spec archive`). The user decides. Do NOT silently fix or silently skip.
+
+---
+
+## Step 4: Version Bump + Changelog (on feature branch)
+
+This step uses the `loaf release` CLI for all mechanical versioning work.
+
+### Preview
+
+Run `loaf release --base <baseRefName> --dry-run` to show:
+- Current version and suggested bump type
+- Generated changelog section from **this branch's commits only** (not everything since the last tag)
+- Which version files will be updated
+
+The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered. Without it, `loaf release` uses the last git tag as the base, which would pull in unrelated already-merged commits.
+
+Present the preview to the user. They may:
+- Accept the suggested bump type
+- Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
+- Edit the changelog content (note: without `$EDITOR` set, editing happens conversationally)
+
+### Execute
+
+Once confirmed, run:
+```bash
+loaf release --base <baseRefName> --bump <type> --no-tag --no-gh
+```
+
+This will:
+1. Bump version in all detected files (package.json, pyproject.toml, etc.)
+2. Generate and insert changelog section from branch commits (preserving `[Unreleased]`)
+3. Run `loaf build` to rebuild all targets with new version
+4. Commit: `release: vX.Y.Z`
+
+After the commit, push to the feature branch (**with user confirmation**).
+
+### Why these flags?
+
+- `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
+- `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
+- `--no-gh` — GitHub release drafts belong to stable releases
+
+The `/release` skill bumps version so the squash commit carries it. Tagging happens later via `loaf release` (without these flags) when cutting a stable release.
+
+---
+
+## Step 5: Squash Merge
+
+1. **Draft a clean squash body**: Read the branch's commit history and PR description. Write a 2–4 sentence summary focusing on *what shipped and why* — not individual commits.
+2. **Present the draft** to the user for review. They may edit it.
+3. **Execute** (after user confirms):
+   ```bash
+   gh pr merge <N> --squash --body "$(cat <<'EOF'
+   <body>
+   EOF
+   )"
+   ```
+4. Let GitHub default the title (`PR title (#N)`).
+5. **NEVER** use `--auto` or the automatic squash description that dumps all commits.
+
+---
+
+## Step 6: Post-Merge Cleanup
+
+After successful merge:
+
+1. Switch to the base branch and pull:
+   ```bash
+   git checkout <baseRefName> && git pull --rebase
+   ```
+2. Delete the merged feature branch locally and remotely:
+   ```bash
+   git branch -d <branch>
+   git push origin --delete <branch>
+   ```
+3. **Suggest `/reflect`** if the session has extractable learnings:
+   - Check session file for `## Key Decisions` with content
+   - Check `traceability.decisions` for ADR entries
+   - If signal present: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."*
+   - If none: stay silent.
+
+---
+
+## Guardrails
+
+1. **BLOCK on pre-flight failure** — do not offer to skip
+2. **User confirms** every destructive action (version bump commit, push, merge, branch deletion)
+3. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
+4. **Clean squash body** — never use the auto-generated commit dump
+5. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
+6. **Detect-first** — auto-detect PR from branch before asking for a number
+7. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
+8. **Never push without confirmation** — even after successful version bump
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks. They remain as safety nets for manual merges:
+
+| Hook | When `/release` Runs |
+|------|---------------------|
+| `workflow-pre-merge` (prompt) | Fires on `gh pr merge`. Redundant — body already crafted. Harmless. |
+| `workflow-post-merge` (bash) | Fires after merge. Outputs checklist the skill already handled. Informational. |
+| `validate-push` (bash) | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
+
+Do not modify, disable, or skip these hooks.
+
+---
+
+## Related Skills
+
+- **implement** — Does the work and housekeeping; `/release` handles the merge afterward
+- **reflect** — Suggested post-merge if session has learnings
+- **git-workflow** — Conventions this skill enforces
+- **cleanup** — Handles artifact hygiene; `/release` verifies it was done

--- a/dist/gemini/skills/release/SKILL.md
+++ b/dist/gemini/skills/release/SKILL.md
@@ -98,7 +98,7 @@ Present findings to the user. They decide whether to fix now or note for later. 
 
 1. **Spec archived**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`.
 2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived.
-3. **CHANGELOG updated**: Verify `CHANGELOG.md` has entries under `[Unreleased]`.
+3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
 4. **Session file**: If a session file exists, check that its status reflects completion.
 
 On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`, `loaf spec archive`). The user decides. Do NOT silently fix or silently skip.
@@ -125,9 +125,9 @@ Present the preview to the user. They may:
 
 ### Execute
 
-Once confirmed, run:
+Once the user confirms, run:
 ```bash
-loaf release --base <baseRefName> --bump <type> --no-tag --no-gh
+loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
 ```
 
 This will:
@@ -143,6 +143,7 @@ After the commit, push to the feature branch (**with user confirmation**).
 - `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
 - `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
 - `--no-gh` — GitHub release drafts belong to stable releases
+- `--yes` — Skip the CLI confirmation prompt (the skill already confirmed with the user conversationally)
 
 The `/release` skill bumps version so the squash commit carries it. Tagging happens later via `loaf release` (without these flags) when cutting a stable release.
 

--- a/dist/gemini/skills/release/SKILL.md
+++ b/dist/gemini/skills/release/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   this PR", "ready to merge", or "ship it." Enforces correct ordering so the
   squash commit on the target branch carries the new version. Not for creating
   PRs (use implement) or strategic reflection (use reflect).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Release
@@ -212,12 +212,13 @@ After successful merge:
 
 1. **BLOCK on pre-flight failure** — do not offer to skip
 2. **User confirms** every destructive action (version bump commit, push, merge, branch deletion)
-3. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
-4. **Clean squash body** — never use the auto-generated commit dump
-5. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
-6. **Detect-first** — auto-detect PR from branch before asking for a number
-7. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
-8. **Never push without confirmation** — even after successful version bump
+3. **Use `AskUserQuestion` (or equivalent)** for all confirmation gates — push, merge, branch deletion. Provides structured choices instead of inline text questions. If not available, fall back to inline confirmation.
+4. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
+5. **Clean squash body** — never use the auto-generated commit dump
+6. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
+7. **Detect-first** — auto-detect PR from branch before asking for a number
+8. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
+9. **Never push without confirmation** — even after successful version bump
 
 ---
 

--- a/dist/gemini/skills/release/SKILL.md
+++ b/dist/gemini/skills/release/SKILL.md
@@ -107,40 +107,62 @@ On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`
 
 ## Step 4: Version Bump + Changelog (on feature branch)
 
-This step uses the `loaf release` CLI for all mechanical versioning work.
+This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
 
-### Preview
+### Check for existing changelog entries
 
-Run `loaf release --base <baseRefName> --dry-run` to show:
-- Current version and suggested bump type
-- Generated changelog section from **this branch's commits only** (not everything since the last tag)
-- Which version files will be updated
+Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
 
-The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered. Without it, `loaf release` uses the last git tag as the base, which would pull in unrelated already-merged commits.
+- **If curated entries exist** → Use the **Curated path** (preserve them)
+- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
 
-Present the preview to the user. They may:
-- Accept the suggested bump type
-- Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-- Edit the changelog content (note: without `$EDITOR` set, editing happens conversationally)
+### Curated path (preferred when entries exist)
 
-### Execute
+The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
 
-Once the user confirms, run:
-```bash
-loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
-```
+1. Run `loaf release --base <baseRefName> --dry-run` to get the **suggested bump type** and **current version**
+2. Present the bump suggestion to the user. They may accept or override.
+3. Once confirmed, perform the version bump manually:
+   - Bump version in `package.json` (or other version files)
+   - Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it)
+   - Add a fresh empty `## [Unreleased]` section above it
+   - Run the project's build command (e.g., `npm run build` or `loaf build`)
+   - Commit: `release: vX.Y.Z`
 
-This will:
-1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-2. Generate and insert changelog section from branch commits (preserving `[Unreleased]`)
-3. Run `loaf build` to rebuild all targets with new version
-4. Commit: `release: vX.Y.Z`
+### Generated path (when no entries exist)
 
-After the commit, push to the feature branch (**with user confirmation**).
+When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+
+1. Run `loaf release --base <baseRefName> --dry-run` to preview:
+   - Current version and suggested bump type
+   - Generated changelog section from **this branch's commits only**
+   - Which version files will be updated
+
+   The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered.
+
+2. Present the preview to the user. They may:
+   - Accept the suggested bump type
+   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
+   - Edit the changelog content conversationally
+
+3. Once the user confirms, run:
+   ```bash
+   loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
+   ```
+
+   This will:
+   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
+   2. Generate and insert changelog section from branch commits (adding fresh `[Unreleased]`)
+   3. Run `loaf build` to rebuild all targets with new version
+   4. Commit: `release: vX.Y.Z`
+
+### After either path
+
+Push to the feature branch (**with user confirmation**).
 
 ### Why these flags?
 
-- `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
+- `--base <baseRefName>` — Scopes changelog and bump suggestion to this PR's work, not everything since the last tag
 - `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
 - `--no-gh` — GitHub release drafts belong to stable releases
 - `--yes` — Skip the CLI confirmation prompt (the skill already confirmed with the user conversationally)

--- a/dist/gemini/skills/research/SKILL.md
+++ b/dist/gemini/skills/research/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Produces state assessments, research findings with ranked options, or vision
   change proposals. Not for multi-agent deliberation (use council-session) or
   implementing changes (use implement).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Research

--- a/dist/gemini/skills/resume-session/SKILL.md
+++ b/dist/gemini/skills/resume-session/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   asks "resume that session" or "pick up where we left off." Produces an updated
   session file with synced state and next steps. Not for referencing past
   decisions (use reference-session) or starting new work (use implement).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Resume Session

--- a/dist/gemini/skills/ruby-development/SKILL.md
+++ b/dist/gemini/skills/ruby-development/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   following Rails-specific patterns. Not for database schema decisions (use
   database-design) or frontend-only work outside Hotwire (use
   typescript-development).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Ruby Development

--- a/dist/gemini/skills/security-compliance/SKILL.md
+++ b/dist/gemini/skills/security-compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   secrets or credentials, performing threat analysis, or running compliance
   audits. Not for debugging (use debugging) or general code review (use
   foundations).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Security & Compliance

--- a/dist/gemini/skills/shape/SKILL.md
+++ b/dist/gemini/skills/shape/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   definition to bound into a spec. Produces spec files with scope, acceptance
   criteria, and test conditions. Not for breaking specs into tasks (use
   breakdown) or brainstorming without constraints (use brainstorm).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Shape

--- a/dist/gemini/skills/ship/SKILL.md
+++ b/dist/gemini/skills/ship/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: ship
+description: >-
+  Alias for /release. Orchestrates the full release ritual for squash-merging a
+  feature branch. Use when the user says "ship it", "let's ship", or "ship this
+  PR." See release skill for full documentation.
+version: 2.0.0-dev.6
+---
+
+# Ship
+
+This is an alias for `/release`. Follow the release skill's full process.
+
+**Input:** $ARGUMENTS
+
+Load and execute the `/release` skill with the same arguments. All steps, guardrails, and conventions from the release skill apply.

--- a/dist/gemini/skills/ship/SKILL.md
+++ b/dist/gemini/skills/ship/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Alias for /release. Orchestrates the full release ritual for squash-merging a
   feature branch. Use when the user says "ship it", "let's ship", or "ship this
   PR." See release skill for full documentation.
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Ship

--- a/dist/gemini/skills/strategy/SKILL.md
+++ b/dist/gemini/skills/strategy/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   strategic direction." Produces or updates STRATEGY.md with personas, market
   landscape, and problem space. Not for technical architecture (use
   architecture) or reflecting on shipped work (use reflect).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Strategy

--- a/dist/gemini/skills/typescript-development/SKILL.md
+++ b/dist/gemini/skills/typescript-development/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   applications, React components, or Node.js services. Not for UI/UX design
   decisions (use interface-design), database schema design (use
   database-design), or backend Python services (use python-development).
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # TypeScript Development

--- a/dist/opencode/commands/architecture.md
+++ b/dist/opencode/commands/architecture.md
@@ -5,7 +5,7 @@ description: >-
   Y?" Produces ADRs and updates to ARCHITECTURE.md. Not for strategic direction
   (use strategy) or multi-perspective deliberation (use council-session).
 subtask: false
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Architecture

--- a/dist/opencode/commands/brainstorm.md
+++ b/dist/opencode/commands/brainstorm.md
@@ -8,7 +8,7 @@ description: >-
   ideas via /idea. Not for capturing a single quick idea (use idea) or shaping
   into a bounded spec (use shape).
 subtask: false
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Brainstorm

--- a/dist/opencode/commands/breakdown.md
+++ b/dist/opencode/commands/breakdown.md
@@ -5,7 +5,7 @@ description: >-
   files with estimates, dependencies, and acceptance criteria. Not for shaping
   ideas into specs (use shape) or implementing tasks (use implement).
 subtask: false
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Breakdown

--- a/dist/opencode/commands/cleanup.md
+++ b/dist/opencode/commands/cleanup.md
@@ -7,7 +7,7 @@ description: >-
   preserved. Not for reflecting on learnings (use reflect) or managing knowledge
   files (use knowledge-base).
 subtask: false
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Cleanup

--- a/dist/opencode/commands/council-session.md
+++ b/dist/opencode/commands/council-session.md
@@ -9,7 +9,7 @@ description: >-
   (use architecture). Produces structured council reports with per-specialist
   analysis and synthesized recommendations.
 subtask: false
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Council Deliberation Session

--- a/dist/opencode/commands/idea.md
+++ b/dist/opencode/commands/idea.md
@@ -7,7 +7,7 @@ description: >-
   with context and evaluation criteria. Not for deep exploration (use
   brainstorm) or shaping into specs (use shape).
 subtask: false
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Idea

--- a/dist/opencode/commands/implement.md
+++ b/dist/opencode/commands/implement.md
@@ -189,7 +189,7 @@ After creating session AND plan files:
    - Update session file (status: complete, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After merge lands on main: switch to main, pull, delete merged branch.
+5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)

--- a/dist/opencode/commands/implement.md
+++ b/dist/opencode/commands/implement.md
@@ -5,7 +5,7 @@ description: >-
   TASK-XXX." Produces session files, plans, and coordinated agent output. Not
   for shaping work (use shape) or breaking down specs (use breakdown).
 subtask: false
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Implement

--- a/dist/opencode/commands/reference-session.md
+++ b/dist/opencode/commands/reference-session.md
@@ -6,7 +6,7 @@ description: >-
   for resuming active work (use resume-session) or general research (use
   research).
 subtask: false
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Reference Session

--- a/dist/opencode/commands/reflect.md
+++ b/dist/opencode/commands/reflect.md
@@ -6,7 +6,7 @@ description: >-
   proven implementation. Not for pre-implementation strategy (use strategy) or
   architecture decisions (use architecture).
 subtask: false
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Reflect

--- a/dist/opencode/commands/research.md
+++ b/dist/opencode/commands/research.md
@@ -6,7 +6,7 @@ description: >-
   change proposals. Not for multi-agent deliberation (use council-session) or
   implementing changes (use implement).
 subtask: false
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Research

--- a/dist/opencode/commands/resume-session.md
+++ b/dist/opencode/commands/resume-session.md
@@ -5,7 +5,7 @@ description: >-
   session file with synced state and next steps. Not for referencing past
   decisions (use reference-session) or starting new work (use implement).
 subtask: false
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Resume Session

--- a/dist/opencode/commands/shape.md
+++ b/dist/opencode/commands/shape.md
@@ -7,7 +7,7 @@ description: >-
   criteria, and test conditions. Not for breaking specs into tasks (use
   breakdown) or brainstorming without constraints (use brainstorm).
 subtask: false
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Shape

--- a/dist/opencode/commands/strategy.md
+++ b/dist/opencode/commands/strategy.md
@@ -6,7 +6,7 @@ description: >-
   landscape, and problem space. Not for technical architecture (use
   architecture) or reflecting on shipped work (use reflect).
 subtask: false
-version: 2.0.0-dev.6
+version: 2.0.0-dev.7
 ---
 
 # Strategy

--- a/dist/opencode/plugins/hooks/instructions/post-merge.md
+++ b/dist/opencode/plugins/hooks/instructions/post-merge.md
@@ -1,3 +1,5 @@
+**Note:** If you used `/release`, these steps were already handled by the skill. This checklist is for manual merges.
+
 # Pre-Merge Checklist
 
 Complete these steps on the feature branch before creating the PR.

--- a/dist/opencode/skills/git-workflow/SKILL.md
+++ b/dist/opencode/skills/git-workflow/SKILL.md
@@ -19,3 +19,4 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, pre-PR/pre-push/post-merge hooks |
+| Release ritual | `/release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |

--- a/dist/opencode/skills/git-workflow/references/commits.md
+++ b/dist/opencode/skills/git-workflow/references/commits.md
@@ -168,6 +168,7 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a concise summary of the branch's work (2-4 lines)
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
+- The `/release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
 
 ## Critical Rules
 

--- a/dist/opencode/skills/implement/SKILL.md
+++ b/dist/opencode/skills/implement/SKILL.md
@@ -188,7 +188,7 @@ After creating session AND plan files:
    - Update session file (status: complete, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After merge lands on main: switch to main, pull, delete merged branch.
+5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)

--- a/dist/opencode/skills/release/SKILL.md
+++ b/dist/opencode/skills/release/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: release
+description: >-
+  Orchestrates the full release ritual for squash-merging a feature branch:
+  pre-flight checks, documentation freshness review, housekeeping verification,
+  version bump and changelog via `loaf release` CLI, squash merge with clean
+  body, and post-merge cleanup. Use when the user says "release this", "merge
+  this PR", "ready to merge", or "ship it." Enforces correct ordering so the
+  squash commit on the target branch carries the new version. Not for creating
+  PRs (use implement) or strategic reflection (use reflect).
+---
+
+# Release
+
+Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+
+## Contents
+- Context Detection
+- Step 1: Pre-Flight Checks
+- Step 2: Documentation Freshness
+- Step 3: Housekeeping Verification
+- Step 4: Version Bump + Changelog
+- Step 5: Squash Merge
+- Step 6: Post-Merge Cleanup
+- Guardrails
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Context Detection
+
+Before anything, detect where we are:
+
+1. **Get current branch and repo default branch:**
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
+3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
+4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName
+   ```
+5. If no PR exists for this branch, STOP — suggest creating one first.
+6. **Save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
+7. Confirm the PR identity with the user before proceeding: show PR title, number, branch, and target base.
+
+---
+
+## Step 1: Pre-Flight Checks (BLOCKING)
+
+Run these and **BLOCK on any failure** — do not offer to skip.
+
+### Detect project type
+
+Inspect the repo to determine available checks:
+- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
+- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config
+- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
+- **Go** (`go.mod`): `go vet`, `go test`
+
+### Run checks
+
+Run whichever checks the project supports. Examples for a Node project:
+1. `npm run typecheck` (if the script exists)
+2. `npm run test` (if the script exists)
+3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
+
+For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
+
+**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
+
+On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
+
+---
+
+## Step 2: Documentation Freshness
+
+Check whether documentation is stale relative to the branch's changes:
+
+1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
+2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
+3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
+4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
+
+Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
+
+---
+
+## Step 3: Housekeeping Verification
+
+**Verify** that implementation housekeeping was done. Do NOT do it — that's the implement skill's job. Each check produces pass/fail:
+
+1. **Spec archived**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`.
+2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived.
+3. **CHANGELOG updated**: Verify `CHANGELOG.md` has entries under `[Unreleased]`.
+4. **Session file**: If a session file exists, check that its status reflects completion.
+
+On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`, `loaf spec archive`). The user decides. Do NOT silently fix or silently skip.
+
+---
+
+## Step 4: Version Bump + Changelog (on feature branch)
+
+This step uses the `loaf release` CLI for all mechanical versioning work.
+
+### Preview
+
+Run `loaf release --base <baseRefName> --dry-run` to show:
+- Current version and suggested bump type
+- Generated changelog section from **this branch's commits only** (not everything since the last tag)
+- Which version files will be updated
+
+The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered. Without it, `loaf release` uses the last git tag as the base, which would pull in unrelated already-merged commits.
+
+Present the preview to the user. They may:
+- Accept the suggested bump type
+- Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
+- Edit the changelog content (note: without `$EDITOR` set, editing happens conversationally)
+
+### Execute
+
+Once confirmed, run:
+```bash
+loaf release --base <baseRefName> --bump <type> --no-tag --no-gh
+```
+
+This will:
+1. Bump version in all detected files (package.json, pyproject.toml, etc.)
+2. Generate and insert changelog section from branch commits (preserving `[Unreleased]`)
+3. Run `loaf build` to rebuild all targets with new version
+4. Commit: `release: vX.Y.Z`
+
+After the commit, push to the feature branch (**with user confirmation**).
+
+### Why these flags?
+
+- `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
+- `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
+- `--no-gh` — GitHub release drafts belong to stable releases
+
+The `/release` skill bumps version so the squash commit carries it. Tagging happens later via `loaf release` (without these flags) when cutting a stable release.
+
+---
+
+## Step 5: Squash Merge
+
+1. **Draft a clean squash body**: Read the branch's commit history and PR description. Write a 2–4 sentence summary focusing on *what shipped and why* — not individual commits.
+2. **Present the draft** to the user for review. They may edit it.
+3. **Execute** (after user confirms):
+   ```bash
+   gh pr merge <N> --squash --body "$(cat <<'EOF'
+   <body>
+   EOF
+   )"
+   ```
+4. Let GitHub default the title (`PR title (#N)`).
+5. **NEVER** use `--auto` or the automatic squash description that dumps all commits.
+
+---
+
+## Step 6: Post-Merge Cleanup
+
+After successful merge:
+
+1. Switch to the base branch and pull:
+   ```bash
+   git checkout <baseRefName> && git pull --rebase
+   ```
+2. Delete the merged feature branch locally and remotely:
+   ```bash
+   git branch -d <branch>
+   git push origin --delete <branch>
+   ```
+3. **Suggest `/reflect`** if the session has extractable learnings:
+   - Check session file for `## Key Decisions` with content
+   - Check `traceability.decisions` for ADR entries
+   - If signal present: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."*
+   - If none: stay silent.
+
+---
+
+## Guardrails
+
+1. **BLOCK on pre-flight failure** — do not offer to skip
+2. **User confirms** every destructive action (version bump commit, push, merge, branch deletion)
+3. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
+4. **Clean squash body** — never use the auto-generated commit dump
+5. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
+6. **Detect-first** — auto-detect PR from branch before asking for a number
+7. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
+8. **Never push without confirmation** — even after successful version bump
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks. They remain as safety nets for manual merges:
+
+| Hook | When `/release` Runs |
+|------|---------------------|
+| `workflow-pre-merge` (prompt) | Fires on `gh pr merge`. Redundant — body already crafted. Harmless. |
+| `workflow-post-merge` (bash) | Fires after merge. Outputs checklist the skill already handled. Informational. |
+| `validate-push` (bash) | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
+
+Do not modify, disable, or skip these hooks.
+
+---
+
+## Related Skills
+
+- **implement** — Does the work and housekeeping; `/release` handles the merge afterward
+- **reflect** — Suggested post-merge if session has learnings
+- **git-workflow** — Conventions this skill enforces
+- **cleanup** — Handles artifact hygiene; `/release` verifies it was done

--- a/dist/opencode/skills/release/SKILL.md
+++ b/dist/opencode/skills/release/SKILL.md
@@ -106,40 +106,62 @@ On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`
 
 ## Step 4: Version Bump + Changelog (on feature branch)
 
-This step uses the `loaf release` CLI for all mechanical versioning work.
+This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
 
-### Preview
+### Check for existing changelog entries
 
-Run `loaf release --base <baseRefName> --dry-run` to show:
-- Current version and suggested bump type
-- Generated changelog section from **this branch's commits only** (not everything since the last tag)
-- Which version files will be updated
+Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
 
-The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered. Without it, `loaf release` uses the last git tag as the base, which would pull in unrelated already-merged commits.
+- **If curated entries exist** → Use the **Curated path** (preserve them)
+- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
 
-Present the preview to the user. They may:
-- Accept the suggested bump type
-- Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-- Edit the changelog content (note: without `$EDITOR` set, editing happens conversationally)
+### Curated path (preferred when entries exist)
 
-### Execute
+The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
 
-Once the user confirms, run:
-```bash
-loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
-```
+1. Run `loaf release --base <baseRefName> --dry-run` to get the **suggested bump type** and **current version**
+2. Present the bump suggestion to the user. They may accept or override.
+3. Once confirmed, perform the version bump manually:
+   - Bump version in `package.json` (or other version files)
+   - Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it)
+   - Add a fresh empty `## [Unreleased]` section above it
+   - Run the project's build command (e.g., `npm run build` or `loaf build`)
+   - Commit: `release: vX.Y.Z`
 
-This will:
-1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-2. Generate and insert changelog section from branch commits (preserving `[Unreleased]`)
-3. Run `loaf build` to rebuild all targets with new version
-4. Commit: `release: vX.Y.Z`
+### Generated path (when no entries exist)
 
-After the commit, push to the feature branch (**with user confirmation**).
+When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+
+1. Run `loaf release --base <baseRefName> --dry-run` to preview:
+   - Current version and suggested bump type
+   - Generated changelog section from **this branch's commits only**
+   - Which version files will be updated
+
+   The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered.
+
+2. Present the preview to the user. They may:
+   - Accept the suggested bump type
+   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
+   - Edit the changelog content conversationally
+
+3. Once the user confirms, run:
+   ```bash
+   loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
+   ```
+
+   This will:
+   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
+   2. Generate and insert changelog section from branch commits (adding fresh `[Unreleased]`)
+   3. Run `loaf build` to rebuild all targets with new version
+   4. Commit: `release: vX.Y.Z`
+
+### After either path
+
+Push to the feature branch (**with user confirmation**).
 
 ### Why these flags?
 
-- `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
+- `--base <baseRefName>` — Scopes changelog and bump suggestion to this PR's work, not everything since the last tag
 - `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
 - `--no-gh` — GitHub release drafts belong to stable releases
 - `--yes` — Skip the CLI confirmation prompt (the skill already confirmed with the user conversationally)

--- a/dist/opencode/skills/release/SKILL.md
+++ b/dist/opencode/skills/release/SKILL.md
@@ -211,12 +211,13 @@ After successful merge:
 
 1. **BLOCK on pre-flight failure** — do not offer to skip
 2. **User confirms** every destructive action (version bump commit, push, merge, branch deletion)
-3. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
-4. **Clean squash body** — never use the auto-generated commit dump
-5. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
-6. **Detect-first** — auto-detect PR from branch before asking for a number
-7. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
-8. **Never push without confirmation** — even after successful version bump
+3. **Use `AskUserQuestion` (or equivalent)** for all confirmation gates — push, merge, branch deletion. Provides structured choices instead of inline text questions. If not available, fall back to inline confirmation.
+4. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
+5. **Clean squash body** — never use the auto-generated commit dump
+6. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
+7. **Detect-first** — auto-detect PR from branch before asking for a number
+8. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
+9. **Never push without confirmation** — even after successful version bump
 
 ---
 

--- a/dist/opencode/skills/release/SKILL.md
+++ b/dist/opencode/skills/release/SKILL.md
@@ -97,7 +97,7 @@ Present findings to the user. They decide whether to fix now or note for later. 
 
 1. **Spec archived**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`.
 2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived.
-3. **CHANGELOG updated**: Verify `CHANGELOG.md` has entries under `[Unreleased]`.
+3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
 4. **Session file**: If a session file exists, check that its status reflects completion.
 
 On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`, `loaf spec archive`). The user decides. Do NOT silently fix or silently skip.
@@ -124,9 +124,9 @@ Present the preview to the user. They may:
 
 ### Execute
 
-Once confirmed, run:
+Once the user confirms, run:
 ```bash
-loaf release --base <baseRefName> --bump <type> --no-tag --no-gh
+loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
 ```
 
 This will:
@@ -142,6 +142,7 @@ After the commit, push to the feature branch (**with user confirmation**).
 - `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
 - `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
 - `--no-gh` — GitHub release drafts belong to stable releases
+- `--yes` — Skip the CLI confirmation prompt (the skill already confirmed with the user conversationally)
 
 The `/release` skill bumps version so the squash commit carries it. Tagging happens later via `loaf release` (without these flags) when cutting a stable release.
 

--- a/dist/opencode/skills/ship/SKILL.md
+++ b/dist/opencode/skills/ship/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: ship
+description: >-
+  Alias for /release. Orchestrates the full release ritual for squash-merging a
+  feature branch. Use when the user says "ship it", "let's ship", or "ship this
+  PR." See release skill for full documentation.
+---
+
+# Ship
+
+This is an alias for `/release`. Follow the release skill's full process.
+
+**Input:** $ARGUMENTS
+
+Load and execute the `/release` skill with the same arguments. All steps, guardrails, and conventions from the release skill apply.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loaf",
-  "version": "2.0.0-dev.6",
+  "version": "2.0.0-dev.7",
   "description": "Loaf - An Opinionated Agentic Framework for Claude Code, OpenCode, Cursor, Codex, and Gemini",
   "type": "module",
   "bin": {

--- a/plugins/loaf/.claude-plugin/plugin.json
+++ b/plugins/loaf/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loaf",
-  "version": "2.0.0-dev.6",
+  "version": "2.0.0-dev.7",
   "description": "Loaf - An Opinionated Agentic Framework",
   "repository": "https://github.com/levifig/loaf",
   "license": "MIT",

--- a/plugins/loaf/hooks/instructions/post-merge.md
+++ b/plugins/loaf/hooks/instructions/post-merge.md
@@ -1,3 +1,5 @@
+**Note:** If you used `/release`, these steps were already handled by the skill. This checklist is for manual merges.
+
 # Pre-Merge Checklist
 
 Complete these steps on the feature branch before creating the PR.

--- a/plugins/loaf/skills/git-workflow/SKILL.md
+++ b/plugins/loaf/skills/git-workflow/SKILL.md
@@ -21,3 +21,4 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, pre-PR/pre-push/post-merge hooks |
+| Release ritual | `/loaf:release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |

--- a/plugins/loaf/skills/git-workflow/references/commits.md
+++ b/plugins/loaf/skills/git-workflow/references/commits.md
@@ -168,6 +168,7 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a concise summary of the branch's work (2-4 lines)
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
+- The `/loaf:release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
 
 ## Critical Rules
 

--- a/plugins/loaf/skills/implement/SKILL.md
+++ b/plugins/loaf/skills/implement/SKILL.md
@@ -189,7 +189,7 @@ After creating session AND plan files:
    - Update session file (status: complete, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After merge lands on main: switch to main, pull, delete merged branch.
+5. After PR is created and approved, use `/loaf:release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)

--- a/plugins/loaf/skills/release/SKILL.md
+++ b/plugins/loaf/skills/release/SKILL.md
@@ -107,40 +107,62 @@ On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`
 
 ## Step 4: Version Bump + Changelog (on feature branch)
 
-This step uses the `loaf release` CLI for all mechanical versioning work.
+This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
 
-### Preview
+### Check for existing changelog entries
 
-Run `loaf release --base <baseRefName> --dry-run` to show:
-- Current version and suggested bump type
-- Generated changelog section from **this branch's commits only** (not everything since the last tag)
-- Which version files will be updated
+Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
 
-The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered. Without it, `loaf release` uses the last git tag as the base, which would pull in unrelated already-merged commits.
+- **If curated entries exist** → Use the **Curated path** (preserve them)
+- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
 
-Present the preview to the user. They may:
-- Accept the suggested bump type
-- Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-- Edit the changelog content (note: without `$EDITOR` set, editing happens conversationally)
+### Curated path (preferred when entries exist)
 
-### Execute
+The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
 
-Once the user confirms, run:
-```bash
-loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
-```
+1. Run `loaf release --base <baseRefName> --dry-run` to get the **suggested bump type** and **current version**
+2. Present the bump suggestion to the user. They may accept or override.
+3. Once confirmed, perform the version bump manually:
+   - Bump version in `package.json` (or other version files)
+   - Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it)
+   - Add a fresh empty `## [Unreleased]` section above it
+   - Run the project's build command (e.g., `npm run build` or `loaf build`)
+   - Commit: `release: vX.Y.Z`
 
-This will:
-1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-2. Generate and insert changelog section from branch commits (preserving `[Unreleased]`)
-3. Run `loaf build` to rebuild all targets with new version
-4. Commit: `release: vX.Y.Z`
+### Generated path (when no entries exist)
 
-After the commit, push to the feature branch (**with user confirmation**).
+When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+
+1. Run `loaf release --base <baseRefName> --dry-run` to preview:
+   - Current version and suggested bump type
+   - Generated changelog section from **this branch's commits only**
+   - Which version files will be updated
+
+   The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered.
+
+2. Present the preview to the user. They may:
+   - Accept the suggested bump type
+   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
+   - Edit the changelog content conversationally
+
+3. Once the user confirms, run:
+   ```bash
+   loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
+   ```
+
+   This will:
+   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
+   2. Generate and insert changelog section from branch commits (adding fresh `[Unreleased]`)
+   3. Run `loaf build` to rebuild all targets with new version
+   4. Commit: `release: vX.Y.Z`
+
+### After either path
+
+Push to the feature branch (**with user confirmation**).
 
 ### Why these flags?
 
-- `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
+- `--base <baseRefName>` — Scopes changelog and bump suggestion to this PR's work, not everything since the last tag
 - `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
 - `--no-gh` — GitHub release drafts belong to stable releases
 - `--yes` — Skip the CLI confirmation prompt (the skill already confirmed with the user conversationally)

--- a/plugins/loaf/skills/release/SKILL.md
+++ b/plugins/loaf/skills/release/SKILL.md
@@ -212,12 +212,13 @@ After successful merge:
 
 1. **BLOCK on pre-flight failure** — do not offer to skip
 2. **User confirms** every destructive action (version bump commit, push, merge, branch deletion)
-3. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
-4. **Clean squash body** — never use the auto-generated commit dump
-5. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
-6. **Detect-first** — auto-detect PR from branch before asking for a number
-7. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
-8. **Never push without confirmation** — even after successful version bump
+3. **Use `AskUserQuestion` (or equivalent)** for all confirmation gates — push, merge, branch deletion. Provides structured choices instead of inline text questions. If not available, fall back to inline confirmation.
+4. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
+5. **Clean squash body** — never use the auto-generated commit dump
+6. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
+7. **Detect-first** — auto-detect PR from branch before asking for a number
+8. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
+9. **Never push without confirmation** — even after successful version bump
 
 ---
 

--- a/plugins/loaf/skills/release/SKILL.md
+++ b/plugins/loaf/skills/release/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: release
+description: >-
+  Orchestrates the full release ritual for squash-merging a feature branch:
+  pre-flight checks, documentation freshness review, housekeeping verification,
+  version bump and changelog via `loaf release` CLI, squash merge with clean
+  body, and post-merge cleanup. Use when the user says "release this", "merge
+  this PR", "ready to merge", or "ship it." Enforces correct ordering so the
+  squash commit on the target branch carries the new version. Not for creating
+  PRs (use implement) or strategic reflection (use reflect).
+argument-hint: '[PR number or URL]'
+---
+
+# Release
+
+Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+
+## Contents
+- Context Detection
+- Step 1: Pre-Flight Checks
+- Step 2: Documentation Freshness
+- Step 3: Housekeeping Verification
+- Step 4: Version Bump + Changelog
+- Step 5: Squash Merge
+- Step 6: Post-Merge Cleanup
+- Guardrails
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Context Detection
+
+Before anything, detect where we are:
+
+1. **Get current branch and repo default branch:**
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
+3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
+4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName
+   ```
+5. If no PR exists for this branch, STOP — suggest creating one first.
+6. **Save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
+7. Confirm the PR identity with the user before proceeding: show PR title, number, branch, and target base.
+
+---
+
+## Step 1: Pre-Flight Checks (BLOCKING)
+
+Run these and **BLOCK on any failure** — do not offer to skip.
+
+### Detect project type
+
+Inspect the repo to determine available checks:
+- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
+- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config
+- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
+- **Go** (`go.mod`): `go vet`, `go test`
+
+### Run checks
+
+Run whichever checks the project supports. Examples for a Node project:
+1. `npm run typecheck` (if the script exists)
+2. `npm run test` (if the script exists)
+3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
+
+For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
+
+**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
+
+On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
+
+---
+
+## Step 2: Documentation Freshness
+
+Check whether documentation is stale relative to the branch's changes:
+
+1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
+2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
+3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
+4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
+
+Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
+
+---
+
+## Step 3: Housekeeping Verification
+
+**Verify** that implementation housekeeping was done. Do NOT do it — that's the implement skill's job. Each check produces pass/fail:
+
+1. **Spec archived**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`.
+2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived.
+3. **CHANGELOG updated**: Verify `CHANGELOG.md` has entries under `[Unreleased]`.
+4. **Session file**: If a session file exists, check that its status reflects completion.
+
+On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`, `loaf spec archive`). The user decides. Do NOT silently fix or silently skip.
+
+---
+
+## Step 4: Version Bump + Changelog (on feature branch)
+
+This step uses the `loaf release` CLI for all mechanical versioning work.
+
+### Preview
+
+Run `loaf release --base <baseRefName> --dry-run` to show:
+- Current version and suggested bump type
+- Generated changelog section from **this branch's commits only** (not everything since the last tag)
+- Which version files will be updated
+
+The `--base` flag scopes the commit analysis to `<baseRefName>..HEAD`, so only commits on the feature branch are considered. Without it, `loaf release` uses the last git tag as the base, which would pull in unrelated already-merged commits.
+
+Present the preview to the user. They may:
+- Accept the suggested bump type
+- Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
+- Edit the changelog content (note: without `$EDITOR` set, editing happens conversationally)
+
+### Execute
+
+Once confirmed, run:
+```bash
+loaf release --base <baseRefName> --bump <type> --no-tag --no-gh
+```
+
+This will:
+1. Bump version in all detected files (package.json, pyproject.toml, etc.)
+2. Generate and insert changelog section from branch commits (preserving `[Unreleased]`)
+3. Run `loaf build` to rebuild all targets with new version
+4. Commit: `release: vX.Y.Z`
+
+After the commit, push to the feature branch (**with user confirmation**).
+
+### Why these flags?
+
+- `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
+- `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
+- `--no-gh` — GitHub release drafts belong to stable releases
+
+The `/loaf:release` skill bumps version so the squash commit carries it. Tagging happens later via `loaf release` (without these flags) when cutting a stable release.
+
+---
+
+## Step 5: Squash Merge
+
+1. **Draft a clean squash body**: Read the branch's commit history and PR description. Write a 2–4 sentence summary focusing on *what shipped and why* — not individual commits.
+2. **Present the draft** to the user for review. They may edit it.
+3. **Execute** (after user confirms):
+   ```bash
+   gh pr merge <N> --squash --body "$(cat <<'EOF'
+   <body>
+   EOF
+   )"
+   ```
+4. Let GitHub default the title (`PR title (#N)`).
+5. **NEVER** use `--auto` or the automatic squash description that dumps all commits.
+
+---
+
+## Step 6: Post-Merge Cleanup
+
+After successful merge:
+
+1. Switch to the base branch and pull:
+   ```bash
+   git checkout <baseRefName> && git pull --rebase
+   ```
+2. Delete the merged feature branch locally and remotely:
+   ```bash
+   git branch -d <branch>
+   git push origin --delete <branch>
+   ```
+3. **Suggest `/loaf:reflect`** if the session has extractable learnings:
+   - Check session file for `## Key Decisions` with content
+   - Check `traceability.decisions` for ADR entries
+   - If signal present: *"This session produced key decisions. Consider running `/loaf:reflect` to update strategic docs."*
+   - If none: stay silent.
+
+---
+
+## Guardrails
+
+1. **BLOCK on pre-flight failure** — do not offer to skip
+2. **User confirms** every destructive action (version bump commit, push, merge, branch deletion)
+3. **Version bump before merge** — this is the skill's reason for existing; never defer the bump to post-merge
+4. **Clean squash body** — never use the auto-generated commit dump
+5. **Verify, don't do** — housekeeping is the implementer's job; this skill verifies it was done
+6. **Detect-first** — auto-detect PR from branch before asking for a number
+7. **Abort gracefully** — if user cancels at any step, stop cleanly with no partial state
+8. **Never push without confirmation** — even after successful version bump
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks. They remain as safety nets for manual merges:
+
+| Hook | When `/loaf:release` Runs |
+|------|---------------------|
+| `workflow-pre-merge` (prompt) | Fires on `gh pr merge`. Redundant — body already crafted. Harmless. |
+| `workflow-post-merge` (bash) | Fires after merge. Outputs checklist the skill already handled. Informational. |
+| `validate-push` (bash) | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
+
+Do not modify, disable, or skip these hooks.
+
+---
+
+## Related Skills
+
+- **implement** — Does the work and housekeeping; `/loaf:release` handles the merge afterward
+- **reflect** — Suggested post-merge if session has learnings
+- **git-workflow** — Conventions this skill enforces
+- **cleanup** — Handles artifact hygiene; `/loaf:release` verifies it was done

--- a/plugins/loaf/skills/release/SKILL.md
+++ b/plugins/loaf/skills/release/SKILL.md
@@ -98,7 +98,7 @@ Present findings to the user. They decide whether to fix now or note for later. 
 
 1. **Spec archived**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`.
 2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived.
-3. **CHANGELOG updated**: Verify `CHANGELOG.md` has entries under `[Unreleased]`.
+3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
 4. **Session file**: If a session file exists, check that its status reflects completion.
 
 On gaps: present them to the user. Offer to fix (delegate to `loaf task archive`, `loaf spec archive`). The user decides. Do NOT silently fix or silently skip.
@@ -125,9 +125,9 @@ Present the preview to the user. They may:
 
 ### Execute
 
-Once confirmed, run:
+Once the user confirms, run:
 ```bash
-loaf release --base <baseRefName> --bump <type> --no-tag --no-gh
+loaf release --base <baseRefName> --bump <type> --no-tag --no-gh --yes
 ```
 
 This will:
@@ -143,6 +143,7 @@ After the commit, push to the feature branch (**with user confirmation**).
 - `--base <baseRefName>` — Scopes changelog to this PR's work, not everything since the last tag
 - `--no-tag` — Tags belong to stable releases, not pre-merge bumps (also implies `--no-gh`)
 - `--no-gh` — GitHub release drafts belong to stable releases
+- `--yes` — Skip the CLI confirmation prompt (the skill already confirmed with the user conversationally)
 
 The `/loaf:release` skill bumps version so the squash commit carries it. Tagging happens later via `loaf release` (without these flags) when cutting a stable release.
 

--- a/plugins/loaf/skills/ship/SKILL.md
+++ b/plugins/loaf/skills/ship/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: ship
+description: >-
+  Alias for /release. Orchestrates the full release ritual for squash-merging a
+  feature branch. Use when the user says "ship it", "let's ship", or "ship this
+  PR." See release skill for full documentation.
+argument-hint: '[PR number or URL]'
+---
+
+# Ship
+
+This is an alias for `/loaf:release`. Follow the release skill's full process.
+
+**Input:** $ARGUMENTS
+
+Load and execute the `/loaf:release` skill with the same arguments. All steps, guardrails, and conventions from the release skill apply.


### PR DESCRIPTION
## Summary
- New `/release` skill orchestrates the full squash merge ritual: pre-flight checks, documentation freshness review, housekeeping verification, version bump via `loaf release` CLI, squash merge with clean body, and post-merge cleanup
- CLI enhancements to `loaf release`: `--bump <type>`, `--base <ref>`, `--no-tag` (implies `--no-gh`) for non-interactive use from the skill
- Option logic extracted to `cli/lib/release/options.ts` with full test coverage (helper + command-level integration tests)
- Fixes missing `[Unreleased]` section in CHANGELOG.md
- Cross-references updated in implement, git-workflow, and post-merge instructions

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (345 tests across 19 files, including 7 new release test files)
- [x] `npx loaf build` succeeds across all 5 targets
- [x] `loaf release --base main --bump prerelease --no-tag --no-gh --dry-run` shows branch-scoped changelog
- [x] `loaf release --bump bogus` rejects with error
- [x] `loaf release --base fake-ref` rejects with error
- [x] `--no-tag` shows both tag and gh as skipped
- [x] `/loaf:release` appears in built skill output with merged sidecar