### PR TITLE
chore: reconcile SQLite shaping artifacts

### DIFF
--- a/.agents/ideas/20260522-101624-sqlite-backed-operational-state.md
+++ b/.agents/ideas/20260522-101624-sqlite-backed-operational-state.md
@@ -1,11 +1,13 @@
 ---
 title: SQLite-backed operational state for Loaf
 captured: 2026-05-22T10:16:24Z
-status: raw
+status: absorbed
+absorbed_by: SPEC-040
 tags: [sqlite, state, tasks, ideas, sessions, triage, architecture]
 related:
   - 20260325-012120-task-staleness-prevention.md
   - 20260315-014055-loaf-interactive-harness.md
+  - SPEC-040
 ---
 
 # SQLite-backed operational state for Loaf

--- a/.agents/ideas/20260522-101625-loaf-cli-tui-state-workbench.md
+++ b/.agents/ideas/20260522-101625-loaf-cli-tui-state-workbench.md
@@ -1,11 +1,13 @@
 ---
 title: Loaf CLI/TUI as the primary state workbench
 captured: 2026-05-22T10:16:25Z
-status: raw
+status: absorbed
+absorbed_by: SPEC-040
 tags: [cli, tui, state, workflow, interface]
 related:
   - 20260315-014055-loaf-interactive-harness.md
   - 20260522-101624-sqlite-backed-operational-state.md
+  - SPEC-040
 ---
 
 # Loaf CLI/TUI as the primary state workbench

--- a/.agents/ideas/20260522-101626-generated-markdown-review-exports.md
+++ b/.agents/ideas/20260522-101626-generated-markdown-review-exports.md
@@ -1,11 +1,13 @@
 ---
 title: Generated Markdown exports for Git and review
 captured: 2026-05-22T10:16:26Z
-status: raw
+status: absorbed
+absorbed_by: SPEC-040
 tags: [reports, markdown, git, review, export]
 related:
   - 20260522-101624-sqlite-backed-operational-state.md
   - 20260522-101625-loaf-cli-tui-state-workbench.md
+  - SPEC-040
 ---
 
 # Generated Markdown exports for Git and review

--- a/.agents/ideas/20260522-101627-structured-session-transcripts-and-reports.md
+++ b/.agents/ideas/20260522-101627-structured-session-transcripts-and-reports.md
@@ -1,11 +1,13 @@
 ---
 title: Structured session transcripts and generated reports
 captured: 2026-05-22T10:16:27Z
-status: raw
+status: absorbed
+absorbed_by: SPEC-040
 tags: [sessions, transcripts, audit, reports, provenance]
 related:
   - 20260522-101624-sqlite-backed-operational-state.md
   - 20260522-101626-generated-markdown-review-exports.md
+  - SPEC-040
 ---
 
 # Structured session transcripts and generated reports

--- a/.agents/ideas/20260522-101628-triage-resolution-graph.md
+++ b/.agents/ideas/20260522-101628-triage-resolution-graph.md
@@ -1,11 +1,13 @@
 ---
 title: Triage resolution graph for sparks, ideas, tasks, and specs
 captured: 2026-05-22T10:16:28Z
-status: raw
+status: absorbed
+absorbed_by: SPEC-040
 tags: [triage, sparks, ideas, tasks, graph, closure]
 related:
   - 20260522-101624-sqlite-backed-operational-state.md
   - 20260411-003000-auto-scaffold-spark-ideas.md
+  - SPEC-040
 ---
 
 # Triage resolution graph for sparks, ideas, tasks, and specs

--- a/.agents/sessions/20260529-011134-session.md
+++ b/.agents/sessions/20260529-011134-session.md
@@ -1,0 +1,35 @@
+---
+branch: cwt/brave-joliot-4dc5b3
+status: stopped
+created: '2026-05-29T00:11:34.215Z'
+last_entry: '2026-05-29T18:50:27.289Z'
+claude_session_id: dc62d641-c241-4bec-99fa-4dcdeed61844
+last_updated: '2026-05-29T18:50:27.289Z'
+---
+# Session: Ad-hoc
+
+## Journal
+
+[2026-05-29 01:11] session(start):  === SESSION STARTED === (session dc62d641)
+[2026-05-29 13:41] session(end): at commit 503f1f18
+[2026-05-29 13:41] session(stop):   === SESSION STOPPED ===
+
+[2026-05-29 16:02] session(resume): === SESSION RESUMED === (session dc62d641)
+[2026-05-29 16:02] session(context): from commit 503f1f18
+[2026-05-29 16:13] session(end): at commit 503f1f18
+[2026-05-29 16:13] session(stop):   === SESSION STOPPED ===
+
+[2026-05-29 16:40] session(resume): === SESSION RESUMED === (session dc62d641)
+[2026-05-29 16:40] session(context): from commit 503f1f18
+[2026-05-29 17:20] session(end): at commit 503f1f18
+[2026-05-29 17:20] session(stop):   === SESSION STOPPED ===
+
+[2026-05-29 18:10] session(resume): === SESSION RESUMED === (session dc62d641)
+[2026-05-29 18:10] session(context): from commit 503f1f18
+[2026-05-29 18:39] session(end): at commit 503f1f18
+[2026-05-29 18:39] session(stop):   === SESSION STOPPED ===
+
+[2026-05-29 19:35] session(resume): === SESSION RESUMED === (session dc62d641)
+[2026-05-29 19:35] session(context): from commit 503f1f18
+[2026-05-29 19:50] session(end): at commit 503f1f18
+[2026-05-29 19:50] session(stop):   === SESSION STOPPED ===


### PR DESCRIPTION
## Summary
- mark five SPEC-040 shaping ideas as absorbed by SPEC-040 in Markdown compatibility metadata
- preserve the worktree-only cwt/brave-joliot session before removing its redundant worktree
- keep the cleanup small after rescuing all worktree .agents trees under ~/.local/state/loaf/rescue/worktree-agents-20260531-012936

## Verification
- git diff --check
- bin/loaf idea resolve <five shaping ideas> --by SPEC-040
- bin/loaf state migrate markdown --apply

Note: `bin/loaf state migrate markdown --apply --resume` was rejected because those flags are mutually exclusive; reran with `--apply` only.