### PR TITLE
chore: sync lockfile to dev.30 and ignore Stakpak session files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ npm-debug.log*
 yarn.lock
 pnpm-lock.yaml
 bun.lockb
+
+# Stakpak session files
+.stakpak/session*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loaf",
-  "version": "2.0.0-dev.25",
+  "version": "2.0.0-dev.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loaf",
-      "version": "2.0.0-dev.25",
+      "version": "2.0.0-dev.30",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
@@ -21,7 +21,6 @@
         "@types/node": "^25.5.0",
         "@types/picomatch": "^4.0.2",
         "tsup": "^8.5.1",
-        "tsx": "^4.19.3",
         "typescript": "^5.9.3",
         "vitest": "^4.1.0"
       },
@@ -1714,19 +1713,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.7",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/gray-matter": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
@@ -2312,16 +2298,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
@@ -2643,26 +2619,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typescript": {


### PR DESCRIPTION
## Summary

Two small housekeeping items split out of PR #36 (bootstrap) per Codex review:

1. **Lockfile sync.** `package.json` is `2.0.0-dev.30` but `package-lock.json` referenced `2.0.0-dev.25` and still listed `tsx` in devDeps even though `package.json` had removed it. Regenerated via `npm install` to bring them back in line.
2. **Stakpak gitignore.** Adds `.stakpak/session*` to `.gitignore` so per-session state files from the Stakpak CLI tool aren't accidentally committed.

## Test plan

- [x] `git diff --stat main` shows only `package-lock.json` and `.gitignore`
- [x] No retained-package version bumps in the lockfile (only the version reference + tsx + tsx transitives removed)
- [x] `npm run typecheck` clean