### PR TITLE
docs: add Loaf restructuring spec program

### DIFF
--- a/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md
+++ b/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md
@@ -1,0 +1,332 @@
+---
+title: "Roadmap: Loaf Holistic Restructuring"
+type: roadmap
+created: 2026-06-21T02:03:42Z
+status: draft
+source: report-loaf-skill-suite-deep-evaluation
+tags:
+  - roadmap
+  - skills
+  - harness
+  - targets
+  - sqlite-cli-ux
+  - install
+  - routing-eval
+---
+
+# Roadmap: Loaf Holistic Restructuring
+
+A program-level plan that fuses the deep skill-suite evaluation
+(`report-loaf-skill-suite-deep-evaluation`, 2026-06-21) with the structural decisions taken in
+this session. It defines the **target architecture**, decomposes the work into **seven
+workstreams** (each becomes a spec via `/shape`), sequences them with dependencies, and isolates
+the **breaking-change/migration gate**.
+
+The governing insight from the evaluation: *the taxonomy is healthy — the diseases are a
+half-shipped SQLite migration, a build that validates nothing, and duplicated reference mass.*
+The structural decisions below add a deliberate **target-surface simplification** and a
+**SQLite CLI-UX investment** on top of finishing that migration.
+
+---
+
+## 1. Target architecture (the end state)
+
+### Harness targets: 6 → 5, simplified
+| Target | Before | After | Change |
+|--------|--------|-------|--------|
+| claude-code | plugin (`plugins/loaf/`) | plugin | unchanged (the one exception to `~/.agents/`) |
+| cursor | skills + agents + hooks | skills + agents + hooks | install dir → `~/.agents/` where supported |
+| codex | skills + hooks.json | skills + hooks.json | install dir → `~/.agents/`; codex hook semantics fixed |
+| opencode | skills + commands + hooks.ts | skills + commands + hooks.ts | install dir → `~/.agents/`; command coverage fixed |
+| **amp** | broken `loaf.js` plugin + skills | **fixed TS plugin + skills** | **first-class**: rewrite the plugin as valid TypeScript at Amp's real path (`.amp/plugins/` or `~/.config/amp/plugins/`) using the stable event API |
+| **gemini** | skills | **removed** | **dropped entirely** |
+
+### Harness tiers & the parity contract
+Parity across the harnesses is a first-class architectural goal, not a nice-to-have.
+
+| Tier | Harnesses | Expectation |
+|------|-----------|-------------|
+| **First-class (full parity)** | **Claude Code, Codex, Cursor, OpenCode, Amp** | Every user-invocable skill is reachable; hooks/enforcement work via each harness's hook surface; advisory hooks stay advisory; no harness-specific language leaks; behavior is equivalent within each harness's native idioms. |
+| **Removed** | Gemini | — |
+
+**Parity = equivalent capability via each harness's native idiom — NOT identical artifacts.**
+Skills are reached differently per harness, and that is correct: Claude Code and Amp **auto-load
+skills** (no command files needed); Cursor / Codex / OpenCode get **generated command files**.
+Hooks likewise use each harness's own surface.
+
+**The parity contract (a testable invariant, owned by WS-A):**
+1. Every `user-invocable` workflow skill is reachable on **all five** first-class harnesses —
+   as an auto-loaded skill (Claude Code, Amp) or a generated command (Cursor, Codex, OpenCode).
+2. Every advisory hook stays advisory on all five; every enforcement hook stays enforcing on all
+   five, via each hook surface: Claude Code plugin, Codex `hooks.json`, Cursor `hooks.json`,
+   OpenCode `hooks.ts`, **Amp TS plugin** (`.amp/plugins/`).
+3. No Claude-isms (or any single-harness terminology) leak into another harness's output.
+4. The `~/.agents/` install convention applies to Codex, Cursor, OpenCode, and Amp's *skills*
+   (Amp already reads `~/.agents/skills/` natively); Claude Code is the documented exception via
+   its plugin mechanism. (Amp's *plugin* uses its own `.amp/plugins/` ⁄ `~/.config/amp/plugins/`
+   path, separate from skills.)
+
+A single parity-matrix test enumerates these cells and fails the build on any gap — so the next
+skill or hook added cannot silently break parity. This is the structural difference from today,
+where each target drifted independently.
+
+### Invariants (unchanged)
+- **The loaf CLI is the harness.** Everything routes through it.
+- **One global SQLite database is the operational backend AND the source of truth for artifact
+  bodies.** Markdown is a projection/export — PR-reviewable in git for durable docs (specs, ADRs),
+  never the source (SPEC-040, extended by the decision below). *This migration gets finished.*
+
+### New conventions
+- **`~/.agents/` global install convention** for every harness that supports a configurable
+  agents/skills directory. Amp already reads `~/.agents/skills/` natively (a free win); Codex,
+  Cursor, and OpenCode need their install destinations pointed there. Claude Code keeps its plugin
+  mechanism (the documented exception). Per-harness capability must be verified — not every harness
+  reads a custom dir today (gemini used `~/.gemini`, codex `~/.codex`, etc.).
+- **A first-class CLI UX for browsing SQLite state** — list *and* view reports, drafts, ideas,
+  sparks, sessions, tasks, specs with consistent, human-readable output.
+
+### State content & retrieval model (decided)
+Today SQLite stores only metadata + relationships + a `sources` row (`path`, `hash`); bodies live
+as in-tree `.agents/<type>/*.md`, read from disk (`readImportedSourceBody`). That centralized the
+*index* but not the *content* — bodies stay branch/worktree-variant, non-cross-project, and
+unsearchable, and writing a `.md` registers nothing (proven: this session's report is absent from
+`loaf report list`). Decision:
+
+- **SQLite is the source of truth for ALL artifact bodies** (ideas, sparks, sessions, brainstorms,
+  drafts, reports, specs, ADRs, …). Finishes centralization: branch/worktree-immune, cross-project,
+  and **searchable** via SQLite FTS5.
+- **Durable in-repo docs are also rendered to git as PR artifacts.** Specs and ADRs (and final
+  reports — TBD) render deterministically from SQLite into committed markdown (`.agents/specs/…`,
+  `docs/decisions/…`) so they are PR-reviewable and persist in history — the same
+  generated-artifact-committed-with-source pattern Loaf already uses for `dist/` + `plugins/`.
+- **A drift gate guarantees sync:** `loaf check` verifies committed exports match SQLite — the same
+  contract as `git diff --exit-code -- dist plugins`. The `.md` is a projection, never hand-edited
+  as source.
+- **Authoring goes through the CLI/skills**, not hand-edited generated files: `loaf <entity>
+  new/edit` writes SQLite (scaffolded from a render template), then re-renders the git export.
+  **Templates become render templates, not file scaffolds.**
+- **Ephemeral artifacts become SQLite-only** (no in-tree `.md`): ideas, sparks, sessions,
+  brainstorms, drafts, tasks. Cleans the `.agents/` tree and removes their branch/worktree variance.
+
+### Consequences of the surface changes (accept explicitly)
+- **Amp's plugin is rebuilt, not dropped.** Today's `dist/amp/plugins/loaf.js` is invalid JS
+  written against a stale/experimental API shape. It is replaced by a valid TypeScript plugin at
+  Amp's real path using the now-stable event API — so Amp keeps full hook enforcement and is
+  first-class. The old `loaf.js` artifact goes away (handled by the install change). The cost is
+  owning one TS plugin against Amp's API.
+- **Dropping gemini and relocating install paths are breaking changes** for already-installed
+  users. They require a migration/cleanup mechanism *before* they ship (see WS-G gate).
+
+---
+
+## 2. Workstreams
+
+Each workstream is spec-sized. They are ordered by dependency, not priority.
+
+### WS-A — Build integrity & target simplification  *(keystone; do first)*
+The evaluation's keystone (make the build prove its own output) merged with the structural
+target changes, because they touch the same Go build code and must be tested together.
+
+- **Validate output:** drop the fake `node` (`build_test.go:31,56`); run real `node --check` /
+  `tsc --noEmit` on every emitted JS/TS artifact (opencode `hooks.ts`, the Amp TS plugin);
+  **delete the assertion requiring TypeScript syntax inside `loaf.js`** (`build_test.go:283`).
+- **Amp plugin → fix it (first-class):** in `build_amp.go`, emit a valid **TypeScript** plugin at
+  Amp's real path (`.amp/plugins/` or `~/.config/amp/plugins/`) using the stable event API
+  (`session.start`, `tool.call`, `tool.result`), not the broken `dist/amp/plugins/loaf.js`; fix
+  the handler that reads an undefined `call` (the param is `input`); drop the
+  `@i-know-the-amp-plugin-api-is-wip` header — the API is stable now.
+- **Drop gemini:** remove from `targets.yaml`, build wiring, `dist/gemini/`, install detection,
+  `install_fenced.go:23`, `install_mcp` gemini handling, and tests.
+- **Codex advisory hooks:** default `failClosed:false`; parse `value=="true"`; carry `blocking`/
+  `if` (`build_codex.go:629,646,24-30,638-649`).
+- **OpenCode command coverage:** drive generation off `user-invocable`, not sidecar presence
+  (`build_opencode.go:94`).
+- **Cross-target harness-language transform + lint:** tokenize Claude-isms at source
+  (`{{HARNESS_NAME}}`, `{{INTERVIEW_TOOL}}`, `{{SUBAGENT_MECHANISM}}`, `{{TODO_TOOL}}`,
+  `{{AGENTS_FILE}}`), resolve per target in `transformMd`; add a build-failing content lint over
+  the four first-class harnesses.
+- **git-workflow commit-format fix** rides here as a cheap correctness blocker
+  (`SKILL.md:31,40` → unscoped; the native `check.go:249` hook already rejects scoped commits).
+- **Encode the parity contract as a test** (§1): a single parity-matrix test asserting, across all
+  five first-class harnesses — skill reachability (auto-loaded for Claude Code/Amp, generated
+  command for Cursor/Codex/OpenCode), advisory/enforcement hook semantics preserved on each hook
+  surface (incl. the Amp TS plugin), and zero cross-harness language leakage.
+- **Regression tests (the durable guard):** JS/TS validity via real `node --check`/`tsc` (opencode
+  `hooks.ts`, the Amp TS plugin), codex advisory `failClosed:false`, opencode command
+  coverage for all user-invocable skills, cross-harness Claude-ism lint, sidecar-merge
+  correctness, and the parity-matrix test above.
+
+*Net: a smaller, self-validating target matrix (Gemini gone; the other five first-class). The Amp
+invalid-JS defect is fixed at the source — a valid TS plugin the build actually validates — not
+hidden; the build can no longer ship an artifact it hasn't checked.*
+
+### WS-B — State content & retrieval model
+The largest investment and the enabler for WS-C. Promote bodies into SQLite, add retrieval, and
+wire the git-export projection. (Per §1 "State content & retrieval model".)
+
+- **Bodies into SQLite:** extend the schema so the entity/`sources` rows store body *content*, not
+  just `path`+`hash`; `migrate markdown` imports bodies (not just indexes them). SQLite becomes the
+  source of truth.
+- **Search — the unrealized payoff:** add `loaf search` across all entities via SQLite **FTS5**
+  (full-text, filterable by type/tag/status/relationship). Today there is **no** search of
+  operational state (only KB's separate QMD).
+- **Uniform verbs across every entity:** `list / show / new / edit / archive / link` consistent for
+  reports, ideas, sparks, sessions, tasks, specs, brainstorms — and **model the missing types**
+  (`draft`, `plan`, `handoff`, `council`). Add `report show` (today list-only) and
+  `brainstorm capture` (today missing).
+- **Git-export projection for specs + ADRs (+ final reports, TBD):** deterministic render to
+  committed markdown as part of the PR, with a `loaf check` drift gate mirroring `dist`/`plugins`.
+- **Write → register atomically:** `loaf <entity> new` scaffolds from a render template AND creates
+  the row; a `Write`-side hook is the fallback so an artifact can never be written-but-unregistered.
+- **Human-readable output by default** (today JSON-first); keep `--json` for agents. Consider a
+  unified `loaf browse` / TUI.
+- **Fix status-vocabulary drift** (reports surface `active`/`unknown` vs the real
+  `draft`/`final`/`archived`); reconcile with the session-status enum (WS-C).
+- **Reconcile `cli-reference` + `agent-help`** into one generated catalog.
+
+### WS-C — Session-model convergence  *(finish the migration; land atomically)*
+- Anoint `wrap` as the canonical session model (cite it in CLAUDE.md / AGENTS.md).
+- Rewrite in dependency order: `content/templates/session.md` (the schema everyone cites) →
+  `orchestration` (SKILL + `sessions.md`/`context-management.md`/`background-agents.md`) →
+  `implement` **+ the `implementer.md` profile in the same change** → `bootstrap` →
+  `brainstorm` (SQLite-first sparks) → read-side (`reflect`, `research`, `background-runner`).
+- **Remove transcript-archival guidance** (SPEC-040 scope violation).
+- **Fix `housekeeping` dead command** (`loaf session housekeeping` → `loaf housekeeping`) and its
+  `skill(housekeeping)` self-log marker (which fixes `wrap`'s mis-firing nudge).
+- Reconcile the session **status enum** (3 incompatible vocabularies today) against
+  `internal/state/session_*.go`; add a lint: session schema lives in exactly one file.
+- **Sessions become SQLite-only bodies** (per the WS-B content model) — no in-tree session `.md`;
+  the markdown view is render-on-demand. This is the convergence's end state, not just "point at CLI".
+- **Land atomically** — a half-migrated spine (some skills SQLite-first, others markdown-first,
+  cross-referencing each other) is worse than the current consistent-but-wrong state.
+
+### WS-D — De-bloat & content hygiene
+Low-risk content edits; sequence after WS-C to avoid churn collisions on shared files.
+
+- `orchestration` → thin hub (cut ~1,600 duplicating reference lines + 10 unwired scripts).
+- `architecture` = single ADR source of truth (strip the contradictory ADR spec from
+  `documentation-standards`).
+- `research` de-scope (drop ideation/vision modes); `interface-design` reposition as
+  reference + negative-route to `artifact-design`/`frontend-design`; `foundations` de-scope.
+- Unrunnable tooling (infra PyYAML import; power-systems sidecar/script mismatch).
+- Structure/lint hygiene: `## Contents` headers; `knowledge-base` → `.agents/AGENTS.md`;
+  stale skill-name refs; `triage` stray fence; `shape` `source_sessions`; correct
+  `targets.yaml` phantom-sidecar docs.
+
+### WS-E — Routing eval + validated description rewrites  *(eval-gated, per decision)*
+- Build the **skill-creator routing-eval harness**: user-utterance → expected-skill, current vs
+  proposed description, over the named conflict pairs (idea/triage, research/brainstorm,
+  strategy/reflect, ship/release, architecture/shape, foundations/git-workflow/docs).
+- Refresh the stale `cli/scripts/eval-skill-routing.mjs` (references nonexistent skills).
+- **Only ship description rewrites that measurably improve routing** (foundations, research,
+  brainstorm, interface-design, strategy, …). No blind rewrites.
+- Update `docs/knowledge/skill-architecture.md` (stale: says 33 skills; reality 34–35).
+- Add the **self-logging first-action line** to user-invocable workflows (batched here or in WS-C).
+
+### WS-F — `~/.agents/` install convention
+- **Per-harness capability investigation** first: which harnesses (cursor, codex, opencode, amp)
+  can read a configurable `~/.agents/` skills/agents dir, and how.
+- Rework install destination logic accordingly; Claude Code stays on its plugin mechanism.
+- **Breaking** (path relocation) → depends on WS-G's migration mechanism.
+
+### WS-G — Breaking-change migration mechanism + taxonomy decisions  *(gated; needs sign-off)*
+- **Migration mechanism** (the prerequisite): does `loaf install --upgrade` remove orphaned
+  skills (dropped gemini, retired skills) and handle relocated paths? Define deprecation window,
+  tombstone/alias, and upgrade semantics. **Nothing breaking ships before this exists.**
+- **State/body migration** (gated breaking change, pairs with WS-B): `migrate markdown` imports
+  bodies into SQLite and stops treating in-tree ephemeral `.md` as source. Define a one-time,
+  reversible, backed-up migration before ephemeral `.md` are removed from the tree.
+- **Taxonomy decisions:** retire `thermo-nuclear-code-quality-review`; decide `debugging`
+  (tighten description vs `disable-model-invocation` — *not* `user-invocable:false`, which does
+  not stop model routing); language/domain **opt-in install packs**; `librarian` profile
+  (retire or fully wire).
+
+---
+
+## 3. Sequencing & dependencies
+
+```
+WS-A  Build integrity + target simplification   ──┐  (keystone; gemini drop + amp plugin fix here)
+WS-B  CLI state-browse UX                        ──┤  (parallel with A; different code layer)
+                                                   │
+WS-C  Session convergence (atomic)  ←── depends on A (validated build) + B (read commands)
+                                                   │
+WS-D  De-bloat & hygiene            ←── after C (avoid file churn) ; parallelizable
+WS-E  Routing eval + descriptions   ←── independent harness ; parallel with D
+                                                   │
+WS-F  ~/.agents/ install convention ←── after A (stable matrix) ; needs WS-G migration
+WS-G  Migration mechanism + taxonomy ←── gates F and all breaking changes ; USER SIGN-OFF
+```
+
+Recommended order of shaping into specs: **A → B → C → (D ∥ E) → G → F**.
+
+- **A and B can start in parallel** (build layer vs command/state layer).
+- **C waits on A** (so the build validates the convergence) and benefits from **B** (good CLI
+  read commands to point skills at).
+- **D and E are parallel** once C lands; both are mostly content/tooling.
+- **G is the gate** for every breaking change (gemini drop's user-side cleanup, `~/.agents/`
+  relocation, retires, packs). **F and the breaking parts of A** must not reach users until G's
+  migration mechanism exists.
+
+---
+
+## 4. Breaking-change ledger (CLAUDE.md: ask before breaking changes)
+
+| Change | Who it breaks | Mitigation (WS-G) |
+|--------|---------------|-------------------|
+| Drop gemini | gemini users | upgrade removes orphaned `~/.gemini` skills; changelog + announcement |
+| Amp plugin rebuilt + relocated | amp users | strictly better — current plugin is broken; upgrade removes old `loaf.js`, installs the TS plugin at Amp's path |
+| `~/.agents/` relocation | all non-Claude installed users | upgrade migrates/relinks old path; cleanup of stale dirs |
+| Retire `thermo`, opt-in packs | users who installed them | tombstone/alias; upgrade removes; changelog |
+| Bodies move into SQLite (ephemeral `.md` no longer source) | anyone reading/editing `.agents/{ideas,sessions,sparks,brainstorms,drafts,tasks}/*.md` directly | `migrate markdown` imports bodies + `state backup`; ephemeral `.md` become render-on-demand; specs/ADRs still rendered to git |
+
+All of the above are **held behind WS-G** and require your explicit sign-off before shipping.
+
+---
+
+## 5. Evaluation-finding → workstream traceability (nothing dropped)
+
+- Build validates nothing / Amp invalid JS / codex hooks / opencode commands / Claude-isms → **WS-A**
+- `housekeeping` dead command, transcript removal, session drift, status enum, self-logging → **WS-C**
+- bodies-in-SQLite, FTS5 search, read/write/register UX, missing entity types (draft/plan/handoff/
+  council), git-export of specs+ADRs, status drift, cli-reference catalog gap → **WS-B**
+- orchestration bloat, ADR duplication, research/interface/foundations scope, stale refs, tooling → **WS-D**
+- description collisions (foundations/research/brainstorm/interface/strategy), stale routing eval,
+  taxonomy doc drift → **WS-E**
+- install-path convention → **WS-F**
+- thermo / debugging / packs / librarian / migration → **WS-G**
+
+---
+
+## 6. Spec program (WS → SPEC)
+
+The whole process is now captured as a cross-referenced spec program (all `status: drafting`).
+WS-B split into four specs by reversibility; status-unification moved from this roadmap's WS-B
+into WS-C per the SPEC-043 adversarial review.
+
+| Spec | WS | Scope | Breaking? | Gated on |
+|------|----|-------|:--:|---------|
+| **SPEC-043** | B | SQLite-native bodies + uniform verbs + FTS5 search (additive core) | no | — |
+| **SPEC-044** | B | Durable-doc render, finalization & drift gate (self-consistency, not DB-mirror) | no | SPEC-043 |
+| **SPEC-045** | B | Ephemeral-to-SQLite cutover (`.md` removal) | **yes** | SPEC-053 |
+| **SPEC-046** | B | `docs/` Tier-2 indexing & cross-project search | no | SPEC-043 |
+| **SPEC-047** | A | Build integrity, parity contract & target simplification (keystone) | no¹ | — (¹user-side gemini drop → SPEC-053) |
+| **SPEC-048** | C | Session-model convergence to SQLite (atomic) | no | SPEC-043 |
+| **SPEC-049** | C | Status-vocabulary unification | **yes** | SPEC-053 |
+| **SPEC-050** | D | Skill de-bloat & content hygiene | no | — |
+| **SPEC-051** | E | Routing eval & validated description rewrites | no | — |
+| **SPEC-052** | F | `~/.agents` install convention & harness install parity | **yes** | SPEC-053 |
+| **SPEC-053** | G | Breaking-change migration mechanism & taxonomy decisions (the gate) | **yes** | self |
+
+Sequencing (unchanged): **A → B → C → (D ∥ E) → G → F**. The four breaking specs (045, 049, 052,
+and the user-side gemini cleanup in 047) are hard-gated on SPEC-053.
+
+## 7. Next step
+
+Recommended first spec to break down: **SPEC-047** (build integrity — the keystone, independent,
+mostly non-breaking) and/or **SPEC-043** (the WS-B core — additive, immediately valuable: search +
+body storage). SPEC-043 is already drafted and reviewed; the other ten are drafting skeletons that
+should each get a `/shape`-style refinement + adversarial review (like SPEC-043 got) before
+breakdown. Each spec lands on its own `feat/<slug>` branch at breakdown.
+
+*This roadmap is the parent; each spec above is a child.*

--- a/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md
+++ b/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md
@@ -301,8 +301,11 @@ All of the above are **held behind WS-G** and require your explicit sign-off bef
 ## 6. Spec program (WS → SPEC)
 
 The whole process is now captured as a cross-referenced spec program (all `status: drafting`).
-WS-B split into four specs by reversibility; status-unification moved from this roadmap's WS-B
-into WS-C per the SPEC-043 adversarial review.
+WS-B split into five specs by reversibility; status-unification moved from this roadmap's WS-B
+into WS-C per the SPEC-043 adversarial review. The whole program is governed by **ADR-016**
+(artifact storage trichotomy: nouns→SQLite, verbs→git, markdown→render; the DB stores outputs +
+provenance pointers, never code) — surfaced by the parallel gridsight thermonuclear-migration
+session and now the citable rule behind SPEC-043/044/050/053/054.
 
 | Spec | WS | Scope | Breaking? | Gated on |
 |------|----|-------|:--:|---------|
@@ -310,6 +313,7 @@ into WS-C per the SPEC-043 adversarial review.
 | **SPEC-044** | B | Durable-doc render, finalization & drift gate (self-consistency, not DB-mirror) | no | SPEC-043 |
 | **SPEC-045** | B | Ephemeral-to-SQLite cutover (`.md` removal) | **yes** | SPEC-053 |
 | **SPEC-046** | B | `docs/` Tier-2 indexing & cross-project search | no | SPEC-043 |
+| **SPEC-054** | B | Rich artifact entity model (report→finding→verdict+run) & `--format` export | no | SPEC-043 |
 | **SPEC-047** | A | Build integrity, parity contract & target simplification (keystone) | no¹ | — (¹user-side gemini drop → SPEC-053) |
 | **SPEC-048** | C | Session-model convergence to SQLite (atomic) | no | SPEC-043 |
 | **SPEC-049** | C | Status-vocabulary unification | **yes** | SPEC-053 |

--- a/.agents/reports/20260620-214448-audit-loaf-skills-deep-audit.md
+++ b/.agents/reports/20260620-214448-audit-loaf-skills-deep-audit.md
@@ -1,0 +1,587 @@
+---
+title: "Report: Loaf Skills Deep Audit"
+type: audit
+created: 2026-06-20T21:44:48Z
+status: final
+source: manual
+report_alias: report-loaf-skills-deep-audit
+tags:
+  - skills
+  - harnessing
+  - sqlite-state
+  - build-targets
+  - taxonomy
+---
+
+# Report: Loaf Skills Deep Audit
+
+**Question:** What improvements are needed across all Loaf-shipped skills to tighten focus, improve harnessing, reduce clutter, and make the shipped experience more reliable?
+
+## Summary
+
+Loaf's skill system is directionally strong: the verb-led workflow skills and noun-led reference skills are the right foundation. The current shipped surface is not failing because it has too many skills in principle; it is failing because several high-impact skills and target harnesses have drifted from the current SQLite-native runtime, cross-target build behavior, and the intended progressive-disclosure model.
+
+The highest-priority work is not prose polish. It is harness correctness, session-model convergence, and taxonomy visibility. Amp currently ships a plugin file that is not valid JavaScript. Codex hook generation appears to harden advisory workflow hooks into fail-closed hooks. OpenCode omits command files for several intended workflow skills. Major skills still teach markdown-era session file editing even though Loaf's operational state is SQLite-backed. After those are fixed, the next priority is reducing skill clutter by turning roots back into routers, hiding reference-only skills, refreshing routing evals, and cleaning stale cross-skill references.
+
+Confidence: High. Findings are based on direct source inspection, generated artifact inspection, subagent audit reports, and local verification commands.
+
+## Methodology
+
+The audit used five parallel read-only review streams:
+
+1. Workflow/process skills review.
+2. Domain/reference skills review.
+3. Harness, build, sidecar, hook, and target-output review.
+4. Cross-skill taxonomy and discoverability review.
+5. Templates, references, and link integrity review.
+
+The coordinator also ran direct mechanical checks:
+
+- Counted all source `SKILL.md` files and large markdown assets.
+- Compared source skills, sidecars, generated `dist/*` outputs, and `plugins/loaf`.
+- Inspected `config/hooks.yaml`, `config/targets.yaml`, native build code, and routing eval scripts.
+- Verified selected high-risk findings locally.
+
+Verified commands included:
+
+```bash
+find content/skills -mindepth 2 -maxdepth 2 -name 'SKILL.md' | sort | wc -l
+find content/skills -mindepth 2 -maxdepth 2 -name 'SKILL.md' -print0 | xargs -0 wc -l
+node --check dist/amp/plugins/loaf.js
+python3 - <<'PY'
+try:
+ import yaml
+ print('yaml import ok')
+except Exception as e:
+ print(type(e).__name__ + ': ' + str(e))
+PY
+test -f dist/opencode/commands/ship.md
+test -f dist/opencode/commands/release.md
+test -f dist/opencode/commands/bootstrap.md
+```
+
+## Key Findings
+
+1. Amp target output is not runnable JavaScript.
+   Confidence: High.
+
+2. Codex hook generation turns advisory workflow hooks into fail-closed looking hooks.
+   Confidence: High.
+
+3. OpenCode command harnessing is incomplete for intended workflow skills.
+   Confidence: High.
+
+4. Session guidance is split between SQLite-native state and markdown-era session files.
+   Confidence: High.
+
+5. Transcript archival guidance conflicts with SPEC-040's redaction boundary.
+   Confidence: High.
+
+6. Workflow skills mostly log outcomes, not invocation, despite Loaf's self-logging rule.
+   Confidence: High.
+
+7. Progressive disclosure is breaking down: several roots are too long, too broad, or too policy-heavy.
+   Confidence: High.
+
+8. Skill taxonomy and routing evals are stale.
+   Confidence: High.
+
+9. Script guidance is split between native `loaf check`, hooks, and unwired skill-local helpers.
+   Confidence: High.
+
+10. Several concrete contradictions and stale references should be fixed before broad polish.
+   Confidence: High.
+
+## Detailed Analysis
+
+### 1. Harness Correctness
+
+Amp is the most urgent harness issue. The installed Amp plugin path is generated as `dist/amp/plugins/loaf.js`, but it contains TypeScript syntax:
+
+- `dist/amp/plugins/loaf.js:38` contains `interface HookResult`.
+- `node --check dist/amp/plugins/loaf.js` fails with `SyntaxError: Unexpected strict mode reserved word`.
+- `dist/amp/plugins/loaf.js:383` references `call.toolName` inside a handler whose parameter is named `input`.
+
+This is a release-blocking target issue because it means Loaf ships an Amp plugin that cannot even parse as JavaScript.
+
+Codex hook generation is also high risk. In `config/hooks.yaml`, push and PR workflow hooks are explicitly advisory:
+
+- `config/hooks.yaml:37-39` says these hooks are safety nets, not gates.
+- `config/hooks.yaml:40-45` sets `validate-push` as `blocking: false`.
+- `config/hooks.yaml:48-52` starts `workflow-pre-pr` as advisory.
+
+Generated Codex output does not preserve that nuance:
+
+- `dist/codex/.codex/hooks.json:21-35` emits `validate-push` and `workflow-pre-pr` with `failClosed: true`.
+- There is no generated `if` condition in that hook object.
+
+The result is semantic drift between source hook policy and target behavior. Even if Codex happens to interpret the hook layer leniently, the shipped artifact communicates the wrong contract.
+
+OpenCode command generation is incomplete. Commands are only generated for skills with `SKILL.opencode.yaml`, but several Claude-invocable workflow skills do not have OpenCode command files:
+
+- Missing `dist/opencode/commands/ship.md`.
+- Missing `dist/opencode/commands/release.md`.
+- Missing `dist/opencode/commands/bootstrap.md`.
+- Missing `dist/opencode/commands/refactor-deepen.md`.
+
+Recommendation: make workflow command exposure target-explicit. Either every intended workflow has target sidecars, or there is a canonical command allowlist that build tests enforce.
+
+### 2. SQLite-Native Session Model Drift
+
+Loaf's current operational model is one global SQLite database, with markdown as compatibility/source/export material. However, several skills still teach agents to directly create, edit, enrich, archive, or rely on `.agents/sessions/*.md` files as the primary state surface.
+
+High-risk examples:
+
+- `content/skills/implement/SKILL.md:249-273` mandates creating and continuously updating a session file before work.
+- `content/skills/orchestration/SKILL.md:27-32` instructs session-file creation and archive behavior.
+- `content/templates/session.md:1-68` still defines the canonical-looking session file template.
+- `content/skills/orchestration/references/context-management.md` still orients around `## Current State` and old compaction behavior.
+
+`wrap` is the closest current model. It already uses `loaf session list --json`, `loaf session show <session-ref> --json`, and `loaf session end --wrap`, and explicitly says not to invent missing active markdown session files in SQLite mode.
+
+Recommendation: make `wrap` plus SPEC-040 the canonical session model, then rewrite all session-related skill references around `loaf session start/list/show/log/end --wrap`.
+
+### 3. Transcript Archival Risk
+
+`content/skills/implement/references/session-management.md:220-234` instructs agents to copy full transcripts into `.agents/transcripts/`. This conflicts with SPEC-040's decision that raw transcript capture remains harness-native and out of scope until redaction controls exist:
+
+- `.agents/specs/SPEC-040-sqlite-backed-loaf-operational-state.md:456`
+- `.agents/specs/SPEC-040-sqlite-backed-loaf-operational-state.md:458`
+
+Recommendation: remove or quarantine transcript archival guidance immediately. Reintroduce it only through an explicit design that covers redaction, storage location, gitignore policy, and report export boundaries.
+
+### 4. Workflow Skill Invocation Logging
+
+Project guidance says user-invocable workflow skills must log invocation as their first action. Current skill coverage is inconsistent.
+
+Good examples:
+
+- `handoff` logs invocation first.
+- `refactor-deepen` logs invocation first.
+- `wrap` logs invocation first.
+
+Many others log only completion, decisions, or outcomes:
+
+- `architecture`
+- `bootstrap`
+- `brainstorm`
+- `breakdown`
+- `council`
+- `idea`
+- `research`
+- `shape`
+- `ship`
+- `release`
+- `strategy`
+- `reflect`
+- `triage`
+
+Recommendation: add a standard first-action rule to every user-invocable workflow skill:
+
+```bash
+loaf session log "skill(<name>): <intent>"
+```
+
+Where the workflow may run before session initialization, the skill should say to attempt logging when session state is available and continue without fabricating state if not.
+
+### 5. Progressive Disclosure and Root Skill Size
+
+The corpus has 35 source skills. Top-level `SKILL.md` files total roughly 6.3k lines, and skill markdown/scripts total roughly 22k lines. That is manageable only if root files behave as routers.
+
+Outliers:
+
+- `content/skills/cli-reference/SKILL.md` is 908 lines.
+- `content/skills/bootstrap/SKILL.md` is 434 lines.
+- `content/skills/implement/SKILL.md` is 361 lines.
+- `content/skills/breakdown/SKILL.md` is 329 lines.
+- `content/skills/refactor-deepen/SKILL.md` is 322 lines.
+- `content/skills/release/SKILL.md` is 289 lines.
+
+The worst case is `cli-reference`: it is generated, hidden for Claude, and useful, but it violates the intended root overview pattern and should either be split into references or documented as a deliberate generated exception.
+
+Recommendation: root files should contain only:
+
+- Trigger and non-trigger rules.
+- Critical rules.
+- Verification.
+- Quick reference.
+- Topic routing table.
+- A few workflow steps when necessary.
+
+Long policy blocks, examples, and command inventories should live under `references/` or generated command-specific files.
+
+### 6. Taxonomy and Visibility
+
+The taxonomy is basically right, but the visible surface needs tiers.
+
+Recommended tiers:
+
+Core workflows:
+
+- `bootstrap`
+- `idea`
+- `brainstorm`
+- `triage`
+- `shape`
+- `breakdown`
+- `implement`
+- `ship`
+- `release`
+- `wrap`
+
+Advanced workflows:
+
+- `architecture`
+- `council`
+- `research`
+- `strategy`
+- `reflect`
+- `handoff`
+- `housekeeping`
+- `refactor-deepen`
+
+Reference packs:
+
+- `foundations`
+- `git-workflow`
+- `documentation-standards`
+- `security-compliance`
+- `debugging`
+- language skills
+- domain skills
+- `cli-reference`
+- `orchestration`
+
+Candidate changes:
+
+- Hide `debugging` unless it becomes a full workflow.
+- Rename or absorb `thermo-nuclear-code-quality-review`; it currently reads like an imported personal skill and lacks Loaf structure/sidecars.
+- Keep `orchestration` hidden as an internal coordination reference unless Loaf intentionally exposes it as a user command.
+- Consider install profiles or opt-in packs for language/domain reference skills so every Loaf install does not carry every domain by default.
+
+### 7. Routing Eval Drift
+
+`cli/scripts/eval-skill-routing.mjs` is stale:
+
+- It references non-existent skills such as `council-session`, `cleanup`, `resume-session`, and `reference-session`.
+- It expects some prompts to route to `idea` even though `triage` owns queue processing.
+- It does not sufficiently test conflicts such as `ship` vs `release`.
+
+Recommendation: refresh routing evals around current skill names and add conflict prompts for:
+
+- `idea` vs `triage`
+- `research` vs `brainstorm`
+- `strategy` vs `reflect`
+- `ship` vs `release`
+- `architecture` vs `shape`
+- `debugging` vs language skills
+
+### 8. Cross-Target Language Leakage
+
+Generated target outputs still contain harness-specific assumptions.
+
+Examples reported and spot-checked:
+
+- Amp bootstrap says the skill is designed for Claude Code.
+- OpenCode implement includes Claude Code session naming guidance.
+- Codex ships Claude-oriented session resume guidance.
+- Non-Claude target outputs include phrases like `AskUserQuestion`, `Task tool`, and `TodoWrite`.
+
+Recommendation: add cross-target content lint for non-Claude outputs:
+
+```bash
+rg -n 'Claude Code|CLAUDE|AskUserQuestion|Task tool|TodoWrite|\\.claude' dist/{opencode,codex,gemi...
+```
+
+Then either transform those phrases per target or isolate them into Claude-only sidecars/references.
+
+### 9. Script and Validation Policy Drift
+
+Loaf currently has three kinds of validation logic:
+
+- Native `loaf check` hook IDs.
+- Hook registrations in `config/hooks.yaml`.
+- Skill-local scripts in `content/skills/*/scripts`.
+
+The problem is not that helper scripts exist. The problem is that some are presented as authoritative while not being wired into tests or native checks.
+
+Examples:
+
+- `loaf check` recognizes only five hook IDs in the current native check runner.
+- `foundations` has seven scripts but only lists a subset.
+- `infrastructure-management/scripts/validate-k8s-manifest.py` imports `yaml`, but there is no declared Python dependency and local `import yaml` fails.
+- `power-systems-modeling` sidecar allows only `Bash(python:*)` while the skill exposes a shell script.
+
+Recommendation: classify every script as one of:
+
+- CLI-owned: promoted to native `loaf check` or another native command and covered by Go tests.
+- Hook-owned: invoked from `config/hooks.yaml` and covered by build/hook tests.
+- Skill-local helper: optional, documented as a helper, not an enforcement mechanism.
+- Retired: removed from distributed outputs.
+
+### 10. Concrete Content Contradictions
+
+Fix these before broad prose cleanup:
+
+- `git-workflow` says commit format is `type(scope): description`, while `commits.md` and native check code ban scoped commits.
+- `knowledge-base` routes agent instructions to `CLAUDE.md` instead of the current AGENTS entrypoint.
+- `database-design` refers to nonexistent `infrastructure`.
+- `power-systems-modeling` refers to nonexistent `database-patterns`.
+- `foundations/references/code-style.md` refers to `python`, `typescript`, and `rails` instead of current skill names.
+- `triage` has a stray closing code fence after the deferral text.
+- `shape/templates/spec.md` lacks `source_sessions`.
+- `documentation-standards` points an example ADR link through a path that is wrong relative to the reference file.
+- `refactor-deepen` links to an active `.agents/specs/SPEC-034...` path even though the file lives in archive, and distributed skill content should not rely on local `.agents` history.
+
+## Recommended Work Plan
+
+### Track 0: Stop Shipping Broken Harnesses
+
+Goal: target outputs are executable and hook semantics match source policy.
+
+Tasks:
+
+1. Fix Amp plugin generation.
+   - Remove TypeScript syntax from emitted `.js`, or ship/transpile as TypeScript intentionally.
+   - Replace the undefined `call` variable with the actual hook input shape.
+   - Add `node --check dist/amp/plugins/loaf.js` to tests or build verification.
+
+2. Fix Codex hook generation.
+   - Preserve `if`, `blocking`, and `failClosed`.
+   - Generate only real enforcement hooks as fail-closed.
+   - Ensure advisory hooks cannot block unexpectedly.
+
+3. Fix OpenCode command exposure.
+   - Add sidecars for all intended OpenCode commands, or define and test a command allowlist.
+   - Decide explicitly whether `debugging` is visible.
+
+4. Implement or correct target sidecar support.
+   - Either merge `.cursor.yaml`, `.codex.yaml`, `.gemini.yaml`, and `.amp.yaml` from `content/skills`, or remove the documentation claims from `targets.yaml`.
+
+Validation:
+
+```bash
+node --check dist/amp/plugins/loaf.js
+go test ./internal/cli -run 'TestRunnerBuildTarget(Codex|Amp|OpenCode|Cursor|ClaudeCode)'
+npm run build
+git diff --exit-code -- dist plugins .claude-plugin
+```
+
+### Track 1: Canonicalize SQLite-Native Session Guidance
+
+Goal: all skills use current Loaf state surfaces and treat markdown files as compatibility/source/export artifacts.
+
+Tasks:
+
+1. Make `wrap` the model for session shutdown and resumption.
+2. Rewrite:
+   - `implement`
+   - `orchestration/SKILL.md`
+   - `orchestration/references/sessions.md`
+   - `orchestration/references/context-management.md`
+   - `bootstrap`
+   - `handoff`
+   - `council`
+   - `research`
+   - `reflect`
+3. Update or retire `content/templates/session.md`.
+4. Remove transcript archival guidance until redaction/storage policy is designed.
+5. Add `source_sessions` to spec provenance in `shape/templates/spec.md`.
+
+Validation:
+
+```bash
+rg -n 'Create session file|active session file|Update session file|session frontmatter|\\.agents/sessions' content/skills
+rg -n 'transcripts|Transcript Archival|cp /path/to/transcript' content/skills
+loaf session list --json
+loaf session show <active-or-recent-session> --json
+```
+
+### Track 2: Normalize Skill Structure
+
+Goal: every source skill follows the Loaf skill contract or has an explicit generated exception.
+
+Tasks:
+
+1. Add missing standard sections:
+   - `## Contents`
+   - `## Critical Rules`
+   - `## Verification`
+   - `## Quick Reference`
+   - `## Topics`
+2. Prioritize:
+   - `thermo-nuclear-code-quality-review`
+   - `shape`
+   - `strategy`
+   - `bootstrap`
+   - `council`
+   - `brainstorm`
+   - `housekeeping`
+   - `triage`
+   - `wrap`
+3. Add missing sidecars, especially for `thermo-nuclear-code-quality-review`.
+4. Add first-action self-logging to all user-invocable workflow skills.
+5. Decide whether `cli-reference` is split or marked as a generated exception.
+
+Validation:
+
+```bash
+python3 scripts-or-new-check skill-structure-lint
+find content/skills -mindepth 2 -maxdepth 2 -name 'SKILL.md' -print0 | xargs -0 wc -l | sort -nr
+```
+
+### Track 3: Restore Progressive Disclosure
+
+Goal: roots route; references explain.
+
+Tasks:
+
+1. Move long policy sections from root `SKILL.md` files into `references/`.
+2. Split generated CLI reference by command family or generated references.
+3. Move repeated quick-reference tables out of roots when duplicated.
+4. Convert code-span topic references into markdown links where link checking matters.
+5. Extract wrap report skeleton into `templates/`.
+
+Validation:
+
+```bash
+find content/skills -mindepth 2 -maxdepth 2 -name 'SKILL.md' -print0 | xargs -0 wc -l | sort -nr
+rg -n '\\| .*`[^`]+\\.md`|`[^`]+/references/' content/skills/*/SKILL.md
+```
+
+### Track 4: Clean Taxonomy and Routing
+
+Goal: skill discovery is predictable and visible commands are intentional.
+
+Tasks:
+
+1. Update `docs/knowledge/skill-architecture.md` to current counts and tiers.
+2. Hide or demote `debugging`.
+3. Rename or integrate `thermo-nuclear-code-quality-review`.
+4. Make `research` investigation-only.
+5. Make `brainstorm` divergent-thinking-only.
+6. Make `idea` capture-only.
+7. Make `triage` intake processing-only.
+8. Keep `strategy` pre-implementation and `reflect` post-shipping.
+9. Update routing evals to current skill names and conflict prompts.
+
+Validation:
+
+```bash
+npm run eval:routing -- --model <chosen-model>
+rg -n 'council-session|cleanup|resume-session|reference-session' cli/scripts content docs
+```
+
+### Track 5: Script and Hook Policy
+
+Goal: no authoritative-but-unwired scripts.
+
+Tasks:
+
+1. Inventory every `content/skills/*/scripts/*`.
+2. Classify each as CLI-owned, hook-owned, skill-local helper, or retired.
+3. Promote important checks to native `loaf check` or target-specific hooks.
+4. Remove dependencies that are not bundled or declared.
+5. Add script syntax/dependency smoke checks.
+
+Validation:
+
+```bash
+find content/skills -path '*/scripts/*' -type f -maxdepth 4
+go test ./...
+python3 -m py_compile content/skills/*/scripts/*.py
+shellcheck content/skills/*/scripts/*.sh
+```
+
+If `shellcheck` is not required for contributors, replace with POSIX/bash syntax checks already available in the development environment.
+
+### Track 6: Fix Concrete Contradictions
+
+Goal: remove the known sharp edges before larger edits create churn.
+
+Tasks:
+
+1. Align git commit format with native check behavior.
+2. Replace stale skill names:
+   - `infrastructure` -> `infrastructure-management`
+   - `database-patterns` -> `database-design` or another real skill
+   - `python` -> `python-development`
+   - `typescript` -> `typescript-development`
+   - `rails` -> `ruby-development`
+3. Replace `CLAUDE.md` guidance with `.agents/AGENTS.md` / AGENTS entrypoint guidance.
+4. Fix `triage` stray fence.
+5. Fix `shape` provenance.
+6. Fix `refactor-deepen` SPEC-034 link by moving the decision summary into a stable reference file.
+7. Fix Python `uv:latest` example or explicitly mark it as a placeholder that must be pinned.
+8. Fix `power-systems-modeling` conversion claims and sidecar tool permissions.
+
+Validation:
+
+```bash
+rg -n 'CLAUDE.md|database-patterns|`infrastructure`|`python` skill|`typescript` skill|`rails` skill' content/skills docs
+rg -n 'type\\(scope\\): description|scoped commits' content/skills internal/cli
+```
+
+## Suggested Sequencing
+
+Do not try to clean every skill in one PR. This should be a small series:
+
+1. PR 1: Harness correctness.
+   - Amp parse fix.
+   - Codex hook semantics.
+   - OpenCode command exposure.
+   - Cross-target lint.
+
+2. PR 2: SQLite session guidance convergence.
+   - Rewrite session guidance.
+   - Remove transcript archival guidance.
+   - Add `source_sessions`.
+
+3. PR 3: Skill structure and logging.
+   - Standard sections.
+   - Invocation self-log rules.
+   - `thermo` sidecar/rename decision.
+
+4. PR 4: Taxonomy and routing.
+   - Update architecture docs.
+   - Routing eval refresh.
+   - Visibility changes.
+
+5. PR 5: Script policy and concrete contradictions.
+   - Native/script classification.
+   - Stale names.
+   - Commit-format contradiction.
+   - PyYAML/script dependency issue.
+
+6. PR 6: Progressive disclosure cleanup.
+   - Split long roots.
+   - Fix links.
+   - Extract templates.
+
+## Sources
+
+- `content/skills/*/SKILL.md` and sidecars.
+- `content/skills/*/references/*`.
+- `content/skills/*/templates/*`.
+- `content/templates/*`.
+- `config/hooks.yaml`.
+- `config/targets.yaml`.
+- `internal/cli/build_*.go`.
+- `internal/cli/check.go`.
+- `internal/cli/cli_reference.go`.
+- `internal/cli/install_target.go`.
+- `dist/*/skills`.
+- `dist/opencode/commands`.
+- `dist/codex/.codex/hooks.json`.
+- `dist/amp/plugins/loaf.js`.
+- `.agents/specs/SPEC-040-sqlite-backed-loaf-operational-state.md`.
+- `docs/knowledge/skill-architecture.md`.
+- `cli/scripts/eval-skill-routing.mjs`.
+
+## Open Questions
+
+1. Should Loaf continue shipping every reference pack to every target by default, or should install profiles select language/domain packs?
+2. Should `orchestration` remain hidden as a reference skill, or should it become an explicit user workflow?
+3. Should `thermo-nuclear-code-quality-review` be renamed to a Loaf-native `maintainability-review`, merged into `foundations`, or kept as a sharp optional review skill?
+4. Should raw source links be required to resolve before build, or is built-output link validity the only supported contract for shared templates?
+5. Should `cli-reference` remain a single generated hidden skill, or should it become command-family reference files generated under `references/`?

--- a/.agents/reports/20260621-020342-loaf-skill-suite-deep-evaluation.md
+++ b/.agents/reports/20260621-020342-loaf-skill-suite-deep-evaluation.md
@@ -1,0 +1,354 @@
+---
+title: "Report: Loaf Skill Suite — Deep Evaluation & Restructuring Plan"
+type: audit
+created: 2026-06-21T02:03:42Z
+status: final
+source: workflow
+report_alias: report-loaf-skill-suite-deep-evaluation
+supersedes: report-loaf-skills-deep-audit
+tags:
+  - skills
+  - harnessing
+  - sqlite-state
+  - build-targets
+  - taxonomy
+  - triggering
+  - skill-creator
+---
+
+# Report: Loaf Skill Suite — Deep Evaluation & Restructuring Plan
+
+**Question:** What should change across all Loaf-shipped skills to tighten focus, improve
+harnessing, reduce clutter/slop, and make the shipped experience reliable — going beyond the
+2026-06-20 audit, using the skill-creator evaluation lens?
+
+## How this was produced
+
+This extends `report-loaf-skills-deep-audit` (2026-06-20). Method:
+
+1. **Independent re-verification** of the prior report's headline claims against current source.
+2. A **14-agent evaluation workflow**: 8 skill-family clusters + 4 cross-cutting deep dives
+   (harness/build root-cause, session-model drift map, agent/hook layer, mechanical lint) →
+   an opinionated synthesis → an **adversarial critique** that stress-tested the synthesis.
+3. **Manual verification of the net-new load-bearing claims** before promoting them — which
+   caught and corrected one overstatement in the audit itself (see cli-reference).
+
+The skill-creator lens (descriptions *are* the router; progressive disclosure; anti-slop;
+verb/noun fit) was applied to every skill.
+
+Confidence: High on the mechanical/correctness findings (source-verified). **Medium on the
+routing/triggering claims — they are textual-overlap inferences, not measured.** Closing that
+gap is itself a recommendation (§6).
+
+---
+
+## 1. The one-paragraph verdict
+
+**The taxonomy is healthy; stop trying to fix it.** Every one of the 8 family audits
+independently concluded the verbs are distinct and *no merges are warranted*. The suite's real
+diseases are three, and none of them is "too many skills":
+
+1. **A half-shipped migration.** SPEC-040 made one global SQLite database the canonical
+   operational store and demoted markdown in `.agents/` to compatibility/export. Exactly **one**
+   skill — `wrap` — converged. Everything else still teaches the markdown-era model as primary,
+   and in one case (`housekeeping`) drives a command that is now a **no-op**.
+2. **A build that validates nothing.** The target transformers ship broken artifacts (the Amp
+   plugin fails `node --check`), and the test suite *codifies* the breakage — it uses a fake
+   `node` and asserts TypeScript syntax is present in a `.js` file. This is the root cause of
+   four separate cross-target defects shipping at once.
+3. **Duplicated reference mass.** ~1,600 of `orchestration`'s ~4,656 reference lines re-document
+   five dedicated skills; several reference packs over-claim each other's territory in their
+   descriptions. This — not skill count — is the actual clutter.
+
+The single highest-leverage move is **#2: make the build prove its own output.** It is the
+documented cause of the most damaging fact in the audit (a shipped plugin that won't parse), it
+gates the credibility of every other build fix, and — extended with a content lint — it becomes
+the durable guard that stops the session-drift and Claude-ism leakage from ever shipping again.
+Session-model convergence is the right *second* move. Description-tuning and packaging are
+real but second-order, and **must not proceed without measurement** (§6).
+
+---
+
+## 2. Verification of the prior report
+
+Re-checked against current `main` (only change since the prior report: the ship/release split,
+commit `af3549fc`).
+
+### Confirmed (source-verified)
+- **Amp plugin is invalid JS** — `dist/amp/plugins/loaf.js:38` `interface HookResult`;
+  `node --check` fails. ✓
+- **Codex hardens advisory hooks** — `dist/codex/.codex/hooks.json` emits `failClosed: true`
+  for all five hooks, including advisory `validate-push` and `workflow-pre-pr`. ✓
+- **OpenCode drops commands** — no `ship`/`release`/`bootstrap`/`refactor-deepen` (also
+  `debugging`); gated on optional `SKILL.opencode.yaml` presence. ✓
+- **Session-model split (F4), transcript-archival conflict (F5), self-logging gap (F6),
+  oversized roots (F7), unwired scripts (F9)** — all confirmed.
+- **Stale refs (F10):** git-workflow commit format, `database-design → infrastructure`,
+  `power-systems-modeling → database-patterns`, `foundations/code-style.md` python/typescript/rails,
+  `knowledge-base → CLAUDE.md`, `triage` stray fence, `shape` missing `source_sessions`. ✓
+
+### Refuted / corrected (the prior report was wrong here)
+- **"refactor-deepen links an archived SPEC-034"** — refuted. The SKILL.md citation is a prose
+  concept reference and resolves; the real dangling SPEC-034 link is in `interface-design.md`.
+- **"documentation-standards has a broken ADR link"** — refuted. The ADR-013 link is an
+  illustrative example in a fenced block and the target exists. (The *real* defect is a
+  contradictory duplicate ADR **spec** — see §5.)
+- **"11 broken template links"** — refuted as a false positive: they resolve at build time via
+  `shared-templates` in `targets.yaml`. Reading `content/skills/` source directly misleads.
+- **"prompt+if hook gotcha"** — refuted as a live issue: zero `type: prompt` hooks remain in
+  `hooks.yaml`. Latent in build code only.
+
+### Net-new (missed by the prior report) — manually verified
+- **`housekeeping` drives a dead command. (RELEASE-BLOCKING)** Following the skill does nothing:
+  `loaf session housekeeping` returns `Action: "skipped"` (`cli.go:7096`, reason: *"markdown
+  session housekeeping … is not run in SQLite mode"*). The real artifact scanner is the
+  top-level `loaf housekeeping`, which the skill never names; the "Session Enrichment" section
+  is built on `loaf session enrich <file>`, also skipped (`cli.go:7030`).
+- **The build test suite codifies the bugs.** `build_test.go:31` installs a fake `node` and
+  asserts (`:56`) it is *never invoked* — so `node --check` never runs on output. Worse,
+  `:283` asserts the Amp `loaf.js` *contains* `const postToolHooks: Record<string, HookEntry[]> = {`
+  — i.e. the test **requires** TypeScript syntax in the `.js` file. The test guarantees the
+  broken plugin.
+- **`librarian` is a dead agent profile** that loses its `.agents/`-only tool boundary on
+  opencode/cursor (no sidecar, no frontmatter description) and is spawned by zero skills.
+- **Session status enum is itself inconsistent** across three files: `active` (`session.md`)
+  vs `in_progress|paused` (`sessions.md`) vs `active/stopped/done/blocked/archived` (CLAUDE.md).
+- **`foundations` description over-claims three siblings** (commit conventions / documentation
+  standards / security patterns) — the largest *textual* trigger collision in the suite.
+- **`interface-design` now collides with the newer harness design skills** (`artifact-design`,
+  `frontend-design`) over "build distinctive UI."
+
+### Correction to *this* evaluation's own audit (caught by verifying)
+- **cli-reference was OVERSTATED.** The synthesis called it "release-blocking" and claimed
+  `loaf doctor` is "absent." False: it's catalogued as `loaf state doctor`
+  (`cli-reference/SKILL.md:145`) — the actual command. The genuine, narrower defect: the
+  canonical `loaf session` *family* (start/list/show/log/end) isn't catalogued even though the
+  doc's own decision guide tells readers to run `loaf session start` (`:898`), and the
+  `cliReferenceSubcommands` "session" special-case (`cli_reference.go:599`) is dead code (no
+  top-level `session` entry exists to trigger it). **Quality bug, not release-blocking.** This
+  is the audit's one self-caught error — and the reason §6 matters.
+
+---
+
+## 3. Severity-ranked fix plan
+
+### RELEASE-BLOCKING — ship first, independently
+
+| # | Fix | Root cause | Guard |
+|---|-----|-----------|-------|
+| B1 | **Make the build validate output.** Drop the fake `node`; run real `node --check` on `loaf.js` (and `node --check`/`tsc` on opencode `hooks.ts`); **delete the assertion that requires TS syntax in `loaf.js`** (`build_test.go:283`). | `build_test.go:31,56,283` | This *is* the guard — it's the keystone for B2–B5. |
+| B2 | **Amp plugin → valid artifact.** Emit `loaf.ts` (mirror OpenCode) *or* strip type syntax to real JS — one source of truth. Fix the handler reading undefined `call` (param is `input`). | `build_amp.go:103, 355-405` | B1's `node --check`. |
+| B3 | **Codex: stop hardening advisory hooks.** Default `failClosed:false`; parse `value=="true"`; add `blocking`/`if` to the struct + switch. | `build_codex.go:629,646,24-30,638-649` | Test: `validate-push`/`workflow-pre-pr` are `failClosed:false` in codex output. |
+| B4 | **git-workflow commit format.** `SKILL.md:31,40` teach `type(scope):` but `check.go:198,249` (a `failClosed` hook, proven by `check_test.go:339`) **rejects scoped commits**. Change to unscoped `type: description`; add a note that scope is allowed in PR titles + journal entries, banned in commit subjects. | `git-workflow/SKILL.md` | Content lint: commit examples unscoped. |
+| B5 | **`housekeeping` dead command.** Replace `loaf session housekeeping` with `loaf housekeeping` (`--dry-run/--sessions/--specs/--drafts`); delete the Session Enrichment section. | `housekeeping/SKILL.md` + 7 dist copies | — |
+
+B1+B4 are the lowest-risk, highest-certainty items (a test-infra change and a 2-line doc fix with
+a binary-level guard already in place) — they can go out today.
+
+### HIGH
+
+- **H1 — `implement` session-model rewrite (the worst offender, 361-line root).** Replace
+  "MANDATORY: Create session file BEFORE any other work" (`:251,261`) with `loaf session start`;
+  adopt the `wrap` model (`list/show --json` + `log` + `end --wrap`). Delete the **fabricated
+  orchestration flags** (`--continue/--skip/--abort/--parallel/--dry-run` in
+  `batch-orchestration.md` — none exist natively; they will make the model hallucinate commands).
+  Fix the broken `linear-workflow` ref (`session-management.md:62`), the double `6.` numbering,
+  and the duplicate work-type table. **Must change in the same set as the `implementer.md`
+  profile** (which still demands a "session file" — see R2).
+- **H2 — Transcript-archival removal (SPEC-040 scope violation).** Delete the Transcript Archival
+  section (`implement/references/session-management.md:220-254`) and the `transcripts:` rows +
+  layout in `orchestration` (`SKILL.md:131`, `sessions.md:73-87,206-208`). Data-handling
+  liability, not a style nit.
+- **H3 — OpenCode command coverage.** Drive generation off `user-invocable` (the signal used
+  everywhere else), not sidecar presence. `build_opencode.go:94`. Test: every user-invocable
+  workflow yields a command.
+- **H4 — Cross-target harness-language transformation.** `transformMd` is a no-op for
+  codex/gemini/amp; ~60–81 Claude-isms leak per target ("Claude Code", "AskUserQuestion", "Task
+  tool", "TodoWrite", ".claude"). Tokenize at source (`{{HARNESS_NAME}}`, `{{INTERVIEW_TOOL}}`,
+  `{{SUBAGENT_MECHANISM}}`, `{{TODO_TOOL}}`, `{{AGENTS_FILE}}`) and resolve per target; add a
+  cross-target content lint that fails the build on raw Claude-isms (the durable extension of B1).
+- **H5 — `orchestration` → thin hub (the real clutter cut).** Collapse the ~1,600 reference
+  lines that duplicate `council`/`shape`/`breakdown`/`research` into pointers; stop shipping the
+  10 unwired helper scripts to all 6 targets. Converge its session model (H1 family).
+- **H6 — `brainstorm` SQLite reconvergence.** It treats `.agents/drafts/*.md` as canonical while
+  its consumer `triage` reads `loaf spark list`/`loaf brainstorm list` from SQLite. Capture via
+  `loaf spark capture`; the draft doc becomes export. Fix the broken `strategy/references/` link
+  (`:70`) and delete the false "`/idea` scans brainstorm docs" claim (`:63` — that's triage's job).
+- **H7 — `architecture` = single ADR source of truth.** `documentation-standards/references/documentation.md:41-74`
+  defines a *second*, conflicting ADR spec (4 statuses vs 5; `ADRXXX` vs the repo's real
+  `ADR-NNN`); `architecture/SKILL.md:201` even routes readers *at* the stale doc. Strip the ADR
+  spec from documentation-standards; fix the cross-link.
+
+### MEDIUM
+
+- **M1 — Self-logging, done right (NOT 130 edits as a standalone workstream).** Only 2 of ~19
+  user-invocable workflows log invocation first. But the *only proven functional failure* is that
+  `wrap`'s "no housekeeping this session" nudge (`wrap:100`) mis-fires because `housekeeping`
+  never writes its `skill(housekeeping)` marker. **Fix that one marker now (with B5); batch the
+  rest into the convergence pass.** The other "violations" log useful `decision()` outcomes — keep
+  them. Fix the AGENTS.md exemplars (`shape`, `housekeeping`, `implement`) first — they don't
+  follow their own rule, which means the rule or the examples is the real bug (§6e).
+- **M2 — `research` de-scope.** Delete its "Brainstorming" mode (collides with `brainstorm`) and
+  "Vision Evolution" mode (third skill claiming "update VISION", after `reflect`/`strategy`).
+  Reduce to State Assessment + Topic Investigation. Fix stale `docs/specs/` → `.agents/specs/`.
+- **M3 — `interface-design` reposition** as the WCAG-policy + design-token *reference*; add
+  negative routing to `artifact-design`/`frontend-design`; merge the two near-identical a11y refs.
+- **M4 — `foundations` de-scope** to code quality / naming / TDD / verification / review only
+  (description rewrite in §6); fix stale language-skill names in `code-style.md:96-98`; merge the
+  dual code-review references; retire the 5 dead scripts (enforcement is native now).
+- **M5 — Unrunnable tooling.** `infrastructure-management/scripts/validate-k8s-manifest.py:11`
+  imports undeclared PyYAML; `power-systems-modeling` sidecar allows only `Bash(python:*)` but
+  ships a `.sh`. Fix imports or delete scripts; align sidecar tool grants.
+- **M6 — `cli-reference` (corrected scope).** Add the `loaf session` family to the catalog (or
+  make the generator introspect the command tree) and delete the dead session special-case. Do
+  **not** bundle the larger "collapse with agent-help" refactor into the same change (R5).
+- **M7 — Structure/lint hygiene.** Add `## Contents` to architecture/brainstorm/council/database-design/housekeeping;
+  fix `knowledge-base` → `.agents/AGENTS.md` (4 locations) and its banned deep-links; fix
+  `database-design:76 → infrastructure-management` and `power-systems-modeling:93 → database-design`;
+  fix the `triage:136` stray fence; add `source_sessions:` to `shape/templates/spec.md`;
+  correct `targets.yaml:26,37` (it documents `.cursor.yaml`/`.codex.yaml` sidecars that are
+  neither present nor read).
+- **M8 — `librarian` profile: decide.** Retire it (native session CLI covers its role) or add
+  `librarian.opencode.yaml`/`librarian.cursor.yaml` and wire it from orchestration/wrap. Don't
+  leave it half-wired and boundary-less.
+
+### LOW / decisions deferred to §7
+`thermo-nuclear-code-quality-review` (retire), `debugging` invocability (corrected — see §6b),
+language/domain **install profiles** (needs a migration spec — §7), `wrap` description verb-first
+touch-up, CHANGELOG duplication (`documentation-standards` owns it; `git-workflow` links).
+
+---
+
+## 4. Proposed end-state taxonomy
+
+**35 → 34 skills.** The only outright cut is `thermo-nuclear-code-quality-review`. No merges, no
+renames — the audits unanimously confirmed the verbs are distinct. The clutter reduction comes
+from **de-bloating** (orchestration, oversized roots) and **packaging** (opt-in language/domain
+packs), *not* from cutting skills.
+
+| Tier | Skills | Visible |
+|------|--------|:--:|
+| **Core workflow** | bootstrap, idea, brainstorm, triage, shape, breakdown, implement, ship, release, wrap, housekeeping | yes |
+| **Advanced workflow** | architecture, council, research, strategy, reflect, handoff, refactor-deepen | yes |
+| **Reference pack (base)** | foundations, git-workflow, documentation-standards, security-compliance, knowledge-base, database-design, infrastructure-management, interface-design | model-invoked, hidden from `/` |
+| **Reference pack (opt-in)** | go-development, python-development, typescript-development, ruby-development, power-systems-modeling | install-gated |
+| **Internal** | orchestration, cli-reference | hidden |
+| **Retired** | ~~thermo-nuclear-code-quality-review~~ | — |
+| **Visibility-only change** | debugging | see §6b |
+
+---
+
+## 5. What's genuinely slop vs genuinely valuable
+
+- **Slop to cut:** `thermo-nuclear-code-quality-review` (imported third-party, no sidecar,
+  non-standard frontmatter, restates model-known review wisdom, collides with `foundations` +
+  `refactor-deepen`). The critique's correction stands: **just delete it — do not ceremonially
+  "fold its heuristics in,"** because the audit's own justification for cutting it is that the
+  heuristics are model-known (folding them back in would re-introduce the anti-slop violation).
+- **Mass to thin, not cut:** `orchestration` (~1,600 duplicating ref lines + 10 unwired scripts);
+  the language packs' references are 40–60% generic restatement around a thin opinionated core
+  (Stack/Defaults tables + Always/Never lists) — slim each root to a router and keep the core.
+- **Valuable, just mis-placed:** `power-systems-modeling` is the *highest-quality* content in its
+  cluster but a niche personal domain (transmission-line thermal modeling) — the canonical "great
+  skill, wrong default surface." Opt-in, don't delete.
+
+---
+
+## 6. The measurement gap (the most important methodological point)
+
+Every routing/collision claim in this evaluation — `foundations` vs three siblings, `research`
+vs `brainstorm`, `interface-design` vs `artifact-design` — is **textual overlap, not a measured
+mis-route.** The cli-reference self-correction (§2) proves the risk: string-inspection produced a
+confident, wrong, "release-blocking" claim. Two consequences:
+
+**a) Do not churn descriptions on assertion alone.** The user invoked `skill-creator` for exactly
+this — it has a routing/triggering eval loop. Before rewriting any description across 7 targets,
+build a small routing eval (user-utterance → expected-skill, current vs proposed description) and
+the conflict pairs the prior report named (idea/triage, research/brainstorm, strategy/reflect,
+ship/release, architecture/shape, foundations/git-workflow/documentation-standards). Then the
+rewrites below are *validated*, not hoped-for.
+
+**b) `user-invocable: false` does NOT stop model invocation** (the synthesis got this wrong). Per
+the project's own sidecar table, it only hides from the `/` menu; the model still autonomously
+routes to the skill on its description. So "hide `debugging`" does not fix the verb/noun mismatch
+— the model will route to it exactly as before. The real options for `debugging` are: (i) tighten
+its *description* triggers, (ii) set `disable-model-invocation: true` if it should be reference-only,
+or (iii) fold it into `foundations/references/debugging-methodology.md`. The cluster audit argued
+*against* folding (it would lose the hypothesis-tracking methodology), so (i)/(ii) are preferred.
+This same conflation underwrites the opt-in-pack idea: only **not shipping the files** removes a
+skill from a harness; flags do not.
+
+**Candidate description rewrites (to be eval-gated, not shipped blind):** `foundations` (drop the
+three over-claimed domains), `research` (drop ideation/vision modes), `brainstorm` (SQLite-aware +
+research negative-routing), `interface-design` (reference framing + design-skill negative routing),
+`strategy` (add persona/market/competitor triggers — currently under-triggers). Full before/after
+strings are in the workflow synthesis artifact.
+
+---
+
+## 7. Risk, sequencing, and the breaking-change gate
+
+1. **Keystone first:** B1 (validate the build) gates the credibility of B2/B3/H3/H4. Do it before
+   or with the Amp fix — not last.
+2. **Ship the cheap blockers today:** B1 + B4 are low-risk, high-certainty, independent.
+3. **Land the session spine atomically (R1).** The suite is *currently consistent in being wrong*
+   (everyone teaches markdown). A half-done convergence is **worse** — some skills SQLite-first,
+   others markdown-first, cross-referencing each other. Order: `templates/session.md` (the schema
+   everyone cites) → `orchestration` (SKILL + sessions/context-management/background-agents refs)
+   → `implement` **+ `implementer.md` profile together (R2)** → `bootstrap` → `brainstorm` →
+   read-side second wave (`reflect`, `research`, `background-runner`). Reconcile the status enum
+   against `internal/state/session_*.go`. Add a lint: session schema appears in exactly one file.
+4. **The breaking-change gate (R3 — CLAUDE.md "ask before breaking changes").** Retiring `thermo`,
+   changing `debugging`, and moving 5 skills to opt-in packs all affect users who already ran
+   `loaf install --to all`. **There is no orphan-cleanup / upgrade-migration story today.** Does
+   `loaf install --upgrade` remove a retired skill from a user's `~/.claude`/cursor dir? Silently
+   drop opt-in packs they relied on? This needs a small spec (deprecation window, tombstone/alias,
+   upgrade semantics) **before** any retire/relocate. Treat as SPEC work, not a free edit.
+5. **Don't bundle refactors with data fixes (R5).** Add `session` to the cli-reference catalog
+   (M6) ≠ rewrite the generator to introspect + collapse with `agent-help`. Ship the data fix;
+   spec the generator refactor separately.
+
+---
+
+## 8. Recommended PR sequence
+
+1. **PR 1 — Build validates itself + ship the cheap blockers.** B1, B2, B3, B4, H3, H4 (+ the 5
+   regression tests: amp JS validity, codex advisory `failClosed`, opencode command coverage,
+   cross-target Claude-ism lint, sidecar-merge). *This is the keystone PR.*
+2. **PR 2 — `housekeeping` un-break + its self-log marker.** B5 + M1's one real fix.
+3. **PR 3 — Session-model spine (atomic).** `session.md` → orchestration → implement+profile →
+   bootstrap → brainstorm, + transcript removal (H2), + status-enum reconciliation + the
+   "one canonical session file" lint. Batched self-logging rides along.
+4. **PR 4 — De-bloat + de-dupe.** orchestration thin-hub (H5), ADR SoT (H7), research de-scope
+   (M2), interface-design reposition (M3), foundations de-scope (M4), structure/lint hygiene (M7),
+   unrunnable tooling (M5), cli-reference data fix (M6).
+5. **PR 5 — Routing eval + validated description rewrites** (§6). Gated on the eval harness.
+6. **PR 6 — Packaging spec + migration** (§7.4): install profiles, opt-in packs, `thermo` retire,
+   `debugging` decision, `librarian` decision. **Needs sign-off — breaking changes.**
+
+PRs 1–4 are pure correctness/hygiene and need no taxonomy decisions. PRs 5–6 carry the contested
+calls and the breaking changes.
+
+---
+
+## 9. Open decisions (yours)
+
+1. **Scope of my next action:** produce the implementation (starting with the keystone PR 1), or
+   is this evaluation the deliverable?
+2. **Packaging (PR 6):** opt-in language/domain packs — yes, and is a migration spec acceptable
+   as the gate?
+3. **`thermo`:** retire outright (recommended) vs keep-with-edits (add sidecar, conform frontmatter)?
+4. **`debugging`:** tighten description (recommended) vs `disable-model-invocation` vs fold into
+   `foundations`?
+5. **Routing eval:** build the `skill-creator` eval harness before touching descriptions
+   (recommended), or accept asserted rewrites?
+
+## Sources
+- `report-loaf-skills-deep-audit` (2026-06-20) — extended and corrected here.
+- 14-agent evaluation workflow (8 family clusters + harness-build / session-model / agents-hooks /
+  structure-lint cross-dives + synthesis + adversarial critique).
+- Source-verified: `internal/cli/cli.go:7030,7075,7096`, `internal/cli/build_test.go:31,56,283`,
+  `internal/cli/cli_reference.go:44,101,599`, `internal/cli/build_amp.go`, `build_codex.go`,
+  `build_opencode.go`, `internal/cli/check.go`, `config/hooks.yaml`, `config/targets.yaml`,
+  `content/skills/*/SKILL.md` + sidecars, `content/agents/*`, `docs/knowledge/skill-architecture.md`,
+  `.agents/specs/SPEC-040-sqlite-backed-loaf-operational-state.md`.

--- a/.agents/specs/SPEC-043-sqlite-native-content.md
+++ b/.agents/specs/SPEC-043-sqlite-native-content.md
@@ -1,0 +1,171 @@
+---
+id: SPEC-043
+title: "SQLite-Native Artifact Bodies, Retrieval & Search"
+source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-B)"
+source_sessions:
+  - id: 20260621-001541-session
+    role: shaped
+created: 2026-06-22T08:56:30Z
+status: drafting
+branch: feat/sqlite-native-content
+---
+
+# SPEC-043: SQLite-Native Artifact Bodies, Retrieval & Search
+
+## Problem Statement
+
+SPEC-040 centralized operational **metadata** in one global SQLite database but left artifact
+**bodies** as in-tree `.agents/<type>/*.md` files, indexed by a `sources` pointer (`path`+`hash`)
+and read from disk (`readImportedSourceBody`, `internal/state/task_show.go:166`). Consequences:
+bodies stay branch/worktree-variant and non-cross-project; there is **no search** of any kind;
+writing a `.md` registers nothing in state (proven: this session's report was absent from
+`loaf report list`); `report` has no `show`; and `plan`/`handoff`/`council` are stubbed
+`unsupported artifact kind` (`internal/state/markdown_migration.go:361`). This spec is the
+**additive, non-breaking core** of the WS-B state-content model: it makes SQLite *able* to be the
+source of truth for bodies and adds retrieval + search — **without removing any in-tree files**.
+The git-render/finalization layer is SPEC-044; the breaking ephemeral cutover is SPEC-045; `docs/`
+Tier-2 indexing is SPEC-046; status-vocabulary unification is SPEC-049.
+
+## Strategic Alignment
+
+- **Vision:** Advances *Structured Execution* and "mechanical enforcement, not a prompt library" —
+  bodies and journals become queryable state, serving the "no lost context" pillar.
+- **Architecture / CLI-as-protocol:** Fits `docs/ARCHITECTURE.md:55-57` (one XDG-global,
+  project-partitioned SQLite DB). Generalizes the existing in-SQLite body precedent
+  `session_state_snapshots.content`.
+- **Supersedes (intent, realized non-breakingly):** SPEC-040:160 ("keep authored prose in files
+  unless the row is the durable record") — for Loaf-managed artifacts the **row becomes able to be
+  the durable record**. SPEC-043 does this **dual-source**: the existing markdown import path
+  stays; the in-tree `.md` remain authoritative until SPEC-045 cuts over. Nothing is deleted here.
+- **Coordinates with:** **SPEC-044** (render/finalization — out of scope here), **SPEC-045**
+  (ephemeral cutover/removal — out of scope here), **SPEC-046** (`docs/` indexing), **SPEC-049**
+  (status unification — explicitly out of scope here), **SPEC-048** (session convergence; sessions
+  become SQLite-bodied), **SPEC-041** (adopt its `PLAN-*` semantics for the `plan` entity; do not
+  re-derive). Honors **SPEC-038** (committed internal renders may keep IDs; external exports pass
+  `ValidateExternalMarkdownExport`).
+
+## Solution Direction
+
+- **Body store.** Generalize `session_state_snapshots.content` into a body store for Loaf-managed
+  entities. `sources` becomes **provenance-only**; `body_source_id` FK kept **nullable**; add a
+  body column/table (decide in Track 0). **Precedence (dual-source, non-breaking):** if a SQLite
+  body exists for an entity, it wins; otherwise fall back to the `.md` via `body_source_id`. So
+  existing entities keep working unchanged, new ones can be SQLite-bodied.
+- **Un-stub `plan`/`handoff`/`council` storage** (`markdown_migration.go:361`) so the live
+  `handoff`/`council` skills have somewhere to land; adopt SPEC-041's `PLAN-*` definition for
+  `plan`.
+- **Uniform verbs** across entities: `new / edit / show / list / link`; add **`report show`** and
+  **`brainstorm capture`** (both missing today).
+- **Body-edit UX** (the make-or-break input channel — see Resolved Decisions): `--body-file <path>`
+  / `--body -` (stdin, agent-primary), `$EDITOR` round-trip (human, mirrors `git commit`),
+  `--message` for one-line ephemerals.
+- **Write-side enforcement hook** so an artifact cannot be written-but-unregistered (the behavioral
+  contract that stops free-handing `.md`). The auto-generated `cli-reference` skill is regenerated
+  as a build step (it documents verbs, it is not the contract).
+- **Search (`loaf search`)** over Tier-1 bodies + journal entries via **FTS5**, which is compiled
+  into the embedded `ncruces/go-sqlite3` SQLite and reached through `CREATE VIRTUAL TABLE … USING
+  fts5(…)` — **no Go import, no `go.mod` change** (verified: `ext/fts5` does not exist as a package;
+  README lists full-text search as a built-in capability; a `CGO_ENABLED=0` binary runs `MATCH`).
+
+## Resolved Decisions (load-bearing — settled in-spec, not deferred)
+
+1. **Body-edit input channel:** support all three — `--body-file`/`--body -` (stdin), `$EDITOR`
+   round-trip, `--message`. Without an input channel, `new`/`edit` are untestable for multi-line
+   bodies and agents route around the CLI.
+2. **`sources` fate:** provenance-only; keep `body_source_id` nullable; bodies live in a new column
+   or `bodies` table (Track 0 picks the shape; both keep the FK for provenance).
+3. **FTS maintenance:** external-content FTS5 with **Go-side upserts in the same code path as body
+   writes** (single source of truth, no triggers to drift).
+4. **Status vocabulary:** **unchanged** here. SPEC-043 only preserves existing per-entity
+   validation; unification is SPEC-049.
+
+## Scope
+
+### In Scope
+- Track-0 schema migration: body store; `sources`→provenance (FK nullable); `plan`/`handoff`/
+  `council` tables; FTS5 virtual table(s); update `status.go` `entity_kind` allowlists + the
+  `local_entities` CTE for the new entities (else `loaf state doctor` mis-sees them).
+- Bodies-in-SQLite **write/read path** for Loaf artifacts (dual-source precedence); `report show`;
+  `brainstorm capture`; uniform `new/edit/show/list/link`.
+- Body-edit UX; Write-side enforcement hook; `cli-reference` regeneration build step.
+- `loaf search` (FTS5) over bodies + journals.
+- Rewire the ~17 `internal/state` files that read bodies from disk to the dual-source accessor.
+
+### Out of Scope
+- Git render, finalization commit, drift gate (**SPEC-044**).
+- Removing in-tree `.md` / ephemeral cutover (**SPEC-045**).
+- `docs/` Tier-2 indexing (**SPEC-046**).
+- Status-vocabulary unification (**SPEC-049**).
+- Session-skill convergence beyond storage (**SPEC-048**); `/shape` `PLAN-*` routing (**SPEC-041**).
+
+### Rabbit Holes
+- SQLite as a full version/document store — store current body + provenance, not VCS history.
+- FTS as a backdoor for raw transcripts (honor SPEC-040's redaction boundary — see Risks).
+- Over-generalizing accessors — one dual-source body reader, not per-entity special cases.
+
+### No-Gos
+- No new module dependency (FTS5 is the existing driver's built-in; only `ext/unicode` for the
+  tokenizer would be a new import — flag if needed).
+- No file deletion and no status-vocab change in this spec (those are SPEC-045 / SPEC-049).
+- Don't break `CGO_ENABLED=0`; don't write repo markdown as a side effect of mutations.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| FTS5 virtual table fails under `CGO_ENABLED=0` | Low | High | Track-0 smoke: `CREATE VIRTUAL TABLE … USING fts5` runs + `govulncheck`; verified feasible already |
+| Write concurrency on the single global DB drops writes | Med | High | `busy_timeout`+WAL, busy-retry in the journal write path, chunk long migrations, concurrency stress test; note Track-0 migration blocks **all** projects |
+| FTS indexes secrets/PII in bodies, queryable cross-project | Med | High | Decide indexed-vs-stored fields; redaction/exclusion on ingest; planted-secret negative test; honor `secret_boundary_test.go` naming guard |
+| Body migration loses content | Low | High | Two-guarantee parity: byte-exact archival backup (raw bytes + SHA-256) **and** faithful round-trip; never gate on lossy re-render |
+| Unbounded body TEXT in global DB (pasted logs) | Med | Med | Soft size limit + on-disk-with-`sources`-pointer escape hatch; reject non-UTF8 on ingest |
+
+## Open Questions
+- [ ] Body column vs `bodies` table (Track 0).
+- [ ] FTS field set + ranking (bm25) + snippet/redaction; `loaf search` default scope
+      (current-project vs `--all-projects`).
+- [ ] `--body` stdin vs `--body-file` ergonomics for agents (both supported; confirm default).
+
+## Test Conditions
+- [ ] A spec/report created via `loaf <entity> new` stores its body in SQLite; `loaf <entity> show`
+      displays it with **no in-tree file present**; a multi-paragraph body round-trips byte-exact.
+- [ ] Existing entities with only a `.md` still `show` correctly (dual-source fallback) — **nothing
+      regresses**; `git status` shows no deletions.
+- [ ] `loaf search "<term>"` returns hits across ideas/sparks/sessions/specs/reports + journals,
+      including a report body `loaf report list` cannot surface today.
+- [ ] Edit-then-search: an old term stops matching and a new term matches after `loaf <entity> edit`.
+- [ ] `report show` and `brainstorm capture` exist; `plan`/`handoff`/`council` have SQLite storage
+      and appear correctly in `loaf state doctor`.
+- [ ] `CGO_ENABLED=0 go build` + `govulncheck` pass with FTS5 enabled.
+- [ ] A planted secret in a body is excluded from / redacted in FTS results (privacy test).
+- [ ] Concurrency stress: parallel `loaf session log` + a long write transaction do not drop
+      journal writes.
+
+## Priority Order
+
+Tracks ship in order; non-breaking throughout. Drop from the end if scope tightens.
+
+1. **Track 0 — Body-store schema + FTS5.** Migration: body store (generalize
+   `session_state_snapshots.content`), `sources`→provenance (FK nullable), `plan`/`handoff`/
+   `council` tables, FTS5 virtual table, `status.go` allowlist/CTE updates. *Go/no-go:*
+   `CREATE VIRTUAL TABLE … USING fts5` runs under `CGO_ENABLED=0`; `govulncheck` green; migrates
+   cleanly on a copy of real data. *(non-breaking)*
+2. **Track 1 — Bodies + uniform verbs + edit UX + Write-hook.** Dual-source body read/write;
+   `new/edit/show/list/link`; `report show`; `brainstorm capture`; `plan`/`handoff`/`council`
+   storage; body-edit UX; Write-side enforcement hook; `cli-reference` regeneration. *Go/no-go:*
+   create→show round-trips with no in-tree file; multi-paragraph body byte-exact; existing `.md`
+   entities unaffected. *(non-breaking)*
+3. **Track 2 — Search.** `loaf search` (FTS5) over bodies + journals; ranking/snippet/redaction +
+   default scope decided. *Go/no-go:* correct cross-entity hits incl. a body `loaf report list`
+   cannot surface today. *(non-breaking)*
+
+**First shippable PR = Track 0 + the body half of Track 1 + Track 2** — kills the motivating pain
+("no search"; "written report invisible to state") with zero file removal, zero status change, zero
+render. Everything irreversible lives in SPEC-044/045/049.
+
+## Coordination notes (named, not solved here)
+- **SPEC-035 / `TASKS.json`:** tasks remain **dual-source** in SPEC-043 (no removal). Retiring the
+  `TASKS.json` write/rebuild subsystem (single source = SQLite) is **SPEC-045** cutover work.
+- **SPEC-029 / librarian:** enrichment currently edits the session `.md`. Retargeting enrichment to
+  `journal_entries` rows is **SPEC-048** convergence work; SPEC-043 only provides the storage.
+- **SPEC-037:** "Durable" here means **storage-tier** (the row can be the source of truth), **not**
+  immutable — specs remain mutable per SPEC-037.

--- a/.agents/specs/SPEC-044-durable-doc-render-finalization.md
+++ b/.agents/specs/SPEC-044-durable-doc-render-finalization.md
@@ -1,0 +1,259 @@
+---
+id: SPEC-044
+title: "Durable-Doc Render, Finalization & Drift Gate"
+source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-B)"
+source_sessions:
+  - id: 20260621-001541-session
+    role: shaped
+created: 2026-06-22T09:13:21Z
+status: drafting
+branch: feat/durable-doc-render-finalization
+related_specs:
+  - SPEC-043
+  - SPEC-045
+  - SPEC-047
+  - SPEC-040
+  - SPEC-038
+  - SPEC-037
+---
+
+# SPEC-044: Durable-Doc Render, Finalization & Drift Gate
+
+## Problem Statement
+
+Once SPEC-043 makes SQLite the source of truth for Loaf-managed artifact bodies, durable docs
+(specs, reports, and the spec-/report-shaped projections of ADRs) still need to exist as
+**PR-reviewable markdown in git** — that is the whole point of keeping them durable rather than
+ephemeral. But "render SQLite to a committed `.md`" is harder than it sounds, and the existing
+machinery cannot do it safely:
+
+1. **The existing renderer is not deterministic.** `renderSpecMarkdown`
+   (`internal/state/export.go:837-893`) emits live task counts
+   (`export.go:847`), `Created`/`Updated` timestamps (`export.go:848-853`), and absolute
+   project/database paths via `renderMarkdownExportContext` (`export.go:705-727`,
+   `export.go:719-724`). `ExportAllJSON` stamps `time.Now()` (`export.go:221`). Re-running a render
+   produces a different file every time, so it cannot back a byte-for-byte drift gate.
+
+2. **The proven `dist`/`plugins` gate cannot be copied.** That gate works because the artifacts
+   regenerate **in-tree from in-tree source** and CI diffs them with `git diff --exit-code`
+   (`.github/workflows/build.yml:50-66`). A render gate has no such source on a fresh CI checkout:
+   the global `$XDG_DATA_HOME` SQLite database **does not exist** on a clean clone, so CI cannot
+   re-render from the DB and diff against the committed render. A different gate shape is required.
+
+3. **There is no policy for hand-edited renders.** SPEC-043 leaves "hand-edited committed render:
+   re-import vs reject" as an open question. Without a decided policy, a reviewer
+   who edits a committed render in a PR silently forks truth away from SQLite.
+
+4. **Renderer changes would silently rot every committed render.** Any future change to the render
+   template would make every previously committed render "drift" against the new renderer, with no
+   way to tell an intentional renderer upgrade from accidental divergence.
+
+This spec owns the render/finalization half of WS-B: the deterministic renderer, the out-of-tree
+render store, the finalization commit, and a drift gate that actually works at CI checkout time.
+
+## Strategic Alignment
+
+- **Vision:** Advances *Structured Execution* and the "mechanical enforcement, not a prompt
+  library" stance — a render that is byte-deterministic and gate-enforced replaces "trust the author
+  not to hand-edit" with an enforced contract. Durable docs stay PR-reviewable so human review and
+  git history remain first-class.
+- **Architecture / CLI-as-protocol:** The CLI owns the render; the committed `.md` is a projection,
+  never a source. Reuses the render layer in `internal/state/export.go` but adds a **new
+  deterministic body renderer** alongside the existing summary renderers (those keep their live
+  counts/timestamps for human-facing `state export`; the deterministic renderer is a separate code
+  path for committed durable docs).
+- **Supersedes / Coordinates-with (explicit):**
+  - **Coordinates with SPEC-043 (WS-B, bodies):** SPEC-043 owns the body store, retrieval verbs,
+    `loaf search`, and the migration. **This spec promotes the render/finalization layer that
+    SPEC-043 explicitly declares out-of-scope.** The deterministic renderer, the finalization commit,
+    and the render-drift gate are owned here; SPEC-043 should reference SPEC-044 for that work.
+    SPEC-043 still owns the body store this renderer reads from — **hard dependency**.
+  - **Resolves the render store path + namespacing and hand-edited render policy** that SPEC-043
+    leaves out-of-scope — decided below.
+  - **Coordinates with SPEC-045 (WS-B, cutover):** SPEC-045 (BREAKING, gated on SPEC-053) removes
+    in-tree ephemeral `.md`. SPEC-044 only governs **durable** docs, which stay in git; the two are
+    complementary and must agree on which artifact kinds are durable vs ephemeral (durable: specs,
+    reports; ephemeral cutover owned by SPEC-045).
+  - **Soft CI-ordering dependency on SPEC-047 (WS-A, build/parity):** the drift gate is a **new,
+    independent CI workflow step** that does NOT touch the `dist`/`plugins` verifier
+    (`build.yml:50-66`) or the parity-matrix work. Written so it can land before or after SPEC-047.
+  - **Honors SPEC-038:** committed internal renders (specs/ADRs) may keep `SPEC-*`/`TASK-*` IDs;
+    any external export still passes `ValidateExternalMarkdownExport` (`export.go:665-672`). The
+    deterministic durable renderer targets the **internal** audience.
+  - **Amends SPEC-040:455** (no side-effect markdown): preserved — there is still no
+    write-on-every-mutation; the only git write is the deliberate finalization commit, matching
+    SPEC-043's framing.
+  - **Coordinates with SPEC-037** ("specs are mutable"): a committed render is a **snapshot at
+    finalization**, not a frozen artifact; re-finalization re-renders. The render is not the mutable
+    source — SQLite is. This reconciles "mutable spec" with "durable committed render."
+
+## Solution Direction
+
+Four pieces, layered:
+
+1. **A deterministic body renderer.** A new render path (distinct from the live-summary
+   `renderSpecMarkdown`/`renderSessionMarkdown`) that emits a durable doc's body with **no
+   timestamps, no live counts, no absolute paths**, with **locked section/field ordering** and
+   stable list ordering. Volatile fields (created/updated, task tallies, DB path) are either omitted
+   or sourced from immutable provenance, never `time.Now()` or a live query. Determinism is the
+   contract: rendering the same SQLite row twice, or rendering it under two different
+   `$XDG_DATA_HOME` homes, yields **byte-identical** output.
+
+2. **An out-of-tree render store.** Renders during normal work go to an **XDG cache** location
+   (`$XDG_CACHE_HOME/loaf/renders/`, falling back via the existing Go `PathResolver`),
+   **namespaced by project ID and branch** so parallel branches/worktrees don't collide. These are
+   ephemeral scratch outputs (`loaf <entity> render`), never committed, never authoritative.
+
+3. **Render templates + a finalization commit.** Render templates define the markdown projection
+   for each durable kind (spec, report, ADR-projection). At ship time, a **single finalization
+   step** renders the durable docs deterministically and writes them into their git locations
+   (`.agents/specs/…`, `docs/decisions/…`) as one reviewable commit — the same
+   generated-artifact-committed-with-source pattern Loaf already uses for `dist`/`plugins`. Each
+   committed render carries a **renderer-contract-version stamp** (e.g. a trailing HTML comment or
+   frontmatter field) recording the renderer version that produced it.
+
+4. **A render-drift gate (self-consistency round-trip) + local pre-push check.** Because the global
+   SQLite DB does not exist at CI checkout, the gate cannot re-render-from-DB-and-diff like
+   `dist`/`plugins`. Instead it runs a **self-consistency round-trip**: parse the committed render
+   back into a body representation, **re-render** it deterministically, and assert **byte-equality**
+   with the committed file. Hand edits, stale renderer output, or partial renders fail the round
+   trip. The same check runs locally as a **pre-push hook** so drift is caught before CI. The
+   renderer-contract-version stamp lets the gate distinguish "this render predates a renderer
+   upgrade" (actionable: re-render) from "this render was hand-edited" (rejected) — and lets a
+   deliberate renderer change re-render all committed docs in one sweep instead of silently failing
+   every file.
+
+**Hand-edit policy = REJECT + redirect.** A render is never a source. If the gate detects a
+hand-edited committed render, it **fails** with a message instructing the author to run
+`loaf <entity> edit <ref>` (which writes SQLite) and then re-render + re-finalize. The gate never
+silently re-imports a hand edit back into SQLite — that would make the render a covert write path
+and reopen the dual-source drift this whole program closes.
+
+## Scope
+
+### In Scope
+- A **new deterministic body renderer** for durable docs (specs, reports, ADR-projections),
+  separate from the live-summary renderers in `export.go`. No timestamps, no live counts, no
+  absolute paths; locked ordering.
+- **Render templates** for each durable kind (the markdown projection).
+- An **out-of-tree render store** under `$XDG_CACHE_HOME/loaf/renders/`, namespaced by project ID +
+  branch; `loaf <entity> render` writes there.
+- A **single finalization commit** step that renders durable docs into their git locations at ship
+  time (`.agents/specs/…`, `docs/decisions/…`).
+- A **renderer-contract-version stamp** on every committed render + a sweep command to re-render all
+  committed durable docs when the renderer version changes.
+- A **render-drift gate** as a **new, independent CI workflow step** implemented as a
+  self-consistency round-trip (parse committed render → re-render → byte-diff), plus a **local
+  pre-push check** (and `loaf check --hook <id>` parity).
+- **Hand-edit = reject + redirect** policy wired into the gate's failure message.
+- Determinism tests: render-twice byte-equality and render-across-two-`$XDG_DATA_HOME`-homes
+  byte-equality.
+
+### Out of Scope
+- The body store, retrieval verbs (`new/edit/show/list/link`), `loaf search`, and the `.agents/*.md`
+  body migration — **SPEC-043** owns these (hard dependency).
+- Ephemeral-to-SQLite cutover / removal of in-tree ephemeral `.md` — **SPEC-045** (BREAKING).
+- `docs/` Tier-2 indexing and cross-project search — **SPEC-046**.
+- The `dist`/`plugins` parity verifier and target simplification — **SPEC-047** (WS-A); the drift
+  gate must not touch it.
+- A TUI / `loaf browse`.
+- Deciding the canonical unified status vocabulary (SPEC-043 / SPEC-049).
+
+### Rabbit Holes
+- Making the live-summary renderers (`renderSpecMarkdown`, etc.) deterministic in place — leave
+  them as human-facing `state export`; write a **separate** deterministic path so live exports keep
+  their counts/timestamps.
+- Building a Markdown↔SQLite *round-tripping importer* (re-importing hand edits). The round-trip is
+  for **verification only** (re-render and diff), never to re-import edits — that is exactly the
+  hand-edit path we reject.
+- A pretty-diff/three-way-merge UI for drift. Fail with a clear "edit via CLI then re-render"
+  message; that's enough.
+- Per-field render configurability / themes. One canonical projection per durable kind.
+- Trying to mirror the DB at CI checkout (impossible — DB is global/out-of-tree). Use the
+  round-trip, not a DB re-render.
+
+### No-Gos
+- A committed render is **never** the source and is **never** hand-edited; the gate enforces this.
+- The drift gate does **not** modify, extend, or share code with the `dist`/`plugins` verifier
+  (`build.yml:50-66`); it is a standalone step.
+- No `time.Now()`, live counts, or absolute paths in the deterministic renderer output.
+- No silent re-import of hand-edited renders back into SQLite.
+- The finalization commit is the **only** git write — no write-on-every-mutation side effects
+  (honors SPEC-040:455).
+- No new module dependency (renderer is pure Go over the SPEC-043 body store).
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Renderer is subtly non-deterministic (map iteration, locale, line endings) | High | High | Sort all collections explicitly; fixed `\n`; render-twice + two-XDG-home byte-equality tests in CI |
+| Round-trip gate can't reconstruct a body well enough to re-render byte-identically | Med | High | Keep render projection lossless w.r.t. its own re-render (verify re-render, not reconstruct-from-prose); store a normalized body the renderer re-emits verbatim |
+| Renderer version bump silently fails every committed render | Med | Med | Contract-version stamp distinguishes upgrade-vs-edit; provide a one-command re-render sweep + a single finalization commit |
+| Reviewer hand-edits a committed render in a PR | Med | Med | Gate rejects with redirect to `loaf <entity> edit`; local pre-push check catches before CI |
+| Drift gate ordering tangles with SPEC-047 CI changes | Low | Med | Independent workflow step; no shared code with `dist`/`plugins` verifier |
+| Finalization commit churns docs on unrelated renderer noise | Med | Med | Determinism tests + contract-version gating; finalize only changed durable docs |
+| Render store path collisions across branches/worktrees | Low | Med | Namespace XDG cache by project ID + branch; treat as disposable scratch |
+
+## Open Questions
+
+- [ ] Renderer-contract-version stamp location: frontmatter field vs trailing HTML comment vs both
+      (must survive markdown round-trip and be invisible-ish in review).
+- [ ] Exact set of durable kinds that get committed renders: specs + reports confirmed; do ADRs
+      render from SQLite (Tier-1 projection) or stay git-native Tier-2 source (SPEC-046)? Align with
+      SPEC-043's two-tier model (ADRs are Tier-2 git-native).
+- [ ] How the round-trip stores/normalizes the body so re-render is byte-identical (normalized body
+      column vs canonicalization pass on parse).
+- [ ] Pre-push check delivery: dedicated git pre-push hook vs `loaf check --hook render-drift`
+      invoked from existing hook wiring.
+- [ ] Whether `loaf <entity> render` (scratch) and the finalization render share one code path with
+      a "commit" flag, or are distinct commands.
+- [ ] Finalization trigger: explicit `loaf <entity> finalize` / `loaf ship` step vs a `/ship` skill
+      action (coordinate with ship/release workflows).
+
+## Test Conditions
+
+- [ ] Rendering the same durable artifact twice produces **byte-identical** output (no timestamps,
+      counts, or absolute paths differ).
+- [ ] Rendering the same artifact under two different `$XDG_DATA_HOME` homes produces
+      **byte-identical** output.
+- [ ] `loaf <entity> render <ref>` writes a markdown file under `$XDG_CACHE_HOME/loaf/renders/`
+      namespaced by project + branch, and creates **no** in-tree file.
+- [ ] The finalization step writes the deterministic render into its git location
+      (`.agents/specs/…` or `docs/…`) as a reviewable change.
+- [ ] Each committed render carries a renderer-contract-version stamp.
+- [ ] The render-drift gate **passes** when a committed render matches a fresh deterministic
+      re-render (self-consistency round-trip).
+- [ ] The render-drift gate **fails** when a committed render is hand-edited, with a message
+      instructing `loaf <entity> edit` then re-render (REJECT + redirect; no silent re-import).
+- [ ] The render-drift gate is a standalone CI step that does **not** invoke or share code with the
+      `dist`/`plugins` verifier and passes on a fresh checkout with **no SQLite DB present**.
+- [ ] The local pre-push check fails on a hand-edited committed render before push.
+- [ ] Bumping the renderer-contract-version flags affected committed renders as
+      upgrade-needed (not hand-edited) and a single sweep re-renders them into one finalization
+      commit.
+- [ ] The deterministic durable renderer output passes `ValidateExternalMarkdownExport` only where
+      an external audience is targeted; internal renders may retain `SPEC-*`/`TASK-*` (SPEC-038).
+
+## Priority Order
+
+Tracks ship in order; if scope tightens, drop from the end. Tracks 1–3 are **non-breaking**
+(renderer/store/gate add capability without changing existing behavior). Track 4 (finalization
+commit behavior, i.e. writing durable renders into git as the shipping flow) is **gated** —
+coordinate with SPEC-045 cutover sequencing and ship/release workflows. Hard dependency on SPEC-043
+(body store) throughout.
+
+1. **Track 1 — Deterministic renderer + render store (non-breaking).** New deterministic body
+   renderer (no timestamps/counts/absolute paths; locked ordering) + render templates + out-of-tree
+   XDG-cache render store namespaced by project/branch; `loaf <entity> render`. *Go/no-go:*
+   render-twice and two-`$XDG_DATA_HOME`-home byte-equality tests pass; no in-tree file written.
+2. **Track 2 — Contract-version stamp + drift gate (non-breaking).** Renderer-contract-version
+   stamp; self-consistency round-trip gate as a standalone CI step + local pre-push check; REJECT +
+   redirect hand-edit policy. *Go/no-go:* gate passes on matching renders with no DB present, fails
+   on hand edits with the redirect message, never re-imports.
+3. **Track 3 — Renderer-version sweep (non-breaking).** One-command re-render of all committed
+   durable docs on a renderer-version bump; distinguishes upgrade from hand-edit. *Go/no-go:* a
+   version bump flags + re-renders affected docs into a single finalization commit.
+4. **Track 4 — Finalization commit flow (gated).** Wire the finalization render-commit into the
+   ship flow for durable docs (specs, reports). *Go/no-go (sign-off):* durable docs land in git via
+   finalization only; coordinates with SPEC-045 cutover and ship/release workflows; no
+   write-on-mutation side effects.

--- a/.agents/specs/SPEC-045-ephemeral-to-sqlite-cutover.md
+++ b/.agents/specs/SPEC-045-ephemeral-to-sqlite-cutover.md
@@ -1,0 +1,300 @@
+---
+id: SPEC-045
+title: Ephemeral-to-SQLite Cutover
+source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-B)"
+created: 2026-06-22T09:13:21Z
+status: drafting
+branch: feat/ephemeral-to-sqlite-cutover
+source_sessions:
+  - id: 20260621-001541-session
+    role: shaped
+related_specs:
+  - SPEC-040
+  - SPEC-043
+  - SPEC-044
+  - SPEC-053
+  - SPEC-035
+  - SPEC-029
+  - SPEC-036
+---
+
+# SPEC-045: Ephemeral-to-SQLite Cutover
+
+## Problem Statement
+
+SPEC-043 makes SQLite the source of truth for artifact bodies and proves import
+parity, but it stops short of the destructive half: the in-tree ephemeral `.md`
+files still exist alongside the SQLite rows. Until they are removed, Loaf carries
+**dual-source drift** — two homes for the same content, where one is authoritative
+and the other is a stale shadow that agents and humans can still hand-edit. That
+shadow is exactly the disease SPEC-040 set out to cure: branch/worktree variance,
+non-cross-project bodies, and "writing a `.md` registers nothing."
+
+There are 407 tracked ephemeral files today (`git ls-files`):
+
+| Directory | Tracked files |
+|-----------|---------------|
+| `.agents/tasks/` | 248 |
+| `.agents/sessions/` | 97 |
+| `.agents/ideas/` | 53 |
+| `.agents/drafts/` | 9 |
+| `.agents/sparks/` | 0 |
+| `.agents/brainstorms/` | 0 |
+| **Total** | **407** |
+
+(The roadmap's "~159" predates accretion; the real removal surface is ~407 and
+must be recounted at execution time, not hard-coded.)
+
+This is **Loaf's first destructive operation against tracked content**. The risk
+is not theoretical: a botched cutover loses human-authored idea/draft prose and
+session history with no clean recovery, and it dangles ~10 in-tree provenance
+references (`source:` / `source_sessions:` lines) in surviving specs. The
+governing requirement is therefore **reversibility**: byte-exact backup before
+any deletion, byte-verification before any deletion, and a tested one-command
+rollback. Reversal restores the **original file bytes**, never a re-render.
+
+## Strategic Alignment
+
+- **Vision / Architecture:** Completes the SPEC-040 promise that "Markdown stops
+  being the operational database" for ephemerals. Honors the two-tier content
+  model: ephemerals (ideas/sparks/sessions/brainstorms/drafts/tasks) become
+  SQLite-only; durable docs (specs/reports) stay SQLite-sourced and rendered to
+  git (SPEC-043, SPEC-044); Tier-2 `docs/` stay git-native.
+- **Supersedes / amends (explicit):**
+  - **SPEC-040:172** No-Go "Do not remove current Markdown artifacts until
+    import/export parity is proven" — this spec is the deliberate, gated lift of
+    that No-Go *for ephemerals only*, executed only after SPEC-043 proves parity.
+    Durable specs/reports are NOT removed (they render to git per SPEC-044).
+  - **SPEC-040:160** Rabbit Hole "keep authored prose in files unless the row
+    itself is the durable record" — for ephemerals the **row is now the durable
+    record**; amend SPEC-040:160 to record that the ephemeral exception has been
+    exercised (the row is the durable record; the file is gone).
+  - **SPEC-040:418-433** Migration Phases 2-4 assume "Markdown remains the
+    fallback and source link." After cutover there is no markdown fallback for
+    ephemerals; SQLite is the only home. Record this as the terminal state of
+    SPEC-040's migration ladder.
+  - **SPEC-035 (TASKS.json)** — `.agents/TASKS.json` is still live on disk and is
+    a second structured task source. Tasks moving SQLite-only re-creates
+    dual-source drift unless TASKS.json is removed in the same cutover. This spec
+    resolves SPEC-035 by removing TASKS.json authority: single source = SQLite.
+  - **SPEC-029 (JSONL journal sync, archived)** — librarian enrichment that edits
+    session `.md` (SPEC-029) has no file to edit after cutover. Retarget
+    enrichment to write `journal_entries` rows; the SPEC-029 markdown-edit path is
+    retired.
+- **Coordinates with:**
+  - **SPEC-043** (depends on) — provides the body store, ephemeral SQLite-only
+    write paths, and parity import. SPEC-045 cannot start until SPEC-043 Track 1
+    (bodies + uniform verbs) and the parity import test land.
+  - **SPEC-044** (depends on) — provides the deterministic body renderer and drift
+    gate, required so durable docs survive in git while ephemerals are removed,
+    and so reversal output can be byte-compared where relevant.
+  - **SPEC-053** (HARD GATE) — the breaking-change migration mechanism. SPEC-045
+    MUST NOT merge before SPEC-053 ships `loaf install --upgrade` semantics, a
+    one-time reversible backed-up state migration, and the deprecation/tombstone
+    taxonomy. Cutover is a breaking change to anyone reading/editing
+    `.agents/{ideas,sessions,drafts,tasks}/*.md` directly.
+  - **SPEC-036 / ADR-013** — `.agents/` resolves to the MAIN worktree. Cutover
+    *shrinks* the `.agents/` surface (ephemerals leave) but does NOT delete
+    `.agents/` (specs renders, `loaf.json`, durable docs remain). A companion ADR
+    records this reduction AND corrects **ADR-013:12**, which wrongly asserts
+    "ADRs, knowledge ... all live in one place" inside `.agents/` — ADRs and
+    knowledge live in `docs/decisions/` and `docs/` (Tier-2). The companion ADR
+    fixes that factual error as part of recording the surface reduction.
+
+## Solution Direction
+
+A **3-phase hard-barrier cutover protocol** — copy, verify, delete — where no
+phase proceeds until the prior phase's invariant holds. Each barrier is a refusal
+point, not a warning.
+
+1. **COPY (backup + import-confirm).** Import is already done by SPEC-043; this
+   phase produces a **byte-exact archival backup** of every ephemeral file slated
+   for removal: the raw original file bytes plus a SHA-256 manifest, stored
+   out-of-tree (XDG, alongside `loaf state backup`). Backup captures the file as
+   committed/on-disk, never a re-render.
+2. **VERIFY (byte barrier).** For every file, confirm the SQLite body imported by
+   SPEC-043 reproduces the original bytes (or that the original bytes are captured
+   verbatim in the backup manifest). The barrier is: **if any file fails byte
+   verification, the cutover aborts and deletes nothing.** Verification covers all
+   407 (recounted) files; partial verification is not permitted to proceed.
+3. **DELETE (`git rm`).** Only after VERIFY passes for the entire set: `git rm`
+   the ephemeral files in one staged change, and in the **same change** rewrite or
+   tombstone the dangling in-tree provenance references so the repo stays
+   internally consistent.
+
+**Reversibility (the spine of this spec):**
+- `loaf state restore-ephemerals <backup-id>` (one command) restores the exact
+  original bytes from the backup manifest to their original paths and re-stages
+  them. Restore writes the **stored bytes**, never a re-render — a re-render is
+  not guaranteed byte-identical (`renderSpecMarkdown` emits timestamps/live
+  counts/absolute paths and is not deterministic; SPEC-044's deterministic body
+  renderer is for durable docs, not ephemeral round-trip restore).
+- Restore is **tested** in CI: backup → delete → restore → `git diff` shows the
+  restored files byte-identical to pre-cutover.
+
+**Provenance reference handling.** ~10 surviving specs carry `source:` /
+`source_sessions:` lines pointing at ephemeral paths/IDs that will dangle. For
+each: if the referenced ephemeral is in SQLite, rewrite the reference to the
+stable SQLite alias/ID; otherwise tombstone it with a note that the source was
+absorbed into SQLite at cutover. SPEC-040:160 and SPEC-040:172 get the
+amendment notes described above. This rewrite is part of the DELETE change so the
+tree never has a dangling reference at any commit.
+
+**Cross-branch cutover protocol.** Ephemeral `.md` differ per branch (the exact
+problem being solved). `.agents/` resolves to the main worktree (ADR-013), so
+cutover runs against the **main worktree's** `.agents/`. But other live branches
+may carry ephemeral files not present on main. The protocol: (a) cutover lands on
+main; (b) a documented merge/rebase procedure handles branches whose ephemeral
+files were created after they diverged — those files import into SQLite on the
+branch, then the branch drops them on merge; (c) `loaf check` flags any
+re-introduced ephemeral `.md` so a stale branch cannot silently resurrect the
+dual-source state. The detailed branch-reconciliation steps are decided in
+breakdown (see Open Questions).
+
+**TASKS.json removal.** `.agents/TASKS.json` is `git rm`'d in the same cutover,
+its authority retired, single source = SQLite (resolves SPEC-035). Backup
+captures it like any other ephemeral.
+
+**Enforcement after cutover.** The Write-side hook from SPEC-043 (artifact
+written-but-unregistered guard) is extended: a `loaf check` rule **fails** when a
+tracked ephemeral `.md` reappears under `.agents/{ideas,sparks,sessions,brainstorms,drafts,tasks}/`,
+so the cutover cannot silently regress.
+
+## Scope
+
+### In Scope
+- 3-phase hard-barrier cutover protocol (copy → byte-verify → delete) with abort
+  semantics: nothing is deleted unless the entire set verifies.
+- Byte-exact archival backup: raw original file bytes + SHA-256 manifest,
+  out-of-tree, captured before any deletion. Restore = stored bytes, never render.
+- `loaf state restore-ephemerals <backup-id>` (one-command rollback) + CI test
+  proving byte-identical round-trip (backup → delete → restore → `git diff` clean).
+- `git rm` of the recounted ephemeral set (~407 files across
+  ideas/sparks/sessions/brainstorms/drafts/tasks, incl. archive subdirs) in a
+  single staged change.
+- Removal of `.agents/TASKS.json` and retirement of its authority (resolves
+  SPEC-035); single source = SQLite.
+- Rewrite/tombstone of the ~10 dangling in-tree provenance references
+  (`source:` / `source_sessions:`) in surviving specs; amend SPEC-040:160 and
+  SPEC-040:172 with cutover-exercised notes.
+- Companion ADR: records the ADR-013 surface reduction (ephemerals leave the tree)
+  AND corrects the ADR-013:12 factual error (ADRs/knowledge live in `docs/`, not
+  `.agents/`).
+- Retarget SPEC-029 librarian enrichment from editing session `.md` to writing
+  `journal_entries` rows.
+- `loaf check` rule that fails when an ephemeral `.md` reappears under the
+  ephemeral directories (anti-regression / cross-branch guard).
+- Cross-branch cutover procedure documentation + the check that flags
+  re-introduced ephemerals.
+
+### Out of Scope
+- Bodies-in-SQLite, FTS5 search, uniform verbs, parity import (SPEC-043 owns).
+- Deterministic durable-doc render, finalization, drift gate (SPEC-044 owns).
+- Removing durable specs/reports from git — they stay (rendered per SPEC-044).
+- The breaking-change migration mechanism / `loaf install --upgrade` semantics
+  (SPEC-053 owns; this spec consumes it as a hard gate).
+- `docs/` Tier-2 indexing & cross-project search (SPEC-046).
+- Session-model skill convergence (SPEC-048) — though SPEC-029 enrichment
+  retargeting is in scope here because it directly edits a file being removed.
+- Rewriting git history to purge old ephemeral bytes — files are `git rm`'d going
+  forward; history retains them (and the backup is the authoritative restore path).
+
+### Rabbit Holes
+- Re-rendering to "verify" parity. The byte barrier compares stored original bytes;
+  it does not trust a non-deterministic re-render. Restore replays stored bytes.
+- A universal cross-branch auto-merge tool. Document the manual procedure + the
+  regression check; do not build a branch-graph rewriter.
+- Purging ephemeral bytes from git history (BFG/filter-repo). Out of scope and
+  high-risk; the backup is the recovery mechanism, not history surgery.
+- Generalizing restore into a full state time-machine. One command restores this
+  cutover's backup set; broader versioning is future work.
+
+### No-Gos
+- Do NOT delete any file before its byte verification passes AND the full backup
+  manifest is written and self-verified.
+- Do NOT restore via re-render — restore writes the exact stored bytes only.
+- Do NOT merge before SPEC-053 ships the migration mechanism (hard gate).
+- Do NOT remove durable specs/reports or `loaf.json` (SPEC-042 untouched) — only
+  ephemerals.
+- Do NOT leave a dangling provenance reference at any commit — rewrite/tombstone
+  rides in the same change as `git rm`.
+- Do NOT delete `.agents/` itself — the surface shrinks, it does not disappear.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Body loss on delete (import incomplete/corrupt) | Med | Critical | Byte-verify barrier aborts before any delete; out-of-tree byte-exact backup + manifest; tested one-command restore |
+| Non-deterministic render mistaken for parity check | Med | High | Verification compares stored original bytes, not re-renders; restore replays stored bytes only |
+| Dangling provenance refs after `git rm` | High | Med | Rewrite/tombstone the ~10 refs in the SAME change; CI check for dangling `.agents/<ephemeral>/` refs |
+| Cross-branch ephemeral resurrection (stale branch re-adds `.md`) | High | Med | `loaf check` rule fails on reappearing ephemeral `.md`; documented merge procedure |
+| Cutover ships before migration mechanism exists | Low | Critical | Hard gate on SPEC-053; priority order marks the go/no-go |
+| TASKS.json removed but a consumer still reads it | Med | Med | Audit + retire authority in same change; SPEC-035 reconciled; doctor flags presence |
+| Recounted file set drifts from spec (407 stale) | Med | Low | Recount at execution; verify set = `git ls-files` of ephemeral dirs, not a hard-coded number |
+| SPEC-029 enrichment writes to a deleted file | Med | Med | Retarget enrichment to `journal_entries` rows in this spec's scope |
+
+## Open Questions
+- [ ] Backup format: a single tarball + JSON SHA-256 manifest, or per-file copies
+      under a backup-id directory? (Recommend tarball + manifest, addressable by
+      backup-id, co-located with `loaf state backup` output.)
+- [ ] Cross-branch reconciliation: exact merge/rebase procedure and whether
+      `loaf` provides a helper or only documents the manual steps.
+- [ ] Whether `archive/` subdirectories of ephemeral dirs are imported+removed in
+      this cutover or handled as a separate lower-priority pass.
+- [ ] Tombstone format for absorbed provenance refs (frontmatter note vs inline
+      comment) — must remain SPEC-038-clean for any externally-exported spec.
+- [ ] Does restore need to recreate the SQLite rows too, or only the files (with
+      re-import as a follow-up)? (Recommend: restore files only; re-import is the
+      forward path.)
+
+## Test Conditions
+- [ ] Backup of the full ephemeral set produces raw original bytes + a SHA-256
+      manifest out-of-tree; the manifest self-verifies (recomputed hashes match).
+- [ ] Byte-verify barrier: if ANY ephemeral file fails verification, the cutover
+      aborts and **deletes nothing** (observable: `git status` unchanged).
+- [ ] After a successful cutover, `git ls-files .agents/{ideas,sparks,sessions,brainstorms,drafts,tasks}`
+      returns empty and `.agents/TASKS.json` is gone.
+- [ ] `loaf state restore-ephemerals <backup-id>` restores files byte-identical to
+      pre-cutover (`git diff` clean against the pre-cutover tree).
+- [ ] CI round-trip: backup → delete → restore → byte-diff is clean (one command,
+      tested).
+- [ ] No surviving spec contains a dangling `.agents/{ideas,sparks,sessions,brainstorms,drafts,tasks}/`
+      `source:`/`source_sessions:` reference after cutover; SPEC-040:160 and
+      SPEC-040:172 carry the cutover-exercised amendment notes.
+- [ ] A companion ADR exists recording the ADR-013 surface reduction and
+      correcting the ADR-013:12 `docs/` vs `.agents/` claim.
+- [ ] `loaf check` fails when an ephemeral `.md` is (re)introduced under an
+      ephemeral directory.
+- [ ] SPEC-029-style enrichment writes a `journal_entries` row and edits no
+      session `.md` (none exists to edit).
+- [ ] `loaf state doctor` reports zero ephemeral `.md` and no `TASKS.json` after
+      cutover (Markdown-only / dual-source state cleared).
+- [ ] The cutover refuses to run (clear error) if SPEC-053's migration mechanism /
+      `loaf install --upgrade` semantics are not present (gate is enforced, not
+      just documented).
+
+## Priority Order
+
+Tracks ship in order. **All tracks are BREAKING and HARD-GATED on SPEC-053**;
+none merge before SPEC-043 + SPEC-044 land and SPEC-053's migration mechanism
+exists.
+
+1. **Track 0 — Backup + restore primitives (non-destructive).** Byte-exact backup
+   (raw bytes + SHA-256 manifest) and `loaf state restore-ephemerals`. *Go/no-go:*
+   backup→restore round-trips byte-identical on a fixture; manifest self-verifies.
+   *(Buildable independently; touches no tracked content yet.)*
+2. **Track 1 — Byte-verify barrier (non-destructive).** Verification that SQLite
+   bodies / backup bytes reproduce every ephemeral file; abort-on-any-failure.
+   *Go/no-go:* a single injected mismatch aborts and deletes nothing.
+3. **Track 2 — Provenance rewrite + companion ADR (non-destructive prep).** Rewrite
+   /tombstone the ~10 dangling refs; amend SPEC-040:160/172; author companion ADR
+   (surface reduction + ADR-013:12 correction). *Go/no-go:* no dangling ref
+   remains in the staged tree; ADR present.
+4. **Track 3 — Cutover delete (BREAKING; gated on SPEC-053).** `git rm` the
+   recounted ephemeral set + `.agents/TASKS.json` in one change after Tracks 0-2
+   pass; resolve SPEC-035 authority. *Go/no-go:* full byte-verify passed; backup
+   present; restore tested; SPEC-053 gate satisfied.
+5. **Track 4 — SPEC-029 enrichment retarget + regression guard (BREAKING).**
+   Retarget enrichment to `journal_entries`; add the `loaf check` anti-regression
+   rule and cross-branch procedure docs. *Go/no-go:* enrichment edits no `.md`;
+   reappearing ephemeral `.md` fails `loaf check`.

--- a/.agents/specs/SPEC-046-docs-tier2-indexing.md
+++ b/.agents/specs/SPEC-046-docs-tier2-indexing.md
@@ -1,0 +1,202 @@
+---
+id: SPEC-046
+title: "docs/ Tier-2 Indexing & Cross-Project Search"
+source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-B)"
+source_sessions:
+  - id: 20260621-001541-session
+    role: shaped
+created: 2026-06-22T09:13:21Z
+status: drafting
+branch: feat/docs-tier2-indexing
+---
+
+# SPEC-046: docs/ Tier-2 Indexing & Cross-Project Search
+
+## Problem Statement
+
+SPEC-043 establishes the two-tier content model and `loaf search` (FTS5) over **Tier-1**
+SQLite-resident bodies (specs, reports, ephemerals) and journals. It declares **Tier-2** —
+git-native durable docs (`docs/decisions/` ADRs, `docs/ARCHITECTURE.md`, `docs/STRATEGY.md`,
+`docs/VISION.md`, plus the rest of `docs/`) — "git-native source + SQLite-indexed" but declares
+`docs/` Tier-2 indexing out-of-scope, leaving the open question *"which branch's docs, and re-index
+trigger"* unresolved. SPEC-046 owns it.
+
+That open question is the whole reason this is a separate spec. Tier-1 bodies are branch-immune by
+construction (they live in SQLite, project-partitioned). Tier-2 docs are **not**: they are ordinary
+git-tracked files that differ between branches and worktrees. ADR-013 makes `.agents/` resolve to
+the main worktree (ADR-013:12-14), but `docs/` is **source code, not agentic state** — ADR-013 does
+**not** cover it. So "index `docs/`" has no well-defined answer until we say *which checkout's
+`docs/`*, *when it gets re-indexed*, and *what happens to the index when the working tree differs
+from `HEAD`*. Without that, an index built from one branch silently mis-answers `loaf search` on
+another — exactly the branch-variance defect SPEC-043 set out to eliminate, reintroduced through
+the Tier-2 door.
+
+Two further questions ride here because they only make sense once Tier-2 is indexed: the output
+contract for Tier-2 hits (a file with a real path and line — unlike Tier-1's entity-id addressing),
+and whether `loaf search` defaults to the current project or spans all projects in the global DB.
+
+## Strategic Alignment
+
+- **Vision / Architecture:** Completes the "searchable knowledge, no lost context" pillar by
+  bringing the *durable design record* (ADRs, ARCHITECTURE, STRATEGY, VISION) into the same
+  retrieval surface as operational state, while honoring `docs/ARCHITECTURE.md:57` (one
+  XDG-global, project-partitioned SQLite database) — the Tier-2 index is just more rows in that DB.
+- **Supersedes / Coordinates-with (explicit):**
+  - **Depends on SPEC-043** for all search infrastructure: the FTS5 virtual tables, the
+    `loaf search` command surface, and the body/provenance schema. **SPEC-043 declares `docs/`
+    Tier-2 indexing out-of-scope; SPEC-046 owns it** and is the authoritative owner of `docs/`
+    indexing.
+  - **Resolves SPEC-043's open questions** "docs/ indexing strategy: which branch's docs, and
+    re-index trigger" — these are answered here, not in SPEC-043.
+  - **Coordinates with the Tier-2 ADR home (WS-D / SPEC-050):** the roadmap notes ADR-013:12
+    wrongly claims ADRs/knowledge live in `.agents/`; they live in `docs/decisions/` (verified:
+    `docs/decisions/ADR-001…ADR-015`). This spec **assumes** ADRs are git-native under `docs/`
+    and indexes them there; it does **not** itself rewrite ADR-013 (a companion-ADR / WS-D
+    concern). If SPEC-050 corrects ADR-013:12, this spec's index source is already aligned.
+  - **Honors ADR-013** by contrast, not extension: ADR-013's main-worktree resolution applies to
+    `.agents/` only. `docs/` is git-managed source; this spec defines its **own** worktree/branch
+    rule (below) precisely because ADR-013 does not reach it.
+  - **Honors SPEC-038:** indexing reads committed/working-tree doc content verbatim; it neither
+    rewrites IDs nor exports. The index is a derived read-model, not an external export, so
+    `ValidateExternalMarkdownExport` does not apply.
+- **Non-breaking.** Adds an index table + extends `loaf search`; introduces no schema removal, no
+  file moves, no behavior change to existing commands. Ships as a follow-on after SPEC-043 lands.
+
+## Solution Direction
+
+**Index, never move.** Tier-2 docs stay authoritative on disk in git. SQLite gets a derived,
+disposable **doc index** (path, content snapshot for FTS, content hash, indexed-at, the
+git ref/worktree it was indexed from, project id). The index is a cache: it can be dropped and
+rebuilt from the working tree at any time with no data loss.
+
+**Branch/worktree rule (the core decision):** index the **working tree of the invoking checkout**,
+resolved to the **repository the `loaf` command runs in** (current `git rev-parse --show-toplevel`),
+**not** the main worktree. Rationale: `docs/` is code; a search run while working on branch X must
+reflect branch X's `docs/`. This deliberately diverges from ADR-013's `.agents/` rule because the
+content class differs. The index row records the resolved `toplevel` path + the current `HEAD` ref
+(via `internal/project/project.go` git probes, reusing `git rev-parse`) so a stale index from
+another branch is detectable and re-scoped rather than silently served.
+
+**Re-index trigger:** lazy + verifiable, no daemon.
+- **On demand:** `loaf search` checks each candidate doc's on-disk hash against the indexed hash;
+  stale/missing docs are re-indexed transparently before results return (bounded by `docs/` size).
+- **Explicit:** `loaf docs index [--rebuild]` forces a full (re)scan — for CI, post-`git checkout`,
+  or first run.
+- **Optional hook:** a `post-commit` (and/or `post-checkout`) enforcement hook may call
+  `loaf docs index` so the index tracks the branch automatically; advisory, not fail-closed.
+  Whether to wire it by default is an open question (cost vs. freshness).
+
+**Search output contract:** `loaf search` already returns Tier-1 hits by **entity addressing**
+(`spec:SPEC-043`, `idea:<id>`, journal entry). Tier-2 hits use **file addressing**:
+`path:line` (e.g. `docs/decisions/ADR-013-…md:53`) plus a snippet. The result schema carries a
+`tier` discriminator (`tier1`/`tier2`) and a `locator` that is an entity ref for Tier-1 and a
+`path:line` for Tier-2, so human output and `--json` both disambiguate the two without guessing.
+
+**Cross-project scope:** default **current project** (the one resolved from cwd); `--all-projects`
+widens to every project partition in the global DB. Tier-2 cross-project hits always render the
+absolute (or project-relative + project-name) path so a hit from another repo is unambiguous.
+The global DB already partitions by project id (`docs/ARCHITECTURE.md:57`), so cross-project
+search is a scope flag over existing rows, not new plumbing.
+
+## Scope
+
+### In Scope
+- A `docs_index` table (project-partitioned) storing per-doc: path (project-relative), content
+  snapshot for FTS, content hash, indexed-from ref/worktree toplevel, indexed-at; plus the FTS5
+  virtual table over Tier-2 doc content (reusing SPEC-043's FTS5 setup — no new module dep).
+- The branch/worktree resolution rule for `docs/` (working tree of invoking checkout) and the
+  staleness-detection + lazy re-index path.
+- `loaf docs index [--rebuild]` to (re)scan `docs/` into the index.
+- Extending `loaf search` to span Tier-1 bodies/journals **and** Tier-2 docs, with the
+  `tier`/`locator` output contract (`path:line` for Tier-2) in both human and `--json` modes.
+- `--all-projects` scope flag; default current-project.
+- Which `docs/` paths are in scope: `docs/decisions/*` (ADRs), `docs/ARCHITECTURE.md`,
+  `docs/STRATEGY.md`, `docs/VISION.md`, and `docs/**/*.md` generally (decide globs in breakdown);
+  exclude generated/index files (`docs/decisions/README.md` if purely generated).
+- Optional `post-commit`/`post-checkout` re-index hook (advisory), behind the open question.
+
+### Out of Scope
+- Any change that makes SQLite the *source* for Tier-2 docs — they stay git-native source
+  (that is the entire Tier-2 contract; moving them is SPEC-045's ephemeral concern, not this).
+- Tier-1 search mechanics, FTS5 driver setup, body schema — owned by SPEC-043.
+- Render/finalization/drift-gate for durable docs — SPEC-044.
+- Rewriting ADR-013:12's mis-statement about ADR location (WS-D / SPEC-050).
+- A TUI / `loaf browse` (SPEC-043 deferred it; still deferred).
+- Indexing non-`docs/` repo content (source code, READMEs outside docs/) — explicitly not a
+  code-search tool.
+
+### Rabbit Holes
+- **Building a file watcher / daemon.** No background indexer; lazy-on-search + explicit + optional
+  git hook is the ceiling. A persistent watcher is a different product.
+- **Reconciling working-tree vs `HEAD` divergence perfectly.** Index the working tree as-is; record
+  the ref for staleness, do not try to diff staged/unstaged/committed states.
+- **Cross-project ranking/relevance tuning.** Use FTS5's default ranking; do not build a scoring
+  model. `--all-projects` lists hits grouped by project, not globally re-ranked.
+- **Indexing git history.** Only the current working tree is indexed; git is the history store.
+
+### No-Gos
+- No new module dependency — Tier-2 FTS5 reuses SPEC-043's `ncruces/go-sqlite3` setup.
+- Do not resolve `docs/` to the main worktree (would reintroduce branch-variance for code content).
+- Do not treat the index as durable: it must be fully rebuildable from disk (`--rebuild`); never a
+  source of truth.
+- Do not block `loaf search` on a full re-scan when only a few docs are stale (lazy, bounded).
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Index reflects wrong branch's `docs/` | Med | High | Index the invoking checkout's working tree + record ref; staleness check re-scopes before serving; `--rebuild` escape hatch |
+| Stale index after `git checkout`/`rebase` with no hook | Med | Med | Hash-based staleness detection on every `loaf search`; optional `post-checkout` hook; `loaf docs index --rebuild` |
+| Lazy re-index slows `loaf search` on large `docs/` | Low | Med | Hash-compare is cheap; only changed docs re-index; full scan only via explicit `--rebuild` |
+| Tier-2 `path:line` collides/confuses with Tier-1 entity refs in output | Med | Med | Explicit `tier` discriminator + distinct `locator` shape in schema and human output |
+| Cross-project search leaks paths from unrelated repos confusingly | Low | Low | Default current-project; `--all-projects` groups by project + shows project name + absolute path |
+| ADR-013:12 mis-statement makes "where do ADRs live" ambiguous during breakdown | Low | Low | This spec fixes the source of truth (index `docs/decisions/`); SPEC-050 corrects the prose |
+
+## Open Questions
+- [ ] Re-index trigger default: on-demand-only, or also wire a `post-commit`/`post-checkout` hook
+      out of the box? (freshness vs. per-commit cost)
+- [ ] Exact `docs/` glob: all `docs/**/*.md`, or an allowlist (decisions/ + the four top-level
+      durable docs)? Handle non-markdown (`docs/schema/*`?) — index or skip.
+- [ ] Default search scope confirmation: current-project default + `--all-projects` flag (proposed),
+      vs. a configurable default.
+- [ ] Should `loaf docs index` be a top-level verb, or namespaced under `loaf search index` /
+      `loaf docs`? (depends on SPEC-043's final verb layout)
+- [ ] Working-tree vs `HEAD`: index uncommitted edits (proposed — index working tree) vs. only
+      committed content (cleaner ref semantics, staler results)?
+
+## Test Conditions
+- [ ] `loaf docs index` populates `docs_index` from the invoking checkout's `docs/`; a subsequent
+      `loaf search "<term-in-an-ADR>"` returns the ADR with a `docs/decisions/…md:line` locator.
+- [ ] `loaf search` returns **both** Tier-1 hits (entity-addressed) and Tier-2 hits (`path:line`)
+      in one result set, each tagged with its `tier`; `--json` carries the discriminator.
+- [ ] Editing a `docs/` file and re-running `loaf search` reflects the new content **without** an
+      explicit re-index (lazy staleness detection re-indexes the changed doc).
+- [ ] `git checkout`-ing a branch with different `docs/` content and running `loaf search` returns
+      results from the **checked-out branch's** docs, not another branch's (working-tree rule).
+- [ ] `loaf docs index --rebuild` drops and rebuilds the index; results are unchanged vs. a fresh
+      index (index is purely derived).
+- [ ] `loaf search` defaults to the current project; `--all-projects` returns hits across project
+      partitions, each labeled with project + an unambiguous path.
+- [ ] Tier-2 docs are never written/moved by indexing — `git status` stays clean after any
+      `loaf search` / `loaf docs index`.
+- [ ] `CGO_ENABLED=0 go build` stays green (no new dependency; reuses SPEC-043 FTS5 setup).
+
+## Priority Order
+
+Tracks ship in order; all non-breaking. Hard dependency: **SPEC-043 must have landed Tracks 0–2**
+(schema + FTS5 + `loaf search`) before any track here can start.
+
+1. **Track 0 — Index schema + scan.** `docs_index` table + Tier-2 FTS5 table; `loaf docs index
+   [--rebuild]` scans the invoking checkout's `docs/` (records path, hash, ref). *Go/no-go:*
+   `--rebuild` is idempotent; build green under `CGO_ENABLED=0`. *(non-breaking)*
+2. **Track 1 — Search integration + output contract.** Extend `loaf search` to span Tier-2 with
+   the `tier`/`locator` (`path:line`) discriminator in human + `--json` output. *Go/no-go:* mixed
+   Tier-1/Tier-2 result set disambiguates correctly. *(non-breaking)*
+3. **Track 2 — Lazy staleness + branch correctness.** Hash-based staleness detection re-indexes
+   changed docs on `loaf search`; working-tree resolution returns the invoking branch's docs.
+   *Go/no-go:* the branch-switch test condition passes. *(non-breaking)*
+4. **Track 3 — Cross-project scope.** `--all-projects` flag + current-project default + path
+   disambiguation across partitions. *Go/no-go:* cross-project hits are unambiguous. *(non-breaking)*
+5. **Track 4 — Optional re-index hook.** `post-commit`/`post-checkout` advisory hook calling
+   `loaf docs index`, gated on the open question; ships only if breakdown elects to. *(non-breaking;
+   optional)*

--- a/.agents/specs/SPEC-047-build-integrity-parity-targets.md
+++ b/.agents/specs/SPEC-047-build-integrity-parity-targets.md
@@ -1,0 +1,303 @@
+---
+id: SPEC-047
+title: "Build Integrity, Parity Contract & Target Simplification"
+source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-A)"
+created: 2026-06-22T09:13:21Z
+status: drafting
+branch: feat/build-integrity-parity-targets
+source_sessions:
+  - id: 20260621-001541-session
+    role: shaped
+---
+
+# SPEC-047: Build Integrity, Parity Contract & Target Simplification
+
+## Problem Statement
+
+The Loaf build emits artifacts it never validates, ships at least one artifact
+that is statically broken, and lets each target drift independently with no
+contract binding them together. Concretely:
+
+- **The build proves nothing about emitted JS/TS.** `build_test.go` installs a
+  *fake* `node` (`setupFakeNodeForBuild`, used at `internal/cli/build_test.go:31`,
+  asserted absent at `:56`) so the test never runs a real interpreter, and the
+  Amp test asserts that the emitted file *contains TypeScript syntax inside a
+  `.js` file* (`internal/cli/build_test.go:278-292`, e.g. line 283), enshrining
+  the defect instead of catching it.
+- **The Amp plugin is statically broken.** `generateNativeAmpPlugin` writes
+  TypeScript (interfaces, type annotations, `Promise<HookResult>`) into
+  `dist/amp/plugins/loaf.js` (`internal/cli/build_amp.go:103`) — invalid
+  JavaScript. The `tool.call`/`tool.result` handlers take a param named `input`
+  but read `call.toolName`/`call.arguments` (`internal/cli/build_amp.go:357-359,
+  385-388`) — a reference to an undefined `call`, so every hook silently no-ops.
+  The header still declares the API experimental
+  (`@i-know-the-amp-plugin-api-is-wip-and-very-experimental-right-now`,
+  `internal/cli/build_amp.go:114`).
+- **Codex advisory hooks are coerced to enforcing.** The Codex hook parser
+  defaults `failClosed: true` (`internal/cli/build_codex.go:629`) and reads
+  `value != "false"` (`:646`), so any hook missing an explicit `failClosed: false`
+  becomes a hard gate on Codex. The struct and emitted JSON
+  (`nativeBuildCodexHook` at `:24-30`, `nativeCodexPreToolHookJSON` at `:46-53`)
+  drop `blocking` and `if` entirely, so conditional and advisory semantics are
+  lost on Codex.
+- **OpenCode command coverage is keyed off the wrong signal.** Command-file
+  generation skips any skill whose sidecar fields are empty
+  (`internal/cli/build_opencode.go:94`), so a `user-invocable` skill with no
+  OpenCode sidecar gets no command — silently unreachable.
+- **Gemini is a maintained sixth target with no first-class standing.** It exists
+  in `config/targets.yaml:38-42`, build wiring, `dist/gemini/`, install fencing
+  (`internal/cli/install_fenced.go:23`), MCP install
+  (`internal/cli/install_mcp.go:61`), and tests, but the program now scopes five
+  first-class harnesses and drops Gemini.
+- **No cross-harness language hygiene.** Claude-isms (subagent mechanism,
+  interview tool, TODO tool, the agents file name) leak verbatim into every
+  target; only command tokens (`{{IMPLEMENT_CMD}}`, `{{ORCHESTRATE_CMD}}`) are
+  substituted today.
+- **git-workflow documents the wrong commit format.** `git-workflow/SKILL.md`
+  teaches `type(scope): description` (Verification + Quick Reference lines), but
+  the native enforcement hook rejects scoped commits
+  (`internal/cli/check.go:249`, "scoped commits not allowed").
+
+The net effect: the build can ship an artifact it has not checked, and the
+target matrix has no single invariant that fails when a new skill or hook breaks
+parity.
+
+## Strategic Alignment
+
+- **Vision:** "The loaf CLI is the harness." A build that cannot validate its own
+  output undermines every downstream guarantee. This spec makes the build prove
+  its output and encodes harness parity as a testable invariant (roadmap §1).
+- **Architecture:** Five first-class harnesses — Claude Code, Codex, Cursor,
+  OpenCode, Amp — with **parity = equivalent capability via each harness's native
+  idiom, NOT identical artifacts** (roadmap §1). Skills auto-load on Claude
+  Code/Amp; generated commands on Cursor/Codex/OpenCode. Gemini is removed.
+- **Supersedes / retires:** Removes Gemini as a build target and its install
+  surface (`config/targets.yaml:38-42`, `install_fenced.go:23`,
+  `install_mcp.go:61`).
+- **Coordinates with SPEC-053 (WS-G):** The Gemini drop is a breaking change for
+  already-installed users (orphaned `~/.gemini` skills). The *user-side cleanup*
+  (orphan removal on upgrade) is hard-gated on SPEC-053's migration mechanism and
+  must not ship to users before it exists. The in-repo removal (build/test/source)
+  is non-breaking and ships in this spec.
+- **Coordinates with SPEC-052 (WS-F):** This spec stabilizes the target matrix so
+  the `~/.agents/` install relocation can build on a known-good set. SPEC-052
+  depends on SPEC-053; this spec does NOT change install destinations.
+- **Coordinates with SPEC-043/044/045 (WS-B):** Independent of WS-B; can ship
+  first. The Amp TS plugin and the parity-matrix test established here are the
+  hook surfaces any future SQLite-body Write-side enforcement hook (SPEC-043)
+  must satisfy across all five harnesses.
+- **Prior art — SPEC-040 (complete):** The `dist`/`plugins` drift gate
+  (`git diff --exit-code -- dist plugins`) is the pattern this spec leans on:
+  committed artifacts regenerate in-tree and the build fails on drift. The
+  parity-matrix test extends that "build validates committed output" discipline
+  to harness semantics.
+
+## Solution Direction
+
+Make the build validate everything it emits, fix the broken/incorrect target
+output at the source, shrink the matrix from six targets to five, and bind the
+five together with one parity-matrix test that fails the build on any gap.
+
+1. **Real interpreter validation.** Remove the fake-`node` shim and the
+   TypeScript-in-`.js` assertion. After a build, run `node --check` on every
+   emitted JavaScript artifact and `tsc --noEmit` (or equivalent type-check) on
+   every emitted TypeScript artifact (OpenCode `hooks.ts`, the new Amp TS
+   plugin). Validation is part of the build/test gate; a syntactically invalid
+   artifact fails the build. Treat a missing `node`/`tsc` toolchain as a clear
+   skip-with-warning in local dev but a hard requirement in CI (decide the exact
+   gating in Open Questions).
+
+2. **Amp → first-class TypeScript plugin.** In `build_amp.go`, emit a valid
+   TypeScript plugin at Amp's real plugin path (`.amp/plugins/` or
+   `~/.config/amp/plugins/` — pin the path in Open Questions) using the stable
+   event API (`session.start`, `tool.call`, `tool.result`). Fix the handler bug:
+   the handler param is `input`; read tool name/arguments from `input`, not from
+   the undefined `call` (`build_amp.go:357-359, 385-388`). Drop the
+   `@i-know-the-amp-plugin-api-is-wip…` header (`build_amp.go:114`). Stop writing
+   `loaf.js`; emit a `.ts` (or `.mts`) artifact the `tsc` step actually validates.
+   Amp keeps full hook enforcement (advisory stays advisory, enforcement stays
+   enforcing) and is first-class.
+
+3. **Drop Gemini (in-repo, non-breaking).** Remove Gemini from
+   `config/targets.yaml` (lines 38-42), all build wiring, `dist/gemini/`, install
+   detection, `install_fenced.go:23`, `install_mcp.go` Gemini handling
+   (`:61`), and every test reference (including the `dist/gemini/stale.txt`
+   fixtures in `build_test.go:41,69`). The user-facing orphan-cleanup on upgrade
+   is SPEC-053's responsibility.
+
+4. **Codex advisory hook semantics.** In `build_codex.go`: default
+   `failClosed: false` (change `:629`), parse `value == "true"` (change `:646`,
+   matching the Amp parser at `build_amp.go:576`), and carry `blocking` and `if`
+   through the struct and emitted JSON (`:24-30`, `:46-53`). Advisory Codex hooks
+   stay advisory; conditional hooks keep their `if`.
+
+5. **OpenCode command coverage off `user-invocable`.** Drive OpenCode command-file
+   generation off the skill's `user-invocable` flag, not sidecar presence
+   (`build_opencode.go:94`). Every `user-invocable` skill gets a command; pure
+   reference skills (`user-invocable: false`) do not.
+
+6. **Cross-target harness-language transform + content lint.** Extend the
+   existing command-token substitution (which already resolves `{{IMPLEMENT_CMD}}`
+   / `{{ORCHESTRATE_CMD}}` per target inside `transformMd`) with harness tokens —
+   `{{HARNESS_NAME}}`, `{{INTERVIEW_TOOL}}`, `{{SUBAGENT_MECHANISM}}`,
+   `{{TODO_TOOL}}`, `{{AGENTS_FILE}}` — resolved per target. Add a build-failing
+   content lint over the four non-Claude first-class harnesses that fails on
+   residual Claude-isms (literal "subagent", interview/TODO tool names, the
+   Claude agents-file name, unresolved `{{…}}` tokens). The token vocabulary and
+   per-target resolution table are part of this spec; tokenizing every source
+   occurrence is implementation work guided by the lint.
+
+7. **git-workflow commit-format fix.** Change `git-workflow/SKILL.md` from
+   `type(scope): description` to unscoped `type: description` so the documented
+   format matches the native enforcement hook (`check.go:249`). Rebuild the
+   distributed copies.
+
+8. **The parity contract as a single test.** Add one parity-matrix test
+   enumerating, across all five first-class harnesses:
+   - **Skill reachability:** every `user-invocable` workflow skill is reachable —
+     auto-loaded (Claude Code, Amp) or a generated command (Cursor, Codex,
+     OpenCode).
+   - **Hook semantics preserved per surface:** every advisory hook stays advisory
+     and every enforcement hook stays enforcing, via each harness's hook surface
+     (Claude Code plugin, Codex `hooks.json`, Cursor `hooks.json`, OpenCode
+     `hooks.ts`, Amp TS plugin).
+   - **Zero cross-harness language leakage:** no Claude-isms in any non-Claude
+     target output.
+   A new skill or hook that breaks any cell fails the build.
+
+## Scope
+
+### In Scope
+- Removing the fake `node` shim and the TypeScript-in-`.js` assertion from
+  `build_test.go`; adding real `node --check` / `tsc --noEmit` validation over
+  emitted JS/TS.
+- Rewriting the Amp plugin generator (`build_amp.go`) to emit valid TypeScript at
+  Amp's real plugin path using the stable event API, fixing the `input`/`call`
+  handler bug, and dropping the WIP header.
+- Removing Gemini from targets config, build wiring, `dist/gemini/`, install
+  fencing/MCP, and tests (in-repo only).
+- Codex advisory-hook fixes: `failClosed` default/parse, `blocking`/`if`
+  carry-through.
+- OpenCode command coverage driven by `user-invocable`.
+- Harness-language token vocabulary + per-target `transformMd` resolution + a
+  build-failing Claude-ism content lint over the four non-Claude harnesses.
+- git-workflow commit-format correction (unscoped) + rebuilt distributed copies.
+- The parity-matrix regression test plus the per-fix regression tests (JS/TS
+  validity, Codex advisory `failClosed:false`, OpenCode coverage, sidecar-merge
+  correctness, Claude-ism lint).
+
+### Out of Scope
+- Changing install *destinations* to `~/.agents/` (SPEC-052 / WS-F).
+- Any user-side migration or orphan cleanup of installed Gemini/old-Amp artifacts
+  (SPEC-053 / WS-G).
+- SQLite bodies, search, or Write-side body enforcement hooks (SPEC-043 / WS-B).
+- Session-model or status-vocabulary changes (SPEC-048 / SPEC-049).
+- Skill content de-bloat or description rewrites (SPEC-050 / SPEC-051), beyond the
+  single git-workflow commit-format line and mechanical token substitution.
+
+### Rabbit Holes
+- **Bundling/transpiling the Amp plugin.** Emit a `.ts` Amp loads directly via
+  its plugin API; do not build a TS→JS pipeline, a bundler, or a Node toolchain
+  shipped with Loaf. `tsc --noEmit` validates; it does not transpile for ship.
+- **A general harness-abstraction DSL.** The token set is a small fixed
+  vocabulary plus a per-target resolution table — not a templating language or a
+  capability-negotiation framework.
+- **Re-architecting the hooks pipeline.** Fix Codex/Amp semantics within the
+  existing parser/emitter shape; do not redesign `hooks.yaml` or the hook model.
+- **Chasing byte-identical artifacts across harnesses.** Parity is equivalent
+  capability via native idiom, explicitly NOT identical files.
+
+### No-Gos
+- Keeping the fake `node` or any test that asserts an invalid artifact is
+  "correct."
+- Shipping the Gemini *user-side* removal (orphan cleanup) ahead of SPEC-053.
+- Leaving the Amp plugin as `.js` containing TypeScript, or leaving the
+  `call`/`input` handler bug in place.
+- Making a `user-invocable` skill unreachable on any first-class harness.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| CI lacks `node`/`tsc`, so validation silently skips and re-rots | Med | High | Make the toolchain a hard CI requirement; fail (not skip) when absent in CI; document in `.claude/CLAUDE.md` "Before Committing" |
+| Amp's real plugin path or stable event API differs from assumption | Med | High | Pin path + API shape in Open Questions before breakdown; verify against current Amp docs; the handler fix is independent of path choice |
+| Gemini removal misses a reference and breaks the build | Low | Med | Grep-driven removal checklist; the parity-matrix test enumerates exactly five targets, catching a stray sixth |
+| Codex `failClosed` flip relaxes a hook that *should* enforce | Low | High | Audit `hooks.yaml`: enforcement hooks must set `failClosed: true` explicitly; parity test asserts enforcement hooks stay enforcing on Codex |
+| Token substitution corrupts legitimate prose containing `{{…}}` or "subagent" | Med | Med | Lint reports offending file:line; allowlist where a literal is intentional; only substitute the fixed token set |
+| OpenCode coverage flip floods the menu with reference-skill commands | Low | Med | Gate strictly on `user-invocable: true`; reference skills set `user-invocable: false` |
+
+## Open Questions
+
+- [ ] Amp plugin path: `.amp/plugins/` (project) vs `~/.config/amp/plugins/`
+      (global) — which does Amp load, and does install target one or both?
+- [ ] Amp plugin file extension/module format the stable API expects (`.ts` vs
+      `.mts`; default export shape) — confirm against current Amp plugin docs.
+- [ ] `tsc --noEmit` invocation: project-wide `tsconfig` vs per-file
+      `--strict false` check — what is the minimal type-check that proves
+      loadability without false positives?
+- [ ] Behavior when `node`/`tsc` is absent: hard-fail in CI, warn-and-skip
+      locally — exact gating mechanism (env detection vs CI flag).
+- [ ] Canonical Claude-ism token vocabulary and the per-target resolution table
+      (what `{{SUBAGENT_MECHANISM}}` / `{{INTERVIEW_TOOL}}` / `{{TODO_TOOL}}` /
+      `{{AGENTS_FILE}}` resolve to for Codex/Cursor/OpenCode/Amp).
+- [ ] Does the parity-matrix test read live `hooks.yaml` + skill frontmatter and
+      assert against built output, or assert a declared expectation table? (Prefer
+      deriving from source so it cannot silently pass.)
+
+## Test Conditions
+
+- [ ] No fake `node` shim remains in `build_test.go`; the TypeScript-in-`.js`
+      assertion at `build_test.go:283` is gone.
+- [ ] A build with an intentionally malformed emitted `.js` fails `node --check`;
+      a malformed emitted `.ts` fails the `tsc --noEmit` step.
+- [ ] The Amp plugin is emitted as valid TypeScript at Amp's real plugin path,
+      passes `tsc --noEmit`, and contains no `@i-know-the-amp-plugin-api-is-wip`
+      header.
+- [ ] The Amp `tool.call`/`tool.result` handlers read tool name/arguments from
+      `input` (no reference to an undefined `call`); a test exercises a hook
+      firing through the handler.
+- [ ] `dist/gemini/` is not produced; no Gemini entry remains in
+      `config/targets.yaml`, build wiring, `install_fenced.go`, `install_mcp.go`,
+      or any test fixture; `loaf build` succeeds.
+- [ ] A Codex hook with no explicit `failClosed` emits `failClosed: false`; a
+      Codex hook with `if`/`blocking` carries those fields into `hooks.json`.
+- [ ] Every `user-invocable` skill produces an OpenCode command file; a skill with
+      `user-invocable: false` produces none.
+- [ ] The content lint fails the build when a Claude-ism or an unresolved
+      `{{…}}` token appears in any non-Claude first-class target output.
+- [ ] `git-workflow/SKILL.md` documents unscoped `type: description`; the
+      distributed copies are rebuilt to match; a sample commit message passing the
+      doc passes `check.go` enforcement.
+- [ ] The parity-matrix test enumerates exactly the five first-class harnesses and
+      fails if any `user-invocable` skill is unreachable, any advisory hook
+      becomes enforcing (or vice versa) on any surface, or any Claude-ism leaks.
+- [ ] `loaf build`, `npm run typecheck`, and `npm run test` all pass; committed
+      `dist/`/`plugins/` artifacts match regenerated output (`git diff
+      --exit-code -- dist plugins`).
+
+## Priority Order
+
+Tracks ship in this order; if scope tightens, drop from the end. All tracks are
+non-breaking in-repo except the Gemini user-side cleanup, which is deferred to
+SPEC-053 entirely.
+
+1. **Real interpreter validation** (non-breaking) — remove the fake `node` and
+   the bad assertion; wire `node --check` / `tsc --noEmit`. Go/no-go: a malformed
+   emitted artifact fails the build before continuing.
+2. **Amp first-class TS plugin** (non-breaking in-repo) — valid TS at the real
+   path, handler-bug fix, header dropped. Go/no-go: Amp plugin passes the
+   validation from Track 1 and a handler test.
+3. **Drop Gemini, in-repo** (non-breaking in-repo; user-side cleanup gated on
+   SPEC-053) — remove from config/build/install/tests. Go/no-go: `loaf build`
+   succeeds and no Gemini reference remains.
+4. **Codex advisory hooks + OpenCode coverage** (non-breaking) — `failClosed`
+   default/parse, `blocking`/`if` carry-through, command coverage off
+   `user-invocable`. Go/no-go: Codex/OpenCode regression tests pass.
+5. **Harness-language transform + Claude-ism lint** (non-breaking) — token
+   vocabulary, per-target resolution, build-failing lint. Go/no-go: lint fails on
+   a seeded Claude-ism and passes clean output.
+6. **git-workflow commit-format fix** (non-breaking) — unscoped format + rebuilt
+   copies. Can be dropped if scope tightens (it is a one-line doc/correctness fix).
+7. **Parity-matrix test** (non-breaking; the durable guard) — single enumerating
+   test over the five harnesses. Go/no-go: it passes on current output and fails
+   on a seeded parity gap.

--- a/.agents/specs/SPEC-048-session-model-convergence.md
+++ b/.agents/specs/SPEC-048-session-model-convergence.md
@@ -1,0 +1,334 @@
+---
+id: SPEC-048
+title: Session-Model Convergence to SQLite
+source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-C)"
+created: 2026-06-22T09:13:21Z
+status: drafting
+branch: feat/session-model-convergence
+source_sessions:
+  - id: 20260621-001541-session
+    role: shaped
+related_specs:
+  - SPEC-040
+  - SPEC-043
+  - SPEC-044
+  - SPEC-049 # sequenced-with SPEC-049 (soft; SPEC-048 may land first)
+  - SPEC-029
+  - SPEC-037
+---
+
+# SPEC-048: Session-Model Convergence to SQLite
+
+## Problem Statement
+
+SPEC-040 made one global SQLite database the canonical operational store and
+demoted markdown in `.agents/` to compatibility/export. The skill suite never
+followed. Per the deep evaluation
+(`.agents/reports/20260621-020342-loaf-skill-suite-deep-evaluation.md`, §1.1),
+**exactly one skill — `wrap` — converged.** Everything else still teaches the
+markdown-era session model as primary, and in one case drives a command that is
+now a no-op:
+
+- `loaf session housekeeping` returns `Action: "skipped"` in SQLite mode
+  (`internal/cli/cli.go:7096`, reason: *"markdown session housekeeping … is not
+  run in SQLite mode"*). The `housekeeping` skill drives this dead command at
+  `content/skills/housekeeping/SKILL.md:21,49,50,62`. The real artifact scanner
+  is the top-level `loaf housekeeping`, which the skill never names.
+- Because `housekeeping` never runs, it never writes its `skill(housekeeping)`
+  self-log marker, so `wrap`'s "no housekeeping this session" nudge mis-fires
+  (eval report §3 M1).
+- `content/templates/session.md` — the schema *everyone cites* — still documents
+  a markdown file at `.agents/sessions/YYYYMMDD-HHMMSS-session.md` with YAML
+  frontmatter as the routing surface (template lines 3–12, 57–59).
+- `implement` teaches "**MANDATORY: Create session file BEFORE any other work**"
+  (`content/skills/implement/SKILL.md:251,261`), and the `implementer.md`
+  profile (`content/agents/implementer.md:8`) still demands "a session file …
+  provided in your spawn prompt." These cross-reference each other; a half-fix
+  desynchronizes the spine.
+- `content/skills/implement/references/session-management.md:220-254` documents
+  **transcript archival to `.agents/transcripts/`** — a SPEC-040 scope violation
+  (raw transcript capture is explicitly out of scope; SPEC-040:88-89,162) and a
+  data-handling liability.
+
+The taxonomy is healthy (eval §1). The disease is a half-shipped migration. The
+governing constraint from the evaluation (§7.3): **a half-migrated spine — some
+skills SQLite-first, others markdown-first, cross-referencing each other — is
+*worse* than the current consistent-but-wrong state.** This spec finishes the
+convergence and lands it atomically.
+
+## Strategic Alignment
+
+**Vision / Architecture.** The loaf CLI is the harness; operational truth lives
+in one global SQLite store; markdown is a projection. This spec brings the
+session model — the most-cited operational surface in the skill suite — into
+line with that architecture, eliminating the last large pocket of markdown-era
+guidance.
+
+**Supersedes / completes:**
+- **SPEC-040** (`.agents/specs/SPEC-040-sqlite-backed-loaf-operational-state.md`,
+  status `complete`). SPEC-040 shipped the SQLite session model
+  (`session start/end/log/archive`, journal rows, SQLite-only lifecycle) but
+  Priority Order Track E ("Skill and hook migration", SPEC-040:520) was only
+  partially delivered — `wrap` alone converged. SPEC-048 completes Track E for
+  the session-model surface. It also enforces SPEC-040's own out-of-scope
+  decision (SPEC-040:162 — no raw transcript ingestion) by *removing* the
+  transcript-archival guidance that violates it.
+
+**Coordinates with:**
+- **SPEC-043** (WS-B, bodies into SQLite). Sessions become SQLite-only **bodies**
+  per SPEC-043's body store — there is no in-tree session `.md` as source after
+  this spec; the markdown view is render-on-demand. SPEC-048 depends on SPEC-043
+  landing the session-body storage and `session show/list` read path. SPEC-048
+  does the **skill/profile/template** convergence; SPEC-043 does the **storage**
+  convergence. They must be coherent: this spec's guidance assumes SPEC-043's
+  body store exists.
+- **SPEC-044** (WS-B, deterministic render + drift gate). The render-on-demand
+  markdown view of a session uses SPEC-044's deterministic body renderer. SPEC-048
+  benefits from but does not strictly require SPEC-044 — until it lands, sessions
+  are SQLite-only with the existing compatibility export.
+- **SPEC-049** (WS-C, status-vocabulary unification) — **sequenced-with SPEC-049
+  (soft; SPEC-048 may land first)**. The session status enum is
+  inconsistent across three files today: `active` (`content/templates/session.md`),
+  `in_progress`/`paused` (`content/skills/orchestration/references/sessions.md`),
+  and `active/stopped/done/blocked/archived` (CLAUDE.md). SPEC-049 owns the
+  canonical enum and the "schema lives in exactly one file" lint. SPEC-048 must
+  not invent a fourth vocabulary — it cites whatever SPEC-049 anoints. If SPEC-048
+  lands first, it uses the SPEC-040 runtime enum (`internal/state/session_*.go`)
+  as the interim source of truth and SPEC-049 reconciles.
+- **SPEC-029** (librarian journal enrichment). SPEC-029 enriches session journals
+  from JSONL; the `housekeeping` skill currently drives `loaf session enrich`
+  (`content/skills/housekeeping/SKILL.md:52,79`). SPEC-048 keeps enrichment but
+  reroutes/cleans the guidance so it does not depend on the dead markdown
+  housekeeping path. Conflict to name: SPEC-029 edits session `.md`; once sessions
+  are SQLite-only bodies, enrichment writes journal **rows**, not file lines.
+- **SPEC-037** ("specs are mutable internal work definitions"). Unaffected here,
+  noted because the same markdown-vs-SQLite tension recurs; sessions are not specs
+  and are unambiguously SQLite-only (ephemeral tier).
+
+## Solution Direction
+
+Finish the migration the suite never followed, landing it **as one atomic
+change** so the session spine is never internally inconsistent. Anoint `wrap` as
+the canonical session model and propagate it outward in strict dependency order.
+
+The convergence is content-and-CLI, not new storage (SPEC-043 owns storage):
+
+1. **Anoint the model.** Cite `wrap` as the canonical session model in
+   `.claude/CLAUDE.md` and `.agents/AGENTS.md`. The model is: `loaf session
+   start` (find/create + emit context) → `loaf session log "type(scope): desc"`
+   → `loaf session end --wrap`. No hand-authored session file, no mandated
+   frontmatter editing, no transcript archival.
+
+2. **Rewrite in dependency order (one PR/commit set):**
+   `content/templates/session.md` (schema everyone cites) → `orchestration`
+   (SKILL + `references/sessions.md`, `references/context-management.md`,
+   `references/background-agents.md`) → `implement` **+ the `implementer.md`
+   profile in the same change** → `bootstrap` → `brainstorm` (SQLite-first sparks
+   via `loaf spark capture`) → read-side second wave (`reflect`, `research`,
+   `background-runner`).
+
+3. **Sessions become SQLite-only bodies** (per SPEC-043). No in-tree session
+   `.md` as source. The markdown view is render-on-demand (`loaf session show`,
+   and SPEC-044's renderer once available). `content/templates/session.md`
+   becomes a **render template / journal-format reference**, not a file scaffold
+   — the entry-type vocabulary and `[timestamp] type(scope): desc` format are
+   still authoritative; the "create this file" framing is removed.
+
+4. **Remove transcript-archival guidance** entirely
+   (`content/skills/implement/references/session-management.md:220-254` and any
+   `transcripts:` rows/layout in `orchestration`). It violates SPEC-040 scope and
+   is a data-handling liability.
+
+5. **Fix the housekeeping dead command.** Replace `loaf session housekeeping`
+   with `loaf housekeeping` (the real scanner) throughout
+   `content/skills/housekeeping/SKILL.md`, and ensure the `skill(housekeeping)`
+   self-log marker is written on invocation — which fixes `wrap`'s mis-firing
+   nudge. Reroute the `loaf session enrich` guidance so it does not present the
+   skipped markdown path as the primary flow.
+
+6. **Add first-action self-logging** to user-invocable workflow skills (the
+   `loaf session log "skill(<name>): …"` first action, per `.claude/CLAUDE.md`
+   "Session Journal Self-Logging"). Fix the AGENTS.md exemplars (`shape`,
+   `housekeeping`, `implement`) first so the rule and its examples agree
+   (eval §3 M1). Keep existing `decision()` self-logs that carry useful outcomes.
+
+The "all 5 first-class harnesses" parity contract (WS-A / SPEC-047) applies:
+these are content edits in `content/`, regenerated to all five harness outputs.
+No Claude-isms should be introduced; rely on SPEC-047's harness-language
+tokens where harness-specific terms appear.
+
+## Scope
+
+### In Scope
+
+- Cite `wrap` as the canonical session model in `.claude/CLAUDE.md` and
+  `.agents/AGENTS.md`.
+- Rewrite `content/templates/session.md` from a file-scaffold to a render
+  template / journal-format reference (keep entry-type table + format rules;
+  drop the "create `.agents/sessions/*.md`" framing and YAML-frontmatter-as-source).
+- Rewrite `orchestration`: `SKILL.md` session sections + `references/sessions.md`,
+  `references/context-management.md`, `references/background-agents.md` to the
+  SQLite/`wrap` model; remove `transcripts:` rows/layout.
+- Rewrite `implement` `SKILL.md` (replace MANDATORY-session-file framing at
+  `:251,261`, the "session file exists" success criteria at `:49,51`, and the
+  scattered "create session file" steps with `loaf session start` flow) **and**
+  `content/agents/implementer.md:8` in the same change.
+- Delete the Transcript Archival section
+  (`content/skills/implement/references/session-management.md:220-254`) and the
+  list of transcript triggers (`:245-247`).
+- Rewrite `bootstrap` session guidance to the SQLite/`wrap` model.
+- Rewrite `brainstorm` to capture sparks via `loaf spark capture` (SQLite-first)
+  rather than treating draft `.md` as canonical.
+- Rewrite read-side skills (`reflect`, `research`, `background-runner`) that read
+  session state to the SQLite/`wrap` model.
+- Fix `housekeeping` skill: `loaf session housekeeping` → `loaf housekeeping`
+  everywhere; reroute `loaf session enrich` guidance; ensure
+  `skill(housekeeping)` self-log marker is written.
+- Add first-action `loaf session log "skill(<name>): …"` self-logging to the
+  user-invocable workflow skills that lack it; fix the AGENTS.md exemplars first.
+- Regenerate all built target outputs (`dist/*`, `plugins/loaf/`) and commit them
+  with the source changes.
+- Verification: a lint asserting no skill references `loaf session housekeeping`
+  or `.agents/transcripts/`; a check that the canonical session model is cited in
+  exactly the anointed places.
+
+### Out of Scope
+
+- The session **storage** model (body store, `session show/list` read path,
+  SQLite-only bodies mechanics) — owned by **SPEC-043**.
+- The deterministic markdown render of a session body and its drift gate — owned
+  by **SPEC-044**.
+- Canonicalizing the session **status enum** and the "schema in exactly one file"
+  lint — owned by **SPEC-049** (this spec cites, does not define, the enum).
+- Build-integrity / harness-parity / harness-language tokenization — owned by
+  **SPEC-047** (WS-A); SPEC-048 consumes its tokens, does not build them.
+- General skill de-bloat (orchestration thin-hub, research mode cuts) beyond the
+  session-model surface — owned by **SPEC-050** (WS-D).
+- Routing/description rewrites — owned by **SPEC-051** (WS-E).
+- Changing `loaf session`/`loaf housekeeping` CLI *behavior* — this spec aligns
+  guidance to existing commands; it does not add or alter command surface.
+
+### Rabbit Holes
+
+- **Re-litigating the SQLite decision.** SPEC-040 is `complete`; sessions are
+  SQLite. This spec aligns the suite, not the architecture.
+- **Defining a new status enum.** Resist; SPEC-049 owns it. Cite the runtime
+  enum (`internal/state/session_*.go`) as interim truth, no more.
+- **Touching every skill that merely mentions "session."** Limit to the named
+  set in dependency order; a wider sweep risks the non-atomic spine the eval
+  warns against (§7.3).
+- **Folding transcript capture into SQLite "properly."** No — removal only.
+  Raw transcript storage stays out of scope (SPEC-040:162).
+- **Self-logging as a 130-edit standalone workstream** (eval §3 M1). Add it to
+  the user-invocable workflows touched in this convergence + fix the exemplars;
+  do not chase a mechanical line-count target.
+
+### No-Gos
+
+- Do not land a partial convergence. The spine ships atomically or not at all.
+- Do not reintroduce hand-authored session `.md` as a source surface.
+- Do not document `.agents/transcripts/` or transcript archival anywhere.
+- Do not present `loaf session housekeeping` (a no-op in SQLite mode) as a
+  working command in any skill.
+- Do not invent a session vocabulary that conflicts with SPEC-049 / the runtime
+  enum.
+- Do not introduce Claude-isms; use SPEC-047 harness-language tokens.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Non-atomic landing leaves the spine internally inconsistent (some SQLite-first, some markdown-first) | Medium | High | One PR/commit set covering template → orchestration → implement+profile → bootstrap → brainstorm → read-side; reviewer checks cross-references resolve to the same model |
+| SPEC-043 (session bodies) not landed when this ships | Medium | High | Hard dependency: gate SPEC-048 on SPEC-043's session-body store + `session show/list`; until then guidance references nonexistent storage |
+| Status-enum guidance contradicts SPEC-049 | Medium | Medium | Cite runtime enum as interim only; coordinate sequencing so SPEC-049 reconciles; add no fourth vocabulary |
+| `implement` and `implementer.md` desynchronize (one fixed, one not) | Medium | High | Explicit In-Scope coupling: both edited in the same change; verification asserts neither mentions "MANDATORY session file" |
+| Transcript-removal misses a dist copy, leaving the liability shipped | Medium | High | Lint: zero matches for `.agents/transcripts/`/`Transcript Archival` across `content/` + all built outputs |
+| `housekeeping` rewrite reroutes to a command with different flags than the skill assumes | Low | Medium | Verify `loaf housekeeping --dry-run/--sessions/--specs/--drafts` flags against `internal/cli` before rewriting examples |
+| Self-logging churn introduces noise without the marker fix actually firing | Low | Medium | Tie the `skill(housekeeping)` marker fix to a `wrap`-nudge test; verify the nudge stops mis-firing |
+| Built outputs drift from source (uncommitted regeneration) | Medium | Medium | Run `loaf build`; commit `dist/`/`plugins/` with source per CLAUDE.md "Before Committing" |
+
+## Open Questions
+
+- [ ] Does SPEC-049 land before or after SPEC-048? If after, confirm the interim
+  enum source (`internal/state/session_*.go`) is the right citation and that
+  SPEC-049 will reconcile the three documents this spec touches.
+- [ ] After SPEC-043, is `content/templates/session.md` retained as a *render
+  template* consumed by the renderer, or demoted to a pure journal-format
+  *reference* doc? (Affects whether it lives in `templates/` or `references/`.)
+- [ ] Should `loaf session enrich` guidance survive in `housekeeping` at all once
+  sessions are SQLite-only bodies (SPEC-029 writes rows, not file lines), or move
+  wholesale into the SQLite enrichment path?
+- [ ] Exact set of "read-side" skills beyond `reflect`/`research`/`background-runner`
+  that reference session state — confirm by grep before the atomic change so none
+  are left markdown-first.
+- [ ] Which user-invocable workflows still lack a first-action self-log? Enumerate
+  against `content/skills/*` (eval §3 M1 says only 2 of ~19 comply).
+
+## Test Conditions
+
+- [ ] `wrap` is cited as the canonical session model in `.claude/CLAUDE.md` and
+  `.agents/AGENTS.md`; no other document presents a competing "create a session
+  file" model as primary.
+- [ ] `content/templates/session.md` no longer instructs creating
+  `.agents/sessions/*.md` as a source surface; it documents the journal entry
+  format and entry types as a render template / reference.
+- [ ] No skill or agent profile references `loaf session housekeeping`; all
+  housekeeping guidance uses `loaf housekeeping`.
+- [ ] `content/skills/housekeeping/SKILL.md` writes a `skill(housekeeping)`
+  self-log marker on invocation, and `wrap`'s "no housekeeping this session"
+  nudge stops mis-firing when housekeeping has run.
+- [ ] Zero matches for `Transcript Archival` or `.agents/transcripts/` across
+  `content/` and all built outputs (`dist/*`, `plugins/loaf/`).
+- [ ] `content/skills/implement/SKILL.md` no longer contains "MANDATORY: Create
+  session file BEFORE any other work" or "DO NOT PROCEED WITHOUT A SESSION FILE";
+  it teaches `loaf session start`.
+- [ ] `content/agents/implementer.md` no longer demands a hand-authored "session
+  file" and aligns with the `loaf session start` model — changed in the same
+  commit set as `implement`.
+- [ ] `orchestration` SKILL + `sessions.md`/`context-management.md`/
+  `background-agents.md` present the SQLite/`wrap` model and contain no
+  `transcripts:` frontmatter rows/layout.
+- [ ] `brainstorm` captures sparks via `loaf spark capture` (SQLite-first); the
+  draft `.md` is described as export/projection, not canonical source.
+- [ ] Read-side skills (`reflect`, `research`, `background-runner`) reference the
+  SQLite session model, not markdown session files as the routing surface.
+- [ ] User-invocable workflow skills touched in this convergence include a
+  first-action `loaf session log "skill(<name>): …"`; the `shape`, `housekeeping`,
+  and `implement` AGENTS.md exemplars match the documented rule.
+- [ ] The session vocabulary used in the rewritten content matches the runtime
+  enum (`internal/state/session_*.go`) / SPEC-049's canonical enum — no fourth
+  vocabulary introduced.
+- [ ] `loaf build` succeeds; `npm run typecheck` and `npm run test` pass; built
+  outputs committed with source.
+- [ ] The whole convergence lands as one atomic change set — no intermediate
+  commit leaves some session skills SQLite-first and others markdown-first.
+
+## Priority Order
+
+Tracks land **as a single atomic change** (the spine must never be internally
+inconsistent), but in this dependency order within the change. All tracks are
+**non-breaking** content/guidance edits over existing commands; the gate is
+SPEC-043 (session bodies).
+
+0. **Gate — SPEC-043 session bodies.** Go/no-go: SPEC-043's session-body store
+   and `session show/list` read path exist so guidance references real storage.
+   *(non-breaking; dependency gate)*
+1. **Anoint + schema.** Cite `wrap` in CLAUDE.md/AGENTS.md; rewrite
+   `content/templates/session.md` (the schema everyone cites). Go/no-go: the
+   canonical model is stated once and the template no longer scaffolds a file.
+   *(non-breaking)*
+2. **Orchestration.** SKILL + `sessions.md`/`context-management.md`/
+   `background-agents.md` to SQLite/`wrap`; strip `transcripts:`. *(non-breaking)*
+3. **Implement + profile (coupled).** `implement/SKILL.md` and `implementer.md`
+   together; delete `session-management.md` transcript section. Go/no-go: neither
+   demands a hand-authored session file. *(non-breaking)*
+4. **Bootstrap + brainstorm.** Bootstrap session guidance to SQLite/`wrap`;
+   brainstorm to `loaf spark capture`. *(non-breaking)*
+5. **Read-side wave.** `reflect`, `research`, `background-runner`. *(non-breaking)*
+6. **Housekeeping fix + self-logging.** `loaf session housekeeping` →
+   `loaf housekeeping`; write `skill(housekeeping)` marker; add first-action
+   self-logging to touched user-invocable workflows; fix AGENTS.md exemplars.
+   Go/no-go: `wrap` nudge no longer mis-fires. *(non-breaking)*
+7. **Build + verify.** `loaf build`, typecheck, test, commit built outputs; run
+   the transcript/dead-command lints. Go/no-go: lints green, outputs committed.
+   *(non-breaking)*

--- a/.agents/specs/SPEC-049-status-vocabulary-unification.md
+++ b/.agents/specs/SPEC-049-status-vocabulary-unification.md
@@ -1,0 +1,216 @@
+---
+id: SPEC-049
+title: "Status-Vocabulary Unification"
+source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-C)"
+source_sessions:
+  - id: 20260621-001541-session
+    role: shaped
+created: 2026-06-22T09:13:21Z
+status: drafting
+branch: feat/status-vocabulary-unification
+---
+
+# SPEC-049: Status-Vocabulary Unification
+
+## Problem Statement
+
+Loaf carries **five incompatible per-entity lifecycle vocabularies**, each defined and ordered
+independently, with no shared model and no validation against a common set:
+
+| Entity | Statuses (as coded) | Defined at |
+|--------|---------------------|------------|
+| spec | `implementing`, `approved`, `drafting`, `complete`, `archived` | `internal/state/spec_list.go:11` |
+| task | `todo`, `in_progress`, `blocked`, `review`, `done` (+ `archived` for list filter) | `internal/state/task_list.go:12-13` |
+| report | `draft`, `final`, `archived` | `internal/state/report_lifecycle.go:149,158,163` |
+| session | `active`, `stopped`, `done`, `blocked`, `archived` | `internal/state/session_start.go:138,159`, `internal/state/session_end.go:14-15,140-153` |
+| idea / spark / brainstorm | `open` → `resolved` (→ `archived`) | `internal/state/idea.go:568-579`, `internal/state/spark.go:594-605`, `internal/state/brainstorm.go:109-120` |
+
+The drift is not cosmetic. The same conceptual phase (e.g. "this is done / closed / finalized") is
+spelled `complete`, `done`, `final`, and `resolved` across entities. Reports surface `active` and
+`unknown` to users where the real states are `draft`/`final`/`archived` (called out as a defect in
+the roadmap, WS-B note). There is no `Valid*Status` for report, session, idea, spark, or brainstorm
+— only spec (via `specStatusOrder`, `internal/state/spec_list.go:11`) and task
+(`ValidTaskStatus`, `internal/state/task_list.go:198`) validate at all, so invalid statuses can be
+written silently. Every `include*Status` filter hard-codes literals (`status == "resolved"`,
+`status != "active"`) that would all need to change in lockstep.
+
+The lifecycle history compounds the problem: every status transition writes an `events` row with
+`from_status`/`to_status` (`internal/state/migrations/0001_initial.sql:156-157`), populated at ~14
+call sites across `task_*.go`, `spec_archive.go`, `report_lifecycle.go`, `session_*.go`,
+`idea.go`, `spark.go`, `brainstorm_archive.go`. Unifying the vocabulary means rewriting the stored
+strings in already-populated tables — a **data migration**, not just a code change. Without this,
+`loaf search` (SPEC-043), cross-entity status filtering, and any uniform `list --status` flag are
+built on five mutually-unintelligible enums.
+
+## Strategic Alignment
+
+- **Vision:** Advances *Structured Execution* and the "mechanical enforcement, not a prompt
+  library" stance — a single validated vocabulary lets `loaf check`, list filters, and search treat
+  status as a typed dimension instead of free text.
+- **Architecture:** One global SQLite DB is the source of truth (SPEC-040). A coherent status model
+  is the cross-entity contract that makes uniform verbs (`list`/`show`/`new`/`edit`/`archive`,
+  SPEC-043) and FTS5 status-filtered search meaningful across entities.
+
+**Carved out of SPEC-043 (WS-B) per review.** SPEC-043 defers status-vocabulary unification
+(Resolved Decisions #4) to SPEC-049; this spec owns the canonical set, validation, and the `events`
+rewrite. SPEC-043 has **zero hard dependency** on this spec: bodies-in-SQLite, search, and uniform
+verbs can land with the legacy per-entity vocabularies intact, and this unification can follow
+independently.
+
+**Coordinates-with:**
+- **SPEC-048 (WS-C, Session-Model Convergence):** the session enum
+  (`active`/`stopped`/`done`/`blocked`/`archived`) is reconciled *there* — SPEC-048 owns the session
+  schema-in-one-file lint and the `wrap` model. SPEC-049 must adopt whatever canonical session
+  states SPEC-048 settles on; the two are **sequenced together** so the session row is migrated once,
+  not twice. Where they touch the same `session_*.go` files, SPEC-048 lands first or they land in the
+  same change.
+- **SPEC-053 (WS-G, Breaking-Change Migration Mechanism):** this is a **breaking data rewrite** of a
+  populated table and must run behind SPEC-053's reversible/backed-up migration gate with user
+  sign-off.
+- **SPEC-035 (TASKS.json staleness):** the legacy `TASKS.json` subsystem is still live. Task status
+  has two homes; rewriting the SQLite task vocabulary without reconciling `TASKS.json` re-creates the
+  dual-source drift SPEC-035 fights. Name the `TASKS.json` status mapping explicitly (Open Question).
+- **SPEC-037 (mutable specs):** spec status semantics (`drafting`/`approved`/`implementing`) interact
+  with SPEC-037's "specs are mutable work definitions"; do not redefine spec lifecycle *meaning*,
+  only the spelling/validation.
+
+## Solution Direction
+
+Define **one canonical lifecycle vocabulary** as a typed set in a single Go source location, with
+per-entity *allowed subsets* (not every entity uses every state) and a shared validator. The model
+is a small set of universal phases that each entity maps onto; entity-specific nuance is preserved
+where it carries real meaning (e.g. task `blocked`, session `stopped` vs `done`) rather than
+collapsed for tidiness.
+
+Candidate universal phases (exact set is an Open Question, to be decided *with* SPEC-048, not
+bikeshedded):
+
+| Universal phase | Today's spellings it absorbs |
+|-----------------|------------------------------|
+| `open` / `active` | idea/spark/brainstorm `open`; session `active`; task `todo` |
+| `in_progress` | task `in_progress`; spec `implementing` |
+| `blocked` | task `blocked`; session `blocked` |
+| `review` | task `review`; spec `approved`; report `draft` (under review) |
+| `done` | task `done`; spec `complete`; report `final`; idea/spark/brainstorm `resolved`; session `done` |
+| `paused` | session `stopped` |
+| `archived` | all entities' `archived` |
+
+Each entity declares which subset it permits; `Valid<Entity>Status` validates against that subset;
+`<Entity>StatusOrder` returns display order over it. A migration rewrites every populated row in the
+entity tables and the `events` table:
+
+- **Entity rows:** rewrite `status` to the canonical spelling.
+- **`events` rows — the honest contract:** rewrite `to_status` to the canonical spelling.
+  `from_status` for **pre-existing** rows is *not* faithfully reconstructable to the canonical model
+  (the prior state may map ambiguously, and older rows predate consistent capture). Rather than
+  fabricate history, the migration **appends exactly one synthetic normalization event per rewritten
+  entity** (`event_type = "status_normalized"`, `from_status` = the entity's last known legacy
+  status, `to_status` = its canonical equivalent, `note` describing the SPEC-049 migration). Existing
+  `events` rows keep their original `from_status`/`to_status` *spellings as historical record* — the
+  migration does **not** silently rewrite history in place beyond `to_status` normalization needed
+  for current-state queries. (Final in-place-vs-synthetic policy is an Open Question to settle before
+  breakdown; the default here is: normalize `to_status` for query correctness, do not invent
+  `from_status`, emit one synthetic boundary event.)
+
+Migration runs against a **copy of the DB first**, takes a **backup** via the existing state-backup
+mechanism, and is **reversible** (a down-mapping table from canonical → legacy spelling is retained
+so the rewrite can be undone). All of this rides the SPEC-053 migration harness.
+
+After migration, update every `include*Status` filter, the human-readable and `--json` list output,
+and add a lint asserting the canonical vocabulary lives in exactly one source file (mirroring
+SPEC-048's "session schema in one file" lint, generalized).
+
+## Scope
+
+### In Scope
+- Canonical lifecycle vocabulary defined once (single Go file) with per-entity allowed subsets.
+- `Valid<Entity>Status` + `<Entity>StatusOrder` for **every** entity (spec, task, report, session,
+  idea, spark, brainstorm), replacing the ad-hoc literals and missing validators.
+- Rewrite of every `insert*StatusEvent` / events-insert call site
+  (`task_create.go:149`, `task_update.go:204`, `task_archive.go:178`, `spec_archive.go:130`,
+  `report_lifecycle.go:132,208`, `session_start.go:294`, `session_end.go:205`, `idea.go:254,379,552`,
+  `spark.go:367,503`, `brainstorm_archive.go:126`) to emit canonical spellings.
+- A reversible, backed-up data migration that rewrites populated entity `status` and events
+  `to_status`, and emits one synthetic `status_normalized` event per rewritten entity.
+- Update every `include*Status` filter and list/show output (human-readable + `--json`).
+- A lint/test: the canonical vocabulary is defined in exactly one file; no entity uses a status
+  outside its declared subset.
+- Reconcile the report `active`/`unknown` display defect against the canonical set.
+
+### Out of Scope
+- The session-state semantics themselves (`stopped` vs `done`, `wrap` model) — owned by SPEC-048.
+- Bodies-in-SQLite, search, uniform verbs, new entity types — owned by SPEC-043.
+- The migration harness itself (deprecation window, backup/restore plumbing) — owned by SPEC-053;
+  this spec *consumes* it.
+- `TASKS.json` retirement — owned by SPEC-035; this spec only defines the status mapping for it.
+
+### Rabbit Holes
+- **Bikeshedding the exact universal set.** Pick a small set with SPEC-048, migrate, move on. The
+  candidate table above is a starting point, not a debate prompt.
+- **Reconstructing faithful `from_status` history.** It is not faithfully reconstructable for
+  pre-event rows; do not try. The synthetic-boundary-event contract is the honest answer.
+- **Collapsing genuinely distinct states for tidiness** (e.g. merging `blocked` into `paused`, or
+  `review` into `in_progress`). Preserve meaning that drives behavior.
+
+### No-Gos
+- Rewriting `events` history *in place* such that the original transition record is lost.
+- Migrating the live DB without a prior copy-run + backup.
+- Shipping the rewrite before SPEC-053's migration gate and user sign-off exist.
+- Validating only some entities (the current half-validated state is the disease, not a partial fix).
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Data loss / corruption during events + entity rewrite | Med | High | Run on DB copy first; mandatory backup; reversible down-mapping; behind SPEC-053 gate |
+| Divergence from SPEC-048's session enum (two rewrites) | Med | High | Sequence with SPEC-048; adopt its canonical session states; land in same change where files overlap |
+| `TASKS.json` re-introduces dual-source status drift (SPEC-035) | Med | Med | Define explicit status mapping for `TASKS.json`; coordinate with SPEC-035 |
+| Synthetic events confuse downstream history readers | Low | Med | Distinct `event_type = "status_normalized"`; documented; one per entity |
+| Spec/report status *meaning* accidentally redefined (SPEC-037) | Low | Med | Only respell/validate; do not change lifecycle semantics |
+| Missed call site leaves a legacy spelling in new rows | Med | Med | One-file vocabulary + lint; exhaustive call-site list above; test that no status outside subset is writable |
+
+## Open Questions
+- [ ] Exact canonical universal set and per-entity subsets (decide *with* SPEC-048).
+- [ ] `events` rewrite policy: normalize `to_status` only + synthetic boundary event (proposed
+      default) vs full in-place rewrite vs append-only with a normalization marker.
+- [ ] Whether `paused` (session `stopped`) is a universal phase or session-only.
+- [ ] How `TASKS.json` task statuses map to the canonical set and who owns keeping them in sync
+      (this spec vs SPEC-035).
+- [ ] Down-mapping fidelity for reversibility when multiple legacy spellings collapse to one
+      canonical phase (e.g. `complete`/`final`/`done`/`resolved` → `done`): does reverse need the
+      original spelling per entity, or is entity-type sufficient to recover it?
+
+## Test Conditions
+- [ ] A single Go source file defines the canonical vocabulary; a lint fails the build if any
+      status literal is defined elsewhere.
+- [ ] `Valid<Entity>Status` exists for spec, task, report, session, idea, spark, and brainstorm and
+      rejects any status outside that entity's declared subset.
+- [ ] Writing an out-of-subset status to any entity is rejected (was silently accepted for report,
+      session, idea, spark, brainstorm before).
+- [ ] Migration on a DB copy rewrites every entity `status` to its canonical spelling with zero rows
+      left at a legacy spelling.
+- [ ] After migration, each rewritten entity has exactly one `status_normalized` event whose
+      `from_status` is its last legacy status and `to_status` its canonical equivalent.
+- [ ] Pre-existing `events` rows retain their original transition record (history not destroyed).
+- [ ] The migration is reversible: running the down-migration restores legacy spellings byte-for-byte
+      on the entity `status` column.
+- [ ] A backup is taken before the live migration runs (verified by the SPEC-053 harness contract).
+- [ ] Report list no longer surfaces `active`/`unknown`; it shows canonical statuses only.
+- [ ] Session statuses produced match SPEC-048's canonical session set (cross-spec consistency test).
+
+## Priority Order
+
+Tracks ship in this order. If scope needs cutting, drop from the end. Marked non-breaking vs gated.
+
+1. **Define the canonical vocabulary + per-entity subsets + validators** (single file,
+   `Valid<Entity>Status`, `<Entity>StatusOrder`). *Non-breaking* (additive; new rows still accept
+   legacy spellings until track 3). Go/no-go: validators + one-file lint pass before touching call
+   sites.
+2. **Rewrite call sites + `include*Status` filters + list/show output to canonical spellings.**
+   *Non-breaking to stored data* (no rewrite yet); new rows now use canonical spellings. Go/no-go:
+   all 14 events-insert sites and every filter emit/accept canonical only; tests green. Must land
+   *with or after* SPEC-048's session changes where `session_*.go` overlaps.
+3. **Data migration: rewrite populated entity `status` + events `to_status`, emit synthetic
+   normalization events; reversible + backed-up.** **BREAKING — gated on SPEC-053 and user
+   sign-off.** Go/no-go: copy-run succeeds, reverse-migration verified, backup taken, sign-off
+   obtained before running against the live global DB.

--- a/.agents/specs/SPEC-050-skill-debloat-content-hygiene.md
+++ b/.agents/specs/SPEC-050-skill-debloat-content-hygiene.md
@@ -1,0 +1,259 @@
+---
+id: SPEC-050
+title: Skill De-bloat & Content Hygiene
+source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-D)"
+created: 2026-06-22T09:13:21Z
+status: drafting
+branch: feat/skill-debloat-content-hygiene
+source_sessions:
+  - id: 20260621-001541-session
+    role: shaped
+---
+
+# SPEC-050: Skill De-bloat & Content Hygiene
+
+## Problem Statement
+
+The deep skill-suite evaluation (`report-loaf-skills-deep-audit`,
+`.agents/reports/20260620-214448-audit-loaf-skills-deep-audit.md`) found that Loaf's taxonomy is
+healthy but the corpus carries excess reference mass, duplicated authority, over-claimed skill
+descriptions, unrunnable tooling, and a layer of stale cross-references that erode trust in the
+shipped content. None of these break the build, but together they make the skill suite harder to
+maintain, route through, and reason about.
+
+Concretely, the audit verified (and this spec re-verified against source):
+
+- **Orchestration has thin a root but heavy references.** `content/skills/orchestration/SKILL.md`
+  is already 154 lines (a good router), but its `references/` total ~4,156 lines across 16 files —
+  several duplicate authority owned by dedicated workflow skills (`references/councils.md` 404,
+  `references/planning.md` 422, `references/sessions.md` 523, `references/specs.md` 245,
+  `references/product-development.md` 247). Fourteen scripts live in
+  `content/skills/orchestration/scripts/` (e.g. `new-council.sh`, `validate-roadmap.py`,
+  `suggest-team.py`, `extract-decisions.py`) and most are not wired into `loaf check` or any hook —
+  `references/script-surface.md` does not even reference them.
+- **ADR authority is split.** `content/skills/architecture/SKILL.md` is the deep, correct ADR
+  source of truth (template at `templates/adr.md`, triage gate, supersession discipline,
+  numbering — `architecture/SKILL.md:86-204`). Yet `documentation-standards` re-publishes a
+  competing ADR template and format
+  (`content/skills/documentation-standards/references/documentation.md:47-50` "ADR Template" with a
+  full `# ADR-XXX: Title` block, plus `:30-31`, `:45`). Two ADR specs invite drift.
+- **Over-claimed descriptions.** `research` advertises four modes — State Assessment, Topic
+  Investigation, Brainstorming, Vision Evolution (`research/SKILL.md:51-56`, `:69-74`) — colliding
+  with `brainstorm` (ideation) and `strategy`/`reflect` (vision). `interface-design` is a
+  `user-invocable: false` reference skill (`interface-design/SKILL.claude-code.yaml:4`) but is not
+  negative-routed toward `artifact-design`/`frontend-design`. `foundations` claims it
+  "Establishes code quality, commit conventions, documentation standards, and security patterns"
+  (`foundations/SKILL.md:4-5`) — three of those are owned by sibling skills (`git-workflow`,
+  `documentation-standards`, `security-compliance`).
+- **Unrunnable tooling.** `infrastructure-management/scripts/validate-k8s-manifest.py:10` does
+  `import yaml` with no declared/bundled PyYAML dependency (the audit's local `import yaml` failed).
+  `power-systems-modeling/SKILL.claude-code.yaml` allows only `Bash(python:*)` while the skill
+  ships `scripts/check-standard-refs.sh` (a shell script the sidecar can never run).
+- **Structure/lint hygiene & stale references** verified at source:
+  - `database-design/SKILL.md:76` points to a nonexistent `infrastructure` skill (real name:
+    `infrastructure-management`).
+  - `power-systems-modeling/SKILL.md:93` points to a nonexistent `database-patterns`.
+  - `foundations/references/code-style.md:96-98` references `python`, `typescript`, `rails`
+    instead of `python-development`, `typescript-development`, `ruby-development`.
+  - `knowledge-base/SKILL.md:7,53,56,85` routes agent instructions to `CLAUDE.md` rather than the
+    current `.agents/AGENTS.md` entrypoint.
+  - `triage/SKILL.md` carries a stray closing code fence (the audit's finding #10).
+  - `cli-reference/SKILL.md` has effectively no `loaf session` family catalog — only a single
+    incidental mention (`:898`) of `loaf session start`; `start/log/end/list/show/archive` are
+    absent from the generated reference.
+
+## Strategic Alignment
+
+**Vision/Architecture.** This is the low-risk content-hygiene workstream of the Loaf restructuring
+roadmap (`.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md` §2 WS-D, §5). It does not
+change the SQLite-native runtime, targets, or install convention; it tightens the shipped content
+so the structural work landing in earlier specs is not re-buried under duplicated prose.
+
+**Coordinates-with:**
+
+- **SPEC-048 (Session-Model Convergence).** WS-D is explicitly sequenced *after* SPEC-048 to avoid
+  churn collisions on shared files — `orchestration/SKILL.md` and `orchestration/references/
+  sessions.md` / `context-management.md` are rewritten by SPEC-048's session convergence. This spec
+  removes/relocates orchestration's *non-session* duplicated references and unwired scripts only
+  after that rewrite settles. The session references themselves are SPEC-048's domain, not this
+  one's.
+- **SPEC-051 (Routing Eval & Validated Description Rewrites).** The description rewrites here
+  (`research` de-scope, `interface-design` negative-routing, `foundations` de-scope) are *content*
+  edits; SPEC-051 owns the routing-eval harness that *validates* description changes measurably
+  improve routing. This spec proposes the edits; SPEC-051 gates whether they ship. The two run in
+  parallel (roadmap §3: D ∥ E) and must coordinate so a description is not rewritten twice.
+  Per the roadmap decision, *no blind rewrites* — description changes here are staged behind
+  SPEC-051's eval where they affect routing.
+- **SPEC-043 (SQLite-Native Artifact Bodies).** The `cli-reference` catalog gap is a *content*
+  symptom; SPEC-043 introduces uniform `new/edit/show/list/link` verbs and a cli-reference
+  regeneration build-step. This spec only ensures the `loaf session` family is cataloged; it does
+  not re-author the generation mechanism (that is SPEC-043's).
+
+**Prior specs:**
+
+- **SPEC-040 (`.agents/specs/SPEC-040-sqlite-backed-loaf-operational-state.md`).** This spec must
+  not reintroduce markdown-as-source-of-truth assumptions; orchestration reference trimming keeps
+  the SQLite-native model intact.
+- **ADR-013 (`docs/decisions/ADR-013-agentic-state-storage-model.md`).** The `knowledge-base` fix
+  (route to `.agents/AGENTS.md`) aligns with the agentic state model.
+
+**Supersedes:** nothing. This spec retires duplicated content and corrects references; it does not
+supersede any prior spec or ADR.
+
+## Solution Direction
+
+Treat WS-D as a series of small, independently-reviewable content edits, each preserving build
+green (`loaf build`, `npm run typecheck`, `npm run test`) and the in-tree `dist/`+`plugins/` drift
+gate. Group the work into four clusters that can land as separate commits/PRs:
+
+1. **Reference de-duplication.** Make `orchestration` a thin hub: keep `SKILL.md` as the router,
+   and remove or stub references whose authority lives in a dedicated workflow skill
+   (`councils.md`→`council`, `planning.md`→`breakdown`/`shape`, `specs.md`→`shape`,
+   `product-development.md`→appropriate workflow). Leave session references to SPEC-048.
+   Retire or relocate the ~14 orchestration scripts: classify each as CLI-owned (promote to
+   `loaf check`), hook-owned (wire in `config/hooks.yaml`), skill-local helper (document as such),
+   or retired. Strip the competing ADR template/format from
+   `documentation-standards/references/documentation.md` and replace it with a link to
+   `architecture` as the single ADR source of truth.
+
+2. **Description de-scope & repositioning** (staged behind SPEC-051's eval where routing-affecting):
+   drop `research`'s ideation/vision modes (it becomes investigation-only; ideation→`brainstorm`,
+   vision→`strategy`/`reflect`); add negative-routing to `interface-design`'s description toward
+   `artifact-design`/`frontend-design` and keep it `user-invocable: false`; narrow `foundations`'
+   description to its actual surface (code quality + naming + TDD + verification), dropping the
+   git/docs/security over-claim and negative-routing to the sibling skills.
+
+3. **Tooling correctness.** Remove the undeclared PyYAML dependency from
+   `infrastructure-management`'s k8s validator — rewrite without `import yaml` (stdlib-only parse or
+   document an explicit opt-in dependency) — and reconcile `power-systems-modeling`'s sidecar
+   `allowed-tools` with the scripts it actually ships (add `Bash(*.sh)` semantics or convert the
+   shell helper to Python). Add a script smoke check so a skill cannot ship a script its sidecar
+   cannot execute.
+
+4. **Structure/lint hygiene.** Fix every verified stale reference, add missing `## Contents`
+   headers where absent, remove `triage`'s stray fence, and ensure the `loaf session` family
+   appears in the `cli-reference` catalog (coordinate with SPEC-043's regeneration build-step).
+
+## Scope
+
+### In Scope
+
+- Trim `orchestration` references that duplicate `council`/`shape`/`breakdown`/`research`
+  authority; retire or wire the unwired orchestration scripts.
+- Strip the duplicate ADR template/format from `documentation-standards`; link to `architecture`.
+- De-scope `research` (drop ideation/vision modes → investigation-only).
+- Reposition `interface-design` as a reference skill with negative-routing to
+  `artifact-design`/`frontend-design`.
+- De-scope `foundations` description (drop the three over-claimed sibling domains).
+- Fix unrunnable tooling: `infrastructure-management` PyYAML import; `power-systems-modeling`
+  sidecar/script mismatch.
+- Stale skill-name reference fixes: `database-design`→`infrastructure-management`,
+  `power-systems-modeling`→`database-design`, `foundations/code-style` →
+  `python-development`/`typescript-development`/`ruby-development`.
+- `knowledge-base` → route agent instructions to `.agents/AGENTS.md` not `CLAUDE.md`.
+- `triage` stray-fence fix; add missing `## Contents` headers where absent.
+- `cli-reference` `loaf session` family catalog gap (content-side; mechanism is SPEC-043).
+- Rebuild affected `dist/`+`plugins/` artifacts and commit them with the source changes.
+
+### Out of Scope
+
+- Session-model rewrites of `orchestration`/`implement`/`bootstrap` and the session references
+  (`sessions.md`, `context-management.md`) — owned by **SPEC-048**.
+- The routing-eval harness and the decision of *whether* a rewrite ships — owned by **SPEC-051**.
+- The cli-reference *generation mechanism* and uniform entity verbs — owned by **SPEC-043**.
+- Retiring `thermo-nuclear-code-quality-review`, `debugging` disposition, opt-in install packs,
+  `librarian` profile — owned by **SPEC-053** (taxonomy decisions).
+- Any breaking change, install-path relocation, or schema change.
+
+### Rabbit Holes
+
+- **Rewriting the entire orchestration reference set.** Only remove *duplicated* authority; do not
+  re-architect what remains. Resist turning trimming into a rewrite.
+- **Inventing new tooling for the unwired scripts.** Classify-and-decide; do not build a new script
+  runner. Promotion to `loaf check` is allowed only where a script is genuinely an enforcement
+  gate.
+- **Bikeshedding description wording.** Stage routing-affecting wording behind SPEC-051's eval
+  rather than iterating prose blind.
+
+### No-Gos
+
+- Do not start before SPEC-048 lands (avoids churn on shared `orchestration`/session files).
+- Do not reintroduce markdown-as-source-of-truth (SPEC-040).
+- Do not change skill *names* (only fix references *to* skills); name changes are taxonomy
+  decisions (SPEC-053).
+- Do not ship a routing-affecting description rewrite that SPEC-051's eval has not validated.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Trimming orchestration references breaks a link that another skill depends on | Medium | Medium | Grep for inbound references before deletion; run the link-integrity lint; rebuild and `git diff --exit-code -- dist plugins` |
+| Churn collision with SPEC-048 on shared orchestration/session files | Medium | Medium | Hard-sequence after SPEC-048; touch only non-session references here |
+| Description rewrite degrades routing | Medium | Medium | Stage routing-affecting rewrites behind SPEC-051's eval; no blind rewrites |
+| Removing PyYAML breaks the k8s validator's parse behavior | Low | Low | Validate against existing manifest fixtures; stdlib-only or documented opt-in |
+| cli-reference session catalog edit conflicts with SPEC-043's regeneration | Low | Medium | Coordinate; if SPEC-043 lands first, the gap closes there and this item is dropped |
+| Stale-reference fix misses a generated copy in `dist/` | Low | Low | Always rebuild after source edits; drift gate catches divergence |
+
+## Open Questions
+
+1. Should the unwired orchestration scripts that are genuinely useful (`suggest-team.py`,
+   `new-council.sh`) be promoted to `loaf` subcommands, or retired and folded into the relevant
+   skill prose? (Likely defers to whether SPEC-043/SPEC-048 absorb their function.)
+2. Does the `research` de-scope require a new template/mode removal, or only description + Quick
+   Reference table edits? (Verify `research/templates/` after SPEC-051's eval.)
+3. For `power-systems-modeling`: convert the shell helper to Python (matching the sidecar) or widen
+   the sidecar to allow shell? (Convention favors Python parity with the existing `*.py` scripts.)
+4. Is the `cli-reference` session gap fully closed by SPEC-043's regeneration build-step, making
+   this spec's catalog item a no-op? (Coordinate at breakdown time.)
+
+## Test Conditions
+
+- [ ] `loaf build` succeeds and `git diff --exit-code -- dist plugins` is clean after each cluster.
+- [ ] `npm run typecheck` and `npm run test` pass.
+- [ ] `content/skills/orchestration/references/` no longer contains references duplicating
+      `council`/`shape`/`breakdown`/`research` authority (session references untouched, owned by
+      SPEC-048).
+- [ ] Every script under `content/skills/orchestration/scripts/` is either wired (hook or
+      `loaf check`), documented as a skill-local helper, or removed.
+- [ ] `documentation-standards/references/documentation.md` no longer publishes an ADR template;
+      it links to `architecture` as the single ADR source of truth.
+- [ ] `research/SKILL.md` no longer advertises Brainstorming or Vision Evolution modes; routing
+      to `brainstorm`/`strategy`/`reflect` is negative-routed in its description.
+- [ ] `interface-design`'s description negative-routes to `artifact-design`/`frontend-design` and
+      it remains `user-invocable: false`.
+- [ ] `foundations`'s description no longer claims commit conventions, documentation standards, or
+      security patterns as its own surface.
+- [ ] `infrastructure-management/scripts/validate-k8s-manifest.py` runs without an undeclared
+      `import yaml` (or the dependency is explicitly declared/opt-in).
+- [ ] `power-systems-modeling` sidecar `allowed-tools` matches the scripts it ships (no
+      shell-script-without-shell-permission mismatch).
+- [ ] `rg -n 'infrastructure\b|database-patterns' content/skills/database-design content/skills/power-systems-modeling`
+      returns no stale skill-name references.
+- [ ] `rg -n '`python` skill|`typescript` skill|`rails` skill' content/skills/foundations` returns
+      nothing.
+- [ ] `knowledge-base/SKILL.md` routes agent instructions to `.agents/AGENTS.md`, not `CLAUDE.md`.
+- [ ] `triage/SKILL.md` has no stray/unbalanced code fence.
+- [ ] Every source `SKILL.md` over 100 lines has a `## Contents` header.
+- [ ] The `loaf session` family (`start/log/end/list/show/archive`) appears in the generated
+      `cli-reference` catalog (or the gap is closed by SPEC-043).
+
+## Priority Order
+
+All tracks are **non-breaking** content edits. None require a migration gate. Sequence after
+SPEC-048 has landed.
+
+1. **Structure/lint hygiene & stale references** (non-breaking) — triage stray fence, stale
+   skill-name fixes, `knowledge-base`→`.agents/AGENTS.md`, missing `## Contents` headers. Lowest
+   risk; clears sharp edges before larger edits create churn.
+2. **Tooling correctness** (non-breaking) — PyYAML removal, power-systems sidecar/script
+   reconciliation, script smoke check.
+3. **ADR de-duplication** (non-breaking) — strip the competing ADR spec from
+   `documentation-standards`; link to `architecture`.
+4. **Orchestration reference trim & script disposition** (non-breaking)
+   — **go/no-go gate: SPEC-048 must be merged** to avoid churn on shared orchestration/session
+   files.
+5. **Description de-scope & repositioning** (non-breaking)
+   — **go/no-go gate: SPEC-051's routing eval** must validate that routing-affecting rewrites
+   measurably improve routing before they ship (no blind rewrites).
+6. **cli-reference session catalog** (non-breaking) — **conditional on SPEC-043**: drop if
+   SPEC-043's regeneration build-step already closes the gap.

--- a/.agents/specs/SPEC-051-routing-eval-description-rewrites.md
+++ b/.agents/specs/SPEC-051-routing-eval-description-rewrites.md
@@ -1,0 +1,236 @@
+---
+id: SPEC-051
+title: Routing Eval & Validated Description Rewrites
+source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-E)"
+created: 2026-06-22T09:13:21Z
+status: drafting
+branch: feat/routing-eval-description-rewrites
+source_sessions:
+  - id: 20260621-001541-session
+    role: shaped
+---
+
+# SPEC-051: Routing Eval & Validated Description Rewrites
+
+## Problem Statement
+
+Skill routing is the only mechanism that decides which of 35 skills a user
+utterance reaches, and Loaf has no working evidence that routing is correct.
+The one tool that should measure it — `cli/scripts/eval-skill-routing.mjs` — is
+stale: it expects routes to skills that do not exist (`council-session`,
+`cleanup`, `resume-session`, `reference-session` at
+`cli/scripts/eval-skill-routing.mjs:195-244`), routes some prompts to `idea`
+where `triage` now owns queue processing (`:185-189`), and does not test the
+known confusable pairs at all. The actual skill set is
+`architecture, bootstrap, brainstorm, breakdown, cli-reference, council,
+database-design, debugging, documentation-standards, foundations, git-workflow,
+go-development, handoff, housekeeping, idea, implement, infrastructure-management,
+interface-design, knowledge-base, orchestration, power-systems-modeling,
+python-development, refactor-deepen, reflect, release, research, ruby-development,
+security-compliance, shape, ship, strategy, thermo-nuclear-code-quality-review,
+triage, typescript-development, wrap` — 35 skills, none of which is
+`council-session`/`cleanup`/`resume-session`/`reference-session`.
+
+The deep-evaluation report (`report-loaf-skills-deep-audit`,
+`.agents/reports/20260620-214448-audit-loaf-skills-deep-audit.md:262-278`) names
+both the eval drift and a set of description collisions
+(`foundations`/`research`/`brainstorm`/`interface-design`/`strategy`) but warns
+that string-inspection of descriptions is unreliable — the same failure mode the
+cli-reference self-correction exposed. So the rewrites must be **measured**, not
+asserted: a description "reads better" tells us nothing about whether the model
+routes to it correctly. Without a routing-eval gate, every description edit is a
+blind change to the most behaviorally-sensitive string in the system.
+
+One adjacent drift rides here because it shares the same surface:
+`docs/knowledge/skill-architecture.md:88` claims "33 skills total: 17 workflow,
+16 reference/knowledge" while the real count is 35. (The companion drift — that
+the user-invocable workflow skills lack a `skill(<name>)` first-action self-log
+line — is owned by SPEC-048, which rewrites the skills' session interaction.)
+
+## Strategic Alignment
+
+**Vision/Architecture.** Routing accuracy is the load-bearing property of the
+"skills-first" model documented in `.claude/CLAUDE.md` ("Descriptions drive
+routing... The model uses the description to choose from 100+ skills"). This
+spec makes that property *testable* rather than assumed. It touches no runtime
+backend and no harness build — it is a content + tooling workstream.
+
+**Supersedes.** Nothing. This is purely additive (a refreshed eval harness,
+measured description edits, doc-count fix).
+
+**Coordinates-with.**
+- **SPEC-050 (Skill De-bloat & Content Hygiene)** runs in parallel. Both edit
+  skill content. SPEC-050 owns *body* de-bloat (cutting reference mass, fixing
+  stale cross-refs, `## Contents` headers); SPEC-051 owns *frontmatter
+  `description`* and the routing harness. The seam is the YAML frontmatter:
+  SPEC-051 is the only workstream permitted to edit a skill's `description:`
+  block; SPEC-050 edits everything below the closing `---`. This avoids
+  merge collisions on the same files. The roadmap (WS-E) explicitly sequences
+  D ∥ E for this reason.
+- **SPEC-048 (Session-Model Convergence)** adds the self-logging first-action
+  line to workflow skills. **Ownership decision:** the self-log line is owned by
+  SPEC-048 because it is session-journal behavior, and SPEC-048 atomically
+  rewrites the skills' session interaction. SPEC-051 does **not** edit the
+  self-log line; it touches only the frontmatter `description:` block.
+- **SPEC-049 (Status-Vocabulary Unification)** is unaffected — descriptions
+  reference statuses only incidentally.
+- This spec depends on no other spec to begin. The deep-evaluation report it
+  draws from is `report-loaf-skills-deep-audit`
+  (`.agents/reports/20260620-214448-audit-loaf-skills-deep-audit.md`).
+
+## Solution Direction
+
+Build a skill-creator-style routing-eval harness as the gate, then let the gate
+decide which description rewrites ship.
+
+1. **Refresh the harness** (`cli/scripts/eval-skill-routing.mjs`). Drive the
+   skill list and the `<available_skills>` listing from the real
+   `content/skills/*` set (the loader already does this at `:54-84`; the stale
+   part is the hard-coded `TEST_CASES` map at `:89-250`). Replace `TEST_CASES`
+   with the current 35 skills and remove the four phantom skills. Add an
+   explicit **conflict-pair suite**: utterance → expected-skill probes for
+   `idea`/`triage`, `research`/`brainstorm`, `strategy`/`reflect`,
+   `ship`/`release`, `architecture`/`shape`, and
+   `foundations`/`git-workflow`/`documentation-standards`. The harness keeps its
+   current shape (system-prompt listing + single-token model answer +
+   pass/fail + per-skill accuracy + cost report) and the `npm run eval:routing`
+   entrypoint (`package.json:25`).
+
+2. **Establish a baseline.** Run the refreshed harness against the *current*
+   descriptions and record the per-pair accuracy. This is the number every
+   rewrite must beat.
+
+3. **Eval-gate the rewrites.** For each candidate skill
+   (`foundations`, `research`, `brainstorm`, `interface-design`, `strategy`),
+   propose a new `description:`, run the harness on the conflict-pair suite with
+   the proposed description swapped in, and **ship the rewrite only if measured
+   routing accuracy improves and nothing regresses**. A rewrite that reads
+   better but does not move (or worsens) the number is discarded. No blind
+   rewrites — this is the explicit lesson from the cli-reference self-correction
+   that string inspection is unreliable
+   (`.agents/reports/20260620-214448-audit-loaf-skills-deep-audit.md:24`).
+
+4. **Fix the taxonomy doc.** Update `docs/knowledge/skill-architecture.md:88`
+   from "33 skills total" to the verified count (35) with the correct
+   workflow/reference split, and refresh any other stale figure in that file.
+
+The harness is the deliverable that outlasts this spec: it is the regression
+guard so the next description edit or new skill cannot silently degrade routing.
+
+## Scope
+
+### In Scope
+- Rewrite `cli/scripts/eval-skill-routing.mjs` test cases to the real 35-skill
+  set; remove phantom skills (`council-session`, `cleanup`, `resume-session`,
+  `reference-session`).
+- Add a conflict-pair probe suite for the six named pairs/groups.
+- Capture a recorded baseline routing-accuracy result (committed as a fixture or
+  documented in the harness output section of the eval, not as live CI).
+- Eval-gated `description:` rewrites for `foundations`, `research`,
+  `brainstorm`, `interface-design`, `strategy` — ship only measured wins.
+- Fix the skill count and tier figures in
+  `docs/knowledge/skill-architecture.md`.
+- Rebuild artifacts (`dist/*`, `plugins/loaf/`) for any skill whose
+  `description:` changed, committed with the source.
+
+### Out of Scope
+- Editing skill *bodies* below the frontmatter (SPEC-050).
+- Any change to the build pipeline, harness targets, or hook generation
+  (SPEC-047 / WS-A).
+- Adding the eval to CI as a blocking gate (requires an API key in CI and has
+  per-run cost; see Rabbit Holes). The eval is a developer/pre-merge tool here.
+- Renaming, hiding, retiring, or merging any skill (taxonomy decisions are
+  SPEC-053 / WS-G; `debugging`/`thermo` disposition is not decided here).
+- Session-model rewrites or status-enum work (SPEC-048 / SPEC-049).
+- First-action self-logging line (`loaf session log "skill(<name>)"`) — owned by
+  SPEC-048, which atomically rewrites the skills' session interaction.
+- Rewriting descriptions for skills not measurably collision-prone.
+
+### Rabbit Holes
+- **Turning the LLM eval into a hard CI gate.** It costs money per run and needs
+  a key; non-determinism means a single run can flap. Keep it a developer tool
+  invoked on demand; if a deterministic guard is wanted, that is a separate
+  follow-on (a cheaper structural lint, not the LLM eval).
+- **Chasing 100% routing accuracy.** Some utterances are genuinely ambiguous
+  (e.g. "step back and assess" between `research` and `reflect`). The bar is
+  *measured improvement on the named pairs*, not perfection.
+- **Rewriting all 35 descriptions.** Only the five named collision-prone skills
+  are in scope; touching others invites churn without evidence.
+- **Building a bespoke eval framework.** Reuse the existing harness shape; do
+  not import a heavyweight eval dependency (CLAUDE.md: ask before adding deps).
+
+### No-Gos
+- No description ships without a measured routing improvement behind it.
+- No edits to skill bodies (SPEC-050's surface) — frontmatter `description:`
+  only.
+- No new third-party dependency for the harness without explicit approval.
+- No taxonomy/visibility changes (those are gated under SPEC-053).
+
+## Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| LLM eval non-determinism flaps pass/fail between runs | Medium | High | Report accuracy as aggregate over the suite, not single-prompt pass/fail; run N>1 and require the *delta* to hold; never wire as a hard CI gate |
+| Eval requires `ANTHROPIC_API_KEY` + cost; not all contributors can run it | Medium | High | Keep as opt-in developer tool; commit baseline result so reviewers see the number without re-running |
+| Improving one pair regresses another (descriptions interact) | High | Medium | Always run the *full* conflict suite per candidate, not just the target pair; reject any net or per-pair regression |
+| File collision with SPEC-050 editing the same SKILL.md | Medium | Medium | Hard seam: SPEC-051 edits only the `description:` block; SPEC-050 edits below frontmatter; sequence D ∥ E with this boundary |
+| Rebuilt `dist/*` drift if descriptions change but artifacts not regenerated | Medium | Medium | `loaf build` + `git diff --exit-code -- dist plugins` before commit (existing contract) |
+
+## Open Questions
+
+1. What model should the recorded baseline use — Opus (highest fidelity, matches
+   `DEFAULT_MODEL` at `eval-skill-routing.mjs:22`) or a cheaper model for
+   repeatability? Proposed: record baseline on the default model, allow
+   `--model` override for cheap iteration.
+2. How is the baseline persisted for reviewers — a committed JSON fixture under
+   `cli/scripts/` or a documented number in the spec/PR? Proposed: committed
+   fixture so regressions are diffable.
+3. Are `git-workflow` and `documentation-standards` themselves rewrite
+   candidates, or only probe-targets that sharpen `foundations`? Proposed:
+   probe-targets only unless the eval shows `foundations` cannot win without
+   adjusting a sibling's negative routing.
+4. Does the eval need to model the two-tier description truncation (≤250 char
+   first sentence vs full) the harness already slices at
+   `eval-skill-routing.mjs:81`? Confirm the 250-char budget still matches the
+   harnesses' real `<available_skills>` truncation.
+
+## Test Conditions
+
+- [ ] `npm run eval:routing` runs end-to-end with no skipped/"not found" skills
+      (the phantom-skill warning at `eval-skill-routing.mjs:319` never fires).
+- [ ] `rg -n 'council-session|cleanup|resume-session|reference-session' cli/scripts`
+      returns no matches.
+- [ ] The harness includes explicit conflict-pair probes for all six named
+      pairs/groups (`idea`/`triage`, `research`/`brainstorm`, `strategy`/`reflect`,
+      `ship`/`release`, `architecture`/`shape`,
+      `foundations`/`git-workflow`/`documentation-standards`).
+- [ ] A baseline routing-accuracy result is recorded and committed.
+- [ ] Each shipped `description:` rewrite (`foundations`, `research`,
+      `brainstorm`, `interface-design`, `strategy`) has a recorded
+      before/after accuracy showing measured improvement with no per-pair
+      regression; any candidate without a win is documented as discarded.
+- [ ] `docs/knowledge/skill-architecture.md` states the verified skill count
+      (35) and correct workflow/reference split; `rg -n '33 skills' docs`
+      returns no matches.
+- [ ] `loaf build` succeeds and `git diff --exit-code -- dist plugins` is clean
+      (regenerated artifacts committed with source).
+- [ ] `npm run typecheck` and `npm run test` pass.
+
+## Priority Order
+
+All tracks are **non-breaking** (content + developer tooling only; no schema,
+no harness surface, no install change). No SPEC-053 gate applies.
+
+1. **Track 1 — Refresh the harness** *(non-breaking; enables everything below)*.
+   Rewrite `eval-skill-routing.mjs` test cases to the real 35-skill set, drop
+   phantom skills, add conflict-pair probes. Go/no-go: harness runs clean with
+   zero skipped skills.
+2. **Track 2 — Record baseline** *(non-breaking; gate for Track 3)*. Run and
+   commit baseline accuracy. Go/no-go: baseline reproducible within run-to-run
+   variance.
+3. **Track 3 — Eval-gated description rewrites** *(non-breaking; each rewrite
+   independently gated)*. Per-skill go/no-go: ship only on measured
+   improvement, no regression. Skills that do not win are dropped from scope,
+   not forced.
+4. **Track 4 — Doc count fix** *(non-breaking; independent)*. Update
+   `skill-architecture.md`. Can land anytime.

--- a/.agents/specs/SPEC-052-agents-install-convention-parity.md
+++ b/.agents/specs/SPEC-052-agents-install-convention-parity.md
@@ -1,0 +1,209 @@
+---
+id: SPEC-052
+title: "~/.agents Install Convention & Harness Install Parity"
+source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-F)"
+source_sessions:
+  - id: 20260621-001541-session
+    role: shaped
+created: 2026-06-22T09:13:21Z
+status: drafting
+branch: feat/agents-install-convention-parity
+---
+
+# SPEC-052: ~/.agents Install Convention & Harness Install Parity
+
+## Problem Statement
+
+Loaf installs skills to inconsistent, per-harness directories, and the migration to a single
+`~/.agents/` convention is half-done. Cursor, Codex, and Gemini already write skills to
+`~/.agents/skills/` (`internal/cli/install_target.go:121,155,166`), but:
+
+- **OpenCode** still installs skills into its own config dir (`syncTargetSubdir(... "skills")`
+  under `$XDG_CONFIG_HOME/opencode/`, `install_target.go:110-116,499`) — not `~/.agents/`.
+- **Amp** installs skills to `~/.config/agents/skills/` (`install_target.go:175-177`), which is
+  neither `~/.agents/skills/` (the convention) nor Amp's documented native skills path. The
+  roadmap asserts "Amp already reads `~/.agents/skills/` natively" — this claim is **unverified
+  against Amp's manual** and must be confirmed before relocating Amp.
+- The **install marker** (`.loaf-version`) and **installed-detection** still key on each harness's
+  *config dir* (`install_target.go:284`, `install.go:507-517`), while the actual skill *content*
+  now lives under `~/.agents/skills/`. So Loaf can report a harness as "installed" while its skills
+  sit in a relocated, shared directory it does not own — and a relocation leaves **orphaned skill
+  dirs** at the old per-harness path with nothing to clean them up.
+
+There is no single source of truth for "where do skills go for harness X," no capability record of
+which harness can actually read a configurable shared dir, and no orphan-cleanup on relocation.
+This is the last structural gap before the harness matrix is coherent — and because it moves
+already-installed users' files, it is **breaking** and must be gated.
+
+## Strategic Alignment
+
+- **Vision / Architecture:** Advances "the loaf CLI is the harness" by making install destinations
+  a deliberate, tested convention rather than per-target accretion. A shared `~/.agents/skills/`
+  reduces N per-harness skill copies to one canonical location for every harness that can read it.
+- **Coordinates with SPEC-047 (WS-A, keystone parity contract):** SPEC-047 owns the build-time
+  parity-matrix test (skill reachability + hook-surface semantics across the five first-class
+  harnesses). SPEC-052 owns the **install-side** half of clause 4 of that contract: the
+  `~/.agents/` destination convention for Codex, Cursor, OpenCode, and Amp's *skills*; Claude Code
+  remains the documented plugin exception. SPEC-052 **adopts** SPEC-047's harness list and tier
+  definitions — it does not re-derive them. Gemini removal is owned by SPEC-047; SPEC-052 only
+  cleans up Gemini's installed files as orphan removal (it must not re-introduce a Gemini target).
+- **Hard-depends on SPEC-053 (WS-G, migration mechanism):** SPEC-052 is breaking (path
+  relocation). The orphan-cleanup / upgrade semantics, deprecation window, and one-time relocation
+  it needs are the **mechanism** SPEC-053 defines. **Nothing in SPEC-052's breaking tracks ships
+  before SPEC-053's mechanism exists** (roadmap §3, "F … needs WS-G migration"). SPEC-053 also
+  owns the related taxonomy decisions (opt-in install packs, librarian) that this spec must not
+  pre-empt.
+- **Last in sequence (roadmap §3: A -> B -> C -> (D ∥ E) -> G -> F).** SPEC-052 follows the stable
+  build matrix (SPEC-047) and the migration gate (SPEC-053).
+- **Supersedes:** the implicit per-harness skill-destination logic in
+  `internal/cli/install_target.go` — replaced by one capability-driven destination resolver.
+- **Honors:** ADR-013 (`.agents/` resolves to the **main worktree** for *project-local* state).
+  This spec governs the **global** `~/.agents/` user install dir, a distinct location; it must not
+  be confused with project `.agents/`. A companion note in docs/decisions/ records the distinction.
+
+## Solution Direction
+
+1. **Per-harness capability investigation (do first, gate everything on its findings).** For each
+   of Codex, Cursor, OpenCode, Amp: confirm — from each harness's own documentation, not
+   inference — whether it can read a configurable/shared skills (and agents) directory, what that
+   path is, and how it is configured (env var, settings key, native default). Record findings in a
+   capability table checked into docs/decisions/ (a small ADR). **No relocation ships for a harness
+   whose support is unverified.** Specifically resolve the open Amp question: does Amp read
+   `~/.agents/skills/` natively, or only `~/.config/agents/skills/` (its current target,
+   `install_target.go:176`)? The answer decides whether Amp moves or stays.
+
+2. **A single destination resolver.** Replace scattered `filepath.Join(homeDir, ".agents", ...)`
+   literals with one function that maps `(target, capability) -> skills/agents destination`,
+   driven by the capability table. Harnesses that read `~/.agents/` resolve there; any that
+   provably cannot keep their native path with a documented exception. Claude Code is excluded (it
+   uses the plugin mechanism — the one documented exception, `install.go:373-380`).
+
+3. **Decouple the install marker from the skills location.** Today `.loaf-version` and
+   installed-detection key on each harness's config dir while skills live under `~/.agents/`
+   (`install.go:507-517`). Establish a clear record of *what was installed where* so the upgrade
+   path can find and clean relocated content — the input SPEC-053's orphan-cleanup consumes.
+
+4. **Orphan cleanup on relocation (via SPEC-053's mechanism).** When `loaf install --upgrade`
+   relocates a harness's skills to `~/.agents/skills/`, it removes the old per-harness skill copy
+   (e.g. OpenCode's `$XDG_CONFIG_HOME/opencode/skills/`, Amp's `~/.config/agents/skills/`) so users
+   are not left with two diverging skill sets. This reuses SPEC-053's deprecation/tombstone window,
+   not a bespoke remover.
+
+5. **Reconcile with the parity contract (SPEC-047).** Once destinations are capability-driven,
+   feed the install-destination cells into SPEC-047's parity matrix so a future harness or skill
+   cannot silently regress to a per-harness path.
+
+## Scope
+
+### In Scope
+- Per-harness capability investigation (Codex, Cursor, OpenCode, Amp) with a documented capability
+  table / mini-ADR; explicit resolution of the Amp `~/.agents/skills/` native-read question.
+- A single capability-driven destination resolver for skills (and agents where supported),
+  replacing the per-target literals in `internal/cli/install_target.go`.
+- Relocating OpenCode skills to `~/.agents/skills/` **iff** verified-supported; relocating Amp
+  skills to `~/.agents/skills/` **iff** verified-supported (otherwise Amp's native path stays, with
+  a documented exception).
+- Decoupling install-marker / installed-detection from the per-harness config dir so relocation is
+  trackable.
+- Orphan cleanup of old per-harness skill dirs on `--upgrade` (delegating to SPEC-053's mechanism).
+- Tests covering destination resolution per harness, upgrade-relocation + orphan removal, and the
+  Claude Code plugin exception.
+- A companion docs/decisions/ note distinguishing global `~/.agents/` (install) from project
+  `.agents/` (ADR-013).
+
+### Out of Scope
+- The migration mechanism itself (deprecation window, tombstone/alias, upgrade semantics) — owned
+  by **SPEC-053**; SPEC-052 consumes it.
+- Gemini's removal as a target — owned by **SPEC-047**; SPEC-052 only cleans up its installed files.
+- The Amp **plugin** rebuild and its `.amp/plugins/` path — owned by **SPEC-047 (WS-A)**. SPEC-052
+  governs Amp *skills* destination only; the plugin path is separate (roadmap §1, clause 4 note).
+- The build-time parity-matrix test mechanism — owned by **SPEC-047**; SPEC-052 contributes cells.
+- Opt-in language/domain install packs and the librarian profile decision — owned by **SPEC-053**.
+- Any change to project-local `.agents/` resolution (ADR-013) or `loaf.json` location (SPEC-042).
+- SQLite body/state migration — owned by SPEC-043/SPEC-045/SPEC-053.
+
+### Rabbit Holes
+- **Re-architecting the whole install flow.** Keep the change surgical: a resolver + marker
+  decoupling + orphan cleanup. Do not rewrite hook merging, MCP, fenced-section, or symlink logic.
+- **Inventing a config-discovery framework** for harness paths. A static, documented capability
+  table is sufficient; do not build runtime probing of harness settings files.
+- **Speculative support for harnesses that do not document a shared dir.** If a harness cannot read
+  `~/.agents/`, leave it on its native path with a one-line documented exception — do not coerce it.
+
+### No-Gos
+- Do **not** ship any relocation before SPEC-053's migration/orphan-cleanup mechanism exists.
+- Do **not** relocate a harness whose `~/.agents/` support is unverified against its own docs.
+- Do **not** relocate or change Claude Code's plugin install (the documented exception).
+- Do **not** leave orphaned skill dirs at old paths after an `--upgrade` relocation.
+- Do **not** re-introduce Gemini as an install target while cleaning up its files.
+- Do **not** assume the roadmap's "Amp reads `~/.agents/skills/` natively" claim — verify it.
+
+## Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|-----------|------------|
+| Amp does not actually read `~/.agents/skills/` natively (roadmap claim unverified) | Relocating Amp skills silently breaks Amp skill loading | Medium | Capability investigation first; keep Amp on `~/.config/agents/skills/` with a documented exception if unverified |
+| Relocation strands users with skills at two paths | Diverging/duplicate skill sets, stale behavior | Medium | Orphan cleanup on `--upgrade` via SPEC-053; ship behind the migration gate |
+| Shared `~/.agents/skills/` collides with a user's own non-Loaf skills | Loaf overwrites or wipes user content (`syncTargetDirIfExists` clears dest, `install_target.go:218-226`) | Low/Medium | Scope deletion to Loaf-managed entries only; never bulk-clear a shared dir; verify in capability ADR |
+| Install marker keyed on wrong dir after relocation | `--upgrade` cannot find old content to clean | Medium | Decouple marker/detection from per-harness config dir (Solution 3) |
+| Shipping before SPEC-053 | Breaking change with no cleanup path | Low (gated) | Hard go/no-go gate on SPEC-053; CI/spec dependency enforced |
+| Drift from SPEC-047 parity contract | Future skill regresses to a per-harness path | Low | Feed destination cells into SPEC-047's parity matrix |
+
+## Open Questions
+
+- Does Amp read `~/.agents/skills/` natively, or only `~/.config/agents/skills/`? (Decides whether
+  Amp moves.) — resolved by the capability investigation.
+- Can OpenCode be configured/told to read `~/.agents/skills/`, or does it require its own config
+  dir? If it must stay, is that a documented exception or a blocker for OpenCode parity?
+- Should `agents/` (not just `skills/`) also relocate to `~/.agents/agents/` where supported, or is
+  this spec skills-only for now? (Cursor currently installs agents to its config dir,
+  `install_target.go:127`.)
+- Should the install marker live in `~/.agents/` (per-Loaf, global) rather than per-harness config
+  dirs, given content is shared? Coordinate with SPEC-053's upgrade semantics.
+- How does shared `~/.agents/skills/` interact with multiple installed harnesses — one install
+  serves all, or per-harness markers over a shared body? (Detection currently assumes per-harness.)
+
+## Test Conditions
+
+- [ ] A capability table / mini-ADR exists in docs/decisions/ recording, per harness (Codex,
+      Cursor, OpenCode, Amp), whether it reads a configurable/shared skills dir, the path, and the
+      doc citation; the Amp `~/.agents/skills/` question is explicitly answered.
+- [ ] A single destination resolver maps `(target, capability) -> destination`; no per-target
+      `~/.agents` path literals remain scattered in `install_target.go`.
+- [ ] For every harness verified to support `~/.agents/`, `loaf install --to <harness>` writes
+      skills under `~/.agents/skills/` (test asserts the path).
+- [ ] OpenCode skills install to `~/.agents/skills/` iff verified-supported; otherwise the test
+      asserts its native path with a documented exception.
+- [ ] Amp skills install to the resolver's path matching the verified capability (not a hardcoded
+      `~/.config/agents/skills/` unless that is the verified answer).
+- [ ] `loaf install --upgrade` relocating a harness removes the old per-harness skill dir (no
+      orphans), via SPEC-053's mechanism — asserted by a test that seeds the old path and checks it
+      is gone after upgrade.
+- [ ] Claude Code install path and plugin mechanism are unchanged (documented exception) — asserted.
+- [ ] Installed-detection / marker correctly identifies a relocated install (does not report
+      "not installed" after relocation).
+- [ ] Shared `~/.agents/skills/` cleanup never deletes non-Loaf-managed entries (test with a
+      foreign skill present).
+- [ ] No relocation code path executes unless SPEC-053's migration mechanism is present (gate
+      asserted in test or guarded at call site).
+- [ ] Gemini's installed skill files are removed on upgrade as orphans; no Gemini target is
+      re-introduced.
+- [ ] Destination-resolution cells are referenced by SPEC-047's parity-matrix test (or a stub
+      asserting the contract), so a per-harness regression fails the build.
+
+## Priority Order
+
+Tracks within SPEC-052, sequenced after SPEC-047 (stable matrix) and SPEC-053 (migration gate).
+
+1. **Capability investigation + ADR** — *non-breaking*. Produces the capability table; the Amp
+   question is answered. **Go/no-go gate:** no relocation track proceeds for a harness unverified
+   here.
+2. **Destination resolver + marker decoupling** — *non-breaking* (refactor; preserves current
+   destinations until track 3). Centralizes path logic and makes relocation trackable.
+3. **Parity-matrix integration** — *non-breaking*. Feed destination cells into SPEC-047's matrix.
+4. **OpenCode / Amp relocation + orphan cleanup** — **BREAKING; gated on SPEC-053.** Only the
+   verified-supported harnesses move; old per-harness dirs are cleaned via SPEC-053's mechanism.
+   **Go/no-go gate:** SPEC-053 migration mechanism shipped + user sign-off (CLAUDE.md: ask before
+   breaking changes; roadmap §4 ledger).
+5. **Gemini orphan cleanup on upgrade** — **BREAKING; gated on SPEC-053** (coordinated with
+   SPEC-047's Gemini removal).

--- a/.agents/specs/SPEC-053-migration-mechanism-taxonomy.md
+++ b/.agents/specs/SPEC-053-migration-mechanism-taxonomy.md
@@ -1,0 +1,231 @@
+---
+id: SPEC-053
+title: Breaking-Change Migration Mechanism & Taxonomy Decisions
+source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-G)"
+created: 2026-06-22T09:13:21Z
+status: drafting
+branch: feat/migration-mechanism-taxonomy
+source_sessions:
+  - id: 20260621-001541-session
+    role: shaped
+---
+
+# SPEC-053: Breaking-Change Migration Mechanism & Taxonomy Decisions
+
+## Problem Statement
+
+Every breaking change in the restructuring program — dropping Gemini (SPEC-047), moving
+ephemeral artifact bodies into SQLite and deleting in-tree `.md` (SPEC-045), relocating
+non-Claude install destinations to `~/.agents/` (SPEC-052), retiring skills, and converting
+language/domain packs to opt-in — fails the same already-installed user in the same way:
+**Loaf has no mechanism to clean up after itself.**
+
+`loaf install --upgrade` today only re-syncs the targets that still exist. The sync
+(`syncTargetDirIfExists`, `internal/cli/install_target.go:211-227`) mirrors a *source dir*
+into a *destination dir*, removing stale **entries inside a dir Loaf still visits**
+(`install_target.go:223` — `os.RemoveAll` per orphaned child; proven by
+`install_target_test.go:30,66,69`). It has two blind spots that the program's breaking changes
+walk straight into:
+
+1. **A target dropped from the build is never revisited, so its tree is never cleaned.** When
+   Gemini leaves `installValidTargets` (`install.go:41`) and `installDisplayNames`
+   (`install.go:32-39`), upgrade simply stops touching `~/.gemini` (or its `~/.agents/skills`
+   share) — the orphaned skills sit forever. Same for a retired skill once its source dir is gone.
+2. **Relocation is invisible.** SPEC-052 points Codex/Cursor/OpenCode skills at `~/.agents/skills`.
+   Some targets already install there (`install_target.go:121,155,166`); others install to
+   per-tool config dirs. Upgrade has no concept of "old destination → new destination," so a
+   relocation leaves the *old* install live and adds a *second* copy at the new path.
+
+Bodies face the same gap from the other direction. Ephemeral `.md` files in
+`.agents/{ideas,sparks,sessions,brainstorms,drafts,tasks}/` become SQLite-only after SPEC-045.
+There is no defined one-time, reversible, backed-up migration that moves their content into the
+body store and then removes the files — and doing this irreversibly against a user's working
+tree violates the CLAUDE.md non-negotiable on breaking changes.
+
+Finally, the deep-evaluation report (`report-loaf-skills-deep-audit`,
+`.agents/reports/20260620-214448-audit-loaf-skills-deep-audit.md`) left four **taxonomy
+decisions** open that each imply a user-visible change and therefore must ride this gate:
+retiring `thermo-nuclear-code-quality-review`; tightening `debugging`'s routing; making
+language/domain packs opt-in; and resolving the `librarian` profile (today dead and missing its
+cross-target sidecars — only `content/agents/librarian.claude-code.yaml` exists, no
+`.cursor.yaml`/`.opencode.yaml`, so its tool boundary is lost on four of five harnesses).
+
+This spec is the **gate**: it builds the migration mechanism, defines the deprecation/tombstone
+model and reversible body migration, and records the taxonomy decisions — all behind explicit
+user sign-off. **No breaking change in the program ships until this lands.**
+
+## Strategic Alignment
+
+**Vision/Architecture.** Implements the roadmap's WS-G and §4 breaking-change ledger
+(`.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md:232-243,273-283`). Upholds the
+CLAUDE.md non-negotiable "ask before significant or breaking changes" by making the program's
+breaking changes opt-in, reversible, and backed up. Honors ADR-013: `.agents/` resolves to the
+**main** worktree, and moving ephemerals to SQLite *shrinks* that surface (companion ADR) rather
+than deleting `.agents/` — the migration removes ephemeral bodies only, not the directory's role.
+
+**Coordinates-with / Gates:**
+- **SPEC-045** (Ephemeral-to-SQLite Cutover, BREAKING) — *hard-gated on this spec.* SPEC-045's
+  cutover consumes the reversible body-migration + backup defined here. SPEC-045 must not delete
+  any in-tree `.md` until `loaf migrate markdown` (import) and `loaf state backup` are proven.
+- **SPEC-052** (~/.agents Install Convention & Harness Install Parity, BREAKING) — *depends on this
+  spec's* relocation/orphan-cleanup in `loaf install --upgrade`.
+- **SPEC-047** (Build Integrity, Parity Contract & Target Simplification) — drops Gemini from the
+  *build* (independent, non-breaking server-side). The **user-side** orphan cleanup of an already
+  installed Gemini surface is delivered here. SPEC-047 may land first; the user-facing Gemini
+  removal is gated behind this mechanism.
+- **SPEC-043** (SQLite-Native Artifact Bodies) — supplies the body store (`session_state_snapshots.content`
+  precedent generalized) and `migrate markdown` body-import path this spec wraps in reversibility.
+- **SPEC-048/049** (Session convergence / status vocabulary) — sessions become SQLite-only bodies;
+  their `.md` removal is an ephemeral migration governed by this gate.
+
+**Supersedes / resolves conflicts:**
+- Coordinates with **SPEC-035** (TASKS.json subsystem still live): retiring or migrating tasks'
+  in-tree representation is a breaking change and must route through this gate's body migration,
+  not re-create dual-source drift.
+- Coordinates with **SPEC-029** (librarian enrichment edits session `.md`) and the dead
+  `librarian` profile: the taxonomy decision here (retire vs fully wire) must reconcile with
+  SPEC-029's assumption that a librarian edits markdown sessions.
+- Coordinates with **SPEC-037** ("specs are mutable") vs the program's durable-render model:
+  spec/ADR renders remain git-committed (not ephemeral), so they are **out of scope** for the
+  ephemeral body migration here.
+
+## Solution Direction
+
+Deliver three things, all opt-in and reversible, gated on user sign-off:
+
+1. **An upgrade/cleanup mechanism in `loaf install --upgrade`** that knows about (a) targets and
+   skills that no longer exist (orphans) and (b) destinations that have moved (relocation). Driven
+   by a declarative **deprecation manifest** (retired targets, retired skills, old→new path maps)
+   so future breaking changes register an entry instead of writing bespoke cleanup code.
+
+2. **A tombstone/alias + deprecation-window model.** A removed skill or target leaves a tombstone
+   recording what it was, when it was retired, and what (if anything) replaces it. Aliases let a
+   renamed surface keep routing during the deprecation window. Upgrade reports what it removed and
+   why; nothing is deleted silently.
+
+3. **A reversible, backed-up ephemeral body migration.** `loaf state backup` snapshots the SQLite
+   DB and the affected `.agents/` tree before any destructive step; `loaf migrate markdown`
+   imports ephemeral bodies into the body store (idempotent, dry-run capable — see SPEC-040's
+   TASK-197 dry-run precedent) and only then removes the in-tree `.md`, recording a manifest that a
+   `loaf migrate markdown --rollback` can replay from the backup.
+
+The **taxonomy decisions** are recorded here as accepted/decided items (each needs sign-off) and
+implemented as deprecation-manifest entries so they flow through the same mechanism:
+- **Retire `thermo-nuclear-code-quality-review`** (no Loaf structure/sidecars; reads as an imported
+  personal skill — report §6). Tombstone + changelog; upgrade removes it.
+- **`debugging` routing:** tighten the description AND set `disable-model-invocation: true` if it
+  stays a manual workflow. Explicitly **not** `user-invocable: false` — that hides it from the
+  command menu but does **not** stop the model from routing to it (the report's exact warning).
+- **Language/domain packs → opt-in install.** Default install carries core skills; language/domain
+  reference packs are selected explicitly. De-selecting on upgrade is an orphan-cleanup path.
+- **`librarian` profile:** decide retire vs fully wire. If retired, tombstone the profile. If kept,
+  it must gain the missing cross-target sidecars (`.cursor.yaml`, `.opencode.yaml`) so its tool
+  boundary survives on all first-class harnesses (today only `librarian.claude-code.yaml` exists).
+
+## Scope
+
+### In Scope
+- Deprecation manifest format (retired targets, retired skills, renamed/aliased surfaces, old→new
+  path maps) consumed by `loaf install --upgrade`.
+- Orphan cleanup for whole dropped targets (Gemini) and individual retired skills, including
+  surfaces under `~/.agents/skills` and per-tool config dirs.
+- Relocation handling: detect an install at an old destination, migrate/relink to the new one, and
+  remove the stale dir — idempotent, safe to re-run.
+- Tombstone + alias model and a deprecation window with user-visible upgrade reporting.
+- `loaf state backup` (DB + affected `.agents/` snapshot) and reversible `loaf migrate markdown`
+  with `--dry-run` and `--rollback`, used by SPEC-045's cutover.
+- Recording the four taxonomy decisions as accepted, each as a manifest entry; wiring `debugging`'s
+  `disable-model-invocation`; adding librarian cross-target sidecars **iff** the decision is "wire."
+- Tests: upgrade removes a simulated dropped target; relocation produces exactly one copy at the new
+  path with the old removed; migration round-trips (import → rollback restores bytes); tombstones
+  are emitted and reported.
+
+### Out of Scope
+- The actual Gemini *build* removal (SPEC-047), `~/.agents/` *destination* logic (SPEC-052), and the
+  body-store *schema* (SPEC-043) — this spec consumes them, it does not build them.
+- Durable spec/ADR/report renders — they stay git-committed and are not ephemeral-migrated here
+  (SPEC-044's drift gate owns their sync).
+- The taxonomy *content edits* beyond what the manifest needs (description rewrites are SPEC-051;
+  skill de-bloat is SPEC-050). This spec records the decisions and the visibility/removal wiring.
+- Raw transcript capture/redaction (explicitly deferred by SPEC-040).
+
+### Rabbit Holes
+- Building a general-purpose plugin/package manager. The manifest is a flat, append-only ledger of
+  this program's deprecations — not a versioned dependency resolver.
+- A full undo/redo system for all state. Reversibility here means a one-time backup + rollback of
+  the migration, not transactional time-travel.
+- Auto-detecting "old" installs heuristically across every possible historical layout. Support the
+  known prior paths (`~/.gemini`, per-tool config dirs, prior `~/.agents` layouts) explicitly.
+
+### No-Gos
+- No destructive change to a user's `.agents/` tree or install without a verified backup and
+  explicit confirmation (CLAUDE.md non-negotiable).
+- No silent removal — every orphan/relocation/migration action is reported.
+- Do **not** use `user-invocable: false` as the `debugging` routing fix (does not stop model
+  routing).
+- Do not delete the `.agents/` directory or change ADR-013's main-worktree resolution.
+- No breaking change in SPEC-045 / SPEC-052 / user-side SPEC-047 ships before this gate is signed
+  off and proven.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Migration deletes user content irreversibly | Data loss | Mandatory `loaf state backup` + manifest + `--dry-run`/`--rollback` before any delete; tests assert byte round-trip |
+| Relocation creates duplicate installs | Confusing/broken state | Relocation is idempotent: detect old path, move/relink, remove stale; test asserts exactly one copy |
+| Dropped-target cleanup touches a path the user repurposed | Removes unrelated files | Only remove paths Loaf provably wrote (fenced markers / known install layout); confirm before removing unrecognized content |
+| Global DB + parallel agents during migration | Write contention / partial migration | Run migration as a single guarded operation; rely on WAL/busy_timeout; refuse to migrate with active writers |
+| `disable-model-invocation` not honored on a non-Claude harness | `debugging` still over-routes | Verify the field's effect per harness in SPEC-047's parity matrix; fall back to description tightening (SPEC-051) |
+| Deprecation window too short/long | Stale aliases or premature removal | Window is an explicit manifest field per entry; default documented; user can override |
+
+## Open Questions
+
+1. Deprecation window length — one release, N releases, or a date? Per-entry or global default?
+2. Should tombstones live in SQLite (queryable via `loaf`) or as a static manifest in the package,
+   or both?
+3. `librarian`: retire or wire? (Needs user sign-off; affects SPEC-029.)
+4. Where does `loaf state backup` write, and what is its retention/cleanup policy?
+5. For opt-in packs: is de-selection on upgrade an explicit flag, or inferred from a saved install
+   profile? Where is the install profile stored?
+6. Does relocation need to preserve user-local edits at the old path, or is the install dir
+   considered fully Loaf-owned (overwrite-safe)?
+
+## Test Conditions
+
+- [ ] `loaf install --upgrade` removes a previously-installed but now-dropped target's surface
+      (Gemini simulation) and reports what it removed.
+- [ ] `loaf install --upgrade` removes a retired skill's installed files via a manifest entry.
+- [ ] Relocation from an old destination to `~/.agents/skills` results in exactly one copy at the
+      new path and the old path removed; re-running upgrade is a no-op.
+- [ ] `loaf state backup` produces a restorable snapshot of the DB and affected `.agents/` tree.
+- [ ] `loaf migrate markdown --dry-run` reports the bodies it would import and the files it would
+      remove, changing nothing.
+- [ ] `loaf migrate markdown` imports ephemeral bodies, then `--rollback` restores the original
+      `.md` files byte-for-byte from the backup.
+- [ ] Migration refuses to run (with a clear message) without a successful backup.
+- [ ] A retired surface emits a tombstone; upgrade output cites the tombstone reason.
+- [ ] `thermo-nuclear-code-quality-review` is registered as retired and removed on upgrade.
+- [ ] `debugging` carries `disable-model-invocation: true` (not `user-invocable: false`) and a
+      tightened description; the change is reflected in all first-class harness outputs.
+- [ ] Language/domain packs are opt-in: default install omits them; selecting and later
+      de-selecting one cleans it on upgrade.
+- [ ] `librarian` decision applied: either tombstoned, or present with `.cursor.yaml` and
+      `.opencode.yaml` sidecars so its tool boundary holds on all first-class harnesses.
+- [ ] No destructive action runs without confirmation (or `--yes`) and a verified backup.
+
+## Priority Order
+
+Tracks are sequenced so the mechanism exists before any decision that depends on it. This whole
+spec is the **go/no-go gate** for SPEC-045, SPEC-052, and user-side SPEC-047.
+
+1. **Deprecation manifest + orphan cleanup in `--upgrade`** — non-breaking by itself (no entries
+   yet); unblocks every later removal. *Gate: lands before any breaking change registers an entry.*
+2. **Relocation handling** — non-breaking until SPEC-052 adds path maps. *Gate for SPEC-052.*
+3. **`loaf state backup` + reversible `loaf migrate markdown` (dry-run/rollback)** — non-breaking;
+   builds on SPEC-043 body import. *Gate for SPEC-045 cutover.*
+4. **Tombstone/alias + deprecation-window model + upgrade reporting** — non-breaking.
+5. **Taxonomy decisions wired as manifest entries** — *each is breaking/user-visible; needs
+   sign-off:* retire `thermo`, `debugging` `disable-model-invocation`, opt-in packs, `librarian`
+   retire-or-wire. *Gated.*
+6. **Sign-off checkpoint** — confirm backup/rollback proven and decisions accepted; only then do
+   SPEC-045/052 and user-side SPEC-047 removals ship. *Hard gate.*

--- a/.agents/specs/SPEC-054-rich-artifact-entity-model.md
+++ b/.agents/specs/SPEC-054-rich-artifact-entity-model.md
@@ -1,0 +1,144 @@
+---
+id: SPEC-054
+title: "Rich Artifact Entity Model & Export-Format Contract"
+source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-B)"
+source_sessions:
+  - id: 20260621-001541-session
+    role: shaped
+  - id: 18a7629a-8146-44dd-a787-82f19edb9264
+    role: referenced
+    note: "gridsight thermonuclear-pipeline migration session — worked example + motivating analysis"
+created: 2026-06-24T09:30:00Z
+status: drafting
+branch: feat/rich-artifact-entity-model
+governed_by: ADR-016
+---
+
+# SPEC-054: Rich Artifact Entity Model & Export-Format Contract
+
+## Problem Statement
+
+SPEC-043 stores a report as a single **body** (a text blob — "option A"). But the high-value
+artifacts Loaf produces — code reviews, audits, the deep-evaluation report from this very session,
+the gridsight "thermonuclear" pipeline output — are **finding-shaped**: they decompose into
+findings (dimension, severity, confidence, location) and verdicts (confirmed/refuted/partial,
+rationale). You cannot `filter`, `rank`, or `export` a markdown blob; the stated goal — *"list and
+filter and access and print and export holistically"* (`loaf findings list --severity critical
+--status confirmed --export csv`) — only works if the substance is **rows**. Loaf's entity model
+today (`session/spec/task/idea/report/relationship`) is too thin to express `report → finding →
+verdict`, and has no `run` for resumable orchestration. The migrator's "99 skipped files"
+(councils/drafts/plans) is the same thinness. Per **ADR-016** (artifact storage trichotomy), this
+is the "noun" layer that must be modeled as queryable rows.
+
+## Strategic Alignment
+
+- **Governed by ADR-016** (nouns→SQLite, verbs→git, markdown→render). This spec implements the
+  *noun-depth* half of that decision; the verb rule (generators stay in git/loaf with a provenance
+  pointer) is honored here and enforced in SPEC-050/053.
+- **Depends on SPEC-043** (the body store + dual-source accessor + FTS5). SPEC-054 adds typed child
+  entities on top of 043's foundation.
+- **Coordinates with:** **SPEC-044** (durable-doc git render + drift gate — *committed* renders) vs
+  this spec's **ad-hoc `--format` export** (rows → md/json/csv/html on demand); the two share a
+  renderer but differ in purpose. **SPEC-028** (reports become parent rows + findings, superseding
+  the blob model). **SPEC-053** (the gridsight artifact migration is a consumer; this spec defines
+  the target schema). Honors **SPEC-038** (CSV/JSON/MD exports run through
+  `ValidateExternalMarkdownExport` for external audiences; internal keeps IDs).
+- **Worked examples (two, cross-project):** the gridsight thermonuclear report (26 row-shaped JSON
+  finding/verdict files + 282 markdown renders + 8 generator scripts) and this session's
+  deep-evaluation report (findings with severity + confirmed/refuted verdicts). Both are already
+  forward-compatible: the substance was emitted as structured data *before* being rendered to prose.
+
+## Solution Direction
+
+- **New noun entities (rows):**
+  - `finding` — child of a report (or review/run): `dimension`, `severity`, `confidence`,
+    `status`, `location` (path:line ref), title + narrative body.
+  - `verdict` — adjudication of a finding (or claim): `confirmed | refuted | partial`, rationale,
+    optional reproduction notes.
+  - `run` — resumable orchestration: `generator_ref` + `version/hash`, state, stints/steps,
+    timestamps. The **provenance pointer** ADR-016 requires — records *which generator+version*
+    produced outputs, **never the generator code itself**.
+- **Report decomposition (option C):** a report becomes a parent row + `finding`/`verdict` rows,
+  with narrative as text fields, and an **optional cached rendered markdown** on the report row for
+  instant `loaf report show`. Markdown stops being the artifact and becomes a `--format` target.
+- **Unified export-format contract:** `--format md | json | csv | html` across queryable entities
+  (`loaf findings list --severity critical --status confirmed --export csv`). Rows render on
+  demand; this is the "render subsystem" that turns *stored in SQLite* into *print and export*.
+- **Loaders:** because finding/verdict data is already row-shaped JSON in real pipelines, provide
+  importers that load JSON-shaped findings into rows (the migration is "load 26 JSON files," not
+  "parse 282 markdown files").
+
+## Scope
+
+### In Scope
+- `finding`, `verdict`, `run` entities: schema (migration on top of SPEC-043's), CRUD, and
+  `list`/`show`/`filter`/`link`.
+- Report decomposition to option C (parent row + child finding/verdict rows + cached render).
+- The unified `--format md|json|csv|html` export contract across queryable entities.
+- JSON loaders for row-shaped finding/verdict data (the importer the gridsight migration consumes).
+- `run` provenance pointer (generator ref + version/hash), per ADR-016.
+
+### Out of Scope
+- The generator/orchestration **code** itself — stays in git or graduates into loaf (ADR-016;
+  graduation tracked in SPEC-050 / a future orchestration spec).
+- The durable-doc **git-committed** render + finalization + drift gate (**SPEC-044** owns that;
+  this spec is on-demand multi-format export, not committed renders).
+- SPEC-043's body store (depended on, not modified).
+- The actual gridsight project migration (consumes this schema; not Loaf's repo work).
+- Status-vocabulary unification (**SPEC-049**) — `finding`/`verdict` get their own validated status
+  sets here; cross-entity unification is 049's.
+
+### Rabbit Holes
+- Storing generator scripts or `run` step-code in SQLite — forbidden by ADR-016 (No-Go).
+- Over-modeling the verdict/finding schema for hypothetical pipelines — model what the two worked
+  examples actually need.
+- Rebuilding a renderer — share SPEC-044's deterministic renderer for the markdown `--format`.
+
+### No-Gos
+- Code in SQLite (ADR-016). `run` stores a pointer + hash, never the body.
+- Markdown as source of truth for findings — the rows are the source; markdown is a render.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Finding/verdict schema too rigid for diverse pipelines | Med | Med | Model from the 2 worked examples; keep a freeform `metadata`/body field; iterate |
+| Export `--format` duplicates SPEC-044's renderer | Med | Low | Share one deterministic renderer; 054 = on-demand export, 044 = committed render |
+| CSV/JSON export leaks internal IDs to external audiences | Low | Med | Route external exports through `ValidateExternalMarkdownExport` (SPEC-038) |
+| Scope creep into building the orchestration engine | Med | Med | `run` is a provenance row only; the engine is git/loaf code (out of scope) |
+
+## Open Questions
+- [ ] `finding`/`verdict` canonical status sets (coordinate with SPEC-049).
+- [ ] Is `run` in this spec, or split to its own (orchestration-provenance) spec? Lean: include the
+      provenance row here; defer a full run/stint engine.
+- [ ] Cached-render staleness on the report row — regenerate on read vs on write (tie to SPEC-044).
+- [ ] CSV schema per entity (columns) and HTML export target (static file vs stdout).
+
+## Test Conditions
+- [ ] `loaf findings list --severity critical --status confirmed` returns matching rows across
+      reports; `--export csv|json|md` produces the corresponding format.
+- [ ] This session's deep-evaluation report imports into queryable `finding`/`verdict` rows; a
+      severity/status filter returns the expected subset.
+- [ ] A `report show` renders parent + findings + verdicts (from rows), with an optional cached
+      markdown for instant display.
+- [ ] A `run` row records `generator_ref` + `version/hash` + state; the generator code is **not**
+      stored in SQLite (assert no script body column exists).
+- [ ] Importing row-shaped finding JSON (the gridsight pipeline's `find.<dimension>.json` /
+      `VERDICTS.json` shape) yields finding/verdict rows without parsing the markdown renders.
+- [ ] An external-audience `--format` export passes `ValidateExternalMarkdownExport` (no leaked IDs).
+
+## Priority Order
+
+Tracks ship in order; non-breaking (additive entities on SPEC-043's foundation). Drop from the end.
+
+1. **Track 0 — Schema.** `finding`/`verdict`/`run` tables + relationships on top of SPEC-043's
+   migration; validated per-entity status sets. *Go/no-go:* migrates cleanly; doctor sees the new
+   entities (per SPEC-043's `status.go` allowlist work).
+2. **Track 1 — Decompose + CRUD.** Report → parent + finding/verdict rows (option C, cached
+   render); `list`/`show`/`filter`/`link`; JSON loaders. *Go/no-go:* the deep-evaluation report
+   decomposes and filters correctly.
+3. **Track 2 — Export-format contract.** `--format md|json|csv|html` across queryable entities,
+   sharing SPEC-044's deterministic renderer; external exports gated by SPEC-038. *Go/no-go:*
+   `loaf findings list --severity critical --export csv` round-trips.
+4. **Track 3 — `run` provenance.** `run` row + generator pointer/hash (no code body). *Go/no-go:* a
+   run records provenance; assert no script-body column. *(Droppable / could split to its own spec.)*

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Loaf's commands form a three-phase workflow that mirrors how good software gets 
 ┌─────────────────────────────────────────────────────────────┐
 │                       PHASE 2: BUILD                        │
 │                                                             │
-│           /breakdown  →  /implement  →  /release            │
+│       /breakdown  →  /implement  →  /ship  →  /release      │
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
                               ↓
@@ -64,7 +64,8 @@ Decompose specs into atomic tasks and execute with specialized agents.
 |---------|--------------|
 | `/breakdown` | Split spec into agent-sized atomic tasks |
 | `/implement` | Execute tasks with orchestrated agent delegation |
-| `/release` (`/ship`) | Orchestrate the merge ritual: pre-flight, docs check, version bump, squash merge, cleanup |
+| `/ship` | Review, verify, and land one PR |
+| `/release` | Publish a version from already-landed work |
 
 ### Phase 3: Learn
 
@@ -93,7 +94,7 @@ CLI commands that support the workflow pipeline:
 | `loaf session` | Session journal management (list, start, end, log) |
 | `loaf session enrich` | Enrich session journal from JSONL conversation logs |
 | `loaf session housekeeping` | Review and archive agent artifacts |
-| `loaf release` / `loaf ship` | Orchestrate release ritual |
+| `loaf release` | Publish a release: version bump, changelog, tag, and release artifacts |
 
 ## Profiles
 
@@ -119,7 +120,8 @@ Skills you invoke directly to drive work forward.
 | `shape` | Shaping ideas into bounded specs |
 | `breakdown` | Decomposing specs into atomic tasks |
 | `implement` | Starting task or spec implementation |
-| `release` | Orchestrating the release ritual (version bump, squash merge) |
+| `ship` | Reviewing, verifying, and landing one PR |
+| `release` | Publishing a version from already-landed work |
 | `brainstorm` | Deep exploration of a problem space |
 | `research` | Investigating questions, comparing options |
 | `strategy` | Discovering or updating strategic direction |

--- a/cli/scripts/eval-skill-routing.mjs
+++ b/cli/scripts/eval-skill-routing.mjs
@@ -95,7 +95,7 @@ const TEST_CASES = {
   "git-workflow": [
     "Write a commit message for these changes",
     "Create a PR for this branch",
-    "merge this PR",
+    "What branch name should I use?",
   ],
   debugging: [
     "This test is flaky, help me fix it",
@@ -207,10 +207,15 @@ const TEST_CASES = {
     "Create an ADR for the caching approach",
     "Evaluate the tradeoffs for this technical decision",
   ],
-  release: [
-    "Release this branch",
+  ship: [
     "Ready to merge this PR",
     "Ship it",
+    "Land this branch",
+  ],
+  release: [
+    "Cut a release from main",
+    "Publish a new version",
+    "Should we batch the landed PRs into a release?",
   ],
   reflect: [
     "What did we learn from shipping this?",

--- a/config/hooks.yaml
+++ b/config/hooks.yaml
@@ -35,7 +35,7 @@ hooks:
       description: Run security audit on bash commands
 
     # Git Workflow - Push and PR guards (ADVISORY)
-    # These are safety nets, not gates — the release skill orchestrates the same checks.
+    # These are safety nets, not gates — ship/release skills orchestrate the same checks.
     # Security hooks (above) stay blocking; workflow hooks warn but don't block.
     - id: validate-push
       skill: git-workflow

--- a/content/hooks/instructions/post-merge.md
+++ b/content/hooks/instructions/post-merge.md
@@ -1,4 +1,4 @@
-**Note:** If you used `/release`, these steps were already handled by the skill. This checklist is for manual merges.
+**Note:** If you used `/ship`, these steps were already handled by the skill. This checklist is for manual merges.
 
 # Pre-Merge Checklist
 
@@ -12,27 +12,19 @@ Complete these steps on the feature branch before creating the PR.
    ```
    Archive session file (status: done, `archived_at`, `archived_by`, move to archive/).
 
-2. **Update CHANGELOG.md:**
-   Add entries under `[Unreleased]` describing what the PR ships.
+2. **Update CHANGELOG.md when the PR has release-facing impact:**
+   Add curated entries under `[Unreleased]` describing what the PR lands. Do not move entries to a versioned section here; `/release` publishes the batch later.
 
-3. **Bump version** in `package.json`:
-   - `feat` commit -> minor bump (or dev bump if pre-release)
-   - `fix` commit -> patch bump
-   - Breaking change -> major bump
-
-4. **Move `[Unreleased]` to versioned section:**
-   `## [X.Y.Z] - YYYY-MM-DD`
-
-5. **Rebuild all targets:**
+3. **Rebuild all targets:**
    ```
    npx loaf build
    ```
 
-6. **Commit and push** the changelog + version + archived artifacts to the PR branch.
+4. **Commit and push** the changelog and generated artifacts to the PR branch.
 
-7. **Create PR** with `gh pr create` — title + summary + test plan.
+5. **Create PR** with `gh pr create` — title + summary + test plan.
 
-8. **Squash merge** with a clean commit body:
+6. **Squash merge** with a clean commit body:
    - Let GitHub default the title: `PR title (#N)`
    - Write a concise 2-4 sentence summary as `--body` (use a HEREDOC)
    - **Never** use the automatic squash description that dumps all individual commit messages
@@ -55,3 +47,5 @@ Complete these steps on main after merging.
    ```
 
 3. **Suggest reflection** if the session had key decisions or learnings.
+
+4. **Suggest `/release` only when appropriate** — if this PR completes a coherent batch or release branch, publish from the base branch after the landed work is present there.

--- a/content/hooks/instructions/pre-pr-checklist.md
+++ b/content/hooks/instructions/pre-pr-checklist.md
@@ -29,7 +29,7 @@ If `CHANGELOG.md` does not exist, create it first:
 
 This project follows [Common Changelog](https://common-changelog.org/) and
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). `## [Unreleased]`
-is a workflow staging section for curated entries before release.
+is a workflow staging section for curated entries that land with PRs before a later release.
 
 ## [Unreleased]
 

--- a/content/skills/git-workflow/SKILL.md
+++ b/content/skills/git-workflow/SKILL.md
@@ -46,4 +46,5 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, curating CHANGELOG entries, pre-PR/pre-push/post-merge hooks |
-| Release ritual | `/release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |
+| PR shipping | `/ship` skill | Reviewing, verifying, and squash-merging one PR |
+| Release ritual | `/release` skill | Publishing a version from already-landed work |

--- a/content/skills/git-workflow/references/commits.md
+++ b/content/skills/git-workflow/references/commits.md
@@ -169,13 +169,13 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
-- The `/release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
+- The `/ship` skill automates this workflow when ready to squash merge a PR; `/release` publishes a version later from already-landed work
 
 ## Changelog Discipline
 
 `CHANGELOG.md` entries follow Loaf's Common Changelog profile: write for
 humans, communicate the release impact, and curate git history instead of
-copying it. Curate the `[Unreleased]` section before bumping the version so the
+copying it. Curate the `[Unreleased]` section as PRs land so the later
 published release notes read as user-facing prose, not an internal worklog.
 
 ### Drop
@@ -204,9 +204,9 @@ Internal terms that have no meaning outside the team's working context:
 
 ### Auto-generated Entries
 
-When `loaf release --pre-merge` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
+When `loaf release` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
 
-Before approving a release bump, compare `[Unreleased]` against the actual squashed change set and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the branch was organized, it does not belong in the changelog.
+Before approving a release bump, compare `[Unreleased]` against the actual release range and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the work was organized, it does not belong in the changelog.
 
 ## Critical Rules
 
@@ -285,7 +285,7 @@ When developing toward a major version, use pre-release suffixes to mark develop
 
 **Convention:**
 - Set the target version with `-dev.0` when starting a major effort (e.g. `2.0.0-dev.0`)
-- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of work ships — a spec completing, a group of related features landing
+- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of landed work is ready to publish — a completed spec, a related feature group, or a release train
 - Don't bump for every commit — that's what git history is for
 - Strip the suffix (`-dev.N` → `2.0.0`) when all planned work is complete
 - `loaf release` handles all bump types: `prerelease`, `release`, `major`, `minor`, `patch`

--- a/content/skills/implement/SKILL.md
+++ b/content/skills/implement/SKILL.md
@@ -332,7 +332,7 @@ After creating session file:
    - Update session file (status: done, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
+5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
@@ -351,7 +351,7 @@ After creating session file:
 
 ## Suggests Next
 
-After all tasks are complete, suggest `/release` to merge the work.
+After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release` only when the landed work forms a coherent release batch.
 
 ## Related Skills
 

--- a/content/skills/release/SKILL.md
+++ b/content/skills/release/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: release
 description: >-
-  Orchestrates releases: pre-flight checks, version bump via `loaf release`,
-  squash merge, and post-merge cleanup. Use when the user says "release this,"
-  "merge this PR," "ready to merge," or "ship it." Produces version bumps,
-  changelog updates, and merged code.
-  Not for creating PRs (use git-workflow) or reflection (use reflect).
+  Orchestrates standalone releases from already-landed work: release readiness,
+  version selection, changelog curation, release commit, tag, GitHub Release,
+  install verification, and post-release follow-up. Use when the user says
+  "cut a release," "publish a version," "release from main," or asks whether
+  enough landed work should become a release. Not for reviewing or merging a PR
+  (use ship).
 ---
 
 # Release
 
-Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+Publish a coherent version from work that has already landed.
 
 ## Contents
 - Critical Rules
@@ -18,13 +19,13 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 - Quick Reference
 - Topics
 - Context Detection
-- Step 1: Pre-Flight Checks
-- Step 2: Documentation Freshness
-- Step 3: Housekeeping Verification
-- Step 3b: Create PR (if needed)
-- Step 4: Version Bump + Changelog
-- Step 5: Squash Merge
-- Step 6: Post-Merge Cleanup
+- Step 1: Release Readiness
+- Step 2: Change Collection
+- Step 3: Version + Changelog
+- Step 4: Release Execution
+- Step 5: Protected-Branch Handoff
+- Step 6: Publication Verification
+- Step 7: Post-Release Follow-Up
 - Hook Interaction
 - Related Skills
 
@@ -34,308 +35,255 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 
 ## Critical Rules
 
-- **Block on pre-flight failure** -- do not offer to skip any failing check
-- **Use `AskUserQuestion` for all decisions and confirmations** -- version bump type, push approval, merge approval, branch deletion. Never use inline text questions for permission/decision prompts
-- **Version bump before merge** -- this is the skill's reason for existing; never defer to post-merge
-- **Wrap after version bump** -- wrap needs PR# and version to produce a complete session summary
-- **Clean squash body** -- never use the auto-generated commit dump
-- **Orchestrate the full lifecycle** -- if housekeeping or reflect haven't been run, trigger them (with user confirmation via `AskUserQuestion`) rather than just flagging gaps
-- **Detect-first** -- auto-detect PR from branch before asking for a number
-- **Never push without confirmation** -- even after successful version bump
-- **Log release** -- log to session journal after merge: `loaf session log "decision(release): vX.Y.Z shipped via PR #N"`
+- **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
+- **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
+- **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
+- **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
+- **Never push, tag, or publish without confirmation** -- present the exact actions first.
+- **Use `AskUserQuestion` for release decisions when available** -- version bump type, release PR handoff, push/tag/GitHub Release confirmation.
+- **Log release** -- after publication, run `loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"` when session state is available.
 
 ## Verification
 
-- Pre-flight checks (typecheck, test, build) all pass before proceeding
-- Version bump commit exists on the feature branch before merge
-- Squash merge body is a one-line summary followed by bullet points grouped by feature area, not a commit dump
-- Git tag points to the squash merge commit on the base branch, not a branch commit
-- GitHub Release exists with changelog body (not auto-generated notes)
-- Post-merge cleanup completed: base branch pulled, feature branch deleted
+- Release base branch is clean, current, and contains the intended landed PRs
+- Pre-flight checks pass before versioning or publication
+- Changelog entries are curated user-facing prose, not commit or PR-title dumps
+- Version files, changelog heading, git tag, and GitHub Release all agree
+- Tag points at the released base-branch commit or release commit, not an abandoned feature branch
+- Downstream install path is verified when applicable, especially Homebrew for Loaf releases
 
 ## Quick Reference
 
 | Step | Gate | Blocking? |
 |------|------|-----------|
-| Pre-Flight | typecheck + test + build pass | Yes |
-| Doc Freshness | User reviews stale docs | No (user decides) |
-| Housekeeping | Spec/tasks archived, CHANGELOG ready | No (user decides) |
-| PR Creation | Only if no PR exists yet | Yes (if needed) |
-| Version Bump | User confirms bump type; `loaf release --pre-merge` | Yes |
-| Wrap | Session summary (after version bump, has PR# + version) | Yes |
-| Squash Merge | User approves body text | Yes |
-| Post-Merge | `loaf release --post-merge` (tag, GH Release, cleanup) | Yes |
+| Readiness | clean/current base branch, no unresolved release collisions | Yes |
+| Change Collection | landed work since last tag grouped into release themes | Yes |
+| Version + Changelog | bump selected, notes curated, files updated | Yes |
+| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Verification | release and install paths checked | Yes |
+| Follow-Up | reflect/housekeeping suggested when useful | No |
 
 ## Topics
 
 | Topic | Use When |
 |-------|----------|
-| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
+| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
 
 ## Context Detection
 
-Before anything, detect where we are:
+Before anything, establish the release surface:
 
-1. **Get current branch and repo default branch:**
+1. Get current branch and repo default branch:
    ```bash
    git branch --show-current
    gh repo view --json defaultBranchRef -q .defaultBranchRef.name
    ```
-2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
-3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
-4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
+3. Verify the current branch:
+   - If already on the release base, continue.
+   - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
+   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
+4. Find the previous release tag:
    ```bash
-   gh pr view --json number,title,url,headRefName,baseRefName
+   git describe --tags --abbrev=0
    ```
-5. If no PR exists for this branch, note `pr_exists = false` and set `baseRefName` to the repo default branch. Continue — the PR will be created in Step 3b.
-6. If PR exists, **save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
-7. Confirm the PR identity (or intent to create one) with the user before proceeding.
-
----
-
-## Step 1: Pre-Flight Checks (BLOCKING)
-
-Run these and **BLOCK on any failure** — do not offer to skip.
-
-### Detect project type
-
-Inspect the repo to determine available checks:
-- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
-- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config; if the project is uv-managed, expect release artifact refresh to run `uv sync`
-- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
-- **Go** (`go.mod`): `go vet`, `go test`
-
-### Run checks
-
-Run whichever checks the project supports. Examples for a Node project:
-1. `npm run typecheck` (if the script exists)
-2. `npm run test` (if the script exists)
-3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
-
-For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
-
-**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
-
-On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
-
----
-
-## Step 2: Documentation Freshness
-
-Check whether documentation is stale relative to the branch's changes:
-
-1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
-2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
-3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
-4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
-
-Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
-
----
-
-## Step 3: Housekeeping
-
-Check each item. If missing, **offer to run it** (with user confirmation) rather than just flagging it.
-
-1. **Spec status**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`. If not, offer to update it.
-2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived. If found, offer to run `loaf task archive`.
-3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
-4. **Journal flushed**: Review conversation for unrecorded decisions/discoveries. Log them now — this is the last chance before wrap.
-
-Present the results as a checklist. Use `AskUserQuestion` for any decisions or approvals.
-
-**Note:** Wrap (`/wrap`) runs AFTER version bump (Step 4b) so it can reference the PR# and version in the session summary. Reflection runs post-merge (Step 6).
-
----
-
-## Step 3b: Create PR (if needed)
-
-**Only run this step if `pr_exists = false` from Context Detection.**
-
-The PR must be created BEFORE the version bump so that `[Unreleased]` changelog entries are still present (advisory hooks check for this).
-
-1. Push the branch if not already pushed.
-2. Create the PR following the format in [git-workflow/references/commits.md](../git-workflow/references/commits.md) (Pull Request Format section).
-3. Save the PR number and `baseRefName` for subsequent steps.
-
----
-
-## Step 4: Version Bump + Changelog (on feature branch)
-
-This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
-
-### Check for existing changelog entries
-
-Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
-
-- **If curated entries exist** → Use the **Curated path** (preserve them)
-- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
-
-### Curated path (preferred when entries exist)
-
-The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
-
-**Review curated entries for quality before bumping:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Follow Loaf's Common Changelog profile: imperative, self-describing,
-  one-line entries grouped as `Changed`, `Added`, `Removed`, `Fixed`
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Include the best public reference when available, such as a PR, issue, ADR, release, or commit link
-
-1. Run `loaf release --pre-merge --dry-run` to get the **suggested bump type** and **current version** (the `--pre-merge` flag auto-detects the base branch — see [Why `--pre-merge`?](#why---pre-merge) below).
-2. Present the bump suggestion to the user. They may accept or override.
-3. Once confirmed, run:
+5. Gather the candidate release range:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git log --oneline <last-tag>..HEAD
+   git diff --stat <last-tag>..HEAD
    ```
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it) and re-insert a fresh empty `## [Unreleased]` section above
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+---
 
-### Generated path (when no entries exist)
+## Step 1: Release Readiness
 
-When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+Run release pre-flight checks before editing release files:
 
-**After generation, review and rewrite entries before committing:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Rewrite generated commit text into Loaf's Common Changelog profile
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Keep entries concise but descriptive enough to understand the change without reading the diff
-
-1. Run `loaf release --pre-merge --dry-run` to preview:
-   - Current version and suggested bump type
-   - Generated changelog section from **this branch's commits only**
-   - Which version files will be updated
-
-   The `--pre-merge` flag scopes the commit analysis to `<auto-detected base>..HEAD`, so only commits on the feature branch are considered.
-
-2. Present the preview to the user. They may:
-   - Accept the suggested bump type
-   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-   - Edit the changelog content conversationally
-
-3. Once the user confirms, run:
+1. Ensure worktree is clean:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git status --short
    ```
+2. Ensure the release base is current:
+   ```bash
+   git fetch --tags origin
+   git status --branch --short
+   ```
+3. Check for existing tag or GitHub Release collisions for the target version once known:
+   ```bash
+   git tag --list vX.Y.Z
+   gh release view vX.Y.Z
+   ```
+4. Run project checks:
+   - Node: `npm run typecheck`, `npm run test`, `npm run build` when scripts exist
+   - Go: `go vet ./...`, `go test ./...` when `go.mod` exists
+   - Python: `pytest`, `mypy .`, `ruff check .` when configured
+   - Rust: `cargo check`, `cargo test` when `Cargo.toml` exists
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Generate and insert changelog section from branch commits (adding a fresh `[Unreleased]`)
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+If no checks are detected, warn explicitly. If a check fails, stop and fix before release.
 
-### After either path
+---
 
-Before pushing, verify generated artifacts are still current. This matters if
-any fix commits landed after the release bump commit:
+## Step 2: Change Collection
+
+Collect landed work since the last release and group it for release notes.
+
+1. Inspect commits:
+   ```bash
+   git log --first-parent --oneline <last-tag>..HEAD
+   git log --oneline <last-tag>..HEAD
+   ```
+2. Inspect merged PRs when GitHub is available:
+   ```bash
+   gh pr list --state merged --base <base> --json number,title,mergedAt,url
+   ```
+3. Group changes by user-facing outcome:
+   - `CR-*` change bundle, when referenced
+   - spec or task family, when public enough to be useful
+   - feature/fix/documentation/build themes
+   - operational release work, when it affects users or maintainers
+4. Drop noise:
+   - purely internal task/session labels
+   - reverted work that is not present in `HEAD`
+   - individual commit mechanics that collapse into one user-facing change
+
+Present the grouped release contents before choosing the bump.
+
+---
+
+## Step 3: Version + Changelog
+
+Choose the bump and curate the changelog from the grouped landed work.
+
+1. Run a dry run:
+   ```bash
+   loaf release --dry-run
+   ```
+   Use `--base <ref>` when the project expects a non-default release base.
+2. Present:
+   - current version
+   - proposed next version
+   - detected version files
+   - release actions the CLI would perform
+   - draft changelog entries
+3. Curate `CHANGELOG.md` before publishing:
+   - write from the upgrading user's perspective
+   - group under Common Changelog categories: `Changed`, `Added`, `Removed`, `Fixed`
+   - use one self-describing line per meaningful change
+   - include public PR, issue, ADR, release, or commit links when helpful
+   - avoid dumping commit subjects, task IDs, session mechanics, or internal gate language
+4. Confirm the bump type: `prerelease`, `release`, `major`, `minor`, or `patch`.
+
+---
+
+## Step 4: Release Execution
+
+For a direct release from the base branch, run:
+
+```bash
+loaf release --bump <type> --yes
+```
+
+This should:
+
+1. Update version files
+2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
+3. Reinsert a fresh empty `[Unreleased]` section
+4. Run configured release artifact commands
+5. Create the release commit
+6. Create/push the release tag
+7. Create the GitHub Release when enabled
+
+After execution, verify generated artifacts are current:
 
 ```bash
 npm run build
-git diff --exit-code -- plugins/loaf/bin/loaf dist content/skills/cli-reference/SKILL.md
+git diff --exit-code -- dist plugins content/skills/cli-reference/SKILL.md
 ```
 
-If the diff check fails, commit the regenerated artifacts with the source change
-that made them stale, then rerun the check.
-
-Push to the feature branch (**with user confirmation**).
-
-### Why `--pre-merge`?
-
-`--pre-merge` bundles the canonical pre-merge flag set so the skill no longer needs to spell each one out:
-
-- Equivalent to `--no-tag --no-gh --base <auto-detected>` (tag and GH release land post-merge in Step 6, not on the soon-to-be-squashed feature commit).
-- Auto-detects the base ref via a 4-step priority: explicit `--base <ref>` → open PR's `baseRefName` → `git config loaf.release.base` → repo default branch. Run `loaf release --help` to see the full priority order.
-- Pass `--base <ref>` explicitly to override auto-detection (useful for non-default base branches like `release/1.0` when no PR exists yet).
-- `--yes` skips the CLI confirmation prompt — the skill already confirmed with the user conversationally.
+Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
 ---
 
-## Step 4b: Wrap Session
+## Step 5: Protected-Branch Handoff
 
-Run `/wrap` AFTER version bump so the session summary can reference the PR# and final version.
+If branch protection prevents direct release commits on the base branch:
 
-The wrap skill will:
-1. Flush any remaining journal entries
-2. Gather git state (commits, working tree, unpushed)
-3. Generate the `## Session Wrap-Up` report
-4. Write it to the session file (replaces `## Current State`)
-5. Run `loaf session end --wrap` to set status to `complete`
+1. Create a dedicated release branch.
+2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+3. Open a release PR with a concise release-focused body.
+4. Hand the PR to `/ship` for review and landing.
+5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
 
-When called from `/release`, wrap skips the version bump and changelog prompts (already handled).
+Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
 ---
 
-## Step 5: Squash Merge
+## Step 6: Publication Verification
 
-1. Draft a clean squash body from the branch's commit history and PR description. Descriptive, not verbose:
-   - One-line summary, then bullet points grouped by feature area
-   - Plain text — no bold, no headings, only backticks for `code`
-   - Not a paragraph dump, not a commit log
-2. Present the draft to the user for review. They may edit it.
-3. Execute (after user confirms):
+After publishing, verify the public release state:
+
+1. Confirm tag location:
    ```bash
-   gh pr merge <N> --squash --body "$(cat <<'EOF'
-   <body>
-   EOF
-   )"
+   git show --stat vX.Y.Z
    ```
-4. Let GitHub default the title (`PR title (#N)`).
-5. NEVER use `--auto` or the automatic squash description that dumps all commits.
+2. Confirm GitHub Release:
+   ```bash
+   gh release view vX.Y.Z
+   ```
+3. Confirm package or installer availability when applicable:
+   - npm: `npm view <package> version`
+   - Homebrew: `brew update && brew info <tap>/<formula>`
+   - project-specific deploy or artifact registry checks
+4. For Loaf/Homebrew, report readiness only after the GitHub release exists, assets are uploaded, the tap formula is updated, and tap CI has passed.
+
+If publication partially completes, do not retag casually. Name the exact state and continue with the smallest repair or patch release path.
 
 ---
 
-## Step 6: Post-Merge Cleanup
+## Step 7: Post-Release Follow-Up
 
-After successful merge, run a single command:
+After verification:
 
-```bash
-loaf release --post-merge
-```
-
-This verifies HEAD state against an 8-point guardrail checklist (clean worktree, on the base branch with the merge commit at HEAD, readable HEAD subject for optional PR-number lookup, version-file agreement, CHANGELOG section present, no pre-existing tag or GH release, HEAD untagged). The squash subject should describe the shipped work (`feat:`, `fix:`, etc.); post-merge derives the release version from version files and `CHANGELOG.md`, not from a `chore: release` subject. Once all guardrails pass it tags the squash merge commit, pushes the tag, creates the GitHub Release from the matching `## [X.Y.Z]` CHANGELOG section, pulls the base branch, and best-effort deletes the local + remote feature branch. Manual `git tag`, `git push --tags`, `gh release create`, `git checkout`, `git pull --rebase`, and `git branch -d` are no longer needed — the flag subsumes them.
-
-If anything aborts:
-
-1. Read the actionable error message — each guardrail failure names the exact manual fix (e.g., "tag v1.2.3 already exists locally — run `git tag -d v1.2.3` and rerun").
-2. Perform the named fix.
-3. Rerun `loaf release --post-merge`. The command is idempotent on stateless reads, so reruns after a transient `gh` failure or a half-completed prior run pick up exactly where they left off.
-
-After the release finalizes, **run `/reflect`** — already on the base branch. Reflect looks back at the shipped work and updates strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) with learnings. Use `AskUserQuestion` to confirm before running.
+1. Log the release decision when session state is healthy:
+   ```bash
+   loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"
+   ```
+2. Suggest `/reflect` when the release produced durable product or workflow learnings.
+3. Suggest `/housekeeping` when session artifacts, release branches, or temporary reports need cleanup.
+4. Keep future-work discoveries out of the release notes; capture them as tasks, ideas, or sparks instead.
 
 ---
 
 ## Hook Interaction
 
-This skill coexists with existing hooks. Git workflow hooks are **advisory** (warn but don't block); security hooks remain blocking.
+This skill coexists with existing hooks. Git workflow hooks are advisory unless
+configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `workflow-pre-pr` (command) | Advisory | Fires on `gh pr create`. Reminds about CHANGELOG — redundant when release skill manages entries. |
-| `workflow-pre-merge` (instruction) | Advisory | Fires on `gh pr merge`. Reminds about squash conventions — redundant since body is already crafted. |
-| `workflow-post-merge` (instruction) | Advisory | Fires after merge. Outputs checklist the skill already handled. |
-| `validate-push` (command) | Advisory | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
-| `check-secrets` (command) | **Blocking** | Security gate. Always fires, always respected. |
+| `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
+| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
+| `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
 
-Do not modify, disable, or skip these hooks.
+Do not disable hooks to force a release through.
 
 ---
 
 ## Suggests Next
 
-After a successful release, suggest `/housekeeping` if session artifacts need archiving.
+After a successful release, suggest `/reflect` for durable learnings and `/housekeeping` if temporary release artifacts need attention.
 
 ## Related Skills
 
-- **implement** — Does the work and housekeeping; `/release` handles the merge afterward
-- **reflect** — Suggested post-merge if session has learnings
-- **git-workflow** — Conventions this skill enforces
-- **housekeeping** — Handles artifact hygiene; `/release` verifies it was done
+- **ship** -- Reviews, verifies, and lands a PR before it becomes release input
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **documentation-standards** -- Changelog and release-note quality
+- **reflect** -- Updates strategy from shipped/released learnings
+- **housekeeping** -- Cleans up completed session and release artifacts

--- a/content/skills/ship/SKILL.claude-code.yaml
+++ b/content/skills/ship/SKILL.claude-code.yaml
@@ -1,3 +1,3 @@
 # Claude Code skill configuration
 user-invocable: true
-argument-hint: "[version, base, or release intent]"
+argument-hint: "[PR number or URL]"

--- a/content/skills/ship/SKILL.md
+++ b/content/skills/ship/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: ship
+description: >-
+  Reviews, verifies, and lands one pull request. Use when the user says
+  "ship it," "merge this PR," "ready to merge," "land this branch," or asks for
+  a final merge gate. Produces a reviewed, squash-merged PR and post-merge
+  cleanup. Not for version bumps, tags, GitHub Releases, or install
+  verification (use release).
+---
+
+# Ship
+
+Review, verify, and land one PR. Shipping is the PR gate; releasing is the version-publication gate.
+
+## Contents
+- Critical Rules
+- Verification
+- Quick Reference
+- Topics
+- Context Detection
+- Step 1: PR Readiness
+- Step 2: Evidence Review
+- Step 3: Local Verification
+- Step 4: Squash Merge
+- Step 5: Post-Merge Cleanup
+- Step 6: Release Suggestion
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Critical Rules
+
+- **Ship is not release** -- do not bump versions, create tags, publish GitHub Releases, or verify package installation here.
+- **Keep PR quality local** -- smaller PRs are welcome, but `/ship` must still verify correctness before merge.
+- **Detect-first** -- auto-detect the PR from the current branch before asking for a PR number.
+- **Review before merge** -- inspect code, docs, tests, changelog, PR body, and CI state before approval.
+- **Never merge without explicit confirmation** -- present the PR, checks, findings, and squash body first.
+- **Clean squash body** -- write an intentional squash commit body; never accept the automatic commit dump.
+- **Keep landed and released distinct** -- after merge, describe the PR as landed or shipped, not necessarily released.
+- **Log shipping** -- after merge, run `loaf session log "decision(ship): PR #N landed via squash merge"` when session state is available.
+
+## Verification
+
+- PR identity, base branch, and head branch are confirmed
+- CI status is passing or the user explicitly accepts named non-blocking checks
+- Relevant local checks pass or failures are fixed before merge
+- PR body and durable docs do not overclaim relative to the diff
+- Squash commit title/body are clean, conventional, and user-facing
+- Base branch is updated after merge and the feature branch cleanup state is known
+
+## Quick Reference
+
+| Step | Gate | Blocking? |
+|------|------|-----------|
+| PR Readiness | PR exists, target base known, CI state reviewed | Yes |
+| Evidence Review | findings resolved or explicitly accepted | Yes |
+| Local Verification | relevant checks pass | Yes |
+| Squash Merge | user approves body text | Yes |
+| Cleanup | base pulled, branch deletion handled | No |
+| Release Suggestion | enough landed work may justify `/release` | No |
+
+## Topics
+
+| Topic | Use When |
+|-------|----------|
+| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
+
+---
+
+## Context Detection
+
+Before anything, detect the PR surface:
+
+1. Get current branch and repo default branch:
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. Parse `$ARGUMENTS`: may be a PR number, PR URL, branch name, or empty.
+3. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName,state,mergeStateStatus,isDraft
+   ```
+4. If no PR exists for the current branch, stop and offer to create one via `git-workflow` rather than silently merging a branch.
+5. If already on the default branch, stop. There is no PR to ship from the current branch.
+6. Confirm PR identity with the user before merge actions.
+
+---
+
+## Step 1: PR Readiness
+
+Inspect the PR's declared state:
+
+```bash
+gh pr view <N> --json number,title,body,url,headRefName,baseRefName,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+Block or pause when:
+
+- PR is draft
+- merge state is dirty or blocked
+- required checks are failing or pending
+- review decision is changes requested
+- branch is out of date and the project requires update before merge
+
+If checks are unavailable, say so explicitly and compensate with local verification.
+
+---
+
+## Step 2: Evidence Review
+
+Review the landing diff and durable prose together:
+
+1. Gather diff context:
+   ```bash
+   git fetch origin <baseRefName>
+   git diff --stat origin/<baseRefName>...HEAD
+   git diff --name-only origin/<baseRefName>...HEAD
+   ```
+2. Read the PR title/body and changed docs that make behavior claims.
+3. Check for drift:
+   - PR body claims features that are not in the diff
+   - changelog entries mention unreleased or unrelated behavior
+   - docs describe future work as already shipped
+   - comments or runbooks use stale internal vocabulary
+4. Fix blocking drift before merge. For non-blocking polish, name it and let the user decide.
+
+For high-risk PRs, use the project's review skill or read-only review flow before proceeding.
+
+---
+
+## Step 3: Local Verification
+
+Run the checks the project supports. Examples:
+
+- Node: `npm run typecheck`, `npm run test`, `npm run build`
+- Go: `go vet ./...`, `go test ./...`
+- Python: `pytest`, `mypy .`, `ruff check .`
+- Rust: `cargo check`, `cargo test`
+
+If generated artifacts are tracked, verify they are current before merge:
+
+```bash
+git diff --exit-code -- dist plugins
+```
+
+Use the repo's documented pre-commit or pre-PR checklist when present. Stop on failures.
+
+---
+
+## Step 4: Squash Merge
+
+Draft a clean squash body from the reviewed diff and PR body:
+
+- One-line summary, then bullet points grouped by feature area
+- Plain text; use backticks only for code identifiers
+- No commit dump
+- No agent attribution
+- No release-note overclaiming
+
+Present the body and ask for confirmation. Then run:
+
+```bash
+gh pr merge <N> --squash --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+Let GitHub default the title from the PR title so the squash subject remains `type: summary (#N)`.
+
+---
+
+## Step 5: Post-Merge Cleanup
+
+After a successful merge:
+
+1. Switch to the PR base branch:
+   ```bash
+   git checkout <baseRefName>
+   git pull --ff-only origin <baseRefName>
+   ```
+2. Delete the local feature branch when safe:
+   ```bash
+   git branch -d <headRefName>
+   ```
+3. Confirm the remote branch deletion state from GitHub output or run:
+   ```bash
+   gh pr view <N> --json headRefName,state
+   ```
+4. Log the landing when session state is healthy:
+   ```bash
+   loaf session log "decision(ship): PR #N landed via squash merge"
+   ```
+
+If cleanup fails, report the exact residual state. Do not force-delete without user confirmation.
+
+---
+
+## Step 6: Release Suggestion
+
+After landing, decide whether to suggest `/release`:
+
+- Suggest `/release` when the landed PR completes a coherent batch, user-facing feature, fix train, or release branch.
+- Do not suggest `/release` for every small PR by default.
+- If multiple related PRs are expected, say the PR is landed and can wait for a later batched release.
+
+Use language carefully: the PR is **landed** or **shipped**; it is not **released** until `/release` publishes a version.
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks.
+
+| Hook | Type | When `/ship` Runs |
+|------|------|------------------|
+| `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
+| `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
+| `validate-push` | Advisory | May fire if branch updates are needed before merge |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
+
+Do not disable hooks to force a PR through.
+
+---
+
+## Suggests Next
+
+After a successful ship, suggest `/release` only when the landed work forms a coherent release batch or the user asks to publish.
+
+## Related Skills
+
+- **release** -- Publishes a version from already-landed work
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **foundations** -- Verification, code review, and production readiness
+- **documentation-standards** -- Changelog, docs, and durable prose quality
+- **reflect** -- Updates strategy from significant shipped work

--- a/content/skills/wrap/SKILL.md
+++ b/content/skills/wrap/SKILL.md
@@ -41,8 +41,8 @@ Responsible session shutdown — everything that needs a conscious model before 
 - All decisions and discoveries from this session are in the journal
 - Uncommitted/unpushed state is surfaced with clear action prompts
 - Stale KB files are flagged if any
-- `## Session Wrap-Up` section written to session file (replaces `## Current State`)
-- `loaf session end --wrap` run after writing the summary
+- `## Session Wrap-Up` section persisted in the canonical session surface; in SQLite mode this is represented by wrapped session/report state rather than an active `.md` file
+- `loaf session end --wrap` run after generating or writing the summary
 - Session status is `done` (session stays open for further journal entries until `SessionEnd` fires)
 
 ## Quick Reference
@@ -63,7 +63,7 @@ These steps require conversation context — only the model can do them.
 
 Before anything else, complete the session journal:
 
-1. **Enrich from conversation log** — run `loaf session enrich` to fill in gaps from the JSONL conversation log. This catches decisions, discoveries, and context that weren't manually logged. If enrichment fails, continue — manual flush is the fallback.
+1. **Check enrichment state** — run `loaf session enrich --json`. In SQLite mode this is expected to report `action: "skipped"` because `loaf session log` is already the canonical journal writer; in markdown-only compatibility mode it summarizes legacy JSONL enrichment status. If enrichment is skipped or fails, continue — manual flush is the fallback.
 2. **Manual review** — review the conversation for anything enrichment missed:
    - Decisions — design choices, trade-offs, direction changes not yet logged as `decision()` entries
    - Discoveries — anything learned that future sessions would benefit from
@@ -74,7 +74,7 @@ Before anything else, complete the session journal:
 
 Run in parallel:
 
-1. **Session journal** — read the active session file for this branch
+1. **Session journal** — run `loaf session list --json`, choose the active session for the current branch or explicit harness session, then run `loaf session show <session-ref> --json`; if SQLite state is unavailable, fall back to the active markdown session file for this branch
 2. **Commits this session** — `git log --oneline` since session start
 3. **Working tree** — `git status --short`
 4. **Unpushed commits** — `git log --oneline origin/<branch>..HEAD`
@@ -89,7 +89,7 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 |-----------|--------|
 | Uncommitted changes | "N file(s) uncommitted — commit, stash, or leave for next session?" |
 | Unpushed commits | "N commit(s) on <branch> not pushed — push now?" |
-| No version bump | "This session shipped work but no release was run — bump version now?" |
+| Release candidate | "This session landed work that may belong in the next release — run `/release` now?" |
 | Stale KB files | "N stale knowledge file(s) — address now or defer?" |
 | Unresolved blocks | "Block on <scope> still open — note for next session?" |
 | No changelog entries | "N commit(s) on branch but `[Unreleased]` is empty — add changelog entries?" |
@@ -98,15 +98,17 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 **Detection logic:**
 - **Changelog entries:** check if the current branch has commits vs the base branch (e.g., `git rev-list --count origin/main..HEAD`) AND `CHANGELOG.md` `[Unreleased]` section has no list items (`^[-*]\s`). If both are true, prompt. **Skip when HEAD is tagged** (post-release state).
 - **Housekeeping:** scan session journal for `skill(housekeeping)` entry. If absent and the session had significant work, suggest it.
-- **Version bump:** scan session journal for `decision(release)` entry. If absent and the session has commits, offer to run `loaf release --bump prerelease --no-gh --yes`.
+- **Release candidate:** scan session journal for `decision(release)` entry. If absent and the session has landed commits, suggest `/release` only when the work forms a coherent release batch.
 
 ### Step 4: Generate Report
 
 Assemble the report per the format below. Omit empty sections — don't show "None" placeholders.
 
-### Step 5: Write Wrap Summary to Session File
+### Step 5: Persist Wrap Summary
 
-Write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
+In SQLite mode, keep the generated wrap summary in the conversation response and let `loaf session end --wrap` persist the mechanical wrapped state. Do not invent or edit a missing active `.md` session file; `loaf session show <session-ref> --json` is the canonical read surface.
+
+In markdown-only compatibility mode, write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
 
 Use the Edit tool to replace `## Current State (...)` and everything below it (up to `## Journal`) with the wrap-up section. The session file layout after wrap should be:
 
@@ -140,7 +142,7 @@ This handles the mechanical bookkeeping:
 
 ## Composability
 
-When called from `/release`, wrap runs the same steps but skips the version bump prompt (release already handles it). The `/release` skill should invoke `/wrap` first, then proceed with release steps.
+When called near `/ship` or `/release`, wrap runs the same steps but keeps PR landing and version publication distinct. `/ship` may wrap a landed PR; `/release` may wrap a published version.
 
 ## Suggests Next
 

--- a/dist/amp/skills/git-workflow/SKILL.md
+++ b/dist/amp/skills/git-workflow/SKILL.md
@@ -48,4 +48,5 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, curating CHANGELOG entries, pre-PR/pre-push/post-merge hooks |
-| Release ritual | `/release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |
+| PR shipping | `/ship` skill | Reviewing, verifying, and squash-merging one PR |
+| Release ritual | `/release` skill | Publishing a version from already-landed work |

--- a/dist/amp/skills/git-workflow/references/commits.md
+++ b/dist/amp/skills/git-workflow/references/commits.md
@@ -169,13 +169,13 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
-- The `/release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
+- The `/ship` skill automates this workflow when ready to squash merge a PR; `/release` publishes a version later from already-landed work
 
 ## Changelog Discipline
 
 `CHANGELOG.md` entries follow Loaf's Common Changelog profile: write for
 humans, communicate the release impact, and curate git history instead of
-copying it. Curate the `[Unreleased]` section before bumping the version so the
+copying it. Curate the `[Unreleased]` section as PRs land so the later
 published release notes read as user-facing prose, not an internal worklog.
 
 ### Drop
@@ -204,9 +204,9 @@ Internal terms that have no meaning outside the team's working context:
 
 ### Auto-generated Entries
 
-When `loaf release --pre-merge` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
+When `loaf release` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
 
-Before approving a release bump, compare `[Unreleased]` against the actual squashed change set and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the branch was organized, it does not belong in the changelog.
+Before approving a release bump, compare `[Unreleased]` against the actual release range and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the work was organized, it does not belong in the changelog.
 
 ## Critical Rules
 
@@ -285,7 +285,7 @@ When developing toward a major version, use pre-release suffixes to mark develop
 
 **Convention:**
 - Set the target version with `-dev.0` when starting a major effort (e.g. `2.0.0-dev.0`)
-- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of work ships — a spec completing, a group of related features landing
+- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of landed work is ready to publish — a completed spec, a related feature group, or a release train
 - Don't bump for every commit — that's what git history is for
 - Strip the suffix (`-dev.N` → `2.0.0`) when all planned work is complete
 - `loaf release` handles all bump types: `prerelease`, `release`, `major`, `minor`, `patch`

--- a/dist/amp/skills/implement/SKILL.md
+++ b/dist/amp/skills/implement/SKILL.md
@@ -334,7 +334,7 @@ After creating session file:
    - Update session file (status: done, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
+5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
@@ -353,7 +353,7 @@ After creating session file:
 
 ## Suggests Next
 
-After all tasks are complete, suggest `/release` to merge the work.
+After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release` only when the landed work forms a coherent release batch.
 
 ## Related Skills
 

--- a/dist/amp/skills/release/SKILL.md
+++ b/dist/amp/skills/release/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: release
 description: >-
-  Orchestrates releases: pre-flight checks, version bump via `loaf release`,
-  squash merge, and post-merge cleanup. Use when the user says "release this,"
-  "merge this PR," "ready to merge," or "ship it." Produces version bumps,
-  changelog updates, and merged code. Not for creating PRs (use git-workflow) or
-  reflection (use reflect).
+  Orchestrates standalone releases from already-landed work: release readiness,
+  version selection, changelog curation, release commit, tag, GitHub Release,
+  install verification, and post-release follow-up. Use when the user says "cut
+  a release," "publish a version," "release from main," or asks whether enough
+  landed work should become a release. Not for reviewing or merging a PR (use
+  ship).
 version: 2.0.0-pre.20260614235428
 ---
 
 # Release
 
-Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+Publish a coherent version from work that has already landed.
 
 ## Contents
 - Critical Rules
@@ -19,13 +20,13 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 - Quick Reference
 - Topics
 - Context Detection
-- Step 1: Pre-Flight Checks
-- Step 2: Documentation Freshness
-- Step 3: Housekeeping Verification
-- Step 3b: Create PR (if needed)
-- Step 4: Version Bump + Changelog
-- Step 5: Squash Merge
-- Step 6: Post-Merge Cleanup
+- Step 1: Release Readiness
+- Step 2: Change Collection
+- Step 3: Version + Changelog
+- Step 4: Release Execution
+- Step 5: Protected-Branch Handoff
+- Step 6: Publication Verification
+- Step 7: Post-Release Follow-Up
 - Hook Interaction
 - Related Skills
 
@@ -35,308 +36,255 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 
 ## Critical Rules
 
-- **Block on pre-flight failure** -- do not offer to skip any failing check
-- **Use `AskUserQuestion` for all decisions and confirmations** -- version bump type, push approval, merge approval, branch deletion. Never use inline text questions for permission/decision prompts
-- **Version bump before merge** -- this is the skill's reason for existing; never defer to post-merge
-- **Wrap after version bump** -- wrap needs PR# and version to produce a complete session summary
-- **Clean squash body** -- never use the auto-generated commit dump
-- **Orchestrate the full lifecycle** -- if housekeeping or reflect haven't been run, trigger them (with user confirmation via `AskUserQuestion`) rather than just flagging gaps
-- **Detect-first** -- auto-detect PR from branch before asking for a number
-- **Never push without confirmation** -- even after successful version bump
-- **Log release** -- log to session journal after merge: `loaf session log "decision(release): vX.Y.Z shipped via PR #N"`
+- **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
+- **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
+- **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
+- **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
+- **Never push, tag, or publish without confirmation** -- present the exact actions first.
+- **Use `AskUserQuestion` for release decisions when available** -- version bump type, release PR handoff, push/tag/GitHub Release confirmation.
+- **Log release** -- after publication, run `loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"` when session state is available.
 
 ## Verification
 
-- Pre-flight checks (typecheck, test, build) all pass before proceeding
-- Version bump commit exists on the feature branch before merge
-- Squash merge body is a one-line summary followed by bullet points grouped by feature area, not a commit dump
-- Git tag points to the squash merge commit on the base branch, not a branch commit
-- GitHub Release exists with changelog body (not auto-generated notes)
-- Post-merge cleanup completed: base branch pulled, feature branch deleted
+- Release base branch is clean, current, and contains the intended landed PRs
+- Pre-flight checks pass before versioning or publication
+- Changelog entries are curated user-facing prose, not commit or PR-title dumps
+- Version files, changelog heading, git tag, and GitHub Release all agree
+- Tag points at the released base-branch commit or release commit, not an abandoned feature branch
+- Downstream install path is verified when applicable, especially Homebrew for Loaf releases
 
 ## Quick Reference
 
 | Step | Gate | Blocking? |
 |------|------|-----------|
-| Pre-Flight | typecheck + test + build pass | Yes |
-| Doc Freshness | User reviews stale docs | No (user decides) |
-| Housekeeping | Spec/tasks archived, CHANGELOG ready | No (user decides) |
-| PR Creation | Only if no PR exists yet | Yes (if needed) |
-| Version Bump | User confirms bump type; `loaf release --pre-merge` | Yes |
-| Wrap | Session summary (after version bump, has PR# + version) | Yes |
-| Squash Merge | User approves body text | Yes |
-| Post-Merge | `loaf release --post-merge` (tag, GH Release, cleanup) | Yes |
+| Readiness | clean/current base branch, no unresolved release collisions | Yes |
+| Change Collection | landed work since last tag grouped into release themes | Yes |
+| Version + Changelog | bump selected, notes curated, files updated | Yes |
+| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Verification | release and install paths checked | Yes |
+| Follow-Up | reflect/housekeeping suggested when useful | No |
 
 ## Topics
 
 | Topic | Use When |
 |-------|----------|
-| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
+| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
 
 ## Context Detection
 
-Before anything, detect where we are:
+Before anything, establish the release surface:
 
-1. **Get current branch and repo default branch:**
+1. Get current branch and repo default branch:
    ```bash
    git branch --show-current
    gh repo view --json defaultBranchRef -q .defaultBranchRef.name
    ```
-2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
-3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
-4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
+3. Verify the current branch:
+   - If already on the release base, continue.
+   - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
+   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
+4. Find the previous release tag:
    ```bash
-   gh pr view --json number,title,url,headRefName,baseRefName
+   git describe --tags --abbrev=0
    ```
-5. If no PR exists for this branch, note `pr_exists = false` and set `baseRefName` to the repo default branch. Continue — the PR will be created in Step 3b.
-6. If PR exists, **save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
-7. Confirm the PR identity (or intent to create one) with the user before proceeding.
-
----
-
-## Step 1: Pre-Flight Checks (BLOCKING)
-
-Run these and **BLOCK on any failure** — do not offer to skip.
-
-### Detect project type
-
-Inspect the repo to determine available checks:
-- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
-- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config; if the project is uv-managed, expect release artifact refresh to run `uv sync`
-- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
-- **Go** (`go.mod`): `go vet`, `go test`
-
-### Run checks
-
-Run whichever checks the project supports. Examples for a Node project:
-1. `npm run typecheck` (if the script exists)
-2. `npm run test` (if the script exists)
-3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
-
-For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
-
-**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
-
-On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
-
----
-
-## Step 2: Documentation Freshness
-
-Check whether documentation is stale relative to the branch's changes:
-
-1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
-2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
-3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
-4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
-
-Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
-
----
-
-## Step 3: Housekeeping
-
-Check each item. If missing, **offer to run it** (with user confirmation) rather than just flagging it.
-
-1. **Spec status**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`. If not, offer to update it.
-2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived. If found, offer to run `loaf task archive`.
-3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
-4. **Journal flushed**: Review conversation for unrecorded decisions/discoveries. Log them now — this is the last chance before wrap.
-
-Present the results as a checklist. Use `AskUserQuestion` for any decisions or approvals.
-
-**Note:** Wrap (`/wrap`) runs AFTER version bump (Step 4b) so it can reference the PR# and version in the session summary. Reflection runs post-merge (Step 6).
-
----
-
-## Step 3b: Create PR (if needed)
-
-**Only run this step if `pr_exists = false` from Context Detection.**
-
-The PR must be created BEFORE the version bump so that `[Unreleased]` changelog entries are still present (advisory hooks check for this).
-
-1. Push the branch if not already pushed.
-2. Create the PR following the format in [git-workflow/references/commits.md](../git-workflow/references/commits.md) (Pull Request Format section).
-3. Save the PR number and `baseRefName` for subsequent steps.
-
----
-
-## Step 4: Version Bump + Changelog (on feature branch)
-
-This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
-
-### Check for existing changelog entries
-
-Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
-
-- **If curated entries exist** → Use the **Curated path** (preserve them)
-- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
-
-### Curated path (preferred when entries exist)
-
-The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
-
-**Review curated entries for quality before bumping:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Follow Loaf's Common Changelog profile: imperative, self-describing,
-  one-line entries grouped as `Changed`, `Added`, `Removed`, `Fixed`
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Include the best public reference when available, such as a PR, issue, ADR, release, or commit link
-
-1. Run `loaf release --pre-merge --dry-run` to get the **suggested bump type** and **current version** (the `--pre-merge` flag auto-detects the base branch — see [Why `--pre-merge`?](#why---pre-merge) below).
-2. Present the bump suggestion to the user. They may accept or override.
-3. Once confirmed, run:
+5. Gather the candidate release range:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git log --oneline <last-tag>..HEAD
+   git diff --stat <last-tag>..HEAD
    ```
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it) and re-insert a fresh empty `## [Unreleased]` section above
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+---
 
-### Generated path (when no entries exist)
+## Step 1: Release Readiness
 
-When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+Run release pre-flight checks before editing release files:
 
-**After generation, review and rewrite entries before committing:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Rewrite generated commit text into Loaf's Common Changelog profile
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Keep entries concise but descriptive enough to understand the change without reading the diff
-
-1. Run `loaf release --pre-merge --dry-run` to preview:
-   - Current version and suggested bump type
-   - Generated changelog section from **this branch's commits only**
-   - Which version files will be updated
-
-   The `--pre-merge` flag scopes the commit analysis to `<auto-detected base>..HEAD`, so only commits on the feature branch are considered.
-
-2. Present the preview to the user. They may:
-   - Accept the suggested bump type
-   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-   - Edit the changelog content conversationally
-
-3. Once the user confirms, run:
+1. Ensure worktree is clean:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git status --short
    ```
+2. Ensure the release base is current:
+   ```bash
+   git fetch --tags origin
+   git status --branch --short
+   ```
+3. Check for existing tag or GitHub Release collisions for the target version once known:
+   ```bash
+   git tag --list vX.Y.Z
+   gh release view vX.Y.Z
+   ```
+4. Run project checks:
+   - Node: `npm run typecheck`, `npm run test`, `npm run build` when scripts exist
+   - Go: `go vet ./...`, `go test ./...` when `go.mod` exists
+   - Python: `pytest`, `mypy .`, `ruff check .` when configured
+   - Rust: `cargo check`, `cargo test` when `Cargo.toml` exists
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Generate and insert changelog section from branch commits (adding a fresh `[Unreleased]`)
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+If no checks are detected, warn explicitly. If a check fails, stop and fix before release.
 
-### After either path
+---
 
-Before pushing, verify generated artifacts are still current. This matters if
-any fix commits landed after the release bump commit:
+## Step 2: Change Collection
+
+Collect landed work since the last release and group it for release notes.
+
+1. Inspect commits:
+   ```bash
+   git log --first-parent --oneline <last-tag>..HEAD
+   git log --oneline <last-tag>..HEAD
+   ```
+2. Inspect merged PRs when GitHub is available:
+   ```bash
+   gh pr list --state merged --base <base> --json number,title,mergedAt,url
+   ```
+3. Group changes by user-facing outcome:
+   - `CR-*` change bundle, when referenced
+   - spec or task family, when public enough to be useful
+   - feature/fix/documentation/build themes
+   - operational release work, when it affects users or maintainers
+4. Drop noise:
+   - purely internal task/session labels
+   - reverted work that is not present in `HEAD`
+   - individual commit mechanics that collapse into one user-facing change
+
+Present the grouped release contents before choosing the bump.
+
+---
+
+## Step 3: Version + Changelog
+
+Choose the bump and curate the changelog from the grouped landed work.
+
+1. Run a dry run:
+   ```bash
+   loaf release --dry-run
+   ```
+   Use `--base <ref>` when the project expects a non-default release base.
+2. Present:
+   - current version
+   - proposed next version
+   - detected version files
+   - release actions the CLI would perform
+   - draft changelog entries
+3. Curate `CHANGELOG.md` before publishing:
+   - write from the upgrading user's perspective
+   - group under Common Changelog categories: `Changed`, `Added`, `Removed`, `Fixed`
+   - use one self-describing line per meaningful change
+   - include public PR, issue, ADR, release, or commit links when helpful
+   - avoid dumping commit subjects, task IDs, session mechanics, or internal gate language
+4. Confirm the bump type: `prerelease`, `release`, `major`, `minor`, or `patch`.
+
+---
+
+## Step 4: Release Execution
+
+For a direct release from the base branch, run:
+
+```bash
+loaf release --bump <type> --yes
+```
+
+This should:
+
+1. Update version files
+2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
+3. Reinsert a fresh empty `[Unreleased]` section
+4. Run configured release artifact commands
+5. Create the release commit
+6. Create/push the release tag
+7. Create the GitHub Release when enabled
+
+After execution, verify generated artifacts are current:
 
 ```bash
 npm run build
-git diff --exit-code -- plugins/loaf/bin/loaf dist content/skills/cli-reference/SKILL.md
+git diff --exit-code -- dist plugins content/skills/cli-reference/SKILL.md
 ```
 
-If the diff check fails, commit the regenerated artifacts with the source change
-that made them stale, then rerun the check.
-
-Push to the feature branch (**with user confirmation**).
-
-### Why `--pre-merge`?
-
-`--pre-merge` bundles the canonical pre-merge flag set so the skill no longer needs to spell each one out:
-
-- Equivalent to `--no-tag --no-gh --base <auto-detected>` (tag and GH release land post-merge in Step 6, not on the soon-to-be-squashed feature commit).
-- Auto-detects the base ref via a 4-step priority: explicit `--base <ref>` → open PR's `baseRefName` → `git config loaf.release.base` → repo default branch. Run `loaf release --help` to see the full priority order.
-- Pass `--base <ref>` explicitly to override auto-detection (useful for non-default base branches like `release/1.0` when no PR exists yet).
-- `--yes` skips the CLI confirmation prompt — the skill already confirmed with the user conversationally.
+Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
 ---
 
-## Step 4b: Wrap Session
+## Step 5: Protected-Branch Handoff
 
-Run `/wrap` AFTER version bump so the session summary can reference the PR# and final version.
+If branch protection prevents direct release commits on the base branch:
 
-The wrap skill will:
-1. Flush any remaining journal entries
-2. Gather git state (commits, working tree, unpushed)
-3. Generate the `## Session Wrap-Up` report
-4. Write it to the session file (replaces `## Current State`)
-5. Run `loaf session end --wrap` to set status to `complete`
+1. Create a dedicated release branch.
+2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+3. Open a release PR with a concise release-focused body.
+4. Hand the PR to `/ship` for review and landing.
+5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
 
-When called from `/release`, wrap skips the version bump and changelog prompts (already handled).
+Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
 ---
 
-## Step 5: Squash Merge
+## Step 6: Publication Verification
 
-1. Draft a clean squash body from the branch's commit history and PR description. Descriptive, not verbose:
-   - One-line summary, then bullet points grouped by feature area
-   - Plain text — no bold, no headings, only backticks for `code`
-   - Not a paragraph dump, not a commit log
-2. Present the draft to the user for review. They may edit it.
-3. Execute (after user confirms):
+After publishing, verify the public release state:
+
+1. Confirm tag location:
    ```bash
-   gh pr merge <N> --squash --body "$(cat <<'EOF'
-   <body>
-   EOF
-   )"
+   git show --stat vX.Y.Z
    ```
-4. Let GitHub default the title (`PR title (#N)`).
-5. NEVER use `--auto` or the automatic squash description that dumps all commits.
+2. Confirm GitHub Release:
+   ```bash
+   gh release view vX.Y.Z
+   ```
+3. Confirm package or installer availability when applicable:
+   - npm: `npm view <package> version`
+   - Homebrew: `brew update && brew info <tap>/<formula>`
+   - project-specific deploy or artifact registry checks
+4. For Loaf/Homebrew, report readiness only after the GitHub release exists, assets are uploaded, the tap formula is updated, and tap CI has passed.
+
+If publication partially completes, do not retag casually. Name the exact state and continue with the smallest repair or patch release path.
 
 ---
 
-## Step 6: Post-Merge Cleanup
+## Step 7: Post-Release Follow-Up
 
-After successful merge, run a single command:
+After verification:
 
-```bash
-loaf release --post-merge
-```
-
-This verifies HEAD state against an 8-point guardrail checklist (clean worktree, on the base branch with the merge commit at HEAD, readable HEAD subject for optional PR-number lookup, version-file agreement, CHANGELOG section present, no pre-existing tag or GH release, HEAD untagged). The squash subject should describe the shipped work (`feat:`, `fix:`, etc.); post-merge derives the release version from version files and `CHANGELOG.md`, not from a `chore: release` subject. Once all guardrails pass it tags the squash merge commit, pushes the tag, creates the GitHub Release from the matching `## [X.Y.Z]` CHANGELOG section, pulls the base branch, and best-effort deletes the local + remote feature branch. Manual `git tag`, `git push --tags`, `gh release create`, `git checkout`, `git pull --rebase`, and `git branch -d` are no longer needed — the flag subsumes them.
-
-If anything aborts:
-
-1. Read the actionable error message — each guardrail failure names the exact manual fix (e.g., "tag v1.2.3 already exists locally — run `git tag -d v1.2.3` and rerun").
-2. Perform the named fix.
-3. Rerun `loaf release --post-merge`. The command is idempotent on stateless reads, so reruns after a transient `gh` failure or a half-completed prior run pick up exactly where they left off.
-
-After the release finalizes, **run `/reflect`** — already on the base branch. Reflect looks back at the shipped work and updates strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) with learnings. Use `AskUserQuestion` to confirm before running.
+1. Log the release decision when session state is healthy:
+   ```bash
+   loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"
+   ```
+2. Suggest `/reflect` when the release produced durable product or workflow learnings.
+3. Suggest `/housekeeping` when session artifacts, release branches, or temporary reports need cleanup.
+4. Keep future-work discoveries out of the release notes; capture them as tasks, ideas, or sparks instead.
 
 ---
 
 ## Hook Interaction
 
-This skill coexists with existing hooks. Git workflow hooks are **advisory** (warn but don't block); security hooks remain blocking.
+This skill coexists with existing hooks. Git workflow hooks are advisory unless
+configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `workflow-pre-pr` (command) | Advisory | Fires on `gh pr create`. Reminds about CHANGELOG — redundant when release skill manages entries. |
-| `workflow-pre-merge` (instruction) | Advisory | Fires on `gh pr merge`. Reminds about squash conventions — redundant since body is already crafted. |
-| `workflow-post-merge` (instruction) | Advisory | Fires after merge. Outputs checklist the skill already handled. |
-| `validate-push` (command) | Advisory | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
-| `check-secrets` (command) | **Blocking** | Security gate. Always fires, always respected. |
+| `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
+| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
+| `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
 
-Do not modify, disable, or skip these hooks.
+Do not disable hooks to force a release through.
 
 ---
 
 ## Suggests Next
 
-After a successful release, suggest `/housekeeping` if session artifacts need archiving.
+After a successful release, suggest `/reflect` for durable learnings and `/housekeeping` if temporary release artifacts need attention.
 
 ## Related Skills
 
-- **implement** — Does the work and housekeeping; `/release` handles the merge afterward
-- **reflect** — Suggested post-merge if session has learnings
-- **git-workflow** — Conventions this skill enforces
-- **housekeeping** — Handles artifact hygiene; `/release` verifies it was done
+- **ship** -- Reviews, verifies, and lands a PR before it becomes release input
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **documentation-standards** -- Changelog and release-note quality
+- **reflect** -- Updates strategy from shipped/released learnings
+- **housekeeping** -- Cleans up completed session and release artifacts

--- a/dist/amp/skills/ship/SKILL.md
+++ b/dist/amp/skills/ship/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: ship
+description: >-
+  Reviews, verifies, and lands one pull request. Use when the user says "ship
+  it," "merge this PR," "ready to merge," "land this branch," or asks for a
+  final merge gate. Produces a reviewed, squash-merged PR and post-merge
+  cleanup. Not for version bumps, tags, GitHub Releases, or install verification
+  (use release).
+version: 2.0.0-pre.20260614235428
+---
+
+# Ship
+
+Review, verify, and land one PR. Shipping is the PR gate; releasing is the version-publication gate.
+
+## Contents
+- Critical Rules
+- Verification
+- Quick Reference
+- Topics
+- Context Detection
+- Step 1: PR Readiness
+- Step 2: Evidence Review
+- Step 3: Local Verification
+- Step 4: Squash Merge
+- Step 5: Post-Merge Cleanup
+- Step 6: Release Suggestion
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Critical Rules
+
+- **Ship is not release** -- do not bump versions, create tags, publish GitHub Releases, or verify package installation here.
+- **Keep PR quality local** -- smaller PRs are welcome, but `/ship` must still verify correctness before merge.
+- **Detect-first** -- auto-detect the PR from the current branch before asking for a PR number.
+- **Review before merge** -- inspect code, docs, tests, changelog, PR body, and CI state before approval.
+- **Never merge without explicit confirmation** -- present the PR, checks, findings, and squash body first.
+- **Clean squash body** -- write an intentional squash commit body; never accept the automatic commit dump.
+- **Keep landed and released distinct** -- after merge, describe the PR as landed or shipped, not necessarily released.
+- **Log shipping** -- after merge, run `loaf session log "decision(ship): PR #N landed via squash merge"` when session state is available.
+
+## Verification
+
+- PR identity, base branch, and head branch are confirmed
+- CI status is passing or the user explicitly accepts named non-blocking checks
+- Relevant local checks pass or failures are fixed before merge
+- PR body and durable docs do not overclaim relative to the diff
+- Squash commit title/body are clean, conventional, and user-facing
+- Base branch is updated after merge and the feature branch cleanup state is known
+
+## Quick Reference
+
+| Step | Gate | Blocking? |
+|------|------|-----------|
+| PR Readiness | PR exists, target base known, CI state reviewed | Yes |
+| Evidence Review | findings resolved or explicitly accepted | Yes |
+| Local Verification | relevant checks pass | Yes |
+| Squash Merge | user approves body text | Yes |
+| Cleanup | base pulled, branch deletion handled | No |
+| Release Suggestion | enough landed work may justify `/release` | No |
+
+## Topics
+
+| Topic | Use When |
+|-------|----------|
+| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
+
+---
+
+## Context Detection
+
+Before anything, detect the PR surface:
+
+1. Get current branch and repo default branch:
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. Parse `$ARGUMENTS`: may be a PR number, PR URL, branch name, or empty.
+3. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName,state,mergeStateStatus,isDraft
+   ```
+4. If no PR exists for the current branch, stop and offer to create one via `git-workflow` rather than silently merging a branch.
+5. If already on the default branch, stop. There is no PR to ship from the current branch.
+6. Confirm PR identity with the user before merge actions.
+
+---
+
+## Step 1: PR Readiness
+
+Inspect the PR's declared state:
+
+```bash
+gh pr view <N> --json number,title,body,url,headRefName,baseRefName,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+Block or pause when:
+
+- PR is draft
+- merge state is dirty or blocked
+- required checks are failing or pending
+- review decision is changes requested
+- branch is out of date and the project requires update before merge
+
+If checks are unavailable, say so explicitly and compensate with local verification.
+
+---
+
+## Step 2: Evidence Review
+
+Review the landing diff and durable prose together:
+
+1. Gather diff context:
+   ```bash
+   git fetch origin <baseRefName>
+   git diff --stat origin/<baseRefName>...HEAD
+   git diff --name-only origin/<baseRefName>...HEAD
+   ```
+2. Read the PR title/body and changed docs that make behavior claims.
+3. Check for drift:
+   - PR body claims features that are not in the diff
+   - changelog entries mention unreleased or unrelated behavior
+   - docs describe future work as already shipped
+   - comments or runbooks use stale internal vocabulary
+4. Fix blocking drift before merge. For non-blocking polish, name it and let the user decide.
+
+For high-risk PRs, use the project's review skill or read-only review flow before proceeding.
+
+---
+
+## Step 3: Local Verification
+
+Run the checks the project supports. Examples:
+
+- Node: `npm run typecheck`, `npm run test`, `npm run build`
+- Go: `go vet ./...`, `go test ./...`
+- Python: `pytest`, `mypy .`, `ruff check .`
+- Rust: `cargo check`, `cargo test`
+
+If generated artifacts are tracked, verify they are current before merge:
+
+```bash
+git diff --exit-code -- dist plugins
+```
+
+Use the repo's documented pre-commit or pre-PR checklist when present. Stop on failures.
+
+---
+
+## Step 4: Squash Merge
+
+Draft a clean squash body from the reviewed diff and PR body:
+
+- One-line summary, then bullet points grouped by feature area
+- Plain text; use backticks only for code identifiers
+- No commit dump
+- No agent attribution
+- No release-note overclaiming
+
+Present the body and ask for confirmation. Then run:
+
+```bash
+gh pr merge <N> --squash --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+Let GitHub default the title from the PR title so the squash subject remains `type: summary (#N)`.
+
+---
+
+## Step 5: Post-Merge Cleanup
+
+After a successful merge:
+
+1. Switch to the PR base branch:
+   ```bash
+   git checkout <baseRefName>
+   git pull --ff-only origin <baseRefName>
+   ```
+2. Delete the local feature branch when safe:
+   ```bash
+   git branch -d <headRefName>
+   ```
+3. Confirm the remote branch deletion state from GitHub output or run:
+   ```bash
+   gh pr view <N> --json headRefName,state
+   ```
+4. Log the landing when session state is healthy:
+   ```bash
+   loaf session log "decision(ship): PR #N landed via squash merge"
+   ```
+
+If cleanup fails, report the exact residual state. Do not force-delete without user confirmation.
+
+---
+
+## Step 6: Release Suggestion
+
+After landing, decide whether to suggest `/release`:
+
+- Suggest `/release` when the landed PR completes a coherent batch, user-facing feature, fix train, or release branch.
+- Do not suggest `/release` for every small PR by default.
+- If multiple related PRs are expected, say the PR is landed and can wait for a later batched release.
+
+Use language carefully: the PR is **landed** or **shipped**; it is not **released** until `/release` publishes a version.
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks.
+
+| Hook | Type | When `/ship` Runs |
+|------|------|------------------|
+| `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
+| `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
+| `validate-push` | Advisory | May fire if branch updates are needed before merge |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
+
+Do not disable hooks to force a PR through.
+
+---
+
+## Suggests Next
+
+After a successful ship, suggest `/release` only when the landed work forms a coherent release batch or the user asks to publish.
+
+## Related Skills
+
+- **release** -- Publishes a version from already-landed work
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **foundations** -- Verification, code review, and production readiness
+- **documentation-standards** -- Changelog, docs, and durable prose quality
+- **reflect** -- Updates strategy from significant shipped work

--- a/dist/amp/skills/wrap/SKILL.md
+++ b/dist/amp/skills/wrap/SKILL.md
@@ -42,8 +42,8 @@ Responsible session shutdown — everything that needs a conscious model before 
 - All decisions and discoveries from this session are in the journal
 - Uncommitted/unpushed state is surfaced with clear action prompts
 - Stale KB files are flagged if any
-- `## Session Wrap-Up` section written to session file (replaces `## Current State`)
-- `loaf session end --wrap` run after writing the summary
+- `## Session Wrap-Up` section persisted in the canonical session surface; in SQLite mode this is represented by wrapped session/report state rather than an active `.md` file
+- `loaf session end --wrap` run after generating or writing the summary
 - Session status is `done` (session stays open for further journal entries until `SessionEnd` fires)
 
 ## Quick Reference
@@ -64,7 +64,7 @@ These steps require conversation context — only the model can do them.
 
 Before anything else, complete the session journal:
 
-1. **Enrich from conversation log** — run `loaf session enrich` to fill in gaps from the JSONL conversation log. This catches decisions, discoveries, and context that weren't manually logged. If enrichment fails, continue — manual flush is the fallback.
+1. **Check enrichment state** — run `loaf session enrich --json`. In SQLite mode this is expected to report `action: "skipped"` because `loaf session log` is already the canonical journal writer; in markdown-only compatibility mode it summarizes legacy JSONL enrichment status. If enrichment is skipped or fails, continue — manual flush is the fallback.
 2. **Manual review** — review the conversation for anything enrichment missed:
    - Decisions — design choices, trade-offs, direction changes not yet logged as `decision()` entries
    - Discoveries — anything learned that future sessions would benefit from
@@ -75,7 +75,7 @@ Before anything else, complete the session journal:
 
 Run in parallel:
 
-1. **Session journal** — read the active session file for this branch
+1. **Session journal** — run `loaf session list --json`, choose the active session for the current branch or explicit harness session, then run `loaf session show <session-ref> --json`; if SQLite state is unavailable, fall back to the active markdown session file for this branch
 2. **Commits this session** — `git log --oneline` since session start
 3. **Working tree** — `git status --short`
 4. **Unpushed commits** — `git log --oneline origin/<branch>..HEAD`
@@ -90,7 +90,7 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 |-----------|--------|
 | Uncommitted changes | "N file(s) uncommitted — commit, stash, or leave for next session?" |
 | Unpushed commits | "N commit(s) on <branch> not pushed — push now?" |
-| No version bump | "This session shipped work but no release was run — bump version now?" |
+| Release candidate | "This session landed work that may belong in the next release — run `/release` now?" |
 | Stale KB files | "N stale knowledge file(s) — address now or defer?" |
 | Unresolved blocks | "Block on <scope> still open — note for next session?" |
 | No changelog entries | "N commit(s) on branch but `[Unreleased]` is empty — add changelog entries?" |
@@ -99,15 +99,17 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 **Detection logic:**
 - **Changelog entries:** check if the current branch has commits vs the base branch (e.g., `git rev-list --count origin/main..HEAD`) AND `CHANGELOG.md` `[Unreleased]` section has no list items (`^[-*]\s`). If both are true, prompt. **Skip when HEAD is tagged** (post-release state).
 - **Housekeeping:** scan session journal for `skill(housekeeping)` entry. If absent and the session had significant work, suggest it.
-- **Version bump:** scan session journal for `decision(release)` entry. If absent and the session has commits, offer to run `loaf release --bump prerelease --no-gh --yes`.
+- **Release candidate:** scan session journal for `decision(release)` entry. If absent and the session has landed commits, suggest `/release` only when the work forms a coherent release batch.
 
 ### Step 4: Generate Report
 
 Assemble the report per the format below. Omit empty sections — don't show "None" placeholders.
 
-### Step 5: Write Wrap Summary to Session File
+### Step 5: Persist Wrap Summary
 
-Write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
+In SQLite mode, keep the generated wrap summary in the conversation response and let `loaf session end --wrap` persist the mechanical wrapped state. Do not invent or edit a missing active `.md` session file; `loaf session show <session-ref> --json` is the canonical read surface.
+
+In markdown-only compatibility mode, write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
 
 Use the Edit tool to replace `## Current State (...)` and everything below it (up to `## Journal`) with the wrap-up section. The session file layout after wrap should be:
 
@@ -141,7 +143,7 @@ This handles the mechanical bookkeeping:
 
 ## Composability
 
-When called from `/release`, wrap runs the same steps but skips the version bump prompt (release already handles it). The `/release` skill should invoke `/wrap` first, then proceed with release steps.
+When called near `/ship` or `/release`, wrap runs the same steps but keeps PR landing and version publication distinct. `/ship` may wrap a landed PR; `/release` may wrap a published version.
 
 ## Suggests Next
 

--- a/dist/codex/skills/git-workflow/SKILL.md
+++ b/dist/codex/skills/git-workflow/SKILL.md
@@ -48,4 +48,5 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, curating CHANGELOG entries, pre-PR/pre-push/post-merge hooks |
-| Release ritual | `/release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |
+| PR shipping | `/ship` skill | Reviewing, verifying, and squash-merging one PR |
+| Release ritual | `/release` skill | Publishing a version from already-landed work |

--- a/dist/codex/skills/git-workflow/references/commits.md
+++ b/dist/codex/skills/git-workflow/references/commits.md
@@ -169,13 +169,13 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
-- The `/release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
+- The `/ship` skill automates this workflow when ready to squash merge a PR; `/release` publishes a version later from already-landed work
 
 ## Changelog Discipline
 
 `CHANGELOG.md` entries follow Loaf's Common Changelog profile: write for
 humans, communicate the release impact, and curate git history instead of
-copying it. Curate the `[Unreleased]` section before bumping the version so the
+copying it. Curate the `[Unreleased]` section as PRs land so the later
 published release notes read as user-facing prose, not an internal worklog.
 
 ### Drop
@@ -204,9 +204,9 @@ Internal terms that have no meaning outside the team's working context:
 
 ### Auto-generated Entries
 
-When `loaf release --pre-merge` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
+When `loaf release` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
 
-Before approving a release bump, compare `[Unreleased]` against the actual squashed change set and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the branch was organized, it does not belong in the changelog.
+Before approving a release bump, compare `[Unreleased]` against the actual release range and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the work was organized, it does not belong in the changelog.
 
 ## Critical Rules
 
@@ -285,7 +285,7 @@ When developing toward a major version, use pre-release suffixes to mark develop
 
 **Convention:**
 - Set the target version with `-dev.0` when starting a major effort (e.g. `2.0.0-dev.0`)
-- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of work ships — a spec completing, a group of related features landing
+- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of landed work is ready to publish — a completed spec, a related feature group, or a release train
 - Don't bump for every commit — that's what git history is for
 - Strip the suffix (`-dev.N` → `2.0.0`) when all planned work is complete
 - `loaf release` handles all bump types: `prerelease`, `release`, `major`, `minor`, `patch`

--- a/dist/codex/skills/implement/SKILL.md
+++ b/dist/codex/skills/implement/SKILL.md
@@ -334,7 +334,7 @@ After creating session file:
    - Update session file (status: done, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
+5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
@@ -353,7 +353,7 @@ After creating session file:
 
 ## Suggests Next
 
-After all tasks are complete, suggest `/release` to merge the work.
+After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release` only when the landed work forms a coherent release batch.
 
 ## Related Skills
 

--- a/dist/codex/skills/release/SKILL.md
+++ b/dist/codex/skills/release/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: release
 description: >-
-  Orchestrates releases: pre-flight checks, version bump via `loaf release`,
-  squash merge, and post-merge cleanup. Use when the user says "release this,"
-  "merge this PR," "ready to merge," or "ship it." Produces version bumps,
-  changelog updates, and merged code. Not for creating PRs (use git-workflow) or
-  reflection (use reflect).
+  Orchestrates standalone releases from already-landed work: release readiness,
+  version selection, changelog curation, release commit, tag, GitHub Release,
+  install verification, and post-release follow-up. Use when the user says "cut
+  a release," "publish a version," "release from main," or asks whether enough
+  landed work should become a release. Not for reviewing or merging a PR (use
+  ship).
 version: 2.0.0-pre.20260614235428
 ---
 
 # Release
 
-Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+Publish a coherent version from work that has already landed.
 
 ## Contents
 - Critical Rules
@@ -19,13 +20,13 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 - Quick Reference
 - Topics
 - Context Detection
-- Step 1: Pre-Flight Checks
-- Step 2: Documentation Freshness
-- Step 3: Housekeeping Verification
-- Step 3b: Create PR (if needed)
-- Step 4: Version Bump + Changelog
-- Step 5: Squash Merge
-- Step 6: Post-Merge Cleanup
+- Step 1: Release Readiness
+- Step 2: Change Collection
+- Step 3: Version + Changelog
+- Step 4: Release Execution
+- Step 5: Protected-Branch Handoff
+- Step 6: Publication Verification
+- Step 7: Post-Release Follow-Up
 - Hook Interaction
 - Related Skills
 
@@ -35,308 +36,255 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 
 ## Critical Rules
 
-- **Block on pre-flight failure** -- do not offer to skip any failing check
-- **Use `AskUserQuestion` for all decisions and confirmations** -- version bump type, push approval, merge approval, branch deletion. Never use inline text questions for permission/decision prompts
-- **Version bump before merge** -- this is the skill's reason for existing; never defer to post-merge
-- **Wrap after version bump** -- wrap needs PR# and version to produce a complete session summary
-- **Clean squash body** -- never use the auto-generated commit dump
-- **Orchestrate the full lifecycle** -- if housekeeping or reflect haven't been run, trigger them (with user confirmation via `AskUserQuestion`) rather than just flagging gaps
-- **Detect-first** -- auto-detect PR from branch before asking for a number
-- **Never push without confirmation** -- even after successful version bump
-- **Log release** -- log to session journal after merge: `loaf session log "decision(release): vX.Y.Z shipped via PR #N"`
+- **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
+- **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
+- **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
+- **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
+- **Never push, tag, or publish without confirmation** -- present the exact actions first.
+- **Use `AskUserQuestion` for release decisions when available** -- version bump type, release PR handoff, push/tag/GitHub Release confirmation.
+- **Log release** -- after publication, run `loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"` when session state is available.
 
 ## Verification
 
-- Pre-flight checks (typecheck, test, build) all pass before proceeding
-- Version bump commit exists on the feature branch before merge
-- Squash merge body is a one-line summary followed by bullet points grouped by feature area, not a commit dump
-- Git tag points to the squash merge commit on the base branch, not a branch commit
-- GitHub Release exists with changelog body (not auto-generated notes)
-- Post-merge cleanup completed: base branch pulled, feature branch deleted
+- Release base branch is clean, current, and contains the intended landed PRs
+- Pre-flight checks pass before versioning or publication
+- Changelog entries are curated user-facing prose, not commit or PR-title dumps
+- Version files, changelog heading, git tag, and GitHub Release all agree
+- Tag points at the released base-branch commit or release commit, not an abandoned feature branch
+- Downstream install path is verified when applicable, especially Homebrew for Loaf releases
 
 ## Quick Reference
 
 | Step | Gate | Blocking? |
 |------|------|-----------|
-| Pre-Flight | typecheck + test + build pass | Yes |
-| Doc Freshness | User reviews stale docs | No (user decides) |
-| Housekeeping | Spec/tasks archived, CHANGELOG ready | No (user decides) |
-| PR Creation | Only if no PR exists yet | Yes (if needed) |
-| Version Bump | User confirms bump type; `loaf release --pre-merge` | Yes |
-| Wrap | Session summary (after version bump, has PR# + version) | Yes |
-| Squash Merge | User approves body text | Yes |
-| Post-Merge | `loaf release --post-merge` (tag, GH Release, cleanup) | Yes |
+| Readiness | clean/current base branch, no unresolved release collisions | Yes |
+| Change Collection | landed work since last tag grouped into release themes | Yes |
+| Version + Changelog | bump selected, notes curated, files updated | Yes |
+| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Verification | release and install paths checked | Yes |
+| Follow-Up | reflect/housekeeping suggested when useful | No |
 
 ## Topics
 
 | Topic | Use When |
 |-------|----------|
-| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
+| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
 
 ## Context Detection
 
-Before anything, detect where we are:
+Before anything, establish the release surface:
 
-1. **Get current branch and repo default branch:**
+1. Get current branch and repo default branch:
    ```bash
    git branch --show-current
    gh repo view --json defaultBranchRef -q .defaultBranchRef.name
    ```
-2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
-3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
-4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
+3. Verify the current branch:
+   - If already on the release base, continue.
+   - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
+   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
+4. Find the previous release tag:
    ```bash
-   gh pr view --json number,title,url,headRefName,baseRefName
+   git describe --tags --abbrev=0
    ```
-5. If no PR exists for this branch, note `pr_exists = false` and set `baseRefName` to the repo default branch. Continue — the PR will be created in Step 3b.
-6. If PR exists, **save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
-7. Confirm the PR identity (or intent to create one) with the user before proceeding.
-
----
-
-## Step 1: Pre-Flight Checks (BLOCKING)
-
-Run these and **BLOCK on any failure** — do not offer to skip.
-
-### Detect project type
-
-Inspect the repo to determine available checks:
-- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
-- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config; if the project is uv-managed, expect release artifact refresh to run `uv sync`
-- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
-- **Go** (`go.mod`): `go vet`, `go test`
-
-### Run checks
-
-Run whichever checks the project supports. Examples for a Node project:
-1. `npm run typecheck` (if the script exists)
-2. `npm run test` (if the script exists)
-3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
-
-For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
-
-**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
-
-On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
-
----
-
-## Step 2: Documentation Freshness
-
-Check whether documentation is stale relative to the branch's changes:
-
-1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
-2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
-3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
-4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
-
-Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
-
----
-
-## Step 3: Housekeeping
-
-Check each item. If missing, **offer to run it** (with user confirmation) rather than just flagging it.
-
-1. **Spec status**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`. If not, offer to update it.
-2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived. If found, offer to run `loaf task archive`.
-3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
-4. **Journal flushed**: Review conversation for unrecorded decisions/discoveries. Log them now — this is the last chance before wrap.
-
-Present the results as a checklist. Use `AskUserQuestion` for any decisions or approvals.
-
-**Note:** Wrap (`/wrap`) runs AFTER version bump (Step 4b) so it can reference the PR# and version in the session summary. Reflection runs post-merge (Step 6).
-
----
-
-## Step 3b: Create PR (if needed)
-
-**Only run this step if `pr_exists = false` from Context Detection.**
-
-The PR must be created BEFORE the version bump so that `[Unreleased]` changelog entries are still present (advisory hooks check for this).
-
-1. Push the branch if not already pushed.
-2. Create the PR following the format in [git-workflow/references/commits.md](../git-workflow/references/commits.md) (Pull Request Format section).
-3. Save the PR number and `baseRefName` for subsequent steps.
-
----
-
-## Step 4: Version Bump + Changelog (on feature branch)
-
-This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
-
-### Check for existing changelog entries
-
-Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
-
-- **If curated entries exist** → Use the **Curated path** (preserve them)
-- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
-
-### Curated path (preferred when entries exist)
-
-The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
-
-**Review curated entries for quality before bumping:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Follow Loaf's Common Changelog profile: imperative, self-describing,
-  one-line entries grouped as `Changed`, `Added`, `Removed`, `Fixed`
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Include the best public reference when available, such as a PR, issue, ADR, release, or commit link
-
-1. Run `loaf release --pre-merge --dry-run` to get the **suggested bump type** and **current version** (the `--pre-merge` flag auto-detects the base branch — see [Why `--pre-merge`?](#why---pre-merge) below).
-2. Present the bump suggestion to the user. They may accept or override.
-3. Once confirmed, run:
+5. Gather the candidate release range:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git log --oneline <last-tag>..HEAD
+   git diff --stat <last-tag>..HEAD
    ```
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it) and re-insert a fresh empty `## [Unreleased]` section above
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+---
 
-### Generated path (when no entries exist)
+## Step 1: Release Readiness
 
-When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+Run release pre-flight checks before editing release files:
 
-**After generation, review and rewrite entries before committing:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Rewrite generated commit text into Loaf's Common Changelog profile
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Keep entries concise but descriptive enough to understand the change without reading the diff
-
-1. Run `loaf release --pre-merge --dry-run` to preview:
-   - Current version and suggested bump type
-   - Generated changelog section from **this branch's commits only**
-   - Which version files will be updated
-
-   The `--pre-merge` flag scopes the commit analysis to `<auto-detected base>..HEAD`, so only commits on the feature branch are considered.
-
-2. Present the preview to the user. They may:
-   - Accept the suggested bump type
-   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-   - Edit the changelog content conversationally
-
-3. Once the user confirms, run:
+1. Ensure worktree is clean:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git status --short
    ```
+2. Ensure the release base is current:
+   ```bash
+   git fetch --tags origin
+   git status --branch --short
+   ```
+3. Check for existing tag or GitHub Release collisions for the target version once known:
+   ```bash
+   git tag --list vX.Y.Z
+   gh release view vX.Y.Z
+   ```
+4. Run project checks:
+   - Node: `npm run typecheck`, `npm run test`, `npm run build` when scripts exist
+   - Go: `go vet ./...`, `go test ./...` when `go.mod` exists
+   - Python: `pytest`, `mypy .`, `ruff check .` when configured
+   - Rust: `cargo check`, `cargo test` when `Cargo.toml` exists
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Generate and insert changelog section from branch commits (adding a fresh `[Unreleased]`)
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+If no checks are detected, warn explicitly. If a check fails, stop and fix before release.
 
-### After either path
+---
 
-Before pushing, verify generated artifacts are still current. This matters if
-any fix commits landed after the release bump commit:
+## Step 2: Change Collection
+
+Collect landed work since the last release and group it for release notes.
+
+1. Inspect commits:
+   ```bash
+   git log --first-parent --oneline <last-tag>..HEAD
+   git log --oneline <last-tag>..HEAD
+   ```
+2. Inspect merged PRs when GitHub is available:
+   ```bash
+   gh pr list --state merged --base <base> --json number,title,mergedAt,url
+   ```
+3. Group changes by user-facing outcome:
+   - `CR-*` change bundle, when referenced
+   - spec or task family, when public enough to be useful
+   - feature/fix/documentation/build themes
+   - operational release work, when it affects users or maintainers
+4. Drop noise:
+   - purely internal task/session labels
+   - reverted work that is not present in `HEAD`
+   - individual commit mechanics that collapse into one user-facing change
+
+Present the grouped release contents before choosing the bump.
+
+---
+
+## Step 3: Version + Changelog
+
+Choose the bump and curate the changelog from the grouped landed work.
+
+1. Run a dry run:
+   ```bash
+   loaf release --dry-run
+   ```
+   Use `--base <ref>` when the project expects a non-default release base.
+2. Present:
+   - current version
+   - proposed next version
+   - detected version files
+   - release actions the CLI would perform
+   - draft changelog entries
+3. Curate `CHANGELOG.md` before publishing:
+   - write from the upgrading user's perspective
+   - group under Common Changelog categories: `Changed`, `Added`, `Removed`, `Fixed`
+   - use one self-describing line per meaningful change
+   - include public PR, issue, ADR, release, or commit links when helpful
+   - avoid dumping commit subjects, task IDs, session mechanics, or internal gate language
+4. Confirm the bump type: `prerelease`, `release`, `major`, `minor`, or `patch`.
+
+---
+
+## Step 4: Release Execution
+
+For a direct release from the base branch, run:
+
+```bash
+loaf release --bump <type> --yes
+```
+
+This should:
+
+1. Update version files
+2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
+3. Reinsert a fresh empty `[Unreleased]` section
+4. Run configured release artifact commands
+5. Create the release commit
+6. Create/push the release tag
+7. Create the GitHub Release when enabled
+
+After execution, verify generated artifacts are current:
 
 ```bash
 npm run build
-git diff --exit-code -- plugins/loaf/bin/loaf dist content/skills/cli-reference/SKILL.md
+git diff --exit-code -- dist plugins content/skills/cli-reference/SKILL.md
 ```
 
-If the diff check fails, commit the regenerated artifacts with the source change
-that made them stale, then rerun the check.
-
-Push to the feature branch (**with user confirmation**).
-
-### Why `--pre-merge`?
-
-`--pre-merge` bundles the canonical pre-merge flag set so the skill no longer needs to spell each one out:
-
-- Equivalent to `--no-tag --no-gh --base <auto-detected>` (tag and GH release land post-merge in Step 6, not on the soon-to-be-squashed feature commit).
-- Auto-detects the base ref via a 4-step priority: explicit `--base <ref>` → open PR's `baseRefName` → `git config loaf.release.base` → repo default branch. Run `loaf release --help` to see the full priority order.
-- Pass `--base <ref>` explicitly to override auto-detection (useful for non-default base branches like `release/1.0` when no PR exists yet).
-- `--yes` skips the CLI confirmation prompt — the skill already confirmed with the user conversationally.
+Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
 ---
 
-## Step 4b: Wrap Session
+## Step 5: Protected-Branch Handoff
 
-Run `/wrap` AFTER version bump so the session summary can reference the PR# and final version.
+If branch protection prevents direct release commits on the base branch:
 
-The wrap skill will:
-1. Flush any remaining journal entries
-2. Gather git state (commits, working tree, unpushed)
-3. Generate the `## Session Wrap-Up` report
-4. Write it to the session file (replaces `## Current State`)
-5. Run `loaf session end --wrap` to set status to `complete`
+1. Create a dedicated release branch.
+2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+3. Open a release PR with a concise release-focused body.
+4. Hand the PR to `/ship` for review and landing.
+5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
 
-When called from `/release`, wrap skips the version bump and changelog prompts (already handled).
+Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
 ---
 
-## Step 5: Squash Merge
+## Step 6: Publication Verification
 
-1. Draft a clean squash body from the branch's commit history and PR description. Descriptive, not verbose:
-   - One-line summary, then bullet points grouped by feature area
-   - Plain text — no bold, no headings, only backticks for `code`
-   - Not a paragraph dump, not a commit log
-2. Present the draft to the user for review. They may edit it.
-3. Execute (after user confirms):
+After publishing, verify the public release state:
+
+1. Confirm tag location:
    ```bash
-   gh pr merge <N> --squash --body "$(cat <<'EOF'
-   <body>
-   EOF
-   )"
+   git show --stat vX.Y.Z
    ```
-4. Let GitHub default the title (`PR title (#N)`).
-5. NEVER use `--auto` or the automatic squash description that dumps all commits.
+2. Confirm GitHub Release:
+   ```bash
+   gh release view vX.Y.Z
+   ```
+3. Confirm package or installer availability when applicable:
+   - npm: `npm view <package> version`
+   - Homebrew: `brew update && brew info <tap>/<formula>`
+   - project-specific deploy or artifact registry checks
+4. For Loaf/Homebrew, report readiness only after the GitHub release exists, assets are uploaded, the tap formula is updated, and tap CI has passed.
+
+If publication partially completes, do not retag casually. Name the exact state and continue with the smallest repair or patch release path.
 
 ---
 
-## Step 6: Post-Merge Cleanup
+## Step 7: Post-Release Follow-Up
 
-After successful merge, run a single command:
+After verification:
 
-```bash
-loaf release --post-merge
-```
-
-This verifies HEAD state against an 8-point guardrail checklist (clean worktree, on the base branch with the merge commit at HEAD, readable HEAD subject for optional PR-number lookup, version-file agreement, CHANGELOG section present, no pre-existing tag or GH release, HEAD untagged). The squash subject should describe the shipped work (`feat:`, `fix:`, etc.); post-merge derives the release version from version files and `CHANGELOG.md`, not from a `chore: release` subject. Once all guardrails pass it tags the squash merge commit, pushes the tag, creates the GitHub Release from the matching `## [X.Y.Z]` CHANGELOG section, pulls the base branch, and best-effort deletes the local + remote feature branch. Manual `git tag`, `git push --tags`, `gh release create`, `git checkout`, `git pull --rebase`, and `git branch -d` are no longer needed — the flag subsumes them.
-
-If anything aborts:
-
-1. Read the actionable error message — each guardrail failure names the exact manual fix (e.g., "tag v1.2.3 already exists locally — run `git tag -d v1.2.3` and rerun").
-2. Perform the named fix.
-3. Rerun `loaf release --post-merge`. The command is idempotent on stateless reads, so reruns after a transient `gh` failure or a half-completed prior run pick up exactly where they left off.
-
-After the release finalizes, **run `/reflect`** — already on the base branch. Reflect looks back at the shipped work and updates strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) with learnings. Use `AskUserQuestion` to confirm before running.
+1. Log the release decision when session state is healthy:
+   ```bash
+   loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"
+   ```
+2. Suggest `/reflect` when the release produced durable product or workflow learnings.
+3. Suggest `/housekeeping` when session artifacts, release branches, or temporary reports need cleanup.
+4. Keep future-work discoveries out of the release notes; capture them as tasks, ideas, or sparks instead.
 
 ---
 
 ## Hook Interaction
 
-This skill coexists with existing hooks. Git workflow hooks are **advisory** (warn but don't block); security hooks remain blocking.
+This skill coexists with existing hooks. Git workflow hooks are advisory unless
+configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `workflow-pre-pr` (command) | Advisory | Fires on `gh pr create`. Reminds about CHANGELOG — redundant when release skill manages entries. |
-| `workflow-pre-merge` (instruction) | Advisory | Fires on `gh pr merge`. Reminds about squash conventions — redundant since body is already crafted. |
-| `workflow-post-merge` (instruction) | Advisory | Fires after merge. Outputs checklist the skill already handled. |
-| `validate-push` (command) | Advisory | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
-| `check-secrets` (command) | **Blocking** | Security gate. Always fires, always respected. |
+| `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
+| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
+| `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
 
-Do not modify, disable, or skip these hooks.
+Do not disable hooks to force a release through.
 
 ---
 
 ## Suggests Next
 
-After a successful release, suggest `/housekeeping` if session artifacts need archiving.
+After a successful release, suggest `/reflect` for durable learnings and `/housekeeping` if temporary release artifacts need attention.
 
 ## Related Skills
 
-- **implement** — Does the work and housekeeping; `/release` handles the merge afterward
-- **reflect** — Suggested post-merge if session has learnings
-- **git-workflow** — Conventions this skill enforces
-- **housekeeping** — Handles artifact hygiene; `/release` verifies it was done
+- **ship** -- Reviews, verifies, and lands a PR before it becomes release input
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **documentation-standards** -- Changelog and release-note quality
+- **reflect** -- Updates strategy from shipped/released learnings
+- **housekeeping** -- Cleans up completed session and release artifacts

--- a/dist/codex/skills/ship/SKILL.md
+++ b/dist/codex/skills/ship/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: ship
+description: >-
+  Reviews, verifies, and lands one pull request. Use when the user says "ship
+  it," "merge this PR," "ready to merge," "land this branch," or asks for a
+  final merge gate. Produces a reviewed, squash-merged PR and post-merge
+  cleanup. Not for version bumps, tags, GitHub Releases, or install verification
+  (use release).
+version: 2.0.0-pre.20260614235428
+---
+
+# Ship
+
+Review, verify, and land one PR. Shipping is the PR gate; releasing is the version-publication gate.
+
+## Contents
+- Critical Rules
+- Verification
+- Quick Reference
+- Topics
+- Context Detection
+- Step 1: PR Readiness
+- Step 2: Evidence Review
+- Step 3: Local Verification
+- Step 4: Squash Merge
+- Step 5: Post-Merge Cleanup
+- Step 6: Release Suggestion
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Critical Rules
+
+- **Ship is not release** -- do not bump versions, create tags, publish GitHub Releases, or verify package installation here.
+- **Keep PR quality local** -- smaller PRs are welcome, but `/ship` must still verify correctness before merge.
+- **Detect-first** -- auto-detect the PR from the current branch before asking for a PR number.
+- **Review before merge** -- inspect code, docs, tests, changelog, PR body, and CI state before approval.
+- **Never merge without explicit confirmation** -- present the PR, checks, findings, and squash body first.
+- **Clean squash body** -- write an intentional squash commit body; never accept the automatic commit dump.
+- **Keep landed and released distinct** -- after merge, describe the PR as landed or shipped, not necessarily released.
+- **Log shipping** -- after merge, run `loaf session log "decision(ship): PR #N landed via squash merge"` when session state is available.
+
+## Verification
+
+- PR identity, base branch, and head branch are confirmed
+- CI status is passing or the user explicitly accepts named non-blocking checks
+- Relevant local checks pass or failures are fixed before merge
+- PR body and durable docs do not overclaim relative to the diff
+- Squash commit title/body are clean, conventional, and user-facing
+- Base branch is updated after merge and the feature branch cleanup state is known
+
+## Quick Reference
+
+| Step | Gate | Blocking? |
+|------|------|-----------|
+| PR Readiness | PR exists, target base known, CI state reviewed | Yes |
+| Evidence Review | findings resolved or explicitly accepted | Yes |
+| Local Verification | relevant checks pass | Yes |
+| Squash Merge | user approves body text | Yes |
+| Cleanup | base pulled, branch deletion handled | No |
+| Release Suggestion | enough landed work may justify `/release` | No |
+
+## Topics
+
+| Topic | Use When |
+|-------|----------|
+| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
+
+---
+
+## Context Detection
+
+Before anything, detect the PR surface:
+
+1. Get current branch and repo default branch:
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. Parse `$ARGUMENTS`: may be a PR number, PR URL, branch name, or empty.
+3. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName,state,mergeStateStatus,isDraft
+   ```
+4. If no PR exists for the current branch, stop and offer to create one via `git-workflow` rather than silently merging a branch.
+5. If already on the default branch, stop. There is no PR to ship from the current branch.
+6. Confirm PR identity with the user before merge actions.
+
+---
+
+## Step 1: PR Readiness
+
+Inspect the PR's declared state:
+
+```bash
+gh pr view <N> --json number,title,body,url,headRefName,baseRefName,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+Block or pause when:
+
+- PR is draft
+- merge state is dirty or blocked
+- required checks are failing or pending
+- review decision is changes requested
+- branch is out of date and the project requires update before merge
+
+If checks are unavailable, say so explicitly and compensate with local verification.
+
+---
+
+## Step 2: Evidence Review
+
+Review the landing diff and durable prose together:
+
+1. Gather diff context:
+   ```bash
+   git fetch origin <baseRefName>
+   git diff --stat origin/<baseRefName>...HEAD
+   git diff --name-only origin/<baseRefName>...HEAD
+   ```
+2. Read the PR title/body and changed docs that make behavior claims.
+3. Check for drift:
+   - PR body claims features that are not in the diff
+   - changelog entries mention unreleased or unrelated behavior
+   - docs describe future work as already shipped
+   - comments or runbooks use stale internal vocabulary
+4. Fix blocking drift before merge. For non-blocking polish, name it and let the user decide.
+
+For high-risk PRs, use the project's review skill or read-only review flow before proceeding.
+
+---
+
+## Step 3: Local Verification
+
+Run the checks the project supports. Examples:
+
+- Node: `npm run typecheck`, `npm run test`, `npm run build`
+- Go: `go vet ./...`, `go test ./...`
+- Python: `pytest`, `mypy .`, `ruff check .`
+- Rust: `cargo check`, `cargo test`
+
+If generated artifacts are tracked, verify they are current before merge:
+
+```bash
+git diff --exit-code -- dist plugins
+```
+
+Use the repo's documented pre-commit or pre-PR checklist when present. Stop on failures.
+
+---
+
+## Step 4: Squash Merge
+
+Draft a clean squash body from the reviewed diff and PR body:
+
+- One-line summary, then bullet points grouped by feature area
+- Plain text; use backticks only for code identifiers
+- No commit dump
+- No agent attribution
+- No release-note overclaiming
+
+Present the body and ask for confirmation. Then run:
+
+```bash
+gh pr merge <N> --squash --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+Let GitHub default the title from the PR title so the squash subject remains `type: summary (#N)`.
+
+---
+
+## Step 5: Post-Merge Cleanup
+
+After a successful merge:
+
+1. Switch to the PR base branch:
+   ```bash
+   git checkout <baseRefName>
+   git pull --ff-only origin <baseRefName>
+   ```
+2. Delete the local feature branch when safe:
+   ```bash
+   git branch -d <headRefName>
+   ```
+3. Confirm the remote branch deletion state from GitHub output or run:
+   ```bash
+   gh pr view <N> --json headRefName,state
+   ```
+4. Log the landing when session state is healthy:
+   ```bash
+   loaf session log "decision(ship): PR #N landed via squash merge"
+   ```
+
+If cleanup fails, report the exact residual state. Do not force-delete without user confirmation.
+
+---
+
+## Step 6: Release Suggestion
+
+After landing, decide whether to suggest `/release`:
+
+- Suggest `/release` when the landed PR completes a coherent batch, user-facing feature, fix train, or release branch.
+- Do not suggest `/release` for every small PR by default.
+- If multiple related PRs are expected, say the PR is landed and can wait for a later batched release.
+
+Use language carefully: the PR is **landed** or **shipped**; it is not **released** until `/release` publishes a version.
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks.
+
+| Hook | Type | When `/ship` Runs |
+|------|------|------------------|
+| `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
+| `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
+| `validate-push` | Advisory | May fire if branch updates are needed before merge |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
+
+Do not disable hooks to force a PR through.
+
+---
+
+## Suggests Next
+
+After a successful ship, suggest `/release` only when the landed work forms a coherent release batch or the user asks to publish.
+
+## Related Skills
+
+- **release** -- Publishes a version from already-landed work
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **foundations** -- Verification, code review, and production readiness
+- **documentation-standards** -- Changelog, docs, and durable prose quality
+- **reflect** -- Updates strategy from significant shipped work

--- a/dist/codex/skills/wrap/SKILL.md
+++ b/dist/codex/skills/wrap/SKILL.md
@@ -42,8 +42,8 @@ Responsible session shutdown — everything that needs a conscious model before 
 - All decisions and discoveries from this session are in the journal
 - Uncommitted/unpushed state is surfaced with clear action prompts
 - Stale KB files are flagged if any
-- `## Session Wrap-Up` section written to session file (replaces `## Current State`)
-- `loaf session end --wrap` run after writing the summary
+- `## Session Wrap-Up` section persisted in the canonical session surface; in SQLite mode this is represented by wrapped session/report state rather than an active `.md` file
+- `loaf session end --wrap` run after generating or writing the summary
 - Session status is `done` (session stays open for further journal entries until `SessionEnd` fires)
 
 ## Quick Reference
@@ -64,7 +64,7 @@ These steps require conversation context — only the model can do them.
 
 Before anything else, complete the session journal:
 
-1. **Enrich from conversation log** — run `loaf session enrich` to fill in gaps from the JSONL conversation log. This catches decisions, discoveries, and context that weren't manually logged. If enrichment fails, continue — manual flush is the fallback.
+1. **Check enrichment state** — run `loaf session enrich --json`. In SQLite mode this is expected to report `action: "skipped"` because `loaf session log` is already the canonical journal writer; in markdown-only compatibility mode it summarizes legacy JSONL enrichment status. If enrichment is skipped or fails, continue — manual flush is the fallback.
 2. **Manual review** — review the conversation for anything enrichment missed:
    - Decisions — design choices, trade-offs, direction changes not yet logged as `decision()` entries
    - Discoveries — anything learned that future sessions would benefit from
@@ -75,7 +75,7 @@ Before anything else, complete the session journal:
 
 Run in parallel:
 
-1. **Session journal** — read the active session file for this branch
+1. **Session journal** — run `loaf session list --json`, choose the active session for the current branch or explicit harness session, then run `loaf session show <session-ref> --json`; if SQLite state is unavailable, fall back to the active markdown session file for this branch
 2. **Commits this session** — `git log --oneline` since session start
 3. **Working tree** — `git status --short`
 4. **Unpushed commits** — `git log --oneline origin/<branch>..HEAD`
@@ -90,7 +90,7 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 |-----------|--------|
 | Uncommitted changes | "N file(s) uncommitted — commit, stash, or leave for next session?" |
 | Unpushed commits | "N commit(s) on <branch> not pushed — push now?" |
-| No version bump | "This session shipped work but no release was run — bump version now?" |
+| Release candidate | "This session landed work that may belong in the next release — run `/release` now?" |
 | Stale KB files | "N stale knowledge file(s) — address now or defer?" |
 | Unresolved blocks | "Block on <scope> still open — note for next session?" |
 | No changelog entries | "N commit(s) on branch but `[Unreleased]` is empty — add changelog entries?" |
@@ -99,15 +99,17 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 **Detection logic:**
 - **Changelog entries:** check if the current branch has commits vs the base branch (e.g., `git rev-list --count origin/main..HEAD`) AND `CHANGELOG.md` `[Unreleased]` section has no list items (`^[-*]\s`). If both are true, prompt. **Skip when HEAD is tagged** (post-release state).
 - **Housekeeping:** scan session journal for `skill(housekeeping)` entry. If absent and the session had significant work, suggest it.
-- **Version bump:** scan session journal for `decision(release)` entry. If absent and the session has commits, offer to run `loaf release --bump prerelease --no-gh --yes`.
+- **Release candidate:** scan session journal for `decision(release)` entry. If absent and the session has landed commits, suggest `/release` only when the work forms a coherent release batch.
 
 ### Step 4: Generate Report
 
 Assemble the report per the format below. Omit empty sections — don't show "None" placeholders.
 
-### Step 5: Write Wrap Summary to Session File
+### Step 5: Persist Wrap Summary
 
-Write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
+In SQLite mode, keep the generated wrap summary in the conversation response and let `loaf session end --wrap` persist the mechanical wrapped state. Do not invent or edit a missing active `.md` session file; `loaf session show <session-ref> --json` is the canonical read surface.
+
+In markdown-only compatibility mode, write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
 
 Use the Edit tool to replace `## Current State (...)` and everything below it (up to `## Journal`) with the wrap-up section. The session file layout after wrap should be:
 
@@ -141,7 +143,7 @@ This handles the mechanical bookkeeping:
 
 ## Composability
 
-When called from `/release`, wrap runs the same steps but skips the version bump prompt (release already handles it). The `/release` skill should invoke `/wrap` first, then proceed with release steps.
+When called near `/ship` or `/release`, wrap runs the same steps but keeps PR landing and version publication distinct. `/ship` may wrap a landed PR; `/release` may wrap a published version.
 
 ## Suggests Next
 

--- a/dist/cursor/hooks/instructions/post-merge.md
+++ b/dist/cursor/hooks/instructions/post-merge.md
@@ -1,4 +1,4 @@
-**Note:** If you used `/release`, these steps were already handled by the skill. This checklist is for manual merges.
+**Note:** If you used `/ship`, these steps were already handled by the skill. This checklist is for manual merges.
 
 # Pre-Merge Checklist
 
@@ -12,27 +12,19 @@ Complete these steps on the feature branch before creating the PR.
    ```
    Archive session file (status: done, `archived_at`, `archived_by`, move to archive/).
 
-2. **Update CHANGELOG.md:**
-   Add entries under `[Unreleased]` describing what the PR ships.
+2. **Update CHANGELOG.md when the PR has release-facing impact:**
+   Add curated entries under `[Unreleased]` describing what the PR lands. Do not move entries to a versioned section here; `/release` publishes the batch later.
 
-3. **Bump version** in `package.json`:
-   - `feat` commit -> minor bump (or dev bump if pre-release)
-   - `fix` commit -> patch bump
-   - Breaking change -> major bump
-
-4. **Move `[Unreleased]` to versioned section:**
-   `## [X.Y.Z] - YYYY-MM-DD`
-
-5. **Rebuild all targets:**
+3. **Rebuild all targets:**
    ```
    npx loaf build
    ```
 
-6. **Commit and push** the changelog + version + archived artifacts to the PR branch.
+4. **Commit and push** the changelog and generated artifacts to the PR branch.
 
-7. **Create PR** with `gh pr create` — title + summary + test plan.
+5. **Create PR** with `gh pr create` — title + summary + test plan.
 
-8. **Squash merge** with a clean commit body:
+6. **Squash merge** with a clean commit body:
    - Let GitHub default the title: `PR title (#N)`
    - Write a concise 2-4 sentence summary as `--body` (use a HEREDOC)
    - **Never** use the automatic squash description that dumps all individual commit messages
@@ -55,3 +47,5 @@ Complete these steps on main after merging.
    ```
 
 3. **Suggest reflection** if the session had key decisions or learnings.
+
+4. **Suggest `/release` only when appropriate** — if this PR completes a coherent batch or release branch, publish from the base branch after the landed work is present there.

--- a/dist/cursor/hooks/instructions/pre-pr-checklist.md
+++ b/dist/cursor/hooks/instructions/pre-pr-checklist.md
@@ -29,7 +29,7 @@ If `CHANGELOG.md` does not exist, create it first:
 
 This project follows [Common Changelog](https://common-changelog.org/) and
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). `## [Unreleased]`
-is a workflow staging section for curated entries before release.
+is a workflow staging section for curated entries that land with PRs before a later release.
 
 ## [Unreleased]
 

--- a/dist/cursor/skills/git-workflow/SKILL.md
+++ b/dist/cursor/skills/git-workflow/SKILL.md
@@ -48,4 +48,5 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, curating CHANGELOG entries, pre-PR/pre-push/post-merge hooks |
-| Release ritual | `/release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |
+| PR shipping | `/ship` skill | Reviewing, verifying, and squash-merging one PR |
+| Release ritual | `/release` skill | Publishing a version from already-landed work |

--- a/dist/cursor/skills/git-workflow/references/commits.md
+++ b/dist/cursor/skills/git-workflow/references/commits.md
@@ -169,13 +169,13 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
-- The `/release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
+- The `/ship` skill automates this workflow when ready to squash merge a PR; `/release` publishes a version later from already-landed work
 
 ## Changelog Discipline
 
 `CHANGELOG.md` entries follow Loaf's Common Changelog profile: write for
 humans, communicate the release impact, and curate git history instead of
-copying it. Curate the `[Unreleased]` section before bumping the version so the
+copying it. Curate the `[Unreleased]` section as PRs land so the later
 published release notes read as user-facing prose, not an internal worklog.
 
 ### Drop
@@ -204,9 +204,9 @@ Internal terms that have no meaning outside the team's working context:
 
 ### Auto-generated Entries
 
-When `loaf release --pre-merge` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
+When `loaf release` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
 
-Before approving a release bump, compare `[Unreleased]` against the actual squashed change set and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the branch was organized, it does not belong in the changelog.
+Before approving a release bump, compare `[Unreleased]` against the actual release range and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the work was organized, it does not belong in the changelog.
 
 ## Critical Rules
 
@@ -285,7 +285,7 @@ When developing toward a major version, use pre-release suffixes to mark develop
 
 **Convention:**
 - Set the target version with `-dev.0` when starting a major effort (e.g. `2.0.0-dev.0`)
-- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of work ships — a spec completing, a group of related features landing
+- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of landed work is ready to publish — a completed spec, a related feature group, or a release train
 - Don't bump for every commit — that's what git history is for
 - Strip the suffix (`-dev.N` → `2.0.0`) when all planned work is complete
 - `loaf release` handles all bump types: `prerelease`, `release`, `major`, `minor`, `patch`

--- a/dist/cursor/skills/implement/SKILL.md
+++ b/dist/cursor/skills/implement/SKILL.md
@@ -334,7 +334,7 @@ After creating session file:
    - Update session file (status: done, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
+5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
@@ -353,7 +353,7 @@ After creating session file:
 
 ## Suggests Next
 
-After all tasks are complete, suggest `/release` to merge the work.
+After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release` only when the landed work forms a coherent release batch.
 
 ## Related Skills
 

--- a/dist/cursor/skills/release/SKILL.md
+++ b/dist/cursor/skills/release/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: release
 description: >-
-  Orchestrates releases: pre-flight checks, version bump via `loaf release`,
-  squash merge, and post-merge cleanup. Use when the user says "release this,"
-  "merge this PR," "ready to merge," or "ship it." Produces version bumps,
-  changelog updates, and merged code. Not for creating PRs (use git-workflow) or
-  reflection (use reflect).
+  Orchestrates standalone releases from already-landed work: release readiness,
+  version selection, changelog curation, release commit, tag, GitHub Release,
+  install verification, and post-release follow-up. Use when the user says "cut
+  a release," "publish a version," "release from main," or asks whether enough
+  landed work should become a release. Not for reviewing or merging a PR (use
+  ship).
 version: 2.0.0-pre.20260614235428
 ---
 
 # Release
 
-Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+Publish a coherent version from work that has already landed.
 
 ## Contents
 - Critical Rules
@@ -19,13 +20,13 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 - Quick Reference
 - Topics
 - Context Detection
-- Step 1: Pre-Flight Checks
-- Step 2: Documentation Freshness
-- Step 3: Housekeeping Verification
-- Step 3b: Create PR (if needed)
-- Step 4: Version Bump + Changelog
-- Step 5: Squash Merge
-- Step 6: Post-Merge Cleanup
+- Step 1: Release Readiness
+- Step 2: Change Collection
+- Step 3: Version + Changelog
+- Step 4: Release Execution
+- Step 5: Protected-Branch Handoff
+- Step 6: Publication Verification
+- Step 7: Post-Release Follow-Up
 - Hook Interaction
 - Related Skills
 
@@ -35,308 +36,255 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 
 ## Critical Rules
 
-- **Block on pre-flight failure** -- do not offer to skip any failing check
-- **Use `AskUserQuestion` for all decisions and confirmations** -- version bump type, push approval, merge approval, branch deletion. Never use inline text questions for permission/decision prompts
-- **Version bump before merge** -- this is the skill's reason for existing; never defer to post-merge
-- **Wrap after version bump** -- wrap needs PR# and version to produce a complete session summary
-- **Clean squash body** -- never use the auto-generated commit dump
-- **Orchestrate the full lifecycle** -- if housekeeping or reflect haven't been run, trigger them (with user confirmation via `AskUserQuestion`) rather than just flagging gaps
-- **Detect-first** -- auto-detect PR from branch before asking for a number
-- **Never push without confirmation** -- even after successful version bump
-- **Log release** -- log to session journal after merge: `loaf session log "decision(release): vX.Y.Z shipped via PR #N"`
+- **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
+- **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
+- **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
+- **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
+- **Never push, tag, or publish without confirmation** -- present the exact actions first.
+- **Use `AskUserQuestion` for release decisions when available** -- version bump type, release PR handoff, push/tag/GitHub Release confirmation.
+- **Log release** -- after publication, run `loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"` when session state is available.
 
 ## Verification
 
-- Pre-flight checks (typecheck, test, build) all pass before proceeding
-- Version bump commit exists on the feature branch before merge
-- Squash merge body is a one-line summary followed by bullet points grouped by feature area, not a commit dump
-- Git tag points to the squash merge commit on the base branch, not a branch commit
-- GitHub Release exists with changelog body (not auto-generated notes)
-- Post-merge cleanup completed: base branch pulled, feature branch deleted
+- Release base branch is clean, current, and contains the intended landed PRs
+- Pre-flight checks pass before versioning or publication
+- Changelog entries are curated user-facing prose, not commit or PR-title dumps
+- Version files, changelog heading, git tag, and GitHub Release all agree
+- Tag points at the released base-branch commit or release commit, not an abandoned feature branch
+- Downstream install path is verified when applicable, especially Homebrew for Loaf releases
 
 ## Quick Reference
 
 | Step | Gate | Blocking? |
 |------|------|-----------|
-| Pre-Flight | typecheck + test + build pass | Yes |
-| Doc Freshness | User reviews stale docs | No (user decides) |
-| Housekeeping | Spec/tasks archived, CHANGELOG ready | No (user decides) |
-| PR Creation | Only if no PR exists yet | Yes (if needed) |
-| Version Bump | User confirms bump type; `loaf release --pre-merge` | Yes |
-| Wrap | Session summary (after version bump, has PR# + version) | Yes |
-| Squash Merge | User approves body text | Yes |
-| Post-Merge | `loaf release --post-merge` (tag, GH Release, cleanup) | Yes |
+| Readiness | clean/current base branch, no unresolved release collisions | Yes |
+| Change Collection | landed work since last tag grouped into release themes | Yes |
+| Version + Changelog | bump selected, notes curated, files updated | Yes |
+| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Verification | release and install paths checked | Yes |
+| Follow-Up | reflect/housekeeping suggested when useful | No |
 
 ## Topics
 
 | Topic | Use When |
 |-------|----------|
-| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
+| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
 
 ## Context Detection
 
-Before anything, detect where we are:
+Before anything, establish the release surface:
 
-1. **Get current branch and repo default branch:**
+1. Get current branch and repo default branch:
    ```bash
    git branch --show-current
    gh repo view --json defaultBranchRef -q .defaultBranchRef.name
    ```
-2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
-3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
-4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
+3. Verify the current branch:
+   - If already on the release base, continue.
+   - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
+   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
+4. Find the previous release tag:
    ```bash
-   gh pr view --json number,title,url,headRefName,baseRefName
+   git describe --tags --abbrev=0
    ```
-5. If no PR exists for this branch, note `pr_exists = false` and set `baseRefName` to the repo default branch. Continue — the PR will be created in Step 3b.
-6. If PR exists, **save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
-7. Confirm the PR identity (or intent to create one) with the user before proceeding.
-
----
-
-## Step 1: Pre-Flight Checks (BLOCKING)
-
-Run these and **BLOCK on any failure** — do not offer to skip.
-
-### Detect project type
-
-Inspect the repo to determine available checks:
-- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
-- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config; if the project is uv-managed, expect release artifact refresh to run `uv sync`
-- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
-- **Go** (`go.mod`): `go vet`, `go test`
-
-### Run checks
-
-Run whichever checks the project supports. Examples for a Node project:
-1. `npm run typecheck` (if the script exists)
-2. `npm run test` (if the script exists)
-3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
-
-For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
-
-**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
-
-On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
-
----
-
-## Step 2: Documentation Freshness
-
-Check whether documentation is stale relative to the branch's changes:
-
-1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
-2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
-3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
-4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
-
-Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
-
----
-
-## Step 3: Housekeeping
-
-Check each item. If missing, **offer to run it** (with user confirmation) rather than just flagging it.
-
-1. **Spec status**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`. If not, offer to update it.
-2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived. If found, offer to run `loaf task archive`.
-3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
-4. **Journal flushed**: Review conversation for unrecorded decisions/discoveries. Log them now — this is the last chance before wrap.
-
-Present the results as a checklist. Use `AskUserQuestion` for any decisions or approvals.
-
-**Note:** Wrap (`/wrap`) runs AFTER version bump (Step 4b) so it can reference the PR# and version in the session summary. Reflection runs post-merge (Step 6).
-
----
-
-## Step 3b: Create PR (if needed)
-
-**Only run this step if `pr_exists = false` from Context Detection.**
-
-The PR must be created BEFORE the version bump so that `[Unreleased]` changelog entries are still present (advisory hooks check for this).
-
-1. Push the branch if not already pushed.
-2. Create the PR following the format in [git-workflow/references/commits.md](../git-workflow/references/commits.md) (Pull Request Format section).
-3. Save the PR number and `baseRefName` for subsequent steps.
-
----
-
-## Step 4: Version Bump + Changelog (on feature branch)
-
-This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
-
-### Check for existing changelog entries
-
-Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
-
-- **If curated entries exist** → Use the **Curated path** (preserve them)
-- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
-
-### Curated path (preferred when entries exist)
-
-The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
-
-**Review curated entries for quality before bumping:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Follow Loaf's Common Changelog profile: imperative, self-describing,
-  one-line entries grouped as `Changed`, `Added`, `Removed`, `Fixed`
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Include the best public reference when available, such as a PR, issue, ADR, release, or commit link
-
-1. Run `loaf release --pre-merge --dry-run` to get the **suggested bump type** and **current version** (the `--pre-merge` flag auto-detects the base branch — see [Why `--pre-merge`?](#why---pre-merge) below).
-2. Present the bump suggestion to the user. They may accept or override.
-3. Once confirmed, run:
+5. Gather the candidate release range:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git log --oneline <last-tag>..HEAD
+   git diff --stat <last-tag>..HEAD
    ```
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it) and re-insert a fresh empty `## [Unreleased]` section above
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+---
 
-### Generated path (when no entries exist)
+## Step 1: Release Readiness
 
-When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+Run release pre-flight checks before editing release files:
 
-**After generation, review and rewrite entries before committing:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Rewrite generated commit text into Loaf's Common Changelog profile
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Keep entries concise but descriptive enough to understand the change without reading the diff
-
-1. Run `loaf release --pre-merge --dry-run` to preview:
-   - Current version and suggested bump type
-   - Generated changelog section from **this branch's commits only**
-   - Which version files will be updated
-
-   The `--pre-merge` flag scopes the commit analysis to `<auto-detected base>..HEAD`, so only commits on the feature branch are considered.
-
-2. Present the preview to the user. They may:
-   - Accept the suggested bump type
-   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-   - Edit the changelog content conversationally
-
-3. Once the user confirms, run:
+1. Ensure worktree is clean:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git status --short
    ```
+2. Ensure the release base is current:
+   ```bash
+   git fetch --tags origin
+   git status --branch --short
+   ```
+3. Check for existing tag or GitHub Release collisions for the target version once known:
+   ```bash
+   git tag --list vX.Y.Z
+   gh release view vX.Y.Z
+   ```
+4. Run project checks:
+   - Node: `npm run typecheck`, `npm run test`, `npm run build` when scripts exist
+   - Go: `go vet ./...`, `go test ./...` when `go.mod` exists
+   - Python: `pytest`, `mypy .`, `ruff check .` when configured
+   - Rust: `cargo check`, `cargo test` when `Cargo.toml` exists
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Generate and insert changelog section from branch commits (adding a fresh `[Unreleased]`)
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+If no checks are detected, warn explicitly. If a check fails, stop and fix before release.
 
-### After either path
+---
 
-Before pushing, verify generated artifacts are still current. This matters if
-any fix commits landed after the release bump commit:
+## Step 2: Change Collection
+
+Collect landed work since the last release and group it for release notes.
+
+1. Inspect commits:
+   ```bash
+   git log --first-parent --oneline <last-tag>..HEAD
+   git log --oneline <last-tag>..HEAD
+   ```
+2. Inspect merged PRs when GitHub is available:
+   ```bash
+   gh pr list --state merged --base <base> --json number,title,mergedAt,url
+   ```
+3. Group changes by user-facing outcome:
+   - `CR-*` change bundle, when referenced
+   - spec or task family, when public enough to be useful
+   - feature/fix/documentation/build themes
+   - operational release work, when it affects users or maintainers
+4. Drop noise:
+   - purely internal task/session labels
+   - reverted work that is not present in `HEAD`
+   - individual commit mechanics that collapse into one user-facing change
+
+Present the grouped release contents before choosing the bump.
+
+---
+
+## Step 3: Version + Changelog
+
+Choose the bump and curate the changelog from the grouped landed work.
+
+1. Run a dry run:
+   ```bash
+   loaf release --dry-run
+   ```
+   Use `--base <ref>` when the project expects a non-default release base.
+2. Present:
+   - current version
+   - proposed next version
+   - detected version files
+   - release actions the CLI would perform
+   - draft changelog entries
+3. Curate `CHANGELOG.md` before publishing:
+   - write from the upgrading user's perspective
+   - group under Common Changelog categories: `Changed`, `Added`, `Removed`, `Fixed`
+   - use one self-describing line per meaningful change
+   - include public PR, issue, ADR, release, or commit links when helpful
+   - avoid dumping commit subjects, task IDs, session mechanics, or internal gate language
+4. Confirm the bump type: `prerelease`, `release`, `major`, `minor`, or `patch`.
+
+---
+
+## Step 4: Release Execution
+
+For a direct release from the base branch, run:
+
+```bash
+loaf release --bump <type> --yes
+```
+
+This should:
+
+1. Update version files
+2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
+3. Reinsert a fresh empty `[Unreleased]` section
+4. Run configured release artifact commands
+5. Create the release commit
+6. Create/push the release tag
+7. Create the GitHub Release when enabled
+
+After execution, verify generated artifacts are current:
 
 ```bash
 npm run build
-git diff --exit-code -- plugins/loaf/bin/loaf dist content/skills/cli-reference/SKILL.md
+git diff --exit-code -- dist plugins content/skills/cli-reference/SKILL.md
 ```
 
-If the diff check fails, commit the regenerated artifacts with the source change
-that made them stale, then rerun the check.
-
-Push to the feature branch (**with user confirmation**).
-
-### Why `--pre-merge`?
-
-`--pre-merge` bundles the canonical pre-merge flag set so the skill no longer needs to spell each one out:
-
-- Equivalent to `--no-tag --no-gh --base <auto-detected>` (tag and GH release land post-merge in Step 6, not on the soon-to-be-squashed feature commit).
-- Auto-detects the base ref via a 4-step priority: explicit `--base <ref>` → open PR's `baseRefName` → `git config loaf.release.base` → repo default branch. Run `loaf release --help` to see the full priority order.
-- Pass `--base <ref>` explicitly to override auto-detection (useful for non-default base branches like `release/1.0` when no PR exists yet).
-- `--yes` skips the CLI confirmation prompt — the skill already confirmed with the user conversationally.
+Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
 ---
 
-## Step 4b: Wrap Session
+## Step 5: Protected-Branch Handoff
 
-Run `/wrap` AFTER version bump so the session summary can reference the PR# and final version.
+If branch protection prevents direct release commits on the base branch:
 
-The wrap skill will:
-1. Flush any remaining journal entries
-2. Gather git state (commits, working tree, unpushed)
-3. Generate the `## Session Wrap-Up` report
-4. Write it to the session file (replaces `## Current State`)
-5. Run `loaf session end --wrap` to set status to `complete`
+1. Create a dedicated release branch.
+2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+3. Open a release PR with a concise release-focused body.
+4. Hand the PR to `/ship` for review and landing.
+5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
 
-When called from `/release`, wrap skips the version bump and changelog prompts (already handled).
+Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
 ---
 
-## Step 5: Squash Merge
+## Step 6: Publication Verification
 
-1. Draft a clean squash body from the branch's commit history and PR description. Descriptive, not verbose:
-   - One-line summary, then bullet points grouped by feature area
-   - Plain text — no bold, no headings, only backticks for `code`
-   - Not a paragraph dump, not a commit log
-2. Present the draft to the user for review. They may edit it.
-3. Execute (after user confirms):
+After publishing, verify the public release state:
+
+1. Confirm tag location:
    ```bash
-   gh pr merge <N> --squash --body "$(cat <<'EOF'
-   <body>
-   EOF
-   )"
+   git show --stat vX.Y.Z
    ```
-4. Let GitHub default the title (`PR title (#N)`).
-5. NEVER use `--auto` or the automatic squash description that dumps all commits.
+2. Confirm GitHub Release:
+   ```bash
+   gh release view vX.Y.Z
+   ```
+3. Confirm package or installer availability when applicable:
+   - npm: `npm view <package> version`
+   - Homebrew: `brew update && brew info <tap>/<formula>`
+   - project-specific deploy or artifact registry checks
+4. For Loaf/Homebrew, report readiness only after the GitHub release exists, assets are uploaded, the tap formula is updated, and tap CI has passed.
+
+If publication partially completes, do not retag casually. Name the exact state and continue with the smallest repair or patch release path.
 
 ---
 
-## Step 6: Post-Merge Cleanup
+## Step 7: Post-Release Follow-Up
 
-After successful merge, run a single command:
+After verification:
 
-```bash
-loaf release --post-merge
-```
-
-This verifies HEAD state against an 8-point guardrail checklist (clean worktree, on the base branch with the merge commit at HEAD, readable HEAD subject for optional PR-number lookup, version-file agreement, CHANGELOG section present, no pre-existing tag or GH release, HEAD untagged). The squash subject should describe the shipped work (`feat:`, `fix:`, etc.); post-merge derives the release version from version files and `CHANGELOG.md`, not from a `chore: release` subject. Once all guardrails pass it tags the squash merge commit, pushes the tag, creates the GitHub Release from the matching `## [X.Y.Z]` CHANGELOG section, pulls the base branch, and best-effort deletes the local + remote feature branch. Manual `git tag`, `git push --tags`, `gh release create`, `git checkout`, `git pull --rebase`, and `git branch -d` are no longer needed — the flag subsumes them.
-
-If anything aborts:
-
-1. Read the actionable error message — each guardrail failure names the exact manual fix (e.g., "tag v1.2.3 already exists locally — run `git tag -d v1.2.3` and rerun").
-2. Perform the named fix.
-3. Rerun `loaf release --post-merge`. The command is idempotent on stateless reads, so reruns after a transient `gh` failure or a half-completed prior run pick up exactly where they left off.
-
-After the release finalizes, **run `/reflect`** — already on the base branch. Reflect looks back at the shipped work and updates strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) with learnings. Use `AskUserQuestion` to confirm before running.
+1. Log the release decision when session state is healthy:
+   ```bash
+   loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"
+   ```
+2. Suggest `/reflect` when the release produced durable product or workflow learnings.
+3. Suggest `/housekeeping` when session artifacts, release branches, or temporary reports need cleanup.
+4. Keep future-work discoveries out of the release notes; capture them as tasks, ideas, or sparks instead.
 
 ---
 
 ## Hook Interaction
 
-This skill coexists with existing hooks. Git workflow hooks are **advisory** (warn but don't block); security hooks remain blocking.
+This skill coexists with existing hooks. Git workflow hooks are advisory unless
+configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `workflow-pre-pr` (command) | Advisory | Fires on `gh pr create`. Reminds about CHANGELOG — redundant when release skill manages entries. |
-| `workflow-pre-merge` (instruction) | Advisory | Fires on `gh pr merge`. Reminds about squash conventions — redundant since body is already crafted. |
-| `workflow-post-merge` (instruction) | Advisory | Fires after merge. Outputs checklist the skill already handled. |
-| `validate-push` (command) | Advisory | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
-| `check-secrets` (command) | **Blocking** | Security gate. Always fires, always respected. |
+| `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
+| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
+| `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
 
-Do not modify, disable, or skip these hooks.
+Do not disable hooks to force a release through.
 
 ---
 
 ## Suggests Next
 
-After a successful release, suggest `/housekeeping` if session artifacts need archiving.
+After a successful release, suggest `/reflect` for durable learnings and `/housekeeping` if temporary release artifacts need attention.
 
 ## Related Skills
 
-- **implement** — Does the work and housekeeping; `/release` handles the merge afterward
-- **reflect** — Suggested post-merge if session has learnings
-- **git-workflow** — Conventions this skill enforces
-- **housekeeping** — Handles artifact hygiene; `/release` verifies it was done
+- **ship** -- Reviews, verifies, and lands a PR before it becomes release input
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **documentation-standards** -- Changelog and release-note quality
+- **reflect** -- Updates strategy from shipped/released learnings
+- **housekeeping** -- Cleans up completed session and release artifacts

--- a/dist/cursor/skills/ship/SKILL.md
+++ b/dist/cursor/skills/ship/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: ship
+description: >-
+  Reviews, verifies, and lands one pull request. Use when the user says "ship
+  it," "merge this PR," "ready to merge," "land this branch," or asks for a
+  final merge gate. Produces a reviewed, squash-merged PR and post-merge
+  cleanup. Not for version bumps, tags, GitHub Releases, or install verification
+  (use release).
+version: 2.0.0-pre.20260614235428
+---
+
+# Ship
+
+Review, verify, and land one PR. Shipping is the PR gate; releasing is the version-publication gate.
+
+## Contents
+- Critical Rules
+- Verification
+- Quick Reference
+- Topics
+- Context Detection
+- Step 1: PR Readiness
+- Step 2: Evidence Review
+- Step 3: Local Verification
+- Step 4: Squash Merge
+- Step 5: Post-Merge Cleanup
+- Step 6: Release Suggestion
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Critical Rules
+
+- **Ship is not release** -- do not bump versions, create tags, publish GitHub Releases, or verify package installation here.
+- **Keep PR quality local** -- smaller PRs are welcome, but `/ship` must still verify correctness before merge.
+- **Detect-first** -- auto-detect the PR from the current branch before asking for a PR number.
+- **Review before merge** -- inspect code, docs, tests, changelog, PR body, and CI state before approval.
+- **Never merge without explicit confirmation** -- present the PR, checks, findings, and squash body first.
+- **Clean squash body** -- write an intentional squash commit body; never accept the automatic commit dump.
+- **Keep landed and released distinct** -- after merge, describe the PR as landed or shipped, not necessarily released.
+- **Log shipping** -- after merge, run `loaf session log "decision(ship): PR #N landed via squash merge"` when session state is available.
+
+## Verification
+
+- PR identity, base branch, and head branch are confirmed
+- CI status is passing or the user explicitly accepts named non-blocking checks
+- Relevant local checks pass or failures are fixed before merge
+- PR body and durable docs do not overclaim relative to the diff
+- Squash commit title/body are clean, conventional, and user-facing
+- Base branch is updated after merge and the feature branch cleanup state is known
+
+## Quick Reference
+
+| Step | Gate | Blocking? |
+|------|------|-----------|
+| PR Readiness | PR exists, target base known, CI state reviewed | Yes |
+| Evidence Review | findings resolved or explicitly accepted | Yes |
+| Local Verification | relevant checks pass | Yes |
+| Squash Merge | user approves body text | Yes |
+| Cleanup | base pulled, branch deletion handled | No |
+| Release Suggestion | enough landed work may justify `/release` | No |
+
+## Topics
+
+| Topic | Use When |
+|-------|----------|
+| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
+
+---
+
+## Context Detection
+
+Before anything, detect the PR surface:
+
+1. Get current branch and repo default branch:
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. Parse `$ARGUMENTS`: may be a PR number, PR URL, branch name, or empty.
+3. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName,state,mergeStateStatus,isDraft
+   ```
+4. If no PR exists for the current branch, stop and offer to create one via `git-workflow` rather than silently merging a branch.
+5. If already on the default branch, stop. There is no PR to ship from the current branch.
+6. Confirm PR identity with the user before merge actions.
+
+---
+
+## Step 1: PR Readiness
+
+Inspect the PR's declared state:
+
+```bash
+gh pr view <N> --json number,title,body,url,headRefName,baseRefName,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+Block or pause when:
+
+- PR is draft
+- merge state is dirty or blocked
+- required checks are failing or pending
+- review decision is changes requested
+- branch is out of date and the project requires update before merge
+
+If checks are unavailable, say so explicitly and compensate with local verification.
+
+---
+
+## Step 2: Evidence Review
+
+Review the landing diff and durable prose together:
+
+1. Gather diff context:
+   ```bash
+   git fetch origin <baseRefName>
+   git diff --stat origin/<baseRefName>...HEAD
+   git diff --name-only origin/<baseRefName>...HEAD
+   ```
+2. Read the PR title/body and changed docs that make behavior claims.
+3. Check for drift:
+   - PR body claims features that are not in the diff
+   - changelog entries mention unreleased or unrelated behavior
+   - docs describe future work as already shipped
+   - comments or runbooks use stale internal vocabulary
+4. Fix blocking drift before merge. For non-blocking polish, name it and let the user decide.
+
+For high-risk PRs, use the project's review skill or read-only review flow before proceeding.
+
+---
+
+## Step 3: Local Verification
+
+Run the checks the project supports. Examples:
+
+- Node: `npm run typecheck`, `npm run test`, `npm run build`
+- Go: `go vet ./...`, `go test ./...`
+- Python: `pytest`, `mypy .`, `ruff check .`
+- Rust: `cargo check`, `cargo test`
+
+If generated artifacts are tracked, verify they are current before merge:
+
+```bash
+git diff --exit-code -- dist plugins
+```
+
+Use the repo's documented pre-commit or pre-PR checklist when present. Stop on failures.
+
+---
+
+## Step 4: Squash Merge
+
+Draft a clean squash body from the reviewed diff and PR body:
+
+- One-line summary, then bullet points grouped by feature area
+- Plain text; use backticks only for code identifiers
+- No commit dump
+- No agent attribution
+- No release-note overclaiming
+
+Present the body and ask for confirmation. Then run:
+
+```bash
+gh pr merge <N> --squash --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+Let GitHub default the title from the PR title so the squash subject remains `type: summary (#N)`.
+
+---
+
+## Step 5: Post-Merge Cleanup
+
+After a successful merge:
+
+1. Switch to the PR base branch:
+   ```bash
+   git checkout <baseRefName>
+   git pull --ff-only origin <baseRefName>
+   ```
+2. Delete the local feature branch when safe:
+   ```bash
+   git branch -d <headRefName>
+   ```
+3. Confirm the remote branch deletion state from GitHub output or run:
+   ```bash
+   gh pr view <N> --json headRefName,state
+   ```
+4. Log the landing when session state is healthy:
+   ```bash
+   loaf session log "decision(ship): PR #N landed via squash merge"
+   ```
+
+If cleanup fails, report the exact residual state. Do not force-delete without user confirmation.
+
+---
+
+## Step 6: Release Suggestion
+
+After landing, decide whether to suggest `/release`:
+
+- Suggest `/release` when the landed PR completes a coherent batch, user-facing feature, fix train, or release branch.
+- Do not suggest `/release` for every small PR by default.
+- If multiple related PRs are expected, say the PR is landed and can wait for a later batched release.
+
+Use language carefully: the PR is **landed** or **shipped**; it is not **released** until `/release` publishes a version.
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks.
+
+| Hook | Type | When `/ship` Runs |
+|------|------|------------------|
+| `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
+| `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
+| `validate-push` | Advisory | May fire if branch updates are needed before merge |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
+
+Do not disable hooks to force a PR through.
+
+---
+
+## Suggests Next
+
+After a successful ship, suggest `/release` only when the landed work forms a coherent release batch or the user asks to publish.
+
+## Related Skills
+
+- **release** -- Publishes a version from already-landed work
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **foundations** -- Verification, code review, and production readiness
+- **documentation-standards** -- Changelog, docs, and durable prose quality
+- **reflect** -- Updates strategy from significant shipped work

--- a/dist/cursor/skills/wrap/SKILL.md
+++ b/dist/cursor/skills/wrap/SKILL.md
@@ -42,8 +42,8 @@ Responsible session shutdown — everything that needs a conscious model before 
 - All decisions and discoveries from this session are in the journal
 - Uncommitted/unpushed state is surfaced with clear action prompts
 - Stale KB files are flagged if any
-- `## Session Wrap-Up` section written to session file (replaces `## Current State`)
-- `loaf session end --wrap` run after writing the summary
+- `## Session Wrap-Up` section persisted in the canonical session surface; in SQLite mode this is represented by wrapped session/report state rather than an active `.md` file
+- `loaf session end --wrap` run after generating or writing the summary
 - Session status is `done` (session stays open for further journal entries until `SessionEnd` fires)
 
 ## Quick Reference
@@ -64,7 +64,7 @@ These steps require conversation context — only the model can do them.
 
 Before anything else, complete the session journal:
 
-1. **Enrich from conversation log** — run `loaf session enrich` to fill in gaps from the JSONL conversation log. This catches decisions, discoveries, and context that weren't manually logged. If enrichment fails, continue — manual flush is the fallback.
+1. **Check enrichment state** — run `loaf session enrich --json`. In SQLite mode this is expected to report `action: "skipped"` because `loaf session log` is already the canonical journal writer; in markdown-only compatibility mode it summarizes legacy JSONL enrichment status. If enrichment is skipped or fails, continue — manual flush is the fallback.
 2. **Manual review** — review the conversation for anything enrichment missed:
    - Decisions — design choices, trade-offs, direction changes not yet logged as `decision()` entries
    - Discoveries — anything learned that future sessions would benefit from
@@ -75,7 +75,7 @@ Before anything else, complete the session journal:
 
 Run in parallel:
 
-1. **Session journal** — read the active session file for this branch
+1. **Session journal** — run `loaf session list --json`, choose the active session for the current branch or explicit harness session, then run `loaf session show <session-ref> --json`; if SQLite state is unavailable, fall back to the active markdown session file for this branch
 2. **Commits this session** — `git log --oneline` since session start
 3. **Working tree** — `git status --short`
 4. **Unpushed commits** — `git log --oneline origin/<branch>..HEAD`
@@ -90,7 +90,7 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 |-----------|--------|
 | Uncommitted changes | "N file(s) uncommitted — commit, stash, or leave for next session?" |
 | Unpushed commits | "N commit(s) on <branch> not pushed — push now?" |
-| No version bump | "This session shipped work but no release was run — bump version now?" |
+| Release candidate | "This session landed work that may belong in the next release — run `/release` now?" |
 | Stale KB files | "N stale knowledge file(s) — address now or defer?" |
 | Unresolved blocks | "Block on <scope> still open — note for next session?" |
 | No changelog entries | "N commit(s) on branch but `[Unreleased]` is empty — add changelog entries?" |
@@ -99,15 +99,17 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 **Detection logic:**
 - **Changelog entries:** check if the current branch has commits vs the base branch (e.g., `git rev-list --count origin/main..HEAD`) AND `CHANGELOG.md` `[Unreleased]` section has no list items (`^[-*]\s`). If both are true, prompt. **Skip when HEAD is tagged** (post-release state).
 - **Housekeeping:** scan session journal for `skill(housekeeping)` entry. If absent and the session had significant work, suggest it.
-- **Version bump:** scan session journal for `decision(release)` entry. If absent and the session has commits, offer to run `loaf release --bump prerelease --no-gh --yes`.
+- **Release candidate:** scan session journal for `decision(release)` entry. If absent and the session has landed commits, suggest `/release` only when the work forms a coherent release batch.
 
 ### Step 4: Generate Report
 
 Assemble the report per the format below. Omit empty sections — don't show "None" placeholders.
 
-### Step 5: Write Wrap Summary to Session File
+### Step 5: Persist Wrap Summary
 
-Write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
+In SQLite mode, keep the generated wrap summary in the conversation response and let `loaf session end --wrap` persist the mechanical wrapped state. Do not invent or edit a missing active `.md` session file; `loaf session show <session-ref> --json` is the canonical read surface.
+
+In markdown-only compatibility mode, write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
 
 Use the Edit tool to replace `## Current State (...)` and everything below it (up to `## Journal`) with the wrap-up section. The session file layout after wrap should be:
 
@@ -141,7 +143,7 @@ This handles the mechanical bookkeeping:
 
 ## Composability
 
-When called from `/release`, wrap runs the same steps but skips the version bump prompt (release already handles it). The `/release` skill should invoke `/wrap` first, then proceed with release steps.
+When called near `/ship` or `/release`, wrap runs the same steps but keeps PR landing and version publication distinct. `/ship` may wrap a landed PR; `/release` may wrap a published version.
 
 ## Suggests Next
 

--- a/dist/gemini/skills/git-workflow/SKILL.md
+++ b/dist/gemini/skills/git-workflow/SKILL.md
@@ -48,4 +48,5 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, curating CHANGELOG entries, pre-PR/pre-push/post-merge hooks |
-| Release ritual | `/release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |
+| PR shipping | `/ship` skill | Reviewing, verifying, and squash-merging one PR |
+| Release ritual | `/release` skill | Publishing a version from already-landed work |

--- a/dist/gemini/skills/git-workflow/references/commits.md
+++ b/dist/gemini/skills/git-workflow/references/commits.md
@@ -169,13 +169,13 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
-- The `/release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
+- The `/ship` skill automates this workflow when ready to squash merge a PR; `/release` publishes a version later from already-landed work
 
 ## Changelog Discipline
 
 `CHANGELOG.md` entries follow Loaf's Common Changelog profile: write for
 humans, communicate the release impact, and curate git history instead of
-copying it. Curate the `[Unreleased]` section before bumping the version so the
+copying it. Curate the `[Unreleased]` section as PRs land so the later
 published release notes read as user-facing prose, not an internal worklog.
 
 ### Drop
@@ -204,9 +204,9 @@ Internal terms that have no meaning outside the team's working context:
 
 ### Auto-generated Entries
 
-When `loaf release --pre-merge` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
+When `loaf release` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
 
-Before approving a release bump, compare `[Unreleased]` against the actual squashed change set and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the branch was organized, it does not belong in the changelog.
+Before approving a release bump, compare `[Unreleased]` against the actual release range and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the work was organized, it does not belong in the changelog.
 
 ## Critical Rules
 
@@ -285,7 +285,7 @@ When developing toward a major version, use pre-release suffixes to mark develop
 
 **Convention:**
 - Set the target version with `-dev.0` when starting a major effort (e.g. `2.0.0-dev.0`)
-- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of work ships — a spec completing, a group of related features landing
+- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of landed work is ready to publish — a completed spec, a related feature group, or a release train
 - Don't bump for every commit — that's what git history is for
 - Strip the suffix (`-dev.N` → `2.0.0`) when all planned work is complete
 - `loaf release` handles all bump types: `prerelease`, `release`, `major`, `minor`, `patch`

--- a/dist/gemini/skills/implement/SKILL.md
+++ b/dist/gemini/skills/implement/SKILL.md
@@ -334,7 +334,7 @@ After creating session file:
    - Update session file (status: done, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
+5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
@@ -353,7 +353,7 @@ After creating session file:
 
 ## Suggests Next
 
-After all tasks are complete, suggest `/release` to merge the work.
+After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release` only when the landed work forms a coherent release batch.
 
 ## Related Skills
 

--- a/dist/gemini/skills/release/SKILL.md
+++ b/dist/gemini/skills/release/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: release
 description: >-
-  Orchestrates releases: pre-flight checks, version bump via `loaf release`,
-  squash merge, and post-merge cleanup. Use when the user says "release this,"
-  "merge this PR," "ready to merge," or "ship it." Produces version bumps,
-  changelog updates, and merged code. Not for creating PRs (use git-workflow) or
-  reflection (use reflect).
+  Orchestrates standalone releases from already-landed work: release readiness,
+  version selection, changelog curation, release commit, tag, GitHub Release,
+  install verification, and post-release follow-up. Use when the user says "cut
+  a release," "publish a version," "release from main," or asks whether enough
+  landed work should become a release. Not for reviewing or merging a PR (use
+  ship).
 version: 2.0.0-pre.20260614235428
 ---
 
 # Release
 
-Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+Publish a coherent version from work that has already landed.
 
 ## Contents
 - Critical Rules
@@ -19,13 +20,13 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 - Quick Reference
 - Topics
 - Context Detection
-- Step 1: Pre-Flight Checks
-- Step 2: Documentation Freshness
-- Step 3: Housekeeping Verification
-- Step 3b: Create PR (if needed)
-- Step 4: Version Bump + Changelog
-- Step 5: Squash Merge
-- Step 6: Post-Merge Cleanup
+- Step 1: Release Readiness
+- Step 2: Change Collection
+- Step 3: Version + Changelog
+- Step 4: Release Execution
+- Step 5: Protected-Branch Handoff
+- Step 6: Publication Verification
+- Step 7: Post-Release Follow-Up
 - Hook Interaction
 - Related Skills
 
@@ -35,308 +36,255 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 
 ## Critical Rules
 
-- **Block on pre-flight failure** -- do not offer to skip any failing check
-- **Use `AskUserQuestion` for all decisions and confirmations** -- version bump type, push approval, merge approval, branch deletion. Never use inline text questions for permission/decision prompts
-- **Version bump before merge** -- this is the skill's reason for existing; never defer to post-merge
-- **Wrap after version bump** -- wrap needs PR# and version to produce a complete session summary
-- **Clean squash body** -- never use the auto-generated commit dump
-- **Orchestrate the full lifecycle** -- if housekeeping or reflect haven't been run, trigger them (with user confirmation via `AskUserQuestion`) rather than just flagging gaps
-- **Detect-first** -- auto-detect PR from branch before asking for a number
-- **Never push without confirmation** -- even after successful version bump
-- **Log release** -- log to session journal after merge: `loaf session log "decision(release): vX.Y.Z shipped via PR #N"`
+- **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
+- **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
+- **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
+- **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
+- **Never push, tag, or publish without confirmation** -- present the exact actions first.
+- **Use `AskUserQuestion` for release decisions when available** -- version bump type, release PR handoff, push/tag/GitHub Release confirmation.
+- **Log release** -- after publication, run `loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"` when session state is available.
 
 ## Verification
 
-- Pre-flight checks (typecheck, test, build) all pass before proceeding
-- Version bump commit exists on the feature branch before merge
-- Squash merge body is a one-line summary followed by bullet points grouped by feature area, not a commit dump
-- Git tag points to the squash merge commit on the base branch, not a branch commit
-- GitHub Release exists with changelog body (not auto-generated notes)
-- Post-merge cleanup completed: base branch pulled, feature branch deleted
+- Release base branch is clean, current, and contains the intended landed PRs
+- Pre-flight checks pass before versioning or publication
+- Changelog entries are curated user-facing prose, not commit or PR-title dumps
+- Version files, changelog heading, git tag, and GitHub Release all agree
+- Tag points at the released base-branch commit or release commit, not an abandoned feature branch
+- Downstream install path is verified when applicable, especially Homebrew for Loaf releases
 
 ## Quick Reference
 
 | Step | Gate | Blocking? |
 |------|------|-----------|
-| Pre-Flight | typecheck + test + build pass | Yes |
-| Doc Freshness | User reviews stale docs | No (user decides) |
-| Housekeeping | Spec/tasks archived, CHANGELOG ready | No (user decides) |
-| PR Creation | Only if no PR exists yet | Yes (if needed) |
-| Version Bump | User confirms bump type; `loaf release --pre-merge` | Yes |
-| Wrap | Session summary (after version bump, has PR# + version) | Yes |
-| Squash Merge | User approves body text | Yes |
-| Post-Merge | `loaf release --post-merge` (tag, GH Release, cleanup) | Yes |
+| Readiness | clean/current base branch, no unresolved release collisions | Yes |
+| Change Collection | landed work since last tag grouped into release themes | Yes |
+| Version + Changelog | bump selected, notes curated, files updated | Yes |
+| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Verification | release and install paths checked | Yes |
+| Follow-Up | reflect/housekeeping suggested when useful | No |
 
 ## Topics
 
 | Topic | Use When |
 |-------|----------|
-| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
+| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
 
 ## Context Detection
 
-Before anything, detect where we are:
+Before anything, establish the release surface:
 
-1. **Get current branch and repo default branch:**
+1. Get current branch and repo default branch:
    ```bash
    git branch --show-current
    gh repo view --json defaultBranchRef -q .defaultBranchRef.name
    ```
-2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
-3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
-4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
+3. Verify the current branch:
+   - If already on the release base, continue.
+   - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
+   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
+4. Find the previous release tag:
    ```bash
-   gh pr view --json number,title,url,headRefName,baseRefName
+   git describe --tags --abbrev=0
    ```
-5. If no PR exists for this branch, note `pr_exists = false` and set `baseRefName` to the repo default branch. Continue — the PR will be created in Step 3b.
-6. If PR exists, **save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
-7. Confirm the PR identity (or intent to create one) with the user before proceeding.
-
----
-
-## Step 1: Pre-Flight Checks (BLOCKING)
-
-Run these and **BLOCK on any failure** — do not offer to skip.
-
-### Detect project type
-
-Inspect the repo to determine available checks:
-- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
-- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config; if the project is uv-managed, expect release artifact refresh to run `uv sync`
-- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
-- **Go** (`go.mod`): `go vet`, `go test`
-
-### Run checks
-
-Run whichever checks the project supports. Examples for a Node project:
-1. `npm run typecheck` (if the script exists)
-2. `npm run test` (if the script exists)
-3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
-
-For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
-
-**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
-
-On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
-
----
-
-## Step 2: Documentation Freshness
-
-Check whether documentation is stale relative to the branch's changes:
-
-1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
-2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
-3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
-4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
-
-Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
-
----
-
-## Step 3: Housekeeping
-
-Check each item. If missing, **offer to run it** (with user confirmation) rather than just flagging it.
-
-1. **Spec status**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`. If not, offer to update it.
-2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived. If found, offer to run `loaf task archive`.
-3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
-4. **Journal flushed**: Review conversation for unrecorded decisions/discoveries. Log them now — this is the last chance before wrap.
-
-Present the results as a checklist. Use `AskUserQuestion` for any decisions or approvals.
-
-**Note:** Wrap (`/wrap`) runs AFTER version bump (Step 4b) so it can reference the PR# and version in the session summary. Reflection runs post-merge (Step 6).
-
----
-
-## Step 3b: Create PR (if needed)
-
-**Only run this step if `pr_exists = false` from Context Detection.**
-
-The PR must be created BEFORE the version bump so that `[Unreleased]` changelog entries are still present (advisory hooks check for this).
-
-1. Push the branch if not already pushed.
-2. Create the PR following the format in [git-workflow/references/commits.md](../git-workflow/references/commits.md) (Pull Request Format section).
-3. Save the PR number and `baseRefName` for subsequent steps.
-
----
-
-## Step 4: Version Bump + Changelog (on feature branch)
-
-This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
-
-### Check for existing changelog entries
-
-Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
-
-- **If curated entries exist** → Use the **Curated path** (preserve them)
-- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
-
-### Curated path (preferred when entries exist)
-
-The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
-
-**Review curated entries for quality before bumping:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Follow Loaf's Common Changelog profile: imperative, self-describing,
-  one-line entries grouped as `Changed`, `Added`, `Removed`, `Fixed`
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Include the best public reference when available, such as a PR, issue, ADR, release, or commit link
-
-1. Run `loaf release --pre-merge --dry-run` to get the **suggested bump type** and **current version** (the `--pre-merge` flag auto-detects the base branch — see [Why `--pre-merge`?](#why---pre-merge) below).
-2. Present the bump suggestion to the user. They may accept or override.
-3. Once confirmed, run:
+5. Gather the candidate release range:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git log --oneline <last-tag>..HEAD
+   git diff --stat <last-tag>..HEAD
    ```
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it) and re-insert a fresh empty `## [Unreleased]` section above
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+---
 
-### Generated path (when no entries exist)
+## Step 1: Release Readiness
 
-When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+Run release pre-flight checks before editing release files:
 
-**After generation, review and rewrite entries before committing:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Rewrite generated commit text into Loaf's Common Changelog profile
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Keep entries concise but descriptive enough to understand the change without reading the diff
-
-1. Run `loaf release --pre-merge --dry-run` to preview:
-   - Current version and suggested bump type
-   - Generated changelog section from **this branch's commits only**
-   - Which version files will be updated
-
-   The `--pre-merge` flag scopes the commit analysis to `<auto-detected base>..HEAD`, so only commits on the feature branch are considered.
-
-2. Present the preview to the user. They may:
-   - Accept the suggested bump type
-   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-   - Edit the changelog content conversationally
-
-3. Once the user confirms, run:
+1. Ensure worktree is clean:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git status --short
    ```
+2. Ensure the release base is current:
+   ```bash
+   git fetch --tags origin
+   git status --branch --short
+   ```
+3. Check for existing tag or GitHub Release collisions for the target version once known:
+   ```bash
+   git tag --list vX.Y.Z
+   gh release view vX.Y.Z
+   ```
+4. Run project checks:
+   - Node: `npm run typecheck`, `npm run test`, `npm run build` when scripts exist
+   - Go: `go vet ./...`, `go test ./...` when `go.mod` exists
+   - Python: `pytest`, `mypy .`, `ruff check .` when configured
+   - Rust: `cargo check`, `cargo test` when `Cargo.toml` exists
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Generate and insert changelog section from branch commits (adding a fresh `[Unreleased]`)
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+If no checks are detected, warn explicitly. If a check fails, stop and fix before release.
 
-### After either path
+---
 
-Before pushing, verify generated artifacts are still current. This matters if
-any fix commits landed after the release bump commit:
+## Step 2: Change Collection
+
+Collect landed work since the last release and group it for release notes.
+
+1. Inspect commits:
+   ```bash
+   git log --first-parent --oneline <last-tag>..HEAD
+   git log --oneline <last-tag>..HEAD
+   ```
+2. Inspect merged PRs when GitHub is available:
+   ```bash
+   gh pr list --state merged --base <base> --json number,title,mergedAt,url
+   ```
+3. Group changes by user-facing outcome:
+   - `CR-*` change bundle, when referenced
+   - spec or task family, when public enough to be useful
+   - feature/fix/documentation/build themes
+   - operational release work, when it affects users or maintainers
+4. Drop noise:
+   - purely internal task/session labels
+   - reverted work that is not present in `HEAD`
+   - individual commit mechanics that collapse into one user-facing change
+
+Present the grouped release contents before choosing the bump.
+
+---
+
+## Step 3: Version + Changelog
+
+Choose the bump and curate the changelog from the grouped landed work.
+
+1. Run a dry run:
+   ```bash
+   loaf release --dry-run
+   ```
+   Use `--base <ref>` when the project expects a non-default release base.
+2. Present:
+   - current version
+   - proposed next version
+   - detected version files
+   - release actions the CLI would perform
+   - draft changelog entries
+3. Curate `CHANGELOG.md` before publishing:
+   - write from the upgrading user's perspective
+   - group under Common Changelog categories: `Changed`, `Added`, `Removed`, `Fixed`
+   - use one self-describing line per meaningful change
+   - include public PR, issue, ADR, release, or commit links when helpful
+   - avoid dumping commit subjects, task IDs, session mechanics, or internal gate language
+4. Confirm the bump type: `prerelease`, `release`, `major`, `minor`, or `patch`.
+
+---
+
+## Step 4: Release Execution
+
+For a direct release from the base branch, run:
+
+```bash
+loaf release --bump <type> --yes
+```
+
+This should:
+
+1. Update version files
+2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
+3. Reinsert a fresh empty `[Unreleased]` section
+4. Run configured release artifact commands
+5. Create the release commit
+6. Create/push the release tag
+7. Create the GitHub Release when enabled
+
+After execution, verify generated artifacts are current:
 
 ```bash
 npm run build
-git diff --exit-code -- plugins/loaf/bin/loaf dist content/skills/cli-reference/SKILL.md
+git diff --exit-code -- dist plugins content/skills/cli-reference/SKILL.md
 ```
 
-If the diff check fails, commit the regenerated artifacts with the source change
-that made them stale, then rerun the check.
-
-Push to the feature branch (**with user confirmation**).
-
-### Why `--pre-merge`?
-
-`--pre-merge` bundles the canonical pre-merge flag set so the skill no longer needs to spell each one out:
-
-- Equivalent to `--no-tag --no-gh --base <auto-detected>` (tag and GH release land post-merge in Step 6, not on the soon-to-be-squashed feature commit).
-- Auto-detects the base ref via a 4-step priority: explicit `--base <ref>` → open PR's `baseRefName` → `git config loaf.release.base` → repo default branch. Run `loaf release --help` to see the full priority order.
-- Pass `--base <ref>` explicitly to override auto-detection (useful for non-default base branches like `release/1.0` when no PR exists yet).
-- `--yes` skips the CLI confirmation prompt — the skill already confirmed with the user conversationally.
+Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
 ---
 
-## Step 4b: Wrap Session
+## Step 5: Protected-Branch Handoff
 
-Run `/wrap` AFTER version bump so the session summary can reference the PR# and final version.
+If branch protection prevents direct release commits on the base branch:
 
-The wrap skill will:
-1. Flush any remaining journal entries
-2. Gather git state (commits, working tree, unpushed)
-3. Generate the `## Session Wrap-Up` report
-4. Write it to the session file (replaces `## Current State`)
-5. Run `loaf session end --wrap` to set status to `complete`
+1. Create a dedicated release branch.
+2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+3. Open a release PR with a concise release-focused body.
+4. Hand the PR to `/ship` for review and landing.
+5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
 
-When called from `/release`, wrap skips the version bump and changelog prompts (already handled).
+Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
 ---
 
-## Step 5: Squash Merge
+## Step 6: Publication Verification
 
-1. Draft a clean squash body from the branch's commit history and PR description. Descriptive, not verbose:
-   - One-line summary, then bullet points grouped by feature area
-   - Plain text — no bold, no headings, only backticks for `code`
-   - Not a paragraph dump, not a commit log
-2. Present the draft to the user for review. They may edit it.
-3. Execute (after user confirms):
+After publishing, verify the public release state:
+
+1. Confirm tag location:
    ```bash
-   gh pr merge <N> --squash --body "$(cat <<'EOF'
-   <body>
-   EOF
-   )"
+   git show --stat vX.Y.Z
    ```
-4. Let GitHub default the title (`PR title (#N)`).
-5. NEVER use `--auto` or the automatic squash description that dumps all commits.
+2. Confirm GitHub Release:
+   ```bash
+   gh release view vX.Y.Z
+   ```
+3. Confirm package or installer availability when applicable:
+   - npm: `npm view <package> version`
+   - Homebrew: `brew update && brew info <tap>/<formula>`
+   - project-specific deploy or artifact registry checks
+4. For Loaf/Homebrew, report readiness only after the GitHub release exists, assets are uploaded, the tap formula is updated, and tap CI has passed.
+
+If publication partially completes, do not retag casually. Name the exact state and continue with the smallest repair or patch release path.
 
 ---
 
-## Step 6: Post-Merge Cleanup
+## Step 7: Post-Release Follow-Up
 
-After successful merge, run a single command:
+After verification:
 
-```bash
-loaf release --post-merge
-```
-
-This verifies HEAD state against an 8-point guardrail checklist (clean worktree, on the base branch with the merge commit at HEAD, readable HEAD subject for optional PR-number lookup, version-file agreement, CHANGELOG section present, no pre-existing tag or GH release, HEAD untagged). The squash subject should describe the shipped work (`feat:`, `fix:`, etc.); post-merge derives the release version from version files and `CHANGELOG.md`, not from a `chore: release` subject. Once all guardrails pass it tags the squash merge commit, pushes the tag, creates the GitHub Release from the matching `## [X.Y.Z]` CHANGELOG section, pulls the base branch, and best-effort deletes the local + remote feature branch. Manual `git tag`, `git push --tags`, `gh release create`, `git checkout`, `git pull --rebase`, and `git branch -d` are no longer needed — the flag subsumes them.
-
-If anything aborts:
-
-1. Read the actionable error message — each guardrail failure names the exact manual fix (e.g., "tag v1.2.3 already exists locally — run `git tag -d v1.2.3` and rerun").
-2. Perform the named fix.
-3. Rerun `loaf release --post-merge`. The command is idempotent on stateless reads, so reruns after a transient `gh` failure or a half-completed prior run pick up exactly where they left off.
-
-After the release finalizes, **run `/reflect`** — already on the base branch. Reflect looks back at the shipped work and updates strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) with learnings. Use `AskUserQuestion` to confirm before running.
+1. Log the release decision when session state is healthy:
+   ```bash
+   loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"
+   ```
+2. Suggest `/reflect` when the release produced durable product or workflow learnings.
+3. Suggest `/housekeeping` when session artifacts, release branches, or temporary reports need cleanup.
+4. Keep future-work discoveries out of the release notes; capture them as tasks, ideas, or sparks instead.
 
 ---
 
 ## Hook Interaction
 
-This skill coexists with existing hooks. Git workflow hooks are **advisory** (warn but don't block); security hooks remain blocking.
+This skill coexists with existing hooks. Git workflow hooks are advisory unless
+configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `workflow-pre-pr` (command) | Advisory | Fires on `gh pr create`. Reminds about CHANGELOG — redundant when release skill manages entries. |
-| `workflow-pre-merge` (instruction) | Advisory | Fires on `gh pr merge`. Reminds about squash conventions — redundant since body is already crafted. |
-| `workflow-post-merge` (instruction) | Advisory | Fires after merge. Outputs checklist the skill already handled. |
-| `validate-push` (command) | Advisory | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
-| `check-secrets` (command) | **Blocking** | Security gate. Always fires, always respected. |
+| `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
+| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
+| `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
 
-Do not modify, disable, or skip these hooks.
+Do not disable hooks to force a release through.
 
 ---
 
 ## Suggests Next
 
-After a successful release, suggest `/housekeeping` if session artifacts need archiving.
+After a successful release, suggest `/reflect` for durable learnings and `/housekeeping` if temporary release artifacts need attention.
 
 ## Related Skills
 
-- **implement** — Does the work and housekeeping; `/release` handles the merge afterward
-- **reflect** — Suggested post-merge if session has learnings
-- **git-workflow** — Conventions this skill enforces
-- **housekeeping** — Handles artifact hygiene; `/release` verifies it was done
+- **ship** -- Reviews, verifies, and lands a PR before it becomes release input
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **documentation-standards** -- Changelog and release-note quality
+- **reflect** -- Updates strategy from shipped/released learnings
+- **housekeeping** -- Cleans up completed session and release artifacts

--- a/dist/gemini/skills/ship/SKILL.md
+++ b/dist/gemini/skills/ship/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: ship
+description: >-
+  Reviews, verifies, and lands one pull request. Use when the user says "ship
+  it," "merge this PR," "ready to merge," "land this branch," or asks for a
+  final merge gate. Produces a reviewed, squash-merged PR and post-merge
+  cleanup. Not for version bumps, tags, GitHub Releases, or install verification
+  (use release).
+version: 2.0.0-pre.20260614235428
+---
+
+# Ship
+
+Review, verify, and land one PR. Shipping is the PR gate; releasing is the version-publication gate.
+
+## Contents
+- Critical Rules
+- Verification
+- Quick Reference
+- Topics
+- Context Detection
+- Step 1: PR Readiness
+- Step 2: Evidence Review
+- Step 3: Local Verification
+- Step 4: Squash Merge
+- Step 5: Post-Merge Cleanup
+- Step 6: Release Suggestion
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Critical Rules
+
+- **Ship is not release** -- do not bump versions, create tags, publish GitHub Releases, or verify package installation here.
+- **Keep PR quality local** -- smaller PRs are welcome, but `/ship` must still verify correctness before merge.
+- **Detect-first** -- auto-detect the PR from the current branch before asking for a PR number.
+- **Review before merge** -- inspect code, docs, tests, changelog, PR body, and CI state before approval.
+- **Never merge without explicit confirmation** -- present the PR, checks, findings, and squash body first.
+- **Clean squash body** -- write an intentional squash commit body; never accept the automatic commit dump.
+- **Keep landed and released distinct** -- after merge, describe the PR as landed or shipped, not necessarily released.
+- **Log shipping** -- after merge, run `loaf session log "decision(ship): PR #N landed via squash merge"` when session state is available.
+
+## Verification
+
+- PR identity, base branch, and head branch are confirmed
+- CI status is passing or the user explicitly accepts named non-blocking checks
+- Relevant local checks pass or failures are fixed before merge
+- PR body and durable docs do not overclaim relative to the diff
+- Squash commit title/body are clean, conventional, and user-facing
+- Base branch is updated after merge and the feature branch cleanup state is known
+
+## Quick Reference
+
+| Step | Gate | Blocking? |
+|------|------|-----------|
+| PR Readiness | PR exists, target base known, CI state reviewed | Yes |
+| Evidence Review | findings resolved or explicitly accepted | Yes |
+| Local Verification | relevant checks pass | Yes |
+| Squash Merge | user approves body text | Yes |
+| Cleanup | base pulled, branch deletion handled | No |
+| Release Suggestion | enough landed work may justify `/release` | No |
+
+## Topics
+
+| Topic | Use When |
+|-------|----------|
+| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
+
+---
+
+## Context Detection
+
+Before anything, detect the PR surface:
+
+1. Get current branch and repo default branch:
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. Parse `$ARGUMENTS`: may be a PR number, PR URL, branch name, or empty.
+3. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName,state,mergeStateStatus,isDraft
+   ```
+4. If no PR exists for the current branch, stop and offer to create one via `git-workflow` rather than silently merging a branch.
+5. If already on the default branch, stop. There is no PR to ship from the current branch.
+6. Confirm PR identity with the user before merge actions.
+
+---
+
+## Step 1: PR Readiness
+
+Inspect the PR's declared state:
+
+```bash
+gh pr view <N> --json number,title,body,url,headRefName,baseRefName,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+Block or pause when:
+
+- PR is draft
+- merge state is dirty or blocked
+- required checks are failing or pending
+- review decision is changes requested
+- branch is out of date and the project requires update before merge
+
+If checks are unavailable, say so explicitly and compensate with local verification.
+
+---
+
+## Step 2: Evidence Review
+
+Review the landing diff and durable prose together:
+
+1. Gather diff context:
+   ```bash
+   git fetch origin <baseRefName>
+   git diff --stat origin/<baseRefName>...HEAD
+   git diff --name-only origin/<baseRefName>...HEAD
+   ```
+2. Read the PR title/body and changed docs that make behavior claims.
+3. Check for drift:
+   - PR body claims features that are not in the diff
+   - changelog entries mention unreleased or unrelated behavior
+   - docs describe future work as already shipped
+   - comments or runbooks use stale internal vocabulary
+4. Fix blocking drift before merge. For non-blocking polish, name it and let the user decide.
+
+For high-risk PRs, use the project's review skill or read-only review flow before proceeding.
+
+---
+
+## Step 3: Local Verification
+
+Run the checks the project supports. Examples:
+
+- Node: `npm run typecheck`, `npm run test`, `npm run build`
+- Go: `go vet ./...`, `go test ./...`
+- Python: `pytest`, `mypy .`, `ruff check .`
+- Rust: `cargo check`, `cargo test`
+
+If generated artifacts are tracked, verify they are current before merge:
+
+```bash
+git diff --exit-code -- dist plugins
+```
+
+Use the repo's documented pre-commit or pre-PR checklist when present. Stop on failures.
+
+---
+
+## Step 4: Squash Merge
+
+Draft a clean squash body from the reviewed diff and PR body:
+
+- One-line summary, then bullet points grouped by feature area
+- Plain text; use backticks only for code identifiers
+- No commit dump
+- No agent attribution
+- No release-note overclaiming
+
+Present the body and ask for confirmation. Then run:
+
+```bash
+gh pr merge <N> --squash --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+Let GitHub default the title from the PR title so the squash subject remains `type: summary (#N)`.
+
+---
+
+## Step 5: Post-Merge Cleanup
+
+After a successful merge:
+
+1. Switch to the PR base branch:
+   ```bash
+   git checkout <baseRefName>
+   git pull --ff-only origin <baseRefName>
+   ```
+2. Delete the local feature branch when safe:
+   ```bash
+   git branch -d <headRefName>
+   ```
+3. Confirm the remote branch deletion state from GitHub output or run:
+   ```bash
+   gh pr view <N> --json headRefName,state
+   ```
+4. Log the landing when session state is healthy:
+   ```bash
+   loaf session log "decision(ship): PR #N landed via squash merge"
+   ```
+
+If cleanup fails, report the exact residual state. Do not force-delete without user confirmation.
+
+---
+
+## Step 6: Release Suggestion
+
+After landing, decide whether to suggest `/release`:
+
+- Suggest `/release` when the landed PR completes a coherent batch, user-facing feature, fix train, or release branch.
+- Do not suggest `/release` for every small PR by default.
+- If multiple related PRs are expected, say the PR is landed and can wait for a later batched release.
+
+Use language carefully: the PR is **landed** or **shipped**; it is not **released** until `/release` publishes a version.
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks.
+
+| Hook | Type | When `/ship` Runs |
+|------|------|------------------|
+| `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
+| `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
+| `validate-push` | Advisory | May fire if branch updates are needed before merge |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
+
+Do not disable hooks to force a PR through.
+
+---
+
+## Suggests Next
+
+After a successful ship, suggest `/release` only when the landed work forms a coherent release batch or the user asks to publish.
+
+## Related Skills
+
+- **release** -- Publishes a version from already-landed work
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **foundations** -- Verification, code review, and production readiness
+- **documentation-standards** -- Changelog, docs, and durable prose quality
+- **reflect** -- Updates strategy from significant shipped work

--- a/dist/gemini/skills/wrap/SKILL.md
+++ b/dist/gemini/skills/wrap/SKILL.md
@@ -42,8 +42,8 @@ Responsible session shutdown — everything that needs a conscious model before 
 - All decisions and discoveries from this session are in the journal
 - Uncommitted/unpushed state is surfaced with clear action prompts
 - Stale KB files are flagged if any
-- `## Session Wrap-Up` section written to session file (replaces `## Current State`)
-- `loaf session end --wrap` run after writing the summary
+- `## Session Wrap-Up` section persisted in the canonical session surface; in SQLite mode this is represented by wrapped session/report state rather than an active `.md` file
+- `loaf session end --wrap` run after generating or writing the summary
 - Session status is `done` (session stays open for further journal entries until `SessionEnd` fires)
 
 ## Quick Reference
@@ -64,7 +64,7 @@ These steps require conversation context — only the model can do them.
 
 Before anything else, complete the session journal:
 
-1. **Enrich from conversation log** — run `loaf session enrich` to fill in gaps from the JSONL conversation log. This catches decisions, discoveries, and context that weren't manually logged. If enrichment fails, continue — manual flush is the fallback.
+1. **Check enrichment state** — run `loaf session enrich --json`. In SQLite mode this is expected to report `action: "skipped"` because `loaf session log` is already the canonical journal writer; in markdown-only compatibility mode it summarizes legacy JSONL enrichment status. If enrichment is skipped or fails, continue — manual flush is the fallback.
 2. **Manual review** — review the conversation for anything enrichment missed:
    - Decisions — design choices, trade-offs, direction changes not yet logged as `decision()` entries
    - Discoveries — anything learned that future sessions would benefit from
@@ -75,7 +75,7 @@ Before anything else, complete the session journal:
 
 Run in parallel:
 
-1. **Session journal** — read the active session file for this branch
+1. **Session journal** — run `loaf session list --json`, choose the active session for the current branch or explicit harness session, then run `loaf session show <session-ref> --json`; if SQLite state is unavailable, fall back to the active markdown session file for this branch
 2. **Commits this session** — `git log --oneline` since session start
 3. **Working tree** — `git status --short`
 4. **Unpushed commits** — `git log --oneline origin/<branch>..HEAD`
@@ -90,7 +90,7 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 |-----------|--------|
 | Uncommitted changes | "N file(s) uncommitted — commit, stash, or leave for next session?" |
 | Unpushed commits | "N commit(s) on <branch> not pushed — push now?" |
-| No version bump | "This session shipped work but no release was run — bump version now?" |
+| Release candidate | "This session landed work that may belong in the next release — run `/release` now?" |
 | Stale KB files | "N stale knowledge file(s) — address now or defer?" |
 | Unresolved blocks | "Block on <scope> still open — note for next session?" |
 | No changelog entries | "N commit(s) on branch but `[Unreleased]` is empty — add changelog entries?" |
@@ -99,15 +99,17 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 **Detection logic:**
 - **Changelog entries:** check if the current branch has commits vs the base branch (e.g., `git rev-list --count origin/main..HEAD`) AND `CHANGELOG.md` `[Unreleased]` section has no list items (`^[-*]\s`). If both are true, prompt. **Skip when HEAD is tagged** (post-release state).
 - **Housekeeping:** scan session journal for `skill(housekeeping)` entry. If absent and the session had significant work, suggest it.
-- **Version bump:** scan session journal for `decision(release)` entry. If absent and the session has commits, offer to run `loaf release --bump prerelease --no-gh --yes`.
+- **Release candidate:** scan session journal for `decision(release)` entry. If absent and the session has landed commits, suggest `/release` only when the work forms a coherent release batch.
 
 ### Step 4: Generate Report
 
 Assemble the report per the format below. Omit empty sections — don't show "None" placeholders.
 
-### Step 5: Write Wrap Summary to Session File
+### Step 5: Persist Wrap Summary
 
-Write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
+In SQLite mode, keep the generated wrap summary in the conversation response and let `loaf session end --wrap` persist the mechanical wrapped state. Do not invent or edit a missing active `.md` session file; `loaf session show <session-ref> --json` is the canonical read surface.
+
+In markdown-only compatibility mode, write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
 
 Use the Edit tool to replace `## Current State (...)` and everything below it (up to `## Journal`) with the wrap-up section. The session file layout after wrap should be:
 
@@ -141,7 +143,7 @@ This handles the mechanical bookkeeping:
 
 ## Composability
 
-When called from `/release`, wrap runs the same steps but skips the version bump prompt (release already handles it). The `/release` skill should invoke `/wrap` first, then proceed with release steps.
+When called near `/ship` or `/release`, wrap runs the same steps but keeps PR landing and version publication distinct. `/ship` may wrap a landed PR; `/release` may wrap a published version.
 
 ## Suggests Next
 

--- a/dist/opencode/commands/implement.md
+++ b/dist/opencode/commands/implement.md
@@ -334,7 +334,7 @@ After creating session file:
    - Update session file (status: done, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
+5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
@@ -353,7 +353,7 @@ After creating session file:
 
 ## Suggests Next
 
-After all tasks are complete, suggest `/release` to merge the work.
+After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release` only when the landed work forms a coherent release batch.
 
 ## Related Skills
 

--- a/dist/opencode/commands/wrap.md
+++ b/dist/opencode/commands/wrap.md
@@ -42,8 +42,8 @@ Responsible session shutdown — everything that needs a conscious model before 
 - All decisions and discoveries from this session are in the journal
 - Uncommitted/unpushed state is surfaced with clear action prompts
 - Stale KB files are flagged if any
-- `## Session Wrap-Up` section written to session file (replaces `## Current State`)
-- `loaf session end --wrap` run after writing the summary
+- `## Session Wrap-Up` section persisted in the canonical session surface; in SQLite mode this is represented by wrapped session/report state rather than an active `.md` file
+- `loaf session end --wrap` run after generating or writing the summary
 - Session status is `done` (session stays open for further journal entries until `SessionEnd` fires)
 
 ## Quick Reference
@@ -64,7 +64,7 @@ These steps require conversation context — only the model can do them.
 
 Before anything else, complete the session journal:
 
-1. **Enrich from conversation log** — run `loaf session enrich` to fill in gaps from the JSONL conversation log. This catches decisions, discoveries, and context that weren't manually logged. If enrichment fails, continue — manual flush is the fallback.
+1. **Check enrichment state** — run `loaf session enrich --json`. In SQLite mode this is expected to report `action: "skipped"` because `loaf session log` is already the canonical journal writer; in markdown-only compatibility mode it summarizes legacy JSONL enrichment status. If enrichment is skipped or fails, continue — manual flush is the fallback.
 2. **Manual review** — review the conversation for anything enrichment missed:
    - Decisions — design choices, trade-offs, direction changes not yet logged as `decision()` entries
    - Discoveries — anything learned that future sessions would benefit from
@@ -75,7 +75,7 @@ Before anything else, complete the session journal:
 
 Run in parallel:
 
-1. **Session journal** — read the active session file for this branch
+1. **Session journal** — run `loaf session list --json`, choose the active session for the current branch or explicit harness session, then run `loaf session show <session-ref> --json`; if SQLite state is unavailable, fall back to the active markdown session file for this branch
 2. **Commits this session** — `git log --oneline` since session start
 3. **Working tree** — `git status --short`
 4. **Unpushed commits** — `git log --oneline origin/<branch>..HEAD`
@@ -90,7 +90,7 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 |-----------|--------|
 | Uncommitted changes | "N file(s) uncommitted — commit, stash, or leave for next session?" |
 | Unpushed commits | "N commit(s) on <branch> not pushed — push now?" |
-| No version bump | "This session shipped work but no release was run — bump version now?" |
+| Release candidate | "This session landed work that may belong in the next release — run `/release` now?" |
 | Stale KB files | "N stale knowledge file(s) — address now or defer?" |
 | Unresolved blocks | "Block on <scope> still open — note for next session?" |
 | No changelog entries | "N commit(s) on branch but `[Unreleased]` is empty — add changelog entries?" |
@@ -99,15 +99,17 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 **Detection logic:**
 - **Changelog entries:** check if the current branch has commits vs the base branch (e.g., `git rev-list --count origin/main..HEAD`) AND `CHANGELOG.md` `[Unreleased]` section has no list items (`^[-*]\s`). If both are true, prompt. **Skip when HEAD is tagged** (post-release state).
 - **Housekeeping:** scan session journal for `skill(housekeeping)` entry. If absent and the session had significant work, suggest it.
-- **Version bump:** scan session journal for `decision(release)` entry. If absent and the session has commits, offer to run `loaf release --bump prerelease --no-gh --yes`.
+- **Release candidate:** scan session journal for `decision(release)` entry. If absent and the session has landed commits, suggest `/release` only when the work forms a coherent release batch.
 
 ### Step 4: Generate Report
 
 Assemble the report per the format below. Omit empty sections — don't show "None" placeholders.
 
-### Step 5: Write Wrap Summary to Session File
+### Step 5: Persist Wrap Summary
 
-Write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
+In SQLite mode, keep the generated wrap summary in the conversation response and let `loaf session end --wrap` persist the mechanical wrapped state. Do not invent or edit a missing active `.md` session file; `loaf session show <session-ref> --json` is the canonical read surface.
+
+In markdown-only compatibility mode, write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
 
 Use the Edit tool to replace `## Current State (...)` and everything below it (up to `## Journal`) with the wrap-up section. The session file layout after wrap should be:
 
@@ -141,7 +143,7 @@ This handles the mechanical bookkeeping:
 
 ## Composability
 
-When called from `/release`, wrap runs the same steps but skips the version bump prompt (release already handles it). The `/release` skill should invoke `/wrap` first, then proceed with release steps.
+When called near `/ship` or `/release`, wrap runs the same steps but keeps PR landing and version publication distinct. `/ship` may wrap a landed PR; `/release` may wrap a published version.
 
 ## Suggests Next
 

--- a/dist/opencode/plugins/hooks/instructions/post-merge.md
+++ b/dist/opencode/plugins/hooks/instructions/post-merge.md
@@ -1,4 +1,4 @@
-**Note:** If you used `/release`, these steps were already handled by the skill. This checklist is for manual merges.
+**Note:** If you used `/ship`, these steps were already handled by the skill. This checklist is for manual merges.
 
 # Pre-Merge Checklist
 
@@ -12,27 +12,19 @@ Complete these steps on the feature branch before creating the PR.
    ```
    Archive session file (status: done, `archived_at`, `archived_by`, move to archive/).
 
-2. **Update CHANGELOG.md:**
-   Add entries under `[Unreleased]` describing what the PR ships.
+2. **Update CHANGELOG.md when the PR has release-facing impact:**
+   Add curated entries under `[Unreleased]` describing what the PR lands. Do not move entries to a versioned section here; `/release` publishes the batch later.
 
-3. **Bump version** in `package.json`:
-   - `feat` commit -> minor bump (or dev bump if pre-release)
-   - `fix` commit -> patch bump
-   - Breaking change -> major bump
-
-4. **Move `[Unreleased]` to versioned section:**
-   `## [X.Y.Z] - YYYY-MM-DD`
-
-5. **Rebuild all targets:**
+3. **Rebuild all targets:**
    ```
    npx loaf build
    ```
 
-6. **Commit and push** the changelog + version + archived artifacts to the PR branch.
+4. **Commit and push** the changelog and generated artifacts to the PR branch.
 
-7. **Create PR** with `gh pr create` — title + summary + test plan.
+5. **Create PR** with `gh pr create` — title + summary + test plan.
 
-8. **Squash merge** with a clean commit body:
+6. **Squash merge** with a clean commit body:
    - Let GitHub default the title: `PR title (#N)`
    - Write a concise 2-4 sentence summary as `--body` (use a HEREDOC)
    - **Never** use the automatic squash description that dumps all individual commit messages
@@ -55,3 +47,5 @@ Complete these steps on main after merging.
    ```
 
 3. **Suggest reflection** if the session had key decisions or learnings.
+
+4. **Suggest `/release` only when appropriate** — if this PR completes a coherent batch or release branch, publish from the base branch after the landed work is present there.

--- a/dist/opencode/plugins/hooks/instructions/pre-pr-checklist.md
+++ b/dist/opencode/plugins/hooks/instructions/pre-pr-checklist.md
@@ -29,7 +29,7 @@ If `CHANGELOG.md` does not exist, create it first:
 
 This project follows [Common Changelog](https://common-changelog.org/) and
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). `## [Unreleased]`
-is a workflow staging section for curated entries before release.
+is a workflow staging section for curated entries that land with PRs before a later release.
 
 ## [Unreleased]
 

--- a/dist/opencode/skills/git-workflow/SKILL.md
+++ b/dist/opencode/skills/git-workflow/SKILL.md
@@ -48,4 +48,5 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, curating CHANGELOG entries, pre-PR/pre-push/post-merge hooks |
-| Release ritual | `/release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |
+| PR shipping | `/ship` skill | Reviewing, verifying, and squash-merging one PR |
+| Release ritual | `/release` skill | Publishing a version from already-landed work |

--- a/dist/opencode/skills/git-workflow/references/commits.md
+++ b/dist/opencode/skills/git-workflow/references/commits.md
@@ -169,13 +169,13 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
-- The `/release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
+- The `/ship` skill automates this workflow when ready to squash merge a PR; `/release` publishes a version later from already-landed work
 
 ## Changelog Discipline
 
 `CHANGELOG.md` entries follow Loaf's Common Changelog profile: write for
 humans, communicate the release impact, and curate git history instead of
-copying it. Curate the `[Unreleased]` section before bumping the version so the
+copying it. Curate the `[Unreleased]` section as PRs land so the later
 published release notes read as user-facing prose, not an internal worklog.
 
 ### Drop
@@ -204,9 +204,9 @@ Internal terms that have no meaning outside the team's working context:
 
 ### Auto-generated Entries
 
-When `loaf release --pre-merge` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
+When `loaf release` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
 
-Before approving a release bump, compare `[Unreleased]` against the actual squashed change set and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the branch was organized, it does not belong in the changelog.
+Before approving a release bump, compare `[Unreleased]` against the actual release range and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the work was organized, it does not belong in the changelog.
 
 ## Critical Rules
 
@@ -285,7 +285,7 @@ When developing toward a major version, use pre-release suffixes to mark develop
 
 **Convention:**
 - Set the target version with `-dev.0` when starting a major effort (e.g. `2.0.0-dev.0`)
-- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of work ships — a spec completing, a group of related features landing
+- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of landed work is ready to publish — a completed spec, a related feature group, or a release train
 - Don't bump for every commit — that's what git history is for
 - Strip the suffix (`-dev.N` → `2.0.0`) when all planned work is complete
 - `loaf release` handles all bump types: `prerelease`, `release`, `major`, `minor`, `patch`

--- a/dist/opencode/skills/implement/SKILL.md
+++ b/dist/opencode/skills/implement/SKILL.md
@@ -335,7 +335,7 @@ After creating session file:
    - Update session file (status: done, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
+5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
@@ -354,7 +354,7 @@ After creating session file:
 
 ## Suggests Next
 
-After all tasks are complete, suggest `/release` to merge the work.
+After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release` only when the landed work forms a coherent release batch.
 
 ## Related Skills
 

--- a/dist/opencode/skills/release/SKILL.md
+++ b/dist/opencode/skills/release/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: release
 description: >-
-  Orchestrates releases: pre-flight checks, version bump via `loaf release`,
-  squash merge, and post-merge cleanup. Use when the user says "release this,"
-  "merge this PR," "ready to merge," or "ship it." Produces version bumps,
-  changelog updates, and merged code. Not for creating PRs (use git-workflow) or
-  reflection (use reflect).
+  Orchestrates standalone releases from already-landed work: release readiness,
+  version selection, changelog curation, release commit, tag, GitHub Release,
+  install verification, and post-release follow-up. Use when the user says "cut
+  a release," "publish a version," "release from main," or asks whether enough
+  landed work should become a release. Not for reviewing or merging a PR (use
+  ship).
 version: 2.0.0-pre.20260614235428
 ---
 
 # Release
 
-Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+Publish a coherent version from work that has already landed.
 
 ## Contents
 - Critical Rules
@@ -19,13 +20,13 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 - Quick Reference
 - Topics
 - Context Detection
-- Step 1: Pre-Flight Checks
-- Step 2: Documentation Freshness
-- Step 3: Housekeeping Verification
-- Step 3b: Create PR (if needed)
-- Step 4: Version Bump + Changelog
-- Step 5: Squash Merge
-- Step 6: Post-Merge Cleanup
+- Step 1: Release Readiness
+- Step 2: Change Collection
+- Step 3: Version + Changelog
+- Step 4: Release Execution
+- Step 5: Protected-Branch Handoff
+- Step 6: Publication Verification
+- Step 7: Post-Release Follow-Up
 - Hook Interaction
 - Related Skills
 
@@ -35,308 +36,255 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 
 ## Critical Rules
 
-- **Block on pre-flight failure** -- do not offer to skip any failing check
-- **Use `AskUserQuestion` for all decisions and confirmations** -- version bump type, push approval, merge approval, branch deletion. Never use inline text questions for permission/decision prompts
-- **Version bump before merge** -- this is the skill's reason for existing; never defer to post-merge
-- **Wrap after version bump** -- wrap needs PR# and version to produce a complete session summary
-- **Clean squash body** -- never use the auto-generated commit dump
-- **Orchestrate the full lifecycle** -- if housekeeping or reflect haven't been run, trigger them (with user confirmation via `AskUserQuestion`) rather than just flagging gaps
-- **Detect-first** -- auto-detect PR from branch before asking for a number
-- **Never push without confirmation** -- even after successful version bump
-- **Log release** -- log to session journal after merge: `loaf session log "decision(release): vX.Y.Z shipped via PR #N"`
+- **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
+- **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
+- **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
+- **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
+- **Never push, tag, or publish without confirmation** -- present the exact actions first.
+- **Use `AskUserQuestion` for release decisions when available** -- version bump type, release PR handoff, push/tag/GitHub Release confirmation.
+- **Log release** -- after publication, run `loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"` when session state is available.
 
 ## Verification
 
-- Pre-flight checks (typecheck, test, build) all pass before proceeding
-- Version bump commit exists on the feature branch before merge
-- Squash merge body is a one-line summary followed by bullet points grouped by feature area, not a commit dump
-- Git tag points to the squash merge commit on the base branch, not a branch commit
-- GitHub Release exists with changelog body (not auto-generated notes)
-- Post-merge cleanup completed: base branch pulled, feature branch deleted
+- Release base branch is clean, current, and contains the intended landed PRs
+- Pre-flight checks pass before versioning or publication
+- Changelog entries are curated user-facing prose, not commit or PR-title dumps
+- Version files, changelog heading, git tag, and GitHub Release all agree
+- Tag points at the released base-branch commit or release commit, not an abandoned feature branch
+- Downstream install path is verified when applicable, especially Homebrew for Loaf releases
 
 ## Quick Reference
 
 | Step | Gate | Blocking? |
 |------|------|-----------|
-| Pre-Flight | typecheck + test + build pass | Yes |
-| Doc Freshness | User reviews stale docs | No (user decides) |
-| Housekeeping | Spec/tasks archived, CHANGELOG ready | No (user decides) |
-| PR Creation | Only if no PR exists yet | Yes (if needed) |
-| Version Bump | User confirms bump type; `loaf release --pre-merge` | Yes |
-| Wrap | Session summary (after version bump, has PR# + version) | Yes |
-| Squash Merge | User approves body text | Yes |
-| Post-Merge | `loaf release --post-merge` (tag, GH Release, cleanup) | Yes |
+| Readiness | clean/current base branch, no unresolved release collisions | Yes |
+| Change Collection | landed work since last tag grouped into release themes | Yes |
+| Version + Changelog | bump selected, notes curated, files updated | Yes |
+| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Verification | release and install paths checked | Yes |
+| Follow-Up | reflect/housekeeping suggested when useful | No |
 
 ## Topics
 
 | Topic | Use When |
 |-------|----------|
-| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
+| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
 
 ## Context Detection
 
-Before anything, detect where we are:
+Before anything, establish the release surface:
 
-1. **Get current branch and repo default branch:**
+1. Get current branch and repo default branch:
    ```bash
    git branch --show-current
    gh repo view --json defaultBranchRef -q .defaultBranchRef.name
    ```
-2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
-3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
-4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
+3. Verify the current branch:
+   - If already on the release base, continue.
+   - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
+   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
+4. Find the previous release tag:
    ```bash
-   gh pr view --json number,title,url,headRefName,baseRefName
+   git describe --tags --abbrev=0
    ```
-5. If no PR exists for this branch, note `pr_exists = false` and set `baseRefName` to the repo default branch. Continue — the PR will be created in Step 3b.
-6. If PR exists, **save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
-7. Confirm the PR identity (or intent to create one) with the user before proceeding.
-
----
-
-## Step 1: Pre-Flight Checks (BLOCKING)
-
-Run these and **BLOCK on any failure** — do not offer to skip.
-
-### Detect project type
-
-Inspect the repo to determine available checks:
-- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
-- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config; if the project is uv-managed, expect release artifact refresh to run `uv sync`
-- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
-- **Go** (`go.mod`): `go vet`, `go test`
-
-### Run checks
-
-Run whichever checks the project supports. Examples for a Node project:
-1. `npm run typecheck` (if the script exists)
-2. `npm run test` (if the script exists)
-3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
-
-For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
-
-**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
-
-On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
-
----
-
-## Step 2: Documentation Freshness
-
-Check whether documentation is stale relative to the branch's changes:
-
-1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
-2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
-3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
-4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
-
-Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
-
----
-
-## Step 3: Housekeeping
-
-Check each item. If missing, **offer to run it** (with user confirmation) rather than just flagging it.
-
-1. **Spec status**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`. If not, offer to update it.
-2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived. If found, offer to run `loaf task archive`.
-3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
-4. **Journal flushed**: Review conversation for unrecorded decisions/discoveries. Log them now — this is the last chance before wrap.
-
-Present the results as a checklist. Use `AskUserQuestion` for any decisions or approvals.
-
-**Note:** Wrap (`/wrap`) runs AFTER version bump (Step 4b) so it can reference the PR# and version in the session summary. Reflection runs post-merge (Step 6).
-
----
-
-## Step 3b: Create PR (if needed)
-
-**Only run this step if `pr_exists = false` from Context Detection.**
-
-The PR must be created BEFORE the version bump so that `[Unreleased]` changelog entries are still present (advisory hooks check for this).
-
-1. Push the branch if not already pushed.
-2. Create the PR following the format in [git-workflow/references/commits.md](../git-workflow/references/commits.md) (Pull Request Format section).
-3. Save the PR number and `baseRefName` for subsequent steps.
-
----
-
-## Step 4: Version Bump + Changelog (on feature branch)
-
-This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
-
-### Check for existing changelog entries
-
-Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
-
-- **If curated entries exist** → Use the **Curated path** (preserve them)
-- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
-
-### Curated path (preferred when entries exist)
-
-The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
-
-**Review curated entries for quality before bumping:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Follow Loaf's Common Changelog profile: imperative, self-describing,
-  one-line entries grouped as `Changed`, `Added`, `Removed`, `Fixed`
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Include the best public reference when available, such as a PR, issue, ADR, release, or commit link
-
-1. Run `loaf release --pre-merge --dry-run` to get the **suggested bump type** and **current version** (the `--pre-merge` flag auto-detects the base branch — see [Why `--pre-merge`?](#why---pre-merge) below).
-2. Present the bump suggestion to the user. They may accept or override.
-3. Once confirmed, run:
+5. Gather the candidate release range:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git log --oneline <last-tag>..HEAD
+   git diff --stat <last-tag>..HEAD
    ```
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it) and re-insert a fresh empty `## [Unreleased]` section above
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+---
 
-### Generated path (when no entries exist)
+## Step 1: Release Readiness
 
-When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+Run release pre-flight checks before editing release files:
 
-**After generation, review and rewrite entries before committing:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Rewrite generated commit text into Loaf's Common Changelog profile
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Keep entries concise but descriptive enough to understand the change without reading the diff
-
-1. Run `loaf release --pre-merge --dry-run` to preview:
-   - Current version and suggested bump type
-   - Generated changelog section from **this branch's commits only**
-   - Which version files will be updated
-
-   The `--pre-merge` flag scopes the commit analysis to `<auto-detected base>..HEAD`, so only commits on the feature branch are considered.
-
-2. Present the preview to the user. They may:
-   - Accept the suggested bump type
-   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-   - Edit the changelog content conversationally
-
-3. Once the user confirms, run:
+1. Ensure worktree is clean:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git status --short
    ```
+2. Ensure the release base is current:
+   ```bash
+   git fetch --tags origin
+   git status --branch --short
+   ```
+3. Check for existing tag or GitHub Release collisions for the target version once known:
+   ```bash
+   git tag --list vX.Y.Z
+   gh release view vX.Y.Z
+   ```
+4. Run project checks:
+   - Node: `npm run typecheck`, `npm run test`, `npm run build` when scripts exist
+   - Go: `go vet ./...`, `go test ./...` when `go.mod` exists
+   - Python: `pytest`, `mypy .`, `ruff check .` when configured
+   - Rust: `cargo check`, `cargo test` when `Cargo.toml` exists
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Generate and insert changelog section from branch commits (adding a fresh `[Unreleased]`)
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+If no checks are detected, warn explicitly. If a check fails, stop and fix before release.
 
-### After either path
+---
 
-Before pushing, verify generated artifacts are still current. This matters if
-any fix commits landed after the release bump commit:
+## Step 2: Change Collection
+
+Collect landed work since the last release and group it for release notes.
+
+1. Inspect commits:
+   ```bash
+   git log --first-parent --oneline <last-tag>..HEAD
+   git log --oneline <last-tag>..HEAD
+   ```
+2. Inspect merged PRs when GitHub is available:
+   ```bash
+   gh pr list --state merged --base <base> --json number,title,mergedAt,url
+   ```
+3. Group changes by user-facing outcome:
+   - `CR-*` change bundle, when referenced
+   - spec or task family, when public enough to be useful
+   - feature/fix/documentation/build themes
+   - operational release work, when it affects users or maintainers
+4. Drop noise:
+   - purely internal task/session labels
+   - reverted work that is not present in `HEAD`
+   - individual commit mechanics that collapse into one user-facing change
+
+Present the grouped release contents before choosing the bump.
+
+---
+
+## Step 3: Version + Changelog
+
+Choose the bump and curate the changelog from the grouped landed work.
+
+1. Run a dry run:
+   ```bash
+   loaf release --dry-run
+   ```
+   Use `--base <ref>` when the project expects a non-default release base.
+2. Present:
+   - current version
+   - proposed next version
+   - detected version files
+   - release actions the CLI would perform
+   - draft changelog entries
+3. Curate `CHANGELOG.md` before publishing:
+   - write from the upgrading user's perspective
+   - group under Common Changelog categories: `Changed`, `Added`, `Removed`, `Fixed`
+   - use one self-describing line per meaningful change
+   - include public PR, issue, ADR, release, or commit links when helpful
+   - avoid dumping commit subjects, task IDs, session mechanics, or internal gate language
+4. Confirm the bump type: `prerelease`, `release`, `major`, `minor`, or `patch`.
+
+---
+
+## Step 4: Release Execution
+
+For a direct release from the base branch, run:
+
+```bash
+loaf release --bump <type> --yes
+```
+
+This should:
+
+1. Update version files
+2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
+3. Reinsert a fresh empty `[Unreleased]` section
+4. Run configured release artifact commands
+5. Create the release commit
+6. Create/push the release tag
+7. Create the GitHub Release when enabled
+
+After execution, verify generated artifacts are current:
 
 ```bash
 npm run build
-git diff --exit-code -- plugins/loaf/bin/loaf dist content/skills/cli-reference/SKILL.md
+git diff --exit-code -- dist plugins content/skills/cli-reference/SKILL.md
 ```
 
-If the diff check fails, commit the regenerated artifacts with the source change
-that made them stale, then rerun the check.
-
-Push to the feature branch (**with user confirmation**).
-
-### Why `--pre-merge`?
-
-`--pre-merge` bundles the canonical pre-merge flag set so the skill no longer needs to spell each one out:
-
-- Equivalent to `--no-tag --no-gh --base <auto-detected>` (tag and GH release land post-merge in Step 6, not on the soon-to-be-squashed feature commit).
-- Auto-detects the base ref via a 4-step priority: explicit `--base <ref>` → open PR's `baseRefName` → `git config loaf.release.base` → repo default branch. Run `loaf release --help` to see the full priority order.
-- Pass `--base <ref>` explicitly to override auto-detection (useful for non-default base branches like `release/1.0` when no PR exists yet).
-- `--yes` skips the CLI confirmation prompt — the skill already confirmed with the user conversationally.
+Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
 ---
 
-## Step 4b: Wrap Session
+## Step 5: Protected-Branch Handoff
 
-Run `/wrap` AFTER version bump so the session summary can reference the PR# and final version.
+If branch protection prevents direct release commits on the base branch:
 
-The wrap skill will:
-1. Flush any remaining journal entries
-2. Gather git state (commits, working tree, unpushed)
-3. Generate the `## Session Wrap-Up` report
-4. Write it to the session file (replaces `## Current State`)
-5. Run `loaf session end --wrap` to set status to `complete`
+1. Create a dedicated release branch.
+2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+3. Open a release PR with a concise release-focused body.
+4. Hand the PR to `/ship` for review and landing.
+5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
 
-When called from `/release`, wrap skips the version bump and changelog prompts (already handled).
+Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
 ---
 
-## Step 5: Squash Merge
+## Step 6: Publication Verification
 
-1. Draft a clean squash body from the branch's commit history and PR description. Descriptive, not verbose:
-   - One-line summary, then bullet points grouped by feature area
-   - Plain text — no bold, no headings, only backticks for `code`
-   - Not a paragraph dump, not a commit log
-2. Present the draft to the user for review. They may edit it.
-3. Execute (after user confirms):
+After publishing, verify the public release state:
+
+1. Confirm tag location:
    ```bash
-   gh pr merge <N> --squash --body "$(cat <<'EOF'
-   <body>
-   EOF
-   )"
+   git show --stat vX.Y.Z
    ```
-4. Let GitHub default the title (`PR title (#N)`).
-5. NEVER use `--auto` or the automatic squash description that dumps all commits.
+2. Confirm GitHub Release:
+   ```bash
+   gh release view vX.Y.Z
+   ```
+3. Confirm package or installer availability when applicable:
+   - npm: `npm view <package> version`
+   - Homebrew: `brew update && brew info <tap>/<formula>`
+   - project-specific deploy or artifact registry checks
+4. For Loaf/Homebrew, report readiness only after the GitHub release exists, assets are uploaded, the tap formula is updated, and tap CI has passed.
+
+If publication partially completes, do not retag casually. Name the exact state and continue with the smallest repair or patch release path.
 
 ---
 
-## Step 6: Post-Merge Cleanup
+## Step 7: Post-Release Follow-Up
 
-After successful merge, run a single command:
+After verification:
 
-```bash
-loaf release --post-merge
-```
-
-This verifies HEAD state against an 8-point guardrail checklist (clean worktree, on the base branch with the merge commit at HEAD, readable HEAD subject for optional PR-number lookup, version-file agreement, CHANGELOG section present, no pre-existing tag or GH release, HEAD untagged). The squash subject should describe the shipped work (`feat:`, `fix:`, etc.); post-merge derives the release version from version files and `CHANGELOG.md`, not from a `chore: release` subject. Once all guardrails pass it tags the squash merge commit, pushes the tag, creates the GitHub Release from the matching `## [X.Y.Z]` CHANGELOG section, pulls the base branch, and best-effort deletes the local + remote feature branch. Manual `git tag`, `git push --tags`, `gh release create`, `git checkout`, `git pull --rebase`, and `git branch -d` are no longer needed — the flag subsumes them.
-
-If anything aborts:
-
-1. Read the actionable error message — each guardrail failure names the exact manual fix (e.g., "tag v1.2.3 already exists locally — run `git tag -d v1.2.3` and rerun").
-2. Perform the named fix.
-3. Rerun `loaf release --post-merge`. The command is idempotent on stateless reads, so reruns after a transient `gh` failure or a half-completed prior run pick up exactly where they left off.
-
-After the release finalizes, **run `/reflect`** — already on the base branch. Reflect looks back at the shipped work and updates strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) with learnings. Use `AskUserQuestion` to confirm before running.
+1. Log the release decision when session state is healthy:
+   ```bash
+   loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"
+   ```
+2. Suggest `/reflect` when the release produced durable product or workflow learnings.
+3. Suggest `/housekeeping` when session artifacts, release branches, or temporary reports need cleanup.
+4. Keep future-work discoveries out of the release notes; capture them as tasks, ideas, or sparks instead.
 
 ---
 
 ## Hook Interaction
 
-This skill coexists with existing hooks. Git workflow hooks are **advisory** (warn but don't block); security hooks remain blocking.
+This skill coexists with existing hooks. Git workflow hooks are advisory unless
+configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `workflow-pre-pr` (command) | Advisory | Fires on `gh pr create`. Reminds about CHANGELOG — redundant when release skill manages entries. |
-| `workflow-pre-merge` (instruction) | Advisory | Fires on `gh pr merge`. Reminds about squash conventions — redundant since body is already crafted. |
-| `workflow-post-merge` (instruction) | Advisory | Fires after merge. Outputs checklist the skill already handled. |
-| `validate-push` (command) | Advisory | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
-| `check-secrets` (command) | **Blocking** | Security gate. Always fires, always respected. |
+| `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
+| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
+| `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
 
-Do not modify, disable, or skip these hooks.
+Do not disable hooks to force a release through.
 
 ---
 
 ## Suggests Next
 
-After a successful release, suggest `/housekeeping` if session artifacts need archiving.
+After a successful release, suggest `/reflect` for durable learnings and `/housekeeping` if temporary release artifacts need attention.
 
 ## Related Skills
 
-- **implement** — Does the work and housekeeping; `/release` handles the merge afterward
-- **reflect** — Suggested post-merge if session has learnings
-- **git-workflow** — Conventions this skill enforces
-- **housekeeping** — Handles artifact hygiene; `/release` verifies it was done
+- **ship** -- Reviews, verifies, and lands a PR before it becomes release input
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **documentation-standards** -- Changelog and release-note quality
+- **reflect** -- Updates strategy from shipped/released learnings
+- **housekeeping** -- Cleans up completed session and release artifacts

--- a/dist/opencode/skills/ship/SKILL.md
+++ b/dist/opencode/skills/ship/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: ship
+description: >-
+  Reviews, verifies, and lands one pull request. Use when the user says "ship
+  it," "merge this PR," "ready to merge," "land this branch," or asks for a
+  final merge gate. Produces a reviewed, squash-merged PR and post-merge
+  cleanup. Not for version bumps, tags, GitHub Releases, or install verification
+  (use release).
+version: 2.0.0-pre.20260614235428
+---
+
+# Ship
+
+Review, verify, and land one PR. Shipping is the PR gate; releasing is the version-publication gate.
+
+## Contents
+- Critical Rules
+- Verification
+- Quick Reference
+- Topics
+- Context Detection
+- Step 1: PR Readiness
+- Step 2: Evidence Review
+- Step 3: Local Verification
+- Step 4: Squash Merge
+- Step 5: Post-Merge Cleanup
+- Step 6: Release Suggestion
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Critical Rules
+
+- **Ship is not release** -- do not bump versions, create tags, publish GitHub Releases, or verify package installation here.
+- **Keep PR quality local** -- smaller PRs are welcome, but `/ship` must still verify correctness before merge.
+- **Detect-first** -- auto-detect the PR from the current branch before asking for a PR number.
+- **Review before merge** -- inspect code, docs, tests, changelog, PR body, and CI state before approval.
+- **Never merge without explicit confirmation** -- present the PR, checks, findings, and squash body first.
+- **Clean squash body** -- write an intentional squash commit body; never accept the automatic commit dump.
+- **Keep landed and released distinct** -- after merge, describe the PR as landed or shipped, not necessarily released.
+- **Log shipping** -- after merge, run `loaf session log "decision(ship): PR #N landed via squash merge"` when session state is available.
+
+## Verification
+
+- PR identity, base branch, and head branch are confirmed
+- CI status is passing or the user explicitly accepts named non-blocking checks
+- Relevant local checks pass or failures are fixed before merge
+- PR body and durable docs do not overclaim relative to the diff
+- Squash commit title/body are clean, conventional, and user-facing
+- Base branch is updated after merge and the feature branch cleanup state is known
+
+## Quick Reference
+
+| Step | Gate | Blocking? |
+|------|------|-----------|
+| PR Readiness | PR exists, target base known, CI state reviewed | Yes |
+| Evidence Review | findings resolved or explicitly accepted | Yes |
+| Local Verification | relevant checks pass | Yes |
+| Squash Merge | user approves body text | Yes |
+| Cleanup | base pulled, branch deletion handled | No |
+| Release Suggestion | enough landed work may justify `/release` | No |
+
+## Topics
+
+| Topic | Use When |
+|-------|----------|
+| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
+
+---
+
+## Context Detection
+
+Before anything, detect the PR surface:
+
+1. Get current branch and repo default branch:
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. Parse `$ARGUMENTS`: may be a PR number, PR URL, branch name, or empty.
+3. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName,state,mergeStateStatus,isDraft
+   ```
+4. If no PR exists for the current branch, stop and offer to create one via `git-workflow` rather than silently merging a branch.
+5. If already on the default branch, stop. There is no PR to ship from the current branch.
+6. Confirm PR identity with the user before merge actions.
+
+---
+
+## Step 1: PR Readiness
+
+Inspect the PR's declared state:
+
+```bash
+gh pr view <N> --json number,title,body,url,headRefName,baseRefName,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+Block or pause when:
+
+- PR is draft
+- merge state is dirty or blocked
+- required checks are failing or pending
+- review decision is changes requested
+- branch is out of date and the project requires update before merge
+
+If checks are unavailable, say so explicitly and compensate with local verification.
+
+---
+
+## Step 2: Evidence Review
+
+Review the landing diff and durable prose together:
+
+1. Gather diff context:
+   ```bash
+   git fetch origin <baseRefName>
+   git diff --stat origin/<baseRefName>...HEAD
+   git diff --name-only origin/<baseRefName>...HEAD
+   ```
+2. Read the PR title/body and changed docs that make behavior claims.
+3. Check for drift:
+   - PR body claims features that are not in the diff
+   - changelog entries mention unreleased or unrelated behavior
+   - docs describe future work as already shipped
+   - comments or runbooks use stale internal vocabulary
+4. Fix blocking drift before merge. For non-blocking polish, name it and let the user decide.
+
+For high-risk PRs, use the project's review skill or read-only review flow before proceeding.
+
+---
+
+## Step 3: Local Verification
+
+Run the checks the project supports. Examples:
+
+- Node: `npm run typecheck`, `npm run test`, `npm run build`
+- Go: `go vet ./...`, `go test ./...`
+- Python: `pytest`, `mypy .`, `ruff check .`
+- Rust: `cargo check`, `cargo test`
+
+If generated artifacts are tracked, verify they are current before merge:
+
+```bash
+git diff --exit-code -- dist plugins
+```
+
+Use the repo's documented pre-commit or pre-PR checklist when present. Stop on failures.
+
+---
+
+## Step 4: Squash Merge
+
+Draft a clean squash body from the reviewed diff and PR body:
+
+- One-line summary, then bullet points grouped by feature area
+- Plain text; use backticks only for code identifiers
+- No commit dump
+- No agent attribution
+- No release-note overclaiming
+
+Present the body and ask for confirmation. Then run:
+
+```bash
+gh pr merge <N> --squash --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+Let GitHub default the title from the PR title so the squash subject remains `type: summary (#N)`.
+
+---
+
+## Step 5: Post-Merge Cleanup
+
+After a successful merge:
+
+1. Switch to the PR base branch:
+   ```bash
+   git checkout <baseRefName>
+   git pull --ff-only origin <baseRefName>
+   ```
+2. Delete the local feature branch when safe:
+   ```bash
+   git branch -d <headRefName>
+   ```
+3. Confirm the remote branch deletion state from GitHub output or run:
+   ```bash
+   gh pr view <N> --json headRefName,state
+   ```
+4. Log the landing when session state is healthy:
+   ```bash
+   loaf session log "decision(ship): PR #N landed via squash merge"
+   ```
+
+If cleanup fails, report the exact residual state. Do not force-delete without user confirmation.
+
+---
+
+## Step 6: Release Suggestion
+
+After landing, decide whether to suggest `/release`:
+
+- Suggest `/release` when the landed PR completes a coherent batch, user-facing feature, fix train, or release branch.
+- Do not suggest `/release` for every small PR by default.
+- If multiple related PRs are expected, say the PR is landed and can wait for a later batched release.
+
+Use language carefully: the PR is **landed** or **shipped**; it is not **released** until `/release` publishes a version.
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks.
+
+| Hook | Type | When `/ship` Runs |
+|------|------|------------------|
+| `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
+| `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
+| `validate-push` | Advisory | May fire if branch updates are needed before merge |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
+
+Do not disable hooks to force a PR through.
+
+---
+
+## Suggests Next
+
+After a successful ship, suggest `/release` only when the landed work forms a coherent release batch or the user asks to publish.
+
+## Related Skills
+
+- **release** -- Publishes a version from already-landed work
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **foundations** -- Verification, code review, and production readiness
+- **documentation-standards** -- Changelog, docs, and durable prose quality
+- **reflect** -- Updates strategy from significant shipped work

--- a/dist/opencode/skills/wrap/SKILL.md
+++ b/dist/opencode/skills/wrap/SKILL.md
@@ -43,8 +43,8 @@ Responsible session shutdown — everything that needs a conscious model before 
 - All decisions and discoveries from this session are in the journal
 - Uncommitted/unpushed state is surfaced with clear action prompts
 - Stale KB files are flagged if any
-- `## Session Wrap-Up` section written to session file (replaces `## Current State`)
-- `loaf session end --wrap` run after writing the summary
+- `## Session Wrap-Up` section persisted in the canonical session surface; in SQLite mode this is represented by wrapped session/report state rather than an active `.md` file
+- `loaf session end --wrap` run after generating or writing the summary
 - Session status is `done` (session stays open for further journal entries until `SessionEnd` fires)
 
 ## Quick Reference
@@ -65,7 +65,7 @@ These steps require conversation context — only the model can do them.
 
 Before anything else, complete the session journal:
 
-1. **Enrich from conversation log** — run `loaf session enrich` to fill in gaps from the JSONL conversation log. This catches decisions, discoveries, and context that weren't manually logged. If enrichment fails, continue — manual flush is the fallback.
+1. **Check enrichment state** — run `loaf session enrich --json`. In SQLite mode this is expected to report `action: "skipped"` because `loaf session log` is already the canonical journal writer; in markdown-only compatibility mode it summarizes legacy JSONL enrichment status. If enrichment is skipped or fails, continue — manual flush is the fallback.
 2. **Manual review** — review the conversation for anything enrichment missed:
    - Decisions — design choices, trade-offs, direction changes not yet logged as `decision()` entries
    - Discoveries — anything learned that future sessions would benefit from
@@ -76,7 +76,7 @@ Before anything else, complete the session journal:
 
 Run in parallel:
 
-1. **Session journal** — read the active session file for this branch
+1. **Session journal** — run `loaf session list --json`, choose the active session for the current branch or explicit harness session, then run `loaf session show <session-ref> --json`; if SQLite state is unavailable, fall back to the active markdown session file for this branch
 2. **Commits this session** — `git log --oneline` since session start
 3. **Working tree** — `git status --short`
 4. **Unpushed commits** — `git log --oneline origin/<branch>..HEAD`
@@ -91,7 +91,7 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 |-----------|--------|
 | Uncommitted changes | "N file(s) uncommitted — commit, stash, or leave for next session?" |
 | Unpushed commits | "N commit(s) on <branch> not pushed — push now?" |
-| No version bump | "This session shipped work but no release was run — bump version now?" |
+| Release candidate | "This session landed work that may belong in the next release — run `/release` now?" |
 | Stale KB files | "N stale knowledge file(s) — address now or defer?" |
 | Unresolved blocks | "Block on <scope> still open — note for next session?" |
 | No changelog entries | "N commit(s) on branch but `[Unreleased]` is empty — add changelog entries?" |
@@ -100,15 +100,17 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 **Detection logic:**
 - **Changelog entries:** check if the current branch has commits vs the base branch (e.g., `git rev-list --count origin/main..HEAD`) AND `CHANGELOG.md` `[Unreleased]` section has no list items (`^[-*]\s`). If both are true, prompt. **Skip when HEAD is tagged** (post-release state).
 - **Housekeeping:** scan session journal for `skill(housekeeping)` entry. If absent and the session had significant work, suggest it.
-- **Version bump:** scan session journal for `decision(release)` entry. If absent and the session has commits, offer to run `loaf release --bump prerelease --no-gh --yes`.
+- **Release candidate:** scan session journal for `decision(release)` entry. If absent and the session has landed commits, suggest `/release` only when the work forms a coherent release batch.
 
 ### Step 4: Generate Report
 
 Assemble the report per the format below. Omit empty sections — don't show "None" placeholders.
 
-### Step 5: Write Wrap Summary to Session File
+### Step 5: Persist Wrap Summary
 
-Write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
+In SQLite mode, keep the generated wrap summary in the conversation response and let `loaf session end --wrap` persist the mechanical wrapped state. Do not invent or edit a missing active `.md` session file; `loaf session show <session-ref> --json` is the canonical read surface.
+
+In markdown-only compatibility mode, write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
 
 Use the Edit tool to replace `## Current State (...)` and everything below it (up to `## Journal`) with the wrap-up section. The session file layout after wrap should be:
 
@@ -142,7 +144,7 @@ This handles the mechanical bookkeeping:
 
 ## Composability
 
-When called from `/release`, wrap runs the same steps but skips the version bump prompt (release already handles it). The `/release` skill should invoke `/wrap` first, then proceed with release steps.
+When called near `/ship` or `/release`, wrap runs the same steps but keeps PR landing and version publication distinct. `/ship` may wrap a landed PR; `/release` may wrap a published version.
 
 ## Suggests Next
 

--- a/dist/skills/git-workflow/SKILL.md
+++ b/dist/skills/git-workflow/SKILL.md
@@ -47,4 +47,5 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, curating CHANGELOG entries, pre-PR/pre-push/post-merge hooks |
-| Release ritual | `/release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |
+| PR shipping | `/ship` skill | Reviewing, verifying, and squash-merging one PR |
+| Release ritual | `/release` skill | Publishing a version from already-landed work |

--- a/dist/skills/git-workflow/references/commits.md
+++ b/dist/skills/git-workflow/references/commits.md
@@ -169,13 +169,13 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
-- The `/release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
+- The `/ship` skill automates this workflow when ready to squash merge a PR; `/release` publishes a version later from already-landed work
 
 ## Changelog Discipline
 
 `CHANGELOG.md` entries follow Loaf's Common Changelog profile: write for
 humans, communicate the release impact, and curate git history instead of
-copying it. Curate the `[Unreleased]` section before bumping the version so the
+copying it. Curate the `[Unreleased]` section as PRs land so the later
 published release notes read as user-facing prose, not an internal worklog.
 
 ### Drop
@@ -204,9 +204,9 @@ Internal terms that have no meaning outside the team's working context:
 
 ### Auto-generated Entries
 
-When `loaf release --pre-merge` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
+When `loaf release` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
 
-Before approving a release bump, compare `[Unreleased]` against the actual squashed change set and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the branch was organized, it does not belong in the changelog.
+Before approving a release bump, compare `[Unreleased]` against the actual release range and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the work was organized, it does not belong in the changelog.
 
 ## Critical Rules
 
@@ -285,7 +285,7 @@ When developing toward a major version, use pre-release suffixes to mark develop
 
 **Convention:**
 - Set the target version with `-dev.0` when starting a major effort (e.g. `2.0.0-dev.0`)
-- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of work ships — a spec completing, a group of related features landing
+- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of landed work is ready to publish — a completed spec, a related feature group, or a release train
 - Don't bump for every commit — that's what git history is for
 - Strip the suffix (`-dev.N` → `2.0.0`) when all planned work is complete
 - `loaf release` handles all bump types: `prerelease`, `release`, `major`, `minor`, `patch`

--- a/dist/skills/implement/SKILL.md
+++ b/dist/skills/implement/SKILL.md
@@ -333,7 +333,7 @@ After creating session file:
    - Update session file (status: done, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After PR is created and approved, use `/release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
+5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
@@ -352,7 +352,7 @@ After creating session file:
 
 ## Suggests Next
 
-After all tasks are complete, suggest `/release` to merge the work.
+After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release` only when the landed work forms a coherent release batch.
 
 ## Related Skills
 

--- a/dist/skills/release/SKILL.md
+++ b/dist/skills/release/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: release
 description: >-
-  Orchestrates releases: pre-flight checks, version bump via `loaf release`,
-  squash merge, and post-merge cleanup. Use when the user says "release this,"
-  "merge this PR," "ready to merge," or "ship it." Produces version bumps,
-  changelog updates, and merged code. Not for creating PRs (use git-workflow) or
-  reflection (use reflect).
+  Orchestrates standalone releases from already-landed work: release readiness,
+  version selection, changelog curation, release commit, tag, GitHub Release,
+  install verification, and post-release follow-up. Use when the user says "cut
+  a release," "publish a version," "release from main," or asks whether enough
+  landed work should become a release. Not for reviewing or merging a PR (use
+  ship).
 ---
 
 # Release
 
-Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+Publish a coherent version from work that has already landed.
 
 ## Contents
 - Critical Rules
@@ -18,13 +19,13 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 - Quick Reference
 - Topics
 - Context Detection
-- Step 1: Pre-Flight Checks
-- Step 2: Documentation Freshness
-- Step 3: Housekeeping Verification
-- Step 3b: Create PR (if needed)
-- Step 4: Version Bump + Changelog
-- Step 5: Squash Merge
-- Step 6: Post-Merge Cleanup
+- Step 1: Release Readiness
+- Step 2: Change Collection
+- Step 3: Version + Changelog
+- Step 4: Release Execution
+- Step 5: Protected-Branch Handoff
+- Step 6: Publication Verification
+- Step 7: Post-Release Follow-Up
 - Hook Interaction
 - Related Skills
 
@@ -34,308 +35,255 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 
 ## Critical Rules
 
-- **Block on pre-flight failure** -- do not offer to skip any failing check
-- **Use `AskUserQuestion` for all decisions and confirmations** -- version bump type, push approval, merge approval, branch deletion. Never use inline text questions for permission/decision prompts
-- **Version bump before merge** -- this is the skill's reason for existing; never defer to post-merge
-- **Wrap after version bump** -- wrap needs PR# and version to produce a complete session summary
-- **Clean squash body** -- never use the auto-generated commit dump
-- **Orchestrate the full lifecycle** -- if housekeeping or reflect haven't been run, trigger them (with user confirmation via `AskUserQuestion`) rather than just flagging gaps
-- **Detect-first** -- auto-detect PR from branch before asking for a number
-- **Never push without confirmation** -- even after successful version bump
-- **Log release** -- log to session journal after merge: `loaf session log "decision(release): vX.Y.Z shipped via PR #N"`
+- **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
+- **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
+- **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
+- **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
+- **Never push, tag, or publish without confirmation** -- present the exact actions first.
+- **Use `AskUserQuestion` for release decisions when available** -- version bump type, release PR handoff, push/tag/GitHub Release confirmation.
+- **Log release** -- after publication, run `loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"` when session state is available.
 
 ## Verification
 
-- Pre-flight checks (typecheck, test, build) all pass before proceeding
-- Version bump commit exists on the feature branch before merge
-- Squash merge body is a one-line summary followed by bullet points grouped by feature area, not a commit dump
-- Git tag points to the squash merge commit on the base branch, not a branch commit
-- GitHub Release exists with changelog body (not auto-generated notes)
-- Post-merge cleanup completed: base branch pulled, feature branch deleted
+- Release base branch is clean, current, and contains the intended landed PRs
+- Pre-flight checks pass before versioning or publication
+- Changelog entries are curated user-facing prose, not commit or PR-title dumps
+- Version files, changelog heading, git tag, and GitHub Release all agree
+- Tag points at the released base-branch commit or release commit, not an abandoned feature branch
+- Downstream install path is verified when applicable, especially Homebrew for Loaf releases
 
 ## Quick Reference
 
 | Step | Gate | Blocking? |
 |------|------|-----------|
-| Pre-Flight | typecheck + test + build pass | Yes |
-| Doc Freshness | User reviews stale docs | No (user decides) |
-| Housekeeping | Spec/tasks archived, CHANGELOG ready | No (user decides) |
-| PR Creation | Only if no PR exists yet | Yes (if needed) |
-| Version Bump | User confirms bump type; `loaf release --pre-merge` | Yes |
-| Wrap | Session summary (after version bump, has PR# + version) | Yes |
-| Squash Merge | User approves body text | Yes |
-| Post-Merge | `loaf release --post-merge` (tag, GH Release, cleanup) | Yes |
+| Readiness | clean/current base branch, no unresolved release collisions | Yes |
+| Change Collection | landed work since last tag grouped into release themes | Yes |
+| Version + Changelog | bump selected, notes curated, files updated | Yes |
+| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Verification | release and install paths checked | Yes |
+| Follow-Up | reflect/housekeeping suggested when useful | No |
 
 ## Topics
 
 | Topic | Use When |
 |-------|----------|
-| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
+| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
 
 ## Context Detection
 
-Before anything, detect where we are:
+Before anything, establish the release surface:
 
-1. **Get current branch and repo default branch:**
+1. Get current branch and repo default branch:
    ```bash
    git branch --show-current
    gh repo view --json defaultBranchRef -q .defaultBranchRef.name
    ```
-2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
-3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
-4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
+3. Verify the current branch:
+   - If already on the release base, continue.
+   - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
+   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
+4. Find the previous release tag:
    ```bash
-   gh pr view --json number,title,url,headRefName,baseRefName
+   git describe --tags --abbrev=0
    ```
-5. If no PR exists for this branch, note `pr_exists = false` and set `baseRefName` to the repo default branch. Continue — the PR will be created in Step 3b.
-6. If PR exists, **save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
-7. Confirm the PR identity (or intent to create one) with the user before proceeding.
-
----
-
-## Step 1: Pre-Flight Checks (BLOCKING)
-
-Run these and **BLOCK on any failure** — do not offer to skip.
-
-### Detect project type
-
-Inspect the repo to determine available checks:
-- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
-- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config; if the project is uv-managed, expect release artifact refresh to run `uv sync`
-- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
-- **Go** (`go.mod`): `go vet`, `go test`
-
-### Run checks
-
-Run whichever checks the project supports. Examples for a Node project:
-1. `npm run typecheck` (if the script exists)
-2. `npm run test` (if the script exists)
-3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
-
-For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
-
-**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
-
-On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
-
----
-
-## Step 2: Documentation Freshness
-
-Check whether documentation is stale relative to the branch's changes:
-
-1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
-2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
-3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
-4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
-
-Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
-
----
-
-## Step 3: Housekeeping
-
-Check each item. If missing, **offer to run it** (with user confirmation) rather than just flagging it.
-
-1. **Spec status**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`. If not, offer to update it.
-2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived. If found, offer to run `loaf task archive`.
-3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
-4. **Journal flushed**: Review conversation for unrecorded decisions/discoveries. Log them now — this is the last chance before wrap.
-
-Present the results as a checklist. Use `AskUserQuestion` for any decisions or approvals.
-
-**Note:** Wrap (`/wrap`) runs AFTER version bump (Step 4b) so it can reference the PR# and version in the session summary. Reflection runs post-merge (Step 6).
-
----
-
-## Step 3b: Create PR (if needed)
-
-**Only run this step if `pr_exists = false` from Context Detection.**
-
-The PR must be created BEFORE the version bump so that `[Unreleased]` changelog entries are still present (advisory hooks check for this).
-
-1. Push the branch if not already pushed.
-2. Create the PR following the format in [git-workflow/references/commits.md](../git-workflow/references/commits.md) (Pull Request Format section).
-3. Save the PR number and `baseRefName` for subsequent steps.
-
----
-
-## Step 4: Version Bump + Changelog (on feature branch)
-
-This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
-
-### Check for existing changelog entries
-
-Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
-
-- **If curated entries exist** → Use the **Curated path** (preserve them)
-- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
-
-### Curated path (preferred when entries exist)
-
-The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
-
-**Review curated entries for quality before bumping:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Follow Loaf's Common Changelog profile: imperative, self-describing,
-  one-line entries grouped as `Changed`, `Added`, `Removed`, `Fixed`
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Include the best public reference when available, such as a PR, issue, ADR, release, or commit link
-
-1. Run `loaf release --pre-merge --dry-run` to get the **suggested bump type** and **current version** (the `--pre-merge` flag auto-detects the base branch — see [Why `--pre-merge`?](#why---pre-merge) below).
-2. Present the bump suggestion to the user. They may accept or override.
-3. Once confirmed, run:
+5. Gather the candidate release range:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git log --oneline <last-tag>..HEAD
+   git diff --stat <last-tag>..HEAD
    ```
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it) and re-insert a fresh empty `## [Unreleased]` section above
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+---
 
-### Generated path (when no entries exist)
+## Step 1: Release Readiness
 
-When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+Run release pre-flight checks before editing release files:
 
-**After generation, review and rewrite entries before committing:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Rewrite generated commit text into Loaf's Common Changelog profile
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Keep entries concise but descriptive enough to understand the change without reading the diff
-
-1. Run `loaf release --pre-merge --dry-run` to preview:
-   - Current version and suggested bump type
-   - Generated changelog section from **this branch's commits only**
-   - Which version files will be updated
-
-   The `--pre-merge` flag scopes the commit analysis to `<auto-detected base>..HEAD`, so only commits on the feature branch are considered.
-
-2. Present the preview to the user. They may:
-   - Accept the suggested bump type
-   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-   - Edit the changelog content conversationally
-
-3. Once the user confirms, run:
+1. Ensure worktree is clean:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git status --short
    ```
+2. Ensure the release base is current:
+   ```bash
+   git fetch --tags origin
+   git status --branch --short
+   ```
+3. Check for existing tag or GitHub Release collisions for the target version once known:
+   ```bash
+   git tag --list vX.Y.Z
+   gh release view vX.Y.Z
+   ```
+4. Run project checks:
+   - Node: `npm run typecheck`, `npm run test`, `npm run build` when scripts exist
+   - Go: `go vet ./...`, `go test ./...` when `go.mod` exists
+   - Python: `pytest`, `mypy .`, `ruff check .` when configured
+   - Rust: `cargo check`, `cargo test` when `Cargo.toml` exists
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Generate and insert changelog section from branch commits (adding a fresh `[Unreleased]`)
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+If no checks are detected, warn explicitly. If a check fails, stop and fix before release.
 
-### After either path
+---
 
-Before pushing, verify generated artifacts are still current. This matters if
-any fix commits landed after the release bump commit:
+## Step 2: Change Collection
+
+Collect landed work since the last release and group it for release notes.
+
+1. Inspect commits:
+   ```bash
+   git log --first-parent --oneline <last-tag>..HEAD
+   git log --oneline <last-tag>..HEAD
+   ```
+2. Inspect merged PRs when GitHub is available:
+   ```bash
+   gh pr list --state merged --base <base> --json number,title,mergedAt,url
+   ```
+3. Group changes by user-facing outcome:
+   - `CR-*` change bundle, when referenced
+   - spec or task family, when public enough to be useful
+   - feature/fix/documentation/build themes
+   - operational release work, when it affects users or maintainers
+4. Drop noise:
+   - purely internal task/session labels
+   - reverted work that is not present in `HEAD`
+   - individual commit mechanics that collapse into one user-facing change
+
+Present the grouped release contents before choosing the bump.
+
+---
+
+## Step 3: Version + Changelog
+
+Choose the bump and curate the changelog from the grouped landed work.
+
+1. Run a dry run:
+   ```bash
+   loaf release --dry-run
+   ```
+   Use `--base <ref>` when the project expects a non-default release base.
+2. Present:
+   - current version
+   - proposed next version
+   - detected version files
+   - release actions the CLI would perform
+   - draft changelog entries
+3. Curate `CHANGELOG.md` before publishing:
+   - write from the upgrading user's perspective
+   - group under Common Changelog categories: `Changed`, `Added`, `Removed`, `Fixed`
+   - use one self-describing line per meaningful change
+   - include public PR, issue, ADR, release, or commit links when helpful
+   - avoid dumping commit subjects, task IDs, session mechanics, or internal gate language
+4. Confirm the bump type: `prerelease`, `release`, `major`, `minor`, or `patch`.
+
+---
+
+## Step 4: Release Execution
+
+For a direct release from the base branch, run:
+
+```bash
+loaf release --bump <type> --yes
+```
+
+This should:
+
+1. Update version files
+2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
+3. Reinsert a fresh empty `[Unreleased]` section
+4. Run configured release artifact commands
+5. Create the release commit
+6. Create/push the release tag
+7. Create the GitHub Release when enabled
+
+After execution, verify generated artifacts are current:
 
 ```bash
 npm run build
-git diff --exit-code -- plugins/loaf/bin/loaf dist content/skills/cli-reference/SKILL.md
+git diff --exit-code -- dist plugins content/skills/cli-reference/SKILL.md
 ```
 
-If the diff check fails, commit the regenerated artifacts with the source change
-that made them stale, then rerun the check.
-
-Push to the feature branch (**with user confirmation**).
-
-### Why `--pre-merge`?
-
-`--pre-merge` bundles the canonical pre-merge flag set so the skill no longer needs to spell each one out:
-
-- Equivalent to `--no-tag --no-gh --base <auto-detected>` (tag and GH release land post-merge in Step 6, not on the soon-to-be-squashed feature commit).
-- Auto-detects the base ref via a 4-step priority: explicit `--base <ref>` → open PR's `baseRefName` → `git config loaf.release.base` → repo default branch. Run `loaf release --help` to see the full priority order.
-- Pass `--base <ref>` explicitly to override auto-detection (useful for non-default base branches like `release/1.0` when no PR exists yet).
-- `--yes` skips the CLI confirmation prompt — the skill already confirmed with the user conversationally.
+Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
 ---
 
-## Step 4b: Wrap Session
+## Step 5: Protected-Branch Handoff
 
-Run `/wrap` AFTER version bump so the session summary can reference the PR# and final version.
+If branch protection prevents direct release commits on the base branch:
 
-The wrap skill will:
-1. Flush any remaining journal entries
-2. Gather git state (commits, working tree, unpushed)
-3. Generate the `## Session Wrap-Up` report
-4. Write it to the session file (replaces `## Current State`)
-5. Run `loaf session end --wrap` to set status to `complete`
+1. Create a dedicated release branch.
+2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+3. Open a release PR with a concise release-focused body.
+4. Hand the PR to `/ship` for review and landing.
+5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
 
-When called from `/release`, wrap skips the version bump and changelog prompts (already handled).
+Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
 ---
 
-## Step 5: Squash Merge
+## Step 6: Publication Verification
 
-1. Draft a clean squash body from the branch's commit history and PR description. Descriptive, not verbose:
-   - One-line summary, then bullet points grouped by feature area
-   - Plain text — no bold, no headings, only backticks for `code`
-   - Not a paragraph dump, not a commit log
-2. Present the draft to the user for review. They may edit it.
-3. Execute (after user confirms):
+After publishing, verify the public release state:
+
+1. Confirm tag location:
    ```bash
-   gh pr merge <N> --squash --body "$(cat <<'EOF'
-   <body>
-   EOF
-   )"
+   git show --stat vX.Y.Z
    ```
-4. Let GitHub default the title (`PR title (#N)`).
-5. NEVER use `--auto` or the automatic squash description that dumps all commits.
+2. Confirm GitHub Release:
+   ```bash
+   gh release view vX.Y.Z
+   ```
+3. Confirm package or installer availability when applicable:
+   - npm: `npm view <package> version`
+   - Homebrew: `brew update && brew info <tap>/<formula>`
+   - project-specific deploy or artifact registry checks
+4. For Loaf/Homebrew, report readiness only after the GitHub release exists, assets are uploaded, the tap formula is updated, and tap CI has passed.
+
+If publication partially completes, do not retag casually. Name the exact state and continue with the smallest repair or patch release path.
 
 ---
 
-## Step 6: Post-Merge Cleanup
+## Step 7: Post-Release Follow-Up
 
-After successful merge, run a single command:
+After verification:
 
-```bash
-loaf release --post-merge
-```
-
-This verifies HEAD state against an 8-point guardrail checklist (clean worktree, on the base branch with the merge commit at HEAD, readable HEAD subject for optional PR-number lookup, version-file agreement, CHANGELOG section present, no pre-existing tag or GH release, HEAD untagged). The squash subject should describe the shipped work (`feat:`, `fix:`, etc.); post-merge derives the release version from version files and `CHANGELOG.md`, not from a `chore: release` subject. Once all guardrails pass it tags the squash merge commit, pushes the tag, creates the GitHub Release from the matching `## [X.Y.Z]` CHANGELOG section, pulls the base branch, and best-effort deletes the local + remote feature branch. Manual `git tag`, `git push --tags`, `gh release create`, `git checkout`, `git pull --rebase`, and `git branch -d` are no longer needed — the flag subsumes them.
-
-If anything aborts:
-
-1. Read the actionable error message — each guardrail failure names the exact manual fix (e.g., "tag v1.2.3 already exists locally — run `git tag -d v1.2.3` and rerun").
-2. Perform the named fix.
-3. Rerun `loaf release --post-merge`. The command is idempotent on stateless reads, so reruns after a transient `gh` failure or a half-completed prior run pick up exactly where they left off.
-
-After the release finalizes, **run `/reflect`** — already on the base branch. Reflect looks back at the shipped work and updates strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) with learnings. Use `AskUserQuestion` to confirm before running.
+1. Log the release decision when session state is healthy:
+   ```bash
+   loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"
+   ```
+2. Suggest `/reflect` when the release produced durable product or workflow learnings.
+3. Suggest `/housekeeping` when session artifacts, release branches, or temporary reports need cleanup.
+4. Keep future-work discoveries out of the release notes; capture them as tasks, ideas, or sparks instead.
 
 ---
 
 ## Hook Interaction
 
-This skill coexists with existing hooks. Git workflow hooks are **advisory** (warn but don't block); security hooks remain blocking.
+This skill coexists with existing hooks. Git workflow hooks are advisory unless
+configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `workflow-pre-pr` (command) | Advisory | Fires on `gh pr create`. Reminds about CHANGELOG — redundant when release skill manages entries. |
-| `workflow-pre-merge` (instruction) | Advisory | Fires on `gh pr merge`. Reminds about squash conventions — redundant since body is already crafted. |
-| `workflow-post-merge` (instruction) | Advisory | Fires after merge. Outputs checklist the skill already handled. |
-| `validate-push` (command) | Advisory | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
-| `check-secrets` (command) | **Blocking** | Security gate. Always fires, always respected. |
+| `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
+| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
+| `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
 
-Do not modify, disable, or skip these hooks.
+Do not disable hooks to force a release through.
 
 ---
 
 ## Suggests Next
 
-After a successful release, suggest `/housekeeping` if session artifacts need archiving.
+After a successful release, suggest `/reflect` for durable learnings and `/housekeeping` if temporary release artifacts need attention.
 
 ## Related Skills
 
-- **implement** — Does the work and housekeeping; `/release` handles the merge afterward
-- **reflect** — Suggested post-merge if session has learnings
-- **git-workflow** — Conventions this skill enforces
-- **housekeeping** — Handles artifact hygiene; `/release` verifies it was done
+- **ship** -- Reviews, verifies, and lands a PR before it becomes release input
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **documentation-standards** -- Changelog and release-note quality
+- **reflect** -- Updates strategy from shipped/released learnings
+- **housekeeping** -- Cleans up completed session and release artifacts

--- a/dist/skills/ship/SKILL.md
+++ b/dist/skills/ship/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: ship
+description: >-
+  Reviews, verifies, and lands one pull request. Use when the user says "ship
+  it," "merge this PR," "ready to merge," "land this branch," or asks for a
+  final merge gate. Produces a reviewed, squash-merged PR and post-merge
+  cleanup. Not for version bumps, tags, GitHub Releases, or install verification
+  (use release).
+---
+
+# Ship
+
+Review, verify, and land one PR. Shipping is the PR gate; releasing is the version-publication gate.
+
+## Contents
+- Critical Rules
+- Verification
+- Quick Reference
+- Topics
+- Context Detection
+- Step 1: PR Readiness
+- Step 2: Evidence Review
+- Step 3: Local Verification
+- Step 4: Squash Merge
+- Step 5: Post-Merge Cleanup
+- Step 6: Release Suggestion
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Critical Rules
+
+- **Ship is not release** -- do not bump versions, create tags, publish GitHub Releases, or verify package installation here.
+- **Keep PR quality local** -- smaller PRs are welcome, but `/ship` must still verify correctness before merge.
+- **Detect-first** -- auto-detect the PR from the current branch before asking for a PR number.
+- **Review before merge** -- inspect code, docs, tests, changelog, PR body, and CI state before approval.
+- **Never merge without explicit confirmation** -- present the PR, checks, findings, and squash body first.
+- **Clean squash body** -- write an intentional squash commit body; never accept the automatic commit dump.
+- **Keep landed and released distinct** -- after merge, describe the PR as landed or shipped, not necessarily released.
+- **Log shipping** -- after merge, run `loaf session log "decision(ship): PR #N landed via squash merge"` when session state is available.
+
+## Verification
+
+- PR identity, base branch, and head branch are confirmed
+- CI status is passing or the user explicitly accepts named non-blocking checks
+- Relevant local checks pass or failures are fixed before merge
+- PR body and durable docs do not overclaim relative to the diff
+- Squash commit title/body are clean, conventional, and user-facing
+- Base branch is updated after merge and the feature branch cleanup state is known
+
+## Quick Reference
+
+| Step | Gate | Blocking? |
+|------|------|-----------|
+| PR Readiness | PR exists, target base known, CI state reviewed | Yes |
+| Evidence Review | findings resolved or explicitly accepted | Yes |
+| Local Verification | relevant checks pass | Yes |
+| Squash Merge | user approves body text | Yes |
+| Cleanup | base pulled, branch deletion handled | No |
+| Release Suggestion | enough landed work may justify `/release` | No |
+
+## Topics
+
+| Topic | Use When |
+|-------|----------|
+| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
+
+---
+
+## Context Detection
+
+Before anything, detect the PR surface:
+
+1. Get current branch and repo default branch:
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. Parse `$ARGUMENTS`: may be a PR number, PR URL, branch name, or empty.
+3. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName,state,mergeStateStatus,isDraft
+   ```
+4. If no PR exists for the current branch, stop and offer to create one via `git-workflow` rather than silently merging a branch.
+5. If already on the default branch, stop. There is no PR to ship from the current branch.
+6. Confirm PR identity with the user before merge actions.
+
+---
+
+## Step 1: PR Readiness
+
+Inspect the PR's declared state:
+
+```bash
+gh pr view <N> --json number,title,body,url,headRefName,baseRefName,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+Block or pause when:
+
+- PR is draft
+- merge state is dirty or blocked
+- required checks are failing or pending
+- review decision is changes requested
+- branch is out of date and the project requires update before merge
+
+If checks are unavailable, say so explicitly and compensate with local verification.
+
+---
+
+## Step 2: Evidence Review
+
+Review the landing diff and durable prose together:
+
+1. Gather diff context:
+   ```bash
+   git fetch origin <baseRefName>
+   git diff --stat origin/<baseRefName>...HEAD
+   git diff --name-only origin/<baseRefName>...HEAD
+   ```
+2. Read the PR title/body and changed docs that make behavior claims.
+3. Check for drift:
+   - PR body claims features that are not in the diff
+   - changelog entries mention unreleased or unrelated behavior
+   - docs describe future work as already shipped
+   - comments or runbooks use stale internal vocabulary
+4. Fix blocking drift before merge. For non-blocking polish, name it and let the user decide.
+
+For high-risk PRs, use the project's review skill or read-only review flow before proceeding.
+
+---
+
+## Step 3: Local Verification
+
+Run the checks the project supports. Examples:
+
+- Node: `npm run typecheck`, `npm run test`, `npm run build`
+- Go: `go vet ./...`, `go test ./...`
+- Python: `pytest`, `mypy .`, `ruff check .`
+- Rust: `cargo check`, `cargo test`
+
+If generated artifacts are tracked, verify they are current before merge:
+
+```bash
+git diff --exit-code -- dist plugins
+```
+
+Use the repo's documented pre-commit or pre-PR checklist when present. Stop on failures.
+
+---
+
+## Step 4: Squash Merge
+
+Draft a clean squash body from the reviewed diff and PR body:
+
+- One-line summary, then bullet points grouped by feature area
+- Plain text; use backticks only for code identifiers
+- No commit dump
+- No agent attribution
+- No release-note overclaiming
+
+Present the body and ask for confirmation. Then run:
+
+```bash
+gh pr merge <N> --squash --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+Let GitHub default the title from the PR title so the squash subject remains `type: summary (#N)`.
+
+---
+
+## Step 5: Post-Merge Cleanup
+
+After a successful merge:
+
+1. Switch to the PR base branch:
+   ```bash
+   git checkout <baseRefName>
+   git pull --ff-only origin <baseRefName>
+   ```
+2. Delete the local feature branch when safe:
+   ```bash
+   git branch -d <headRefName>
+   ```
+3. Confirm the remote branch deletion state from GitHub output or run:
+   ```bash
+   gh pr view <N> --json headRefName,state
+   ```
+4. Log the landing when session state is healthy:
+   ```bash
+   loaf session log "decision(ship): PR #N landed via squash merge"
+   ```
+
+If cleanup fails, report the exact residual state. Do not force-delete without user confirmation.
+
+---
+
+## Step 6: Release Suggestion
+
+After landing, decide whether to suggest `/release`:
+
+- Suggest `/release` when the landed PR completes a coherent batch, user-facing feature, fix train, or release branch.
+- Do not suggest `/release` for every small PR by default.
+- If multiple related PRs are expected, say the PR is landed and can wait for a later batched release.
+
+Use language carefully: the PR is **landed** or **shipped**; it is not **released** until `/release` publishes a version.
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks.
+
+| Hook | Type | When `/ship` Runs |
+|------|------|------------------|
+| `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
+| `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
+| `validate-push` | Advisory | May fire if branch updates are needed before merge |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
+
+Do not disable hooks to force a PR through.
+
+---
+
+## Suggests Next
+
+After a successful ship, suggest `/release` only when the landed work forms a coherent release batch or the user asks to publish.
+
+## Related Skills
+
+- **release** -- Publishes a version from already-landed work
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **foundations** -- Verification, code review, and production readiness
+- **documentation-standards** -- Changelog, docs, and durable prose quality
+- **reflect** -- Updates strategy from significant shipped work

--- a/dist/skills/wrap/SKILL.md
+++ b/dist/skills/wrap/SKILL.md
@@ -41,8 +41,8 @@ Responsible session shutdown — everything that needs a conscious model before 
 - All decisions and discoveries from this session are in the journal
 - Uncommitted/unpushed state is surfaced with clear action prompts
 - Stale KB files are flagged if any
-- `## Session Wrap-Up` section written to session file (replaces `## Current State`)
-- `loaf session end --wrap` run after writing the summary
+- `## Session Wrap-Up` section persisted in the canonical session surface; in SQLite mode this is represented by wrapped session/report state rather than an active `.md` file
+- `loaf session end --wrap` run after generating or writing the summary
 - Session status is `done` (session stays open for further journal entries until `SessionEnd` fires)
 
 ## Quick Reference
@@ -63,7 +63,7 @@ These steps require conversation context — only the model can do them.
 
 Before anything else, complete the session journal:
 
-1. **Enrich from conversation log** — run `loaf session enrich` to fill in gaps from the JSONL conversation log. This catches decisions, discoveries, and context that weren't manually logged. If enrichment fails, continue — manual flush is the fallback.
+1. **Check enrichment state** — run `loaf session enrich --json`. In SQLite mode this is expected to report `action: "skipped"` because `loaf session log` is already the canonical journal writer; in markdown-only compatibility mode it summarizes legacy JSONL enrichment status. If enrichment is skipped or fails, continue — manual flush is the fallback.
 2. **Manual review** — review the conversation for anything enrichment missed:
    - Decisions — design choices, trade-offs, direction changes not yet logged as `decision()` entries
    - Discoveries — anything learned that future sessions would benefit from
@@ -74,7 +74,7 @@ Before anything else, complete the session journal:
 
 Run in parallel:
 
-1. **Session journal** — read the active session file for this branch
+1. **Session journal** — run `loaf session list --json`, choose the active session for the current branch or explicit harness session, then run `loaf session show <session-ref> --json`; if SQLite state is unavailable, fall back to the active markdown session file for this branch
 2. **Commits this session** — `git log --oneline` since session start
 3. **Working tree** — `git status --short`
 4. **Unpushed commits** — `git log --oneline origin/<branch>..HEAD`
@@ -89,7 +89,7 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 |-----------|--------|
 | Uncommitted changes | "N file(s) uncommitted — commit, stash, or leave for next session?" |
 | Unpushed commits | "N commit(s) on <branch> not pushed — push now?" |
-| No version bump | "This session shipped work but no release was run — bump version now?" |
+| Release candidate | "This session landed work that may belong in the next release — run `/release` now?" |
 | Stale KB files | "N stale knowledge file(s) — address now or defer?" |
 | Unresolved blocks | "Block on <scope> still open — note for next session?" |
 | No changelog entries | "N commit(s) on branch but `[Unreleased]` is empty — add changelog entries?" |
@@ -98,15 +98,17 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 **Detection logic:**
 - **Changelog entries:** check if the current branch has commits vs the base branch (e.g., `git rev-list --count origin/main..HEAD`) AND `CHANGELOG.md` `[Unreleased]` section has no list items (`^[-*]\s`). If both are true, prompt. **Skip when HEAD is tagged** (post-release state).
 - **Housekeeping:** scan session journal for `skill(housekeeping)` entry. If absent and the session had significant work, suggest it.
-- **Version bump:** scan session journal for `decision(release)` entry. If absent and the session has commits, offer to run `loaf release --bump prerelease --no-gh --yes`.
+- **Release candidate:** scan session journal for `decision(release)` entry. If absent and the session has landed commits, suggest `/release` only when the work forms a coherent release batch.
 
 ### Step 4: Generate Report
 
 Assemble the report per the format below. Omit empty sections — don't show "None" placeholders.
 
-### Step 5: Write Wrap Summary to Session File
+### Step 5: Persist Wrap Summary
 
-Write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
+In SQLite mode, keep the generated wrap summary in the conversation response and let `loaf session end --wrap` persist the mechanical wrapped state. Do not invent or edit a missing active `.md` session file; `loaf session show <session-ref> --json` is the canonical read surface.
+
+In markdown-only compatibility mode, write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
 
 Use the Edit tool to replace `## Current State (...)` and everything below it (up to `## Journal`) with the wrap-up section. The session file layout after wrap should be:
 
@@ -140,7 +142,7 @@ This handles the mechanical bookkeeping:
 
 ## Composability
 
-When called from `/release`, wrap runs the same steps but skips the version bump prompt (release already handles it). The `/release` skill should invoke `/wrap` first, then proceed with release steps.
+When called near `/ship` or `/release`, wrap runs the same steps but keeps PR landing and version publication distinct. `/ship` may wrap a landed PR; `/release` may wrap a published version.
 
 ## Suggests Next
 

--- a/docs/decisions/ADR-016-artifact-storage-trichotomy.md
+++ b/docs/decisions/ADR-016-artifact-storage-trichotomy.md
@@ -1,0 +1,100 @@
+---
+id: ADR-016
+title: "Artifact Storage Trichotomy — Nouns in SQLite, Verbs in Git, Markdown is a Render"
+status: Accepted
+date: 2026-06-24
+supersedes: null
+superseded_by: null
+---
+
+# ADR-016: Artifact Storage Trichotomy — Nouns in SQLite, Verbs in Git, Markdown is a Render
+
+## Context
+
+SPEC-040 made one global SQLite database the canonical store for operational **metadata**, with
+markdown demoted to compatibility/export. The WS-B program (SPEC-043 and siblings) extends this to
+artifact **bodies**. As that work was scoped, two independent sessions — the loaf restructuring
+program and a parallel session migrating a large "thermonuclear" code-review pipeline's output into
+a project's SQLite — hit the same unanswered question: *what, exactly, belongs in the database, and
+what does not?*
+
+That review pipeline made the trap concrete. It produced three different kinds of artifact:
+
+- **26 JSON files** — structured findings, verdicts, dedup/index/state (row-shaped data).
+- **282 markdown files** — the report, per-verdict write-ups, maps, critic, fact-check (narrative).
+- **8 scripts** — stint runners, dedup/aggregate/synthesis generators (executable code).
+
+Treating all of these as "a report to store" conflates three categories with fundamentally
+different properties. Code cannot be diffed, linted, reviewed, or `git blame`d inside a database.
+A markdown narrative cannot be queried or filtered. Only the structured rows can be listed,
+filtered, and exported. Without a stated rule, implementers will stuff scripts into SQLite, store
+reports as opaque blobs, and lose the ability to query the substance — defeating the whole reason
+for centralizing state.
+
+## Decision
+
+Every Loaf-managed artifact resolves into exactly one of three categories, each with a fixed home:
+
+1. **Nouns → SQLite rows (the things you query).**
+   Entities you `list / filter / show / link / export`: reports, **findings**, **verdicts**,
+   sessions, specs, tasks, ideas, sparks, relationships, **runs**. These are the source of truth
+   and live as structured rows in the global SQLite database.
+
+2. **Verbs → git, never SQLite (the code you run).**
+   Generator scripts, orchestration/stint runners, build tooling. Code lives in git — either as
+   project-local tooling or graduated into loaf itself as a real command — because it must be
+   diffable, lintable, reviewable, and `git blame`-able. **SQLite stores a provenance pointer**
+   (`run → {generator ref, version/hash, timestamp}`), **never the script body.**
+
+3. **Renders → derived on demand (markdown is not a store).**
+   Markdown, JSON, CSV, HTML are *projections* produced from the nouns via a `--format` contract.
+   Markdown is one output target among several, never the source of truth. A committed markdown
+   render (e.g. a spec/ADR in git for PR review) is a deterministic projection guarded by a drift
+   check, not an authored original.
+
+The boundary test: **if you would want to query, filter, or relate it → noun (SQLite). If you would
+want to diff, review, or execute it → verb (git). If it is a formatted presentation of a noun →
+render (on demand).**
+
+## Consequences
+
+### Positive
+- A citable rule that prevents code from being stuffed into the database and reports from being
+  stored as un-queryable blobs.
+- Forces the entity model to be honest: a report is `report → finding → verdict` rows, not a text
+  blob (SPEC-054); orchestration is a queryable `run`, not a pile of state files.
+- Makes "stored in SQLite" actually deliver the goal (filter/export holistically) instead of just
+  relocating opacity.
+- Keeps generators reviewable and version-controlled while still recording, in the DB, exactly
+  which generator+version produced an output.
+
+### Negative
+- Requires a deeper entity model (finding/verdict/run) and a render subsystem, not just a body
+  column — more schema and more CLI surface.
+- A two-place story for some artifacts (rows in SQLite + generator code in git) that must be tied
+  together by provenance pointers, which adds bookkeeping.
+
+### Neutral
+- Markdown remains everywhere, but reframed as a `--format` target rather than the canonical store.
+- Governs the WS-B program: SPEC-043 (bodies), SPEC-044 (durable-doc git render + drift gate),
+  SPEC-050 (orchestration scripts graduate to git/loaf, not the DB), SPEC-053 (migration imports
+  outputs + provenance, never code), and SPEC-054 (finding/verdict/run decomposition + the
+  `--format` export contract). Extends SPEC-040 ("markdown is compatibility/export"); complements
+  ADR-013 (where state physically lives / worktree resolution).
+
+## Alternatives Considered
+
+### Store whole reports (and their generators) as blobs in SQLite
+Trivial to migrate, but opaque: you cannot filter findings by severity/dimension, cannot diff or
+review a generator, and cannot `git blame` logic. It relocates the artifacts without delivering the
+query/export capability that justified centralizing them. Rejected — it is the trap this ADR exists
+to forbid.
+
+### Keep everything as files in git (no SQLite bodies at all)
+The status quo before WS-B. Loses cross-project querying, branch-immune reads, and full-text
+search — the motivations for SPEC-040/043. Rejected.
+
+### A single "documents" table that stores any artifact body as text
+Uniform but structureless — it cannot express that a report *has* findings that *have* verdicts, so
+the high-value query/filter/export operations remain impossible. Rejected in favor of a typed noun
+model (SPEC-054).

--- a/docs/knowledge/hook-system.md
+++ b/docs/knowledge/hook-system.md
@@ -87,7 +87,7 @@ Five hooks run natively via `loaf check --hook <id>` in `internal/cli/check.go`:
 | `workflow-pre-pr` | git-workflow | Bash | Advisory | Checks PR format, CHANGELOG entry, unpushed base-branch commits |
 | `validate-commit` | orchestration | Bash | Yes (failClosed) | Validates Conventional Commits format, blocks AI attribution |
 
-Security hooks (`check-secrets`, `security-audit`) and `validate-commit` use `failClosed: true`. Workflow hooks (`validate-push`, `workflow-pre-pr`) are advisory (`blocking: false`) -- they warn but do not block, since the release skill orchestrates the same checks.
+Security hooks (`check-secrets`, `security-audit`) and `validate-commit` use `failClosed: true`. Workflow hooks (`validate-push`, `workflow-pre-pr`) are advisory (`blocking: false`) -- they warn but do not block, since `/ship` and `/release` orchestrate the same checks at their respective PR-landing and publication gates.
 
 ## Instruction Hooks
 

--- a/docs/knowledge/skill-architecture.md
+++ b/docs/knowledge/skill-architecture.md
@@ -83,9 +83,9 @@ Skills load into profiles at spawn time. What an agent *can do* is fixed by prof
 | Category | `user-invocable` | Examples |
 |----------|:-:|---------|
 | Reference/Knowledge | `false` | python-development, database-design, foundations, git-workflow, orchestration |
-| Workflow/Process | `true` (default) | implement, research, shape, breakdown, release, housekeeping, wrap |
+| Workflow/Process | `true` (default) | implement, research, shape, breakdown, ship, release, housekeeping, wrap |
 
-32 skills total: 16 workflow, 16 reference/knowledge.
+33 skills total: 17 workflow, 16 reference/knowledge.
 
 ## Cross-References
 

--- a/plugins/loaf/hooks/instructions/post-merge.md
+++ b/plugins/loaf/hooks/instructions/post-merge.md
@@ -1,4 +1,4 @@
-**Note:** If you used `/release`, these steps were already handled by the skill. This checklist is for manual merges.
+**Note:** If you used `/ship`, these steps were already handled by the skill. This checklist is for manual merges.
 
 # Pre-Merge Checklist
 
@@ -12,27 +12,19 @@ Complete these steps on the feature branch before creating the PR.
    ```
    Archive session file (status: done, `archived_at`, `archived_by`, move to archive/).
 
-2. **Update CHANGELOG.md:**
-   Add entries under `[Unreleased]` describing what the PR ships.
+2. **Update CHANGELOG.md when the PR has release-facing impact:**
+   Add curated entries under `[Unreleased]` describing what the PR lands. Do not move entries to a versioned section here; `/release` publishes the batch later.
 
-3. **Bump version** in `package.json`:
-   - `feat` commit -> minor bump (or dev bump if pre-release)
-   - `fix` commit -> patch bump
-   - Breaking change -> major bump
-
-4. **Move `[Unreleased]` to versioned section:**
-   `## [X.Y.Z] - YYYY-MM-DD`
-
-5. **Rebuild all targets:**
+3. **Rebuild all targets:**
    ```
    npx loaf build
    ```
 
-6. **Commit and push** the changelog + version + archived artifacts to the PR branch.
+4. **Commit and push** the changelog and generated artifacts to the PR branch.
 
-7. **Create PR** with `gh pr create` — title + summary + test plan.
+5. **Create PR** with `gh pr create` — title + summary + test plan.
 
-8. **Squash merge** with a clean commit body:
+6. **Squash merge** with a clean commit body:
    - Let GitHub default the title: `PR title (#N)`
    - Write a concise 2-4 sentence summary as `--body` (use a HEREDOC)
    - **Never** use the automatic squash description that dumps all individual commit messages
@@ -55,3 +47,5 @@ Complete these steps on main after merging.
    ```
 
 3. **Suggest reflection** if the session had key decisions or learnings.
+
+4. **Suggest `/release` only when appropriate** — if this PR completes a coherent batch or release branch, publish from the base branch after the landed work is present there.

--- a/plugins/loaf/hooks/instructions/pre-pr-checklist.md
+++ b/plugins/loaf/hooks/instructions/pre-pr-checklist.md
@@ -29,7 +29,7 @@ If `CHANGELOG.md` does not exist, create it first:
 
 This project follows [Common Changelog](https://common-changelog.org/) and
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). `## [Unreleased]`
-is a workflow staging section for curated entries before release.
+is a workflow staging section for curated entries that land with PRs before a later release.
 
 ## [Unreleased]
 

--- a/plugins/loaf/skills/git-workflow/SKILL.md
+++ b/plugins/loaf/skills/git-workflow/SKILL.md
@@ -49,4 +49,5 @@ Git conventions for branching, commits, PRs, and merge workflow.
 | Topic | Reference | Use When |
 |-------|-----------|----------|
 | Commits | `references/commits.md` | Writing commit messages, creating PRs, branching, curating CHANGELOG entries, pre-PR/pre-push/post-merge hooks |
-| Release ritual | `/loaf:release` skill | Orchestrating the full squash merge workflow (pre-flight, version bump, merge, cleanup) |
+| PR shipping | `/loaf:ship` skill | Reviewing, verifying, and squash-merging one PR |
+| Release ritual | `/loaf:release` skill | Publishing a version from already-landed work |

--- a/plugins/loaf/skills/git-workflow/references/commits.md
+++ b/plugins/loaf/skills/git-workflow/references/commits.md
@@ -169,13 +169,13 @@ Refs BACK-124
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
 - Don't push or merge without explicit request
-- The `/loaf:release` skill automates this workflow, including version bump on the feature branch before merge — use it when ready to squash merge a PR
+- The `/loaf:ship` skill automates this workflow when ready to squash merge a PR; `/loaf:release` publishes a version later from already-landed work
 
 ## Changelog Discipline
 
 `CHANGELOG.md` entries follow Loaf's Common Changelog profile: write for
 humans, communicate the release impact, and curate git history instead of
-copying it. Curate the `[Unreleased]` section before bumping the version so the
+copying it. Curate the `[Unreleased]` section as PRs land so the later
 published release notes read as user-facing prose, not an internal worklog.
 
 ### Drop
@@ -204,9 +204,9 @@ Internal terms that have no meaning outside the team's working context:
 
 ### Auto-generated Entries
 
-When `loaf release --pre-merge` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
+When `loaf release` auto-generates the `[Unreleased]` section from commit history, those entries inherit any internal terms present in the commit messages. Treat the generated output as a draft: rewrite it under the curated path before bumping. The release skill preserves curated content when it's already in `[Unreleased]` — curate first, bump second.
 
-Before approving a release bump, compare `[Unreleased]` against the actual squashed change set and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the branch was organized, it does not belong in the changelog.
+Before approving a release bump, compare `[Unreleased]` against the actual release range and remove scaffolding language introduced by specs, reviews, tasks, or session triage. If an entry only explains why the work was discovered or how the work was organized, it does not belong in the changelog.
 
 ## Critical Rules
 
@@ -285,7 +285,7 @@ When developing toward a major version, use pre-release suffixes to mark develop
 
 **Convention:**
 - Set the target version with `-dev.0` when starting a major effort (e.g. `2.0.0-dev.0`)
-- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of work ships — a spec completing, a group of related features landing
+- Bump the dev counter (`-dev.N` → `-dev.N+1`) when a meaningful batch of landed work is ready to publish — a completed spec, a related feature group, or a release train
 - Don't bump for every commit — that's what git history is for
 - Strip the suffix (`-dev.N` → `2.0.0`) when all planned work is complete
 - `loaf release` handles all bump types: `prerelease`, `release`, `major`, `minor`, `patch`

--- a/plugins/loaf/skills/implement/SKILL.md
+++ b/plugins/loaf/skills/implement/SKILL.md
@@ -335,7 +335,7 @@ After creating session file:
    - Update session file (status: done, `archived_at`, `archived_by`)
    - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
-5. After PR is created and approved, use `/loaf:release` to orchestrate the squash merge with correct version ordering, documentation freshness check, and post-merge cleanup.
+5. After PR is created and approved, use `/loaf:ship` to review, verify, and land the PR. Use `/loaf:release` later when a coherent batch of landed work is ready to publish.
 6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
    - `## Key Decisions` has content (not `*(none yet)*` or empty)
    - `traceability.decisions` has entries (ADRs were recorded)
@@ -354,7 +354,7 @@ After creating session file:
 
 ## Suggests Next
 
-After all tasks are complete, suggest `/loaf:release` to merge the work.
+After all tasks are complete, suggest `/loaf:ship` to land the PR. Suggest `/loaf:release` only when the landed work forms a coherent release batch.
 
 ## Related Skills
 

--- a/plugins/loaf/skills/release/SKILL.md
+++ b/plugins/loaf/skills/release/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: release
 description: >-
-  Orchestrates releases: pre-flight checks, version bump via `loaf release`,
-  squash merge, and post-merge cleanup. Use when the user says "release this,"
-  "merge this PR," "ready to merge," or "ship it." Produces version bumps,
-  changelog updates, and...
+  Orchestrates standalone releases from already-landed work: release readiness,
+  version selection, changelog curation, release commit, tag, GitHub Release,
+  install verification, and post-release follow-up. Use when the user says "cut
+  a release," "pu...
 user-invocable: true
-argument-hint: '[PR number or URL]'
+argument-hint: '[version, base, or release intent]'
 version: 2.0.0-pre.20260614235428
 ---
 
 # Release
 
-Orchestrate a squash merge with correct version ordering, documentation checks, and cleanup.
+Publish a coherent version from work that has already landed.
 
 ## Contents
 - Critical Rules
@@ -20,13 +20,13 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 - Quick Reference
 - Topics
 - Context Detection
-- Step 1: Pre-Flight Checks
-- Step 2: Documentation Freshness
-- Step 3: Housekeeping Verification
-- Step 3b: Create PR (if needed)
-- Step 4: Version Bump + Changelog
-- Step 5: Squash Merge
-- Step 6: Post-Merge Cleanup
+- Step 1: Release Readiness
+- Step 2: Change Collection
+- Step 3: Version + Changelog
+- Step 4: Release Execution
+- Step 5: Protected-Branch Handoff
+- Step 6: Publication Verification
+- Step 7: Post-Release Follow-Up
 - Hook Interaction
 - Related Skills
 
@@ -36,308 +36,255 @@ Orchestrate a squash merge with correct version ordering, documentation checks, 
 
 ## Critical Rules
 
-- **Block on pre-flight failure** -- do not offer to skip any failing check
-- **Use `AskUserQuestion` for all decisions and confirmations** -- version bump type, push approval, merge approval, branch deletion. Never use inline text questions for permission/decision prompts
-- **Version bump before merge** -- this is the skill's reason for existing; never defer to post-merge
-- **Wrap after version bump** -- wrap needs PR# and version to produce a complete session summary
-- **Clean squash body** -- never use the auto-generated commit dump
-- **Orchestrate the full lifecycle** -- if housekeeping or reflect haven't been run, trigger them (with user confirmation via `AskUserQuestion`) rather than just flagging gaps
-- **Detect-first** -- auto-detect PR from branch before asking for a number
-- **Never push without confirmation** -- even after successful version bump
-- **Log release** -- log to session journal after merge: `loaf session log "decision(release): vX.Y.Z shipped via PR #N"`
+- **Release is not merge** -- do not use `/loaf:release` to review, approve, or land a feature PR. Use `/loaf:ship` for PR correctness and landing.
+- **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
+- **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
+- **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
+- **Never push, tag, or publish without confirmation** -- present the exact actions first.
+- **Use `AskUserQuestion` for release decisions when available** -- version bump type, release PR handoff, push/tag/GitHub Release confirmation.
+- **Log release** -- after publication, run `loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"` when session state is available.
 
 ## Verification
 
-- Pre-flight checks (typecheck, test, build) all pass before proceeding
-- Version bump commit exists on the feature branch before merge
-- Squash merge body is a one-line summary followed by bullet points grouped by feature area, not a commit dump
-- Git tag points to the squash merge commit on the base branch, not a branch commit
-- GitHub Release exists with changelog body (not auto-generated notes)
-- Post-merge cleanup completed: base branch pulled, feature branch deleted
+- Release base branch is clean, current, and contains the intended landed PRs
+- Pre-flight checks pass before versioning or publication
+- Changelog entries are curated user-facing prose, not commit or PR-title dumps
+- Version files, changelog heading, git tag, and GitHub Release all agree
+- Tag points at the released base-branch commit or release commit, not an abandoned feature branch
+- Downstream install path is verified when applicable, especially Homebrew for Loaf releases
 
 ## Quick Reference
 
 | Step | Gate | Blocking? |
 |------|------|-----------|
-| Pre-Flight | typecheck + test + build pass | Yes |
-| Doc Freshness | User reviews stale docs | No (user decides) |
-| Housekeeping | Spec/tasks archived, CHANGELOG ready | No (user decides) |
-| PR Creation | Only if no PR exists yet | Yes (if needed) |
-| Version Bump | User confirms bump type; `loaf release --pre-merge` | Yes |
-| Wrap | Session summary (after version bump, has PR# + version) | Yes |
-| Squash Merge | User approves body text | Yes |
-| Post-Merge | `loaf release --post-merge` (tag, GH Release, cleanup) | Yes |
+| Readiness | clean/current base branch, no unresolved release collisions | Yes |
+| Change Collection | landed work since last tag grouped into release themes | Yes |
+| Version + Changelog | bump selected, notes curated, files updated | Yes |
+| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Verification | release and install paths checked | Yes |
+| Follow-Up | reflect/loaf:housekeeping suggested when useful | No |
 
 ## Topics
 
 | Topic | Use When |
 |-------|----------|
-| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
+| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
 
 ## Context Detection
 
-Before anything, detect where we are:
+Before anything, establish the release surface:
 
-1. **Get current branch and repo default branch:**
+1. Get current branch and repo default branch:
    ```bash
    git branch --show-current
    gh repo view --json defaultBranchRef -q .defaultBranchRef.name
    ```
-2. **If on the default branch**, STOP — there is no PR to merge. Offer post-merge cleanup only (Step 6), using the default branch as `baseRefName`.
-3. **Parse `$ARGUMENTS`**: may be a PR number (`42`), a PR URL, or empty.
-4. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
+3. Verify the current branch:
+   - If already on the release base, continue.
+   - If on a feature branch, stop and explain that `/loaf:release` publishes from landed work. Offer `/loaf:ship` if the active PR needs landing first.
+   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
+4. Find the previous release tag:
    ```bash
-   gh pr view --json number,title,url,headRefName,baseRefName
+   git describe --tags --abbrev=0
    ```
-5. If no PR exists for this branch, note `pr_exists = false` and set `baseRefName` to the repo default branch. Continue — the PR will be created in Step 3b.
-6. If PR exists, **save `baseRefName`** from the PR metadata (e.g., `main`, `release/1.0`, `develop`). All subsequent steps use this as the base reference for diffs and changelog scoping. Do NOT hardcode `main`.
-7. Confirm the PR identity (or intent to create one) with the user before proceeding.
-
----
-
-## Step 1: Pre-Flight Checks (BLOCKING)
-
-Run these and **BLOCK on any failure** — do not offer to skip.
-
-### Detect project type
-
-Inspect the repo to determine available checks:
-- **Node** (`package.json`): look for `typecheck`, `test`, `build` scripts
-- **Python** (`pyproject.toml`): look for `pytest`, `mypy`, `ruff` in dev dependencies or tool config; if the project is uv-managed, expect release artifact refresh to run `uv sync`
-- **Rust** (`Cargo.toml`): `cargo check`, `cargo test`
-- **Go** (`go.mod`): `go vet`, `go test`
-
-### Run checks
-
-Run whichever checks the project supports. Examples for a Node project:
-1. `npm run typecheck` (if the script exists)
-2. `npm run test` (if the script exists)
-3. `npm run build` (preferred) or `loaf build` if `npm run build` is not available
-
-For Python: `pytest`, `mypy .` (if configured). For Rust: `cargo check`, `cargo test`.
-
-**If no checks are detected**, WARN the user explicitly: *"No pre-flight checks found (no test runner, type checker, or build script detected). Proceeding without verification — consider adding checks before merging."* Do NOT silently skip.
-
-On failure: show the error, STOP, explain what needs fixing. Do not proceed to Step 2.
-
----
-
-## Step 2: Documentation Freshness
-
-Check whether documentation is stale relative to the branch's changes:
-
-1. Run `git diff <baseRefName>..HEAD --name-only -- README.md ARCHITECTURE.md docs/` to identify changed doc files (use the `baseRefName` from Context Detection).
-2. Run `git diff <baseRefName>..HEAD --stat` to understand the scope of code changes.
-3. Read README.md and ARCHITECTURE.md. Look for references to concepts, features, agents, or APIs that the branch may have changed or removed.
-4. If the branch introduced significant changes (new features, removed components, renamed concepts) but docs weren't updated, flag specific sections that may be stale.
-
-Present findings to the user. They decide whether to fix now or note for later. Do NOT silently skip.
-
----
-
-## Step 3: Housekeeping
-
-Check each item. If missing, **offer to run it** (with user confirmation) rather than just flagging it.
-
-1. **Spec status**: If a spec is associated with this branch (check `.agents/specs/` for matching spec), verify its status is `complete`. If not, offer to update it.
-2. **Tasks archived**: Check `.agents/tasks/` for tasks related to the spec that aren't archived. If found, offer to run `loaf task archive`.
-3. **CHANGELOG ready**: Verify `CHANGELOG.md` exists and has the `[Unreleased]` marker (Step 4 will generate the actual entries).
-4. **Journal flushed**: Review conversation for unrecorded decisions/discoveries. Log them now — this is the last chance before wrap.
-
-Present the results as a checklist. Use `AskUserQuestion` for any decisions or approvals.
-
-**Note:** Wrap (`/loaf:wrap`) runs AFTER version bump (Step 4b) so it can reference the PR# and version in the session summary. Reflection runs post-merge (Step 6).
-
----
-
-## Step 3b: Create PR (if needed)
-
-**Only run this step if `pr_exists = false` from Context Detection.**
-
-The PR must be created BEFORE the version bump so that `[Unreleased]` changelog entries are still present (advisory hooks check for this).
-
-1. Push the branch if not already pushed.
-2. Create the PR following the format in [git-workflow/references/commits.md](../git-workflow/references/commits.md) (Pull Request Format section).
-3. Save the PR number and `baseRefName` for subsequent steps.
-
----
-
-## Step 4: Version Bump + Changelog (on feature branch)
-
-This step handles versioning and changelog. The approach depends on whether curated changelog entries already exist.
-
-### Check for existing changelog entries
-
-Read `CHANGELOG.md` and check if `[Unreleased]` has content (entries written during development, often required by pre-PR hooks).
-
-- **If curated entries exist** → Use the **Curated path** (preserve them)
-- **If `[Unreleased]` is empty** → Use the **Generated path** (auto-generate from commits)
-
-### Curated path (preferred when entries exist)
-
-The pre-PR workflow requires writing CHANGELOG entries before creating a PR. These curated entries are typically better than auto-generated ones (grouped by category, human-written descriptions). Preserve them.
-
-**Review curated entries for quality before bumping:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Follow Loaf's Common Changelog profile: imperative, self-describing,
-  one-line entries grouped as `Changed`, `Added`, `Removed`, `Fixed`
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Include the best public reference when available, such as a PR, issue, ADR, release, or commit link
-
-1. Run `loaf release --pre-merge --dry-run` to get the **suggested bump type** and **current version** (the `--pre-merge` flag auto-detects the base branch — see [Why `--pre-merge`?](#why---pre-merge) below).
-2. Present the bump suggestion to the user. They may accept or override.
-3. Once confirmed, run:
+5. Gather the candidate release range:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git log --oneline <last-tag>..HEAD
+   git diff --stat <last-tag>..HEAD
    ```
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Convert the `[Unreleased]` header to `## [X.Y.Z] - YYYY-MM-DD` (preserving the curated entries beneath it) and re-insert a fresh empty `## [Unreleased]` section above
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+---
 
-### Generated path (when no entries exist)
+## Step 1: Release Readiness
 
-When `[Unreleased]` is empty, use `loaf release` to auto-generate changelog entries from branch commits.
+Run release pre-flight checks before editing release files:
 
-**After generation, review and rewrite entries before committing:**
-- Use backticks for code references (file names, commands, config keys, hook names)
-- Remove internal tracking terms (tracks, phases, stages, task IDs, spec IDs)
-- Rewrite generated commit text into Loaf's Common Changelog profile
-- Write from the user's perspective — what upgrading changes, not how it was tracked
-- Keep entries concise but descriptive enough to understand the change without reading the diff
-
-1. Run `loaf release --pre-merge --dry-run` to preview:
-   - Current version and suggested bump type
-   - Generated changelog section from **this branch's commits only**
-   - Which version files will be updated
-
-   The `--pre-merge` flag scopes the commit analysis to `<auto-detected base>..HEAD`, so only commits on the feature branch are considered.
-
-2. Present the preview to the user. They may:
-   - Accept the suggested bump type
-   - Override with a different type (`prerelease`, `release`, `major`, `minor`, `patch`)
-   - Edit the changelog content conversationally
-
-3. Once the user confirms, run:
+1. Ensure worktree is clean:
    ```bash
-   loaf release --pre-merge --bump <type> --yes
+   git status --short
    ```
+2. Ensure the release base is current:
+   ```bash
+   git fetch --tags origin
+   git status --branch --short
+   ```
+3. Check for existing tag or GitHub Release collisions for the target version once known:
+   ```bash
+   git tag --list vX.Y.Z
+   gh release view vX.Y.Z
+   ```
+4. Run project checks:
+   - Node: `npm run typecheck`, `npm run test`, `npm run build` when scripts exist
+   - Go: `go vet ./...`, `go test ./...` when `go.mod` exists
+   - Python: `pytest`, `mypy .`, `ruff check .` when configured
+   - Rust: `cargo check`, `cargo test` when `Cargo.toml` exists
 
-   This will:
-   1. Bump version in all detected files (package.json, pyproject.toml, etc.)
-   2. Generate and insert changelog section from branch commits (adding a fresh `[Unreleased]`)
-   3. Run release artifact commands: `uv sync` for uv-managed Python packages, package-local `npm run build` for Node packages with a build script, or `loaf build` when no package-specific command is detected
-   4. Commit: `chore: release vX.Y.Z`
+If no checks are detected, warn explicitly. If a check fails, stop and fix before release.
 
-### After either path
+---
 
-Before pushing, verify generated artifacts are still current. This matters if
-any fix commits landed after the release bump commit:
+## Step 2: Change Collection
+
+Collect landed work since the last release and group it for release notes.
+
+1. Inspect commits:
+   ```bash
+   git log --first-parent --oneline <last-tag>..HEAD
+   git log --oneline <last-tag>..HEAD
+   ```
+2. Inspect merged PRs when GitHub is available:
+   ```bash
+   gh pr list --state merged --base <base> --json number,title,mergedAt,url
+   ```
+3. Group changes by user-facing outcome:
+   - `CR-*` change bundle, when referenced
+   - spec or task family, when public enough to be useful
+   - feature/fix/documentation/build themes
+   - operational release work, when it affects users or maintainers
+4. Drop noise:
+   - purely internal task/session labels
+   - reverted work that is not present in `HEAD`
+   - individual commit mechanics that collapse into one user-facing change
+
+Present the grouped release contents before choosing the bump.
+
+---
+
+## Step 3: Version + Changelog
+
+Choose the bump and curate the changelog from the grouped landed work.
+
+1. Run a dry run:
+   ```bash
+   loaf release --dry-run
+   ```
+   Use `--base <ref>` when the project expects a non-default release base.
+2. Present:
+   - current version
+   - proposed next version
+   - detected version files
+   - release actions the CLI would perform
+   - draft changelog entries
+3. Curate `CHANGELOG.md` before publishing:
+   - write from the upgrading user's perspective
+   - group under Common Changelog categories: `Changed`, `Added`, `Removed`, `Fixed`
+   - use one self-describing line per meaningful change
+   - include public PR, issue, ADR, release, or commit links when helpful
+   - avoid dumping commit subjects, task IDs, session mechanics, or internal gate language
+4. Confirm the bump type: `prerelease`, `release`, `major`, `minor`, or `patch`.
+
+---
+
+## Step 4: Release Execution
+
+For a direct release from the base branch, run:
+
+```bash
+loaf release --bump <type> --yes
+```
+
+This should:
+
+1. Update version files
+2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
+3. Reinsert a fresh empty `[Unreleased]` section
+4. Run configured release artifact commands
+5. Create the release commit
+6. Create/push the release tag
+7. Create the GitHub Release when enabled
+
+After execution, verify generated artifacts are current:
 
 ```bash
 npm run build
-git diff --exit-code -- plugins/loaf/bin/loaf dist content/skills/cli-reference/SKILL.md
+git diff --exit-code -- dist plugins content/skills/cli-reference/SKILL.md
 ```
 
-If the diff check fails, commit the regenerated artifacts with the source change
-that made them stale, then rerun the check.
-
-Push to the feature branch (**with user confirmation**).
-
-### Why `--pre-merge`?
-
-`--pre-merge` bundles the canonical pre-merge flag set so the skill no longer needs to spell each one out:
-
-- Equivalent to `--no-tag --no-gh --base <auto-detected>` (tag and GH release land post-merge in Step 6, not on the soon-to-be-squashed feature commit).
-- Auto-detects the base ref via a 4-step priority: explicit `--base <ref>` → open PR's `baseRefName` → `git config loaf.release.base` → repo default branch. Run `loaf release --help` to see the full priority order.
-- Pass `--base <ref>` explicitly to override auto-detection (useful for non-default base branches like `release/1.0` when no PR exists yet).
-- `--yes` skips the CLI confirmation prompt — the skill already confirmed with the user conversationally.
+Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
 ---
 
-## Step 4b: Wrap Session
+## Step 5: Protected-Branch Handoff
 
-Run `/loaf:wrap` AFTER version bump so the session summary can reference the PR# and final version.
+If branch protection prevents direct release commits on the base branch:
 
-The wrap skill will:
-1. Flush any remaining journal entries
-2. Gather git state (commits, working tree, unpushed)
-3. Generate the `## Session Wrap-Up` report
-4. Write it to the session file (replaces `## Current State`)
-5. Run `loaf session end --wrap` to set status to `complete`
+1. Create a dedicated release branch.
+2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+3. Open a release PR with a concise release-focused body.
+4. Hand the PR to `/loaf:ship` for review and landing.
+5. After `/loaf:ship` lands the release PR, resume `/loaf:release` on the base branch to tag, publish the GitHub Release, and verify installability.
 
-When called from `/loaf:release`, wrap skips the version bump and changelog prompts (already handled).
+Do not hide this handoff inside `/loaf:release`: `/loaf:ship` remains the PR correctness and merge gate.
 
 ---
 
-## Step 5: Squash Merge
+## Step 6: Publication Verification
 
-1. Draft a clean squash body from the branch's commit history and PR description. Descriptive, not verbose:
-   - One-line summary, then bullet points grouped by feature area
-   - Plain text — no bold, no headings, only backticks for `code`
-   - Not a paragraph dump, not a commit log
-2. Present the draft to the user for review. They may edit it.
-3. Execute (after user confirms):
+After publishing, verify the public release state:
+
+1. Confirm tag location:
    ```bash
-   gh pr merge <N> --squash --body "$(cat <<'EOF'
-   <body>
-   EOF
-   )"
+   git show --stat vX.Y.Z
    ```
-4. Let GitHub default the title (`PR title (#N)`).
-5. NEVER use `--auto` or the automatic squash description that dumps all commits.
+2. Confirm GitHub Release:
+   ```bash
+   gh release view vX.Y.Z
+   ```
+3. Confirm package or installer availability when applicable:
+   - npm: `npm view <package> version`
+   - Homebrew: `brew update && brew info <tap>/<formula>`
+   - project-specific deploy or artifact registry checks
+4. For Loaf/Homebrew, report readiness only after the GitHub release exists, assets are uploaded, the tap formula is updated, and tap CI has passed.
+
+If publication partially completes, do not retag casually. Name the exact state and continue with the smallest repair or patch release path.
 
 ---
 
-## Step 6: Post-Merge Cleanup
+## Step 7: Post-Release Follow-Up
 
-After successful merge, run a single command:
+After verification:
 
-```bash
-loaf release --post-merge
-```
-
-This verifies HEAD state against an 8-point guardrail checklist (clean worktree, on the base branch with the merge commit at HEAD, readable HEAD subject for optional PR-number lookup, version-file agreement, CHANGELOG section present, no pre-existing tag or GH release, HEAD untagged). The squash subject should describe the shipped work (`feat:`, `fix:`, etc.); post-merge derives the release version from version files and `CHANGELOG.md`, not from a `chore: release` subject. Once all guardrails pass it tags the squash merge commit, pushes the tag, creates the GitHub Release from the matching `## [X.Y.Z]` CHANGELOG section, pulls the base branch, and best-effort deletes the local + remote feature branch. Manual `git tag`, `git push --tags`, `gh release create`, `git checkout`, `git pull --rebase`, and `git branch -d` are no longer needed — the flag subsumes them.
-
-If anything aborts:
-
-1. Read the actionable error message — each guardrail failure names the exact manual fix (e.g., "tag v1.2.3 already exists locally — run `git tag -d v1.2.3` and rerun").
-2. Perform the named fix.
-3. Rerun `loaf release --post-merge`. The command is idempotent on stateless reads, so reruns after a transient `gh` failure or a half-completed prior run pick up exactly where they left off.
-
-After the release finalizes, **run `/loaf:reflect`** — already on the base branch. Reflect looks back at the shipped work and updates strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) with learnings. Use `AskUserQuestion` to confirm before running.
+1. Log the release decision when session state is healthy:
+   ```bash
+   loaf session log "decision(release): vX.Y.Z published from <base> with <summary>"
+   ```
+2. Suggest `/loaf:reflect` when the release produced durable product or workflow learnings.
+3. Suggest `/loaf:housekeeping` when session artifacts, release branches, or temporary reports need cleanup.
+4. Keep future-work discoveries out of the release notes; capture them as tasks, ideas, or sparks instead.
 
 ---
 
 ## Hook Interaction
 
-This skill coexists with existing hooks. Git workflow hooks are **advisory** (warn but don't block); security hooks remain blocking.
+This skill coexists with existing hooks. Git workflow hooks are advisory unless
+configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/loaf:release` Runs |
 |------|------|---------------------|
-| `workflow-pre-pr` (command) | Advisory | Fires on `gh pr create`. Reminds about CHANGELOG — redundant when release skill manages entries. |
-| `workflow-pre-merge` (instruction) | Advisory | Fires on `gh pr merge`. Reminds about squash conventions — redundant since body is already crafted. |
-| `workflow-post-merge` (instruction) | Advisory | Fires after merge. Outputs checklist the skill already handled. |
-| `validate-push` (command) | Advisory | Fires on push. Cross-validates version bump — should pass since Step 4 did both. |
-| `check-secrets` (command) | **Blocking** | Security gate. Always fires, always respected. |
+| `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
+| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-merge` | Advisory | Belongs to `/loaf:ship` when a release PR must land |
+| `workflow-post-merge` | Advisory | Belongs to `/loaf:ship` after PR landing |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
 
-Do not modify, disable, or skip these hooks.
+Do not disable hooks to force a release through.
 
 ---
 
 ## Suggests Next
 
-After a successful release, suggest `/loaf:housekeeping` if session artifacts need archiving.
+After a successful release, suggest `/loaf:reflect` for durable learnings and `/loaf:housekeeping` if temporary release artifacts need attention.
 
 ## Related Skills
 
-- **implement** — Does the work and housekeeping; `/loaf:release` handles the merge afterward
-- **reflect** — Suggested post-merge if session has learnings
-- **git-workflow** — Conventions this skill enforces
-- **housekeeping** — Handles artifact hygiene; `/loaf:release` verifies it was done
+- **ship** -- Reviews, verifies, and lands a PR before it becomes release input
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **documentation-standards** -- Changelog and release-note quality
+- **reflect** -- Updates strategy from shipped/released learnings
+- **housekeeping** -- Cleans up completed session and release artifacts

--- a/plugins/loaf/skills/ship/SKILL.md
+++ b/plugins/loaf/skills/ship/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: ship
+description: >-
+  Reviews, verifies, and lands one pull request. Use when the user says "ship
+  it," "merge this PR," "ready to merge," "land this branch," or asks for a
+  final merge gate. Produces a reviewed, squash-merged PR and post-merge
+  cleanup. Not for version b...
+user-invocable: true
+argument-hint: '[PR number or URL]'
+version: 2.0.0-pre.20260614235428
+---
+
+# Ship
+
+Review, verify, and land one PR. Shipping is the PR gate; releasing is the version-publication gate.
+
+## Contents
+- Critical Rules
+- Verification
+- Quick Reference
+- Topics
+- Context Detection
+- Step 1: PR Readiness
+- Step 2: Evidence Review
+- Step 3: Local Verification
+- Step 4: Squash Merge
+- Step 5: Post-Merge Cleanup
+- Step 6: Release Suggestion
+- Hook Interaction
+- Related Skills
+
+**Input:** $ARGUMENTS
+
+---
+
+## Critical Rules
+
+- **Ship is not release** -- do not bump versions, create tags, publish GitHub Releases, or verify package installation here.
+- **Keep PR quality local** -- smaller PRs are welcome, but `/loaf:ship` must still verify correctness before merge.
+- **Detect-first** -- auto-detect the PR from the current branch before asking for a PR number.
+- **Review before merge** -- inspect code, docs, tests, changelog, PR body, and CI state before approval.
+- **Never merge without explicit confirmation** -- present the PR, checks, findings, and squash body first.
+- **Clean squash body** -- write an intentional squash commit body; never accept the automatic commit dump.
+- **Keep landed and released distinct** -- after merge, describe the PR as landed or shipped, not necessarily released.
+- **Log shipping** -- after merge, run `loaf session log "decision(ship): PR #N landed via squash merge"` when session state is available.
+
+## Verification
+
+- PR identity, base branch, and head branch are confirmed
+- CI status is passing or the user explicitly accepts named non-blocking checks
+- Relevant local checks pass or failures are fixed before merge
+- PR body and durable docs do not overclaim relative to the diff
+- Squash commit title/body are clean, conventional, and user-facing
+- Base branch is updated after merge and the feature branch cleanup state is known
+
+## Quick Reference
+
+| Step | Gate | Blocking? |
+|------|------|-----------|
+| PR Readiness | PR exists, target base known, CI state reviewed | Yes |
+| Evidence Review | findings resolved or explicitly accepted | Yes |
+| Local Verification | relevant checks pass | Yes |
+| Squash Merge | user approves body text | Yes |
+| Cleanup | base pulled, branch deletion handled | No |
+| Release Suggestion | enough landed work may justify `/loaf:release` | No |
+
+## Topics
+
+| Topic | Use When |
+|-------|----------|
+| [Context Detection](#context-detection) | Determining current branch and PR state |
+| [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
+
+---
+
+## Context Detection
+
+Before anything, detect the PR surface:
+
+1. Get current branch and repo default branch:
+   ```bash
+   git branch --show-current
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+2. Parse `$ARGUMENTS`: may be a PR number, PR URL, branch name, or empty.
+3. If `$ARGUMENTS` is empty, auto-detect from the current branch:
+   ```bash
+   gh pr view --json number,title,url,headRefName,baseRefName,state,mergeStateStatus,isDraft
+   ```
+4. If no PR exists for the current branch, stop and offer to create one via `git-workflow` rather than silently merging a branch.
+5. If already on the default branch, stop. There is no PR to ship from the current branch.
+6. Confirm PR identity with the user before merge actions.
+
+---
+
+## Step 1: PR Readiness
+
+Inspect the PR's declared state:
+
+```bash
+gh pr view <N> --json number,title,body,url,headRefName,baseRefName,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+Block or pause when:
+
+- PR is draft
+- merge state is dirty or blocked
+- required checks are failing or pending
+- review decision is changes requested
+- branch is out of date and the project requires update before merge
+
+If checks are unavailable, say so explicitly and compensate with local verification.
+
+---
+
+## Step 2: Evidence Review
+
+Review the landing diff and durable prose together:
+
+1. Gather diff context:
+   ```bash
+   git fetch origin <baseRefName>
+   git diff --stat origin/<baseRefName>...HEAD
+   git diff --name-only origin/<baseRefName>...HEAD
+   ```
+2. Read the PR title/body and changed docs that make behavior claims.
+3. Check for drift:
+   - PR body claims features that are not in the diff
+   - changelog entries mention unreleased or unrelated behavior
+   - docs describe future work as already shipped
+   - comments or runbooks use stale internal vocabulary
+4. Fix blocking drift before merge. For non-blocking polish, name it and let the user decide.
+
+For high-risk PRs, use the project's review skill or read-only review flow before proceeding.
+
+---
+
+## Step 3: Local Verification
+
+Run the checks the project supports. Examples:
+
+- Node: `npm run typecheck`, `npm run test`, `npm run build`
+- Go: `go vet ./...`, `go test ./...`
+- Python: `pytest`, `mypy .`, `ruff check .`
+- Rust: `cargo check`, `cargo test`
+
+If generated artifacts are tracked, verify they are current before merge:
+
+```bash
+git diff --exit-code -- dist plugins
+```
+
+Use the repo's documented pre-commit or pre-PR checklist when present. Stop on failures.
+
+---
+
+## Step 4: Squash Merge
+
+Draft a clean squash body from the reviewed diff and PR body:
+
+- One-line summary, then bullet points grouped by feature area
+- Plain text; use backticks only for code identifiers
+- No commit dump
+- No agent attribution
+- No release-note overclaiming
+
+Present the body and ask for confirmation. Then run:
+
+```bash
+gh pr merge <N> --squash --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+Let GitHub default the title from the PR title so the squash subject remains `type: summary (#N)`.
+
+---
+
+## Step 5: Post-Merge Cleanup
+
+After a successful merge:
+
+1. Switch to the PR base branch:
+   ```bash
+   git checkout <baseRefName>
+   git pull --ff-only origin <baseRefName>
+   ```
+2. Delete the local feature branch when safe:
+   ```bash
+   git branch -d <headRefName>
+   ```
+3. Confirm the remote branch deletion state from GitHub output or run:
+   ```bash
+   gh pr view <N> --json headRefName,state
+   ```
+4. Log the landing when session state is healthy:
+   ```bash
+   loaf session log "decision(ship): PR #N landed via squash merge"
+   ```
+
+If cleanup fails, report the exact residual state. Do not force-delete without user confirmation.
+
+---
+
+## Step 6: Release Suggestion
+
+After landing, decide whether to suggest `/loaf:release`:
+
+- Suggest `/loaf:release` when the landed PR completes a coherent batch, user-facing feature, fix train, or release branch.
+- Do not suggest `/loaf:release` for every small PR by default.
+- If multiple related PRs are expected, say the PR is landed and can wait for a later batched release.
+
+Use language carefully: the PR is **landed** or **shipped**; it is not **released** until `/loaf:release` publishes a version.
+
+---
+
+## Hook Interaction
+
+This skill coexists with existing hooks.
+
+| Hook | Type | When `/loaf:ship` Runs |
+|------|------|------------------|
+| `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
+| `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
+| `validate-push` | Advisory | May fire if branch updates are needed before merge |
+| `check-secrets` | Blocking | Always respected before writes or shell actions |
+
+Do not disable hooks to force a PR through.
+
+---
+
+## Suggests Next
+
+After a successful ship, suggest `/loaf:release` only when the landed work forms a coherent release batch or the user asks to publish.
+
+## Related Skills
+
+- **release** -- Publishes a version from already-landed work
+- **git-workflow** -- Branching, PR, commit, and squash merge conventions
+- **foundations** -- Verification, code review, and production readiness
+- **documentation-standards** -- Changelog, docs, and durable prose quality
+- **reflect** -- Updates strategy from significant shipped work

--- a/plugins/loaf/skills/wrap/SKILL.md
+++ b/plugins/loaf/skills/wrap/SKILL.md
@@ -41,8 +41,8 @@ Responsible session shutdown — everything that needs a conscious model before 
 - All decisions and discoveries from this session are in the journal
 - Uncommitted/unpushed state is surfaced with clear action prompts
 - Stale KB files are flagged if any
-- `## Session Wrap-Up` section written to session file (replaces `## Current State`)
-- `loaf session end --wrap` run after writing the summary
+- `## Session Wrap-Up` section persisted in the canonical session surface; in SQLite mode this is represented by wrapped session/report state rather than an active `.md` file
+- `loaf session end --wrap` run after generating or writing the summary
 - Session status is `done` (session stays open for further journal entries until `SessionEnd` fires)
 
 ## Quick Reference
@@ -63,7 +63,7 @@ These steps require conversation context — only the model can do them.
 
 Before anything else, complete the session journal:
 
-1. **Enrich from conversation log** — run `loaf session enrich` to fill in gaps from the JSONL conversation log. This catches decisions, discoveries, and context that weren't manually logged. If enrichment fails, continue — manual flush is the fallback.
+1. **Check enrichment state** — run `loaf session enrich --json`. In SQLite mode this is expected to report `action: "skipped"` because `loaf session log` is already the canonical journal writer; in markdown-only compatibility mode it summarizes legacy JSONL enrichment status. If enrichment is skipped or fails, continue — manual flush is the fallback.
 2. **Manual review** — review the conversation for anything enrichment missed:
    - Decisions — design choices, trade-offs, direction changes not yet logged as `decision()` entries
    - Discoveries — anything learned that future sessions would benefit from
@@ -74,7 +74,7 @@ Before anything else, complete the session journal:
 
 Run in parallel:
 
-1. **Session journal** — read the active session file for this branch
+1. **Session journal** — run `loaf session list --json`, choose the active session for the current branch or explicit harness session, then run `loaf session show <session-ref> --json`; if SQLite state is unavailable, fall back to the active markdown session file for this branch
 2. **Commits this session** — `git log --oneline` since session start
 3. **Working tree** — `git status --short`
 4. **Unpushed commits** — `git log --oneline origin/<branch>..HEAD`
@@ -89,7 +89,7 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 |-----------|--------|
 | Uncommitted changes | "N file(s) uncommitted — commit, stash, or leave for next session?" |
 | Unpushed commits | "N commit(s) on <branch> not pushed — push now?" |
-| No version bump | "This session shipped work but no release was run — bump version now?" |
+| Release candidate | "This session landed work that may belong in the next release — run `/loaf:release` now?" |
 | Stale KB files | "N stale knowledge file(s) — address now or defer?" |
 | Unresolved blocks | "Block on <scope> still open — note for next session?" |
 | No changelog entries | "N commit(s) on branch but `[Unreleased]` is empty — add changelog entries?" |
@@ -98,15 +98,17 @@ Surface each loose end with a clear action the user can take. Ask once, respect 
 **Detection logic:**
 - **Changelog entries:** check if the current branch has commits vs the base branch (e.g., `git rev-list --count origin/main..HEAD`) AND `CHANGELOG.md` `[Unreleased]` section has no list items (`^[-*]\s`). If both are true, prompt. **Skip when HEAD is tagged** (post-release state).
 - **Housekeeping:** scan session journal for `skill(housekeeping)` entry. If absent and the session had significant work, suggest it.
-- **Version bump:** scan session journal for `decision(release)` entry. If absent and the session has commits, offer to run `loaf release --bump prerelease --no-gh --yes`.
+- **Release candidate:** scan session journal for `decision(release)` entry. If absent and the session has landed commits, suggest `/loaf:release` only when the work forms a coherent release batch.
 
 ### Step 4: Generate Report
 
 Assemble the report per the format below. Omit empty sections — don't show "None" placeholders.
 
-### Step 5: Write Wrap Summary to Session File
+### Step 5: Persist Wrap Summary
 
-Write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
+In SQLite mode, keep the generated wrap summary in the conversation response and let `loaf session end --wrap` persist the mechanical wrapped state. Do not invent or edit a missing active `.md` session file; `loaf session show <session-ref> --json` is the canonical read surface.
+
+In markdown-only compatibility mode, write the `## Session Wrap-Up` section into the active session file, **replacing** `## Current State`. The wrap summary IS the final state — it's a superset that includes everything Current State had plus the structured report.
 
 Use the Edit tool to replace `## Current State (...)` and everything below it (up to `## Journal`) with the wrap-up section. The session file layout after wrap should be:
 
@@ -140,7 +142,7 @@ This handles the mechanical bookkeeping:
 
 ## Composability
 
-When called from `/loaf:release`, wrap runs the same steps but skips the version bump prompt (release already handles it). The `/loaf:release` skill should invoke `/loaf:wrap` first, then proceed with release steps.
+When called near `/loaf:ship` or `/loaf:release`, wrap runs the same steps but keeps PR landing and version publication distinct. `/loaf:ship` may wrap a landed PR; `/loaf:release` may wrap a published version.
 
 ## Suggests Next
 


### PR DESCRIPTION
## Summary
- carries the local restructuring program snapshot that later spec branches are based on
- includes the roadmap, ADR-016, SPEC-043..SPEC-054 drafts, and supporting evaluation/report context from local main
- keeps the program documentation reviewable before TASK-197 and implementation branches land

## Verification
- documentation/program snapshot only; implementation gates run on downstream spec PRs
