### PR TITLE
feat: converge session model guidance

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -90,6 +90,10 @@ loaf session log "skill(implement): TASK-042 — add PAUSE headers to session en
 
 This creates an audit trail of which skills ran during a session. `/wrap` uses these entries to check whether housekeeping or other periodic skills were run.
 
+### Canonical Session Model
+
+`wrap` is the canonical session model. Operational session truth lives in SQLite; use `loaf session start` to find or create the active session, `loaf session log "type(scope): desc"` for journal entries, and `loaf session end --wrap` to close a wrapped session. Markdown is a rendered view or compatibility export, not a hand-authored source surface.
+
 ### Naming Conventions
 
 Use domain-focused names in gerund or noun-phrase form:
@@ -220,7 +224,7 @@ description: >-
 
 ### Templates
 
-Artifact format templates (session files, specs, ADRs, task files) live in `templates/` directories. SKILL.md references them with links instead of embedding inline.
+Artifact format templates (session renders, specs, ADRs, task files) live in `templates/` directories. SKILL.md references them with links instead of embedding inline.
 
 **Skill-specific templates:** `content/skills/{name}/templates/` — templates unique to one skill.
 
@@ -236,7 +240,7 @@ shared-templates:
 
 **Reference pattern in SKILL.md:**
 ```markdown
-Create session file following [templates/session.md](templates/session.md).
+Use [templates/session.md](templates/session.md) for rendered session journal format.
 ```
 
 **Templates vs references:**
@@ -327,19 +331,19 @@ Users shouldn't invoke `/python-development` directly.
 
 ### Session Journal Vocabulary
 
-Session journals in `.agents/sessions/` use a **compact inline format** — append-only structured logs. Think "conventional commits meets bullet journal."
+Session journals live in SQLite and render to a **compact inline format** — append-only structured logs. Think "conventional commits meets bullet journal."
 
 | Term | Meaning |
 |------|---------|
-| **Session** | A markdown file with compact inline journal entries |
-| **Session File** | Named `YYYYMMDD-HHMMSS-description.md` in `.agents/sessions/` |
-| **Frontmatter** | YAML header with `spec`, `branch`, `status`, `created`, `last_entry` |
+| **Session** | A SQLite-backed work record with compact inline journal entries |
+| **Session Render** | Markdown view produced from SQLite state |
+| **Session Row** | SQLite record containing branch, status, timestamps, and harness identity |
 | **Journal Entry** | `[YYYY-MM-DD HH:MM] type(scope): description` |
 | **Entry Type** | `session`, `commit`, `decision`, `discover`, `block`, `unblock`, `spark`, `todo`, etc. |
 | **Burst** | Entries grouped without blank lines |
-| **Archive** | Completed sessions moved to `.agents/sessions/archive/` |
+| **Archive** | Completed sessions marked archived with `loaf session archive` |
 
-**Session Status Values:** `active`, `stopped`, `done`, `blocked`, `archived`
+**Session Status Values:** `active`, `stopped`, `done`, `archived` until SPEC-049 unifies vocabulary.
 
 **Entry Format:**
 ```markdown

--- a/.agents/specs/SPEC-048-session-model-convergence.md
+++ b/.agents/specs/SPEC-048-session-model-convergence.md
@@ -3,7 +3,7 @@ id: SPEC-048
 title: Session-Model Convergence to SQLite
 source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-C)"
 created: 2026-06-22T09:13:21Z
-status: implementing
+status: complete
 branch: feat/session-model-convergence
 source_sessions:
   - id: 20260621-001541-session

--- a/.agents/specs/SPEC-048-session-model-convergence.md
+++ b/.agents/specs/SPEC-048-session-model-convergence.md
@@ -3,7 +3,7 @@ id: SPEC-048
 title: Session-Model Convergence to SQLite
 source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-C)"
 created: 2026-06-22T09:13:21Z
-status: drafting
+status: implementing
 branch: feat/session-model-convergence
 source_sessions:
   - id: 20260621-001541-session
@@ -86,15 +86,18 @@ guidance.
   markdown view of a session uses SPEC-044's deterministic body renderer. SPEC-048
   benefits from but does not strictly require SPEC-044 — until it lands, sessions
   are SQLite-only with the existing compatibility export.
-- **SPEC-049** (WS-C, status-vocabulary unification) — **sequenced-with SPEC-049
-  (soft; SPEC-048 may land first)**. The session status enum is
-  inconsistent across three files today: `active` (`content/templates/session.md`),
-  `in_progress`/`paused` (`content/skills/orchestration/references/sessions.md`),
-  and `active/stopped/done/blocked/archived` (CLAUDE.md). SPEC-049 owns the
-  canonical enum and the "schema lives in exactly one file" lint. SPEC-048 must
-  not invent a fourth vocabulary — it cites whatever SPEC-049 anoints. If SPEC-048
-  lands first, it uses the SPEC-040 runtime enum (`internal/state/session_*.go`)
-  as the interim source of truth and SPEC-049 reconciles.
+- **SPEC-049** (WS-C, status-vocabulary unification) — **sequenced-after
+  SPEC-048 for now**. The session status enum is inconsistent across current
+  guidance: `active` (`content/templates/session.md`), `in_progress`/`paused`
+  (`content/skills/orchestration/references/sessions.md`), and
+  `active/stopped/done/blocked/archived` (CLAUDE.md). SPEC-049 owns the canonical
+  enum and the "schema lives in exactly one file" lint. SPEC-048 must not invent
+  a fourth vocabulary. Because SPEC-048 lands first, it cites the current runtime
+  transitions as interim truth: `active` and `stopped` in
+  `internal/state/session_start.go`, `stopped`/`active`/`done` in
+  `internal/state/session_end.go`, and `archived` in
+  `internal/state/session_archive.go`. SPEC-049 reconciles that into the durable
+  vocabulary.
 - **SPEC-029** (librarian journal enrichment). SPEC-029 enriches session journals
   from JSONL; the `housekeeping` skill currently drives `loaf session enrich`
   (`content/skills/housekeeping/SKILL.md:52,79`). SPEC-048 keeps enrichment but
@@ -249,20 +252,36 @@ tokens where harness-specific terms appear.
 
 ## Open Questions
 
-- [ ] Does SPEC-049 land before or after SPEC-048? If after, confirm the interim
-  enum source (`internal/state/session_*.go`) is the right citation and that
-  SPEC-049 will reconcile the three documents this spec touches.
-- [ ] After SPEC-043, is `content/templates/session.md` retained as a *render
+- [x] Does SPEC-049 land before or after SPEC-048? **After.** SPEC-048 cites the
+  runtime transitions in `internal/state/session_start.go`,
+  `internal/state/session_end.go`, and `internal/state/session_archive.go` as the
+  interim source; SPEC-049 will collapse that into the canonical status vocabulary.
+- [x] After SPEC-043, is `content/templates/session.md` retained as a *render
   template* consumed by the renderer, or demoted to a pure journal-format
-  *reference* doc? (Affects whether it lives in `templates/` or `references/`.)
-- [ ] Should `loaf session enrich` guidance survive in `housekeeping` at all once
+  *reference* doc? **Retain in place for this spec.** Reframe it as a render
+  template / journal-format reference, not a file scaffold. Moving it from
+  `templates/` to `references/` would churn target distribution and belongs in
+  SPEC-044/SPEC-050 if the deterministic renderer no longer consumes it.
+- [x] Should `loaf session enrich` guidance survive in `housekeeping` at all once
   sessions are SQLite-only bodies (SPEC-029 writes rows, not file lines), or move
-  wholesale into the SQLite enrichment path?
-- [ ] Exact set of "read-side" skills beyond `reflect`/`research`/`background-runner`
+  wholesale into the SQLite enrichment path? **Demote it out of the primary
+  housekeeping flow.** `wrap` may still mention `loaf session enrich --json` as a
+  compatibility diagnostic; `housekeeping` should not drive legacy file
+  enrichment as normal work.
+- [x] Exact set of "read-side" skills beyond `reflect`/`research`/`background-runner`
   that reference session state — confirm by grep before the atomic change so none
-  are left markdown-first.
-- [ ] Which user-invocable workflows still lack a first-action self-log? Enumerate
-  against `content/skills/*` (eval §3 M1 says only 2 of ~19 comply).
+  are left markdown-first. **In scope:** the named read-side wave plus
+  `content/agents/background-runner.md`; `handoff` and `librarian` are reviewed
+  for explicit conflict but only edited if they present session files as the
+  primary routing surface. Compatibility hooks/scripts may remain as legacy
+  tooling if they are not promoted as the canonical path.
+- [x] Which user-invocable workflows still lack a first-action self-log? Enumerate
+  against `content/skills/*` (eval §3 M1 says only 2 of ~19 comply). **Scope for
+  this spec:** add first-action self-log guidance to touched user-invocable
+  workflows: `bootstrap`, `brainstorm`, `implement`, `housekeeping`, `reflect`,
+  `research`, plus any touched workflow that already has a user-invocable sidecar.
+  A repo-wide self-log sweep remains outside SPEC-048 unless required by a touched
+  cross-reference.
 
 ## Test Conditions
 
@@ -324,7 +343,9 @@ SPEC-043 (session bodies).
    demands a hand-authored session file. *(non-breaking)*
 4. **Bootstrap + brainstorm.** Bootstrap session guidance to SQLite/`wrap`;
    brainstorm to `loaf spark capture`. *(non-breaking)*
-5. **Read-side wave.** `reflect`, `research`, `background-runner`. *(non-breaking)*
+5. **Read-side wave.** `reflect`, `research`, and
+   `content/agents/background-runner.md`; review `handoff` and `librarian` for
+   explicit primary-model conflicts and edit only if needed. *(non-breaking)*
 6. **Housekeeping fix + self-logging.** `loaf session housekeeping` →
    `loaf housekeeping`; write `skill(housekeeping)` marker; add first-action
    self-logging to touched user-invocable workflows; fix AGENTS.md exemplars.

--- a/.agents/specs/SPEC-048-session-model-convergence.md
+++ b/.agents/specs/SPEC-048-session-model-convergence.md
@@ -285,41 +285,41 @@ tokens where harness-specific terms appear.
 
 ## Test Conditions
 
-- [ ] `wrap` is cited as the canonical session model in `.claude/CLAUDE.md` and
+- [x] `wrap` is cited as the canonical session model in `.claude/CLAUDE.md` and
   `.agents/AGENTS.md`; no other document presents a competing "create a session
   file" model as primary.
-- [ ] `content/templates/session.md` no longer instructs creating
+- [x] `content/templates/session.md` no longer instructs creating
   `.agents/sessions/*.md` as a source surface; it documents the journal entry
   format and entry types as a render template / reference.
-- [ ] No skill or agent profile references `loaf session housekeeping`; all
+- [x] No skill or agent profile references `loaf session housekeeping`; all
   housekeeping guidance uses `loaf housekeeping`.
-- [ ] `content/skills/housekeeping/SKILL.md` writes a `skill(housekeeping)`
+- [x] `content/skills/housekeeping/SKILL.md` writes a `skill(housekeeping)`
   self-log marker on invocation, and `wrap`'s "no housekeeping this session"
   nudge stops mis-firing when housekeeping has run.
-- [ ] Zero matches for `Transcript Archival` or `.agents/transcripts/` across
+- [x] Zero matches for `Transcript Archival` or `.agents/transcripts/` across
   `content/` and all built outputs (`dist/*`, `plugins/loaf/`).
-- [ ] `content/skills/implement/SKILL.md` no longer contains "MANDATORY: Create
+- [x] `content/skills/implement/SKILL.md` no longer contains "MANDATORY: Create
   session file BEFORE any other work" or "DO NOT PROCEED WITHOUT A SESSION FILE";
   it teaches `loaf session start`.
-- [ ] `content/agents/implementer.md` no longer demands a hand-authored "session
+- [x] `content/agents/implementer.md` no longer demands a hand-authored "session
   file" and aligns with the `loaf session start` model — changed in the same
   commit set as `implement`.
-- [ ] `orchestration` SKILL + `sessions.md`/`context-management.md`/
+- [x] `orchestration` SKILL + `sessions.md`/`context-management.md`/
   `background-agents.md` present the SQLite/`wrap` model and contain no
   `transcripts:` frontmatter rows/layout.
-- [ ] `brainstorm` captures sparks via `loaf spark capture` (SQLite-first); the
+- [x] `brainstorm` captures sparks via `loaf spark capture` (SQLite-first); the
   draft `.md` is described as export/projection, not canonical source.
-- [ ] Read-side skills (`reflect`, `research`, `background-runner`) reference the
+- [x] Read-side skills (`reflect`, `research`, `background-runner`) reference the
   SQLite session model, not markdown session files as the routing surface.
-- [ ] User-invocable workflow skills touched in this convergence include a
+- [x] User-invocable workflow skills touched in this convergence include a
   first-action `loaf session log "skill(<name>): …"`; the `shape`, `housekeeping`,
   and `implement` AGENTS.md exemplars match the documented rule.
-- [ ] The session vocabulary used in the rewritten content matches the runtime
+- [x] The session vocabulary used in the rewritten content matches the runtime
   enum (`internal/state/session_*.go`) / SPEC-049's canonical enum — no fourth
   vocabulary introduced.
-- [ ] `loaf build` succeeds; `npm run typecheck` and `npm run test` pass; built
+- [x] `loaf build` succeeds; `npm run typecheck` and `npm run test` pass; built
   outputs committed with source.
-- [ ] The whole convergence lands as one atomic change set — no intermediate
+- [x] The whole convergence lands as one atomic change set — no intermediate
   commit leaves some session skills SQLite-first and others markdown-first.
 
 ## Priority Order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ is a Loaf workflow staging section for curated entries before release.
 ### Changed
 
 - Completed SPEC-047 build integrity and parity hardening, including real JS/TS output validation, first-class Amp TypeScript plugin output, Gemini target removal, Codex hook semantics, OpenCode command reachability, and cross-harness parity linting.
+- Converged session workflow guidance in SPEC-048 around SQLite-backed session state, native session journal commands, and render-on-demand Markdown artifacts across skills, templates, agents, and generated targets.
 
 ## [2.0.0-pre.20260614235428] - 2026-06-14
 

--- a/cmd/loaf/session_convergence_content_test.go
+++ b/cmd/loaf/session_convergence_content_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestSessionModelConvergenceContentGuards(t *testing.T) {
+	root := repoRoot(t)
+
+	searchRoots := []string{
+		"content",
+		"dist",
+		filepath.ToSlash(filepath.Join("plugins", "loaf")),
+		".agents/AGENTS.md",
+		".claude/CLAUDE.md",
+	}
+	forbidden := []string{
+		"loaf session housekeeping",
+		".agents/transcripts/",
+		"Transcript Archival",
+		"MANDATORY: Create session file",
+		"DO NOT PROCEED WITHOUT A SESSION FILE",
+		"transcripts:",
+	}
+
+	var failures []string
+	for _, rel := range searchRoots {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		failures = append(failures, forbiddenContentMatches(t, path, forbidden)...)
+	}
+	sort.Strings(failures)
+	if len(failures) > 0 {
+		t.Fatalf("session model convergence forbidden content remains:\n%s", strings.Join(failures, "\n"))
+	}
+}
+
+func TestSessionModelConvergenceAnointsWrapInTopLevelGuidance(t *testing.T) {
+	root := repoRoot(t)
+	for _, rel := range []string{".agents/AGENTS.md", ".claude/CLAUDE.md"} {
+		body := readTextFile(t, filepath.Join(root, filepath.FromSlash(rel)))
+		for _, want := range []string{"canonical session model", "wrap", "loaf session start", "loaf session end --wrap"} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("%s missing %q in canonical session guidance", rel, want)
+			}
+		}
+		if strings.Contains(body, "Create session file following") {
+			t.Fatalf("%s still advertises hand-authored session file scaffolding", rel)
+		}
+	}
+}
+
+func forbiddenContentMatches(t *testing.T, path string, forbidden []string) []string {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("Stat(%s) error = %v", path, err)
+	}
+	if !info.IsDir() {
+		return forbiddenMatchesInFile(t, path, forbidden)
+	}
+	var matches []string
+	err = filepath.WalkDir(path, func(file string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			name := entry.Name()
+			if name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !entry.Type().IsRegular() || !isSessionConvergenceTextFile(file) {
+			return nil
+		}
+		matches = append(matches, forbiddenMatchesInFile(t, file, forbidden)...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir(%s) error = %v", path, err)
+	}
+	return matches
+}
+
+func forbiddenMatchesInFile(t *testing.T, path string, forbidden []string) []string {
+	t.Helper()
+	body := readTextFile(t, path)
+	lines := strings.Split(body, "\n")
+	var matches []string
+	for lineNumber, line := range lines {
+		for _, phrase := range forbidden {
+			if strings.Contains(line, phrase) {
+				matches = append(matches, filepath.ToSlash(path)+":"+strconv.Itoa(lineNumber+1)+": "+phrase)
+			}
+		}
+	}
+	return matches
+}
+
+func readTextFile(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	return string(body)
+}
+
+func isSessionConvergenceTextFile(path string) bool {
+	switch filepath.Ext(path) {
+	case ".md", ".yaml", ".yml", ".sh", ".py", ".json":
+		return true
+	default:
+		return false
+	}
+}

--- a/content/agents/background-runner.md
+++ b/content/agents/background-runner.md
@@ -12,7 +12,7 @@ You execute specific tasks in the background, writing results to a specified loc
 
 1. **Execute assigned task** - Security audits, coverage analysis, code reviews, etc.
 2. **Write results** - Output to specified `.agents/reports/` location
-3. **Update session** - Mark your background agent entry as complete
+3. **Report completion** - Write completion status in the report and log a concise session entry when session context is available
 
 ## Input You Receive
 
@@ -20,7 +20,7 @@ The spawning agent provides:
 - Specific task to execute
 - Files or scope to analyze
 - Output location (`.agents/reports/YYYYMMDD-HHMMSS-<name>.md`)
-- Session reference
+- Session alias or task/spec reference when available
 
 ## Execution Process
 
@@ -30,7 +30,7 @@ Extract from prompt:
 - What to do (audit, analyze, review)
 - Scope (files, directories)
 - Output location
-- Session file path
+- Session alias, task ID, or spec ID when provided
 
 ### 2. Execute Work
 
@@ -52,7 +52,7 @@ report:
   status: unprocessed
   created: "2026-01-23T14:30:00Z"
   background_agent_id: "bg-YYYYMMDD-HHMMSS-description"
-  session_reference: "YYYYMMDD-HHMMSS-session-name.md"
+  session_reference: "session alias or task/spec reference"
 ---
 
 # Report Title
@@ -79,17 +79,13 @@ Prioritized list of actions.
 - `path/to/file2.py`
 ```
 
-### 4. Update Session Frontmatter
+### 4. Report Completion
 
-Read session file and update your background agent entry:
+If the prompt supplied an active session alias and the `loaf` CLI is available,
+log the result:
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: completed  # Changed from running
-    result_location: ".agents/reports/20260123-143000-security.md"  # Set path
+```bash
+loaf session log "discover(background): bg-YYYYMMDD-HHMMSS-description completed; report .agents/reports/..."
 ```
 
 ## Constraints
@@ -106,8 +102,7 @@ Before completing:
 - [ ] Task executed per prompt instructions
 - [ ] Report written to specified location
 - [ ] Report has valid frontmatter with `background_agent_id`
-- [ ] Session frontmatter updated with `status: completed`
-- [ ] Session frontmatter updated with `result_location`
+- [ ] Completion logged to session journal when session context was provided
 - [ ] No user interaction attempted
 
 ## Error Handling
@@ -116,16 +111,11 @@ If task cannot be completed:
 
 1. Write partial report with what was accomplished
 2. Document blockers in report
-3. Update session frontmatter with `status: failed`
+3. Log failure to session journal when session context was provided
 4. Include error details in report
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: failed
-    result_location: ".agents/reports/20260123-143000-security-partial.md"
+```bash
+loaf session log "block(background): bg-YYYYMMDD-HHMMSS-description failed; partial report .agents/reports/..."
 ```
 
 ## Example Task
@@ -142,7 +132,7 @@ Check for OWASP Top 10 vulnerabilities.
 
 Write report to: .agents/reports/20260123-143000-auth-security.md
 
-Session: .agents/sessions/20260123-140000-auth-feature.md
+Session: active session alias if available
 Background Agent ID: bg-20260123-143000-auth-security
 ```
 
@@ -150,4 +140,4 @@ Background Agent ID: bg-20260123-143000-auth-security
 1. Read `src/auth/endpoints.py` and `src/auth/token.py`
 2. Analyze for OWASP vulnerabilities
 3. Write findings to `.agents/reports/20260123-143000-auth-security.md`
-4. Update `.agents/sessions/20260123-140000-auth-feature.md` frontmatter
+4. Log completion to the session journal if session context was provided

--- a/content/agents/implementer.md
+++ b/content/agents/implementer.md
@@ -5,7 +5,7 @@ You are an implementer. You have full write access to the codebase: code, tests,
 ## Behavioral Contract
 
 - Your domain speciality comes from the skills loaded at spawn time, not from this profile. An implementer with Python skills implements Python; an implementer with infrastructure skills writes Terraform. The role is the same; the material differs.
-- Work within an active session. If no session file was provided in your spawn prompt, say so immediately.
+- Work within an active session. If no session alias, task ID, or branch context was provided in your spawn prompt, say so immediately.
 - Follow the conventions defined in your loaded skills. They are your blueprints.
 - Write tests alongside implementation, never after.
 - Run verification commands (linters, type checkers, test suites) before reporting completion.

--- a/content/agents/librarian.md
+++ b/content/agents/librarian.md
@@ -1,20 +1,20 @@
 # Librarian
 
-You are a librarian. You shepherd session files through their lifecycle and tend the operational artifacts under `.agents/`. You have read access to the repository and edit access scoped to `.agents/` only.
+You are a librarian. You shepherd SQLite-backed session journals through their lifecycle and tend operational artifacts under `.agents/`. You have read access to the repository and edit access scoped to `.agents/` only.
 
 ## Behavioral Contract
 
-- Tend session files: Current State summaries, journal quality, wrap summaries, lifecycle transitions.
+- Tend session journals: journal quality, wrap summaries, and lifecycle transitions.
 - Never modify code, tests, or configuration — only `.agents/` artifacts.
 - Never research, review, or orchestrate — those are other profiles' work.
 - Work quickly and silently. The user should not notice you unless something is wrong.
-- Read before writing — always check the current state of a session file before modifying it.
+- Read before writing — always check the current state with `loaf session show` before modifying related artifacts.
 
 ## What You Tend
 
-- **Session files** in `.agents/sessions/` — frontmatter, Current State, journal entries
+- **SQLite sessions** — inspect with `loaf session list --json` and `loaf session show <ref> --json`
 - **Session lifecycle** — status transitions (active → stopped → done → archived)
-- **Pre-compaction preservation** — flush journal entries, write Current State before context compaction
+- **Pre-compaction preservation** — flush journal entries before context compaction
 - **Knowledge artifacts** in `.agents/knowledge/` — staleness markers, coverage notes
 - **Wrap summaries** — end-of-session distillation when invoked by `/wrap`
 - **Decision persistence** — extract decisions to spec changelog via `loaf session end --wrap`

--- a/content/skills/bootstrap/SKILL.md
+++ b/content/skills/bootstrap/SKILL.md
@@ -40,6 +40,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - **BRIEF is input, not output** -- the BRIEF is raw intake. Extract every useful fact into VISION/STRATEGY/ARCHITECTURE/AGENTS during bootstrap.
 - **BRIEF is archeological after bootstrap** -- once extraction completes, the BRIEF is a frozen historical snapshot. No skill, agent, command, or template should reference `docs/BRIEF.md` post-bootstrap. Operating documents must stand on their own.
 - **Suggest, don't execute** -- recommend next skills at the end, never auto-run them
+- **Log first** -- log invocation before interviewing: `loaf session log "skill(bootstrap): <project or intake>"`
 - **Log outcome** -- log bootstrap completion to session journal: `loaf session log "decision(bootstrap): project bootstrapped, mode detected"`
 
 ---
@@ -49,7 +50,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - All expected operating documents (`docs/VISION.md`, `.agents/AGENTS.md` at minimum) exist and contain populated content
 - Useful BRIEF content has been extracted into operating documents (no future reader should need to open the BRIEF)
 - Symlinks are correct: `.claude/CLAUDE.md -> .agents/AGENTS.md` and `./AGENTS.md -> .agents/AGENTS.md`
-- A session file was saved in `.agents/sessions/` capturing key decisions and interview exchanges
+- Key decisions and interview outcomes were logged with `loaf session log` and are readable with `loaf session show`
 
 ---
 
@@ -368,13 +369,13 @@ If symlinks already exist and point to the right targets, skip silently. If they
 
 ### 3. Session Recording
 
-Save the bootstrap interview as a session file:
+Record the bootstrap interview in the active SQLite-backed session:
 
-```
-.agents/sessions/{YYYYMMDD}-{HHMMSS}-bootstrap.md
-```
+1. Run `loaf session start` if there is no active session.
+2. Log mode detection and key interview decisions with `loaf session log`.
+3. Use `loaf session show <session-ref>` to inspect the rendered session view.
 
-The session should capture:
+The session journal should capture:
 - Mode detected and why
 - Key decisions made during the interview
 - Key interview exchanges that informed those decisions
@@ -382,7 +383,8 @@ The session should capture:
 - The original problem framing and user intent
 - Any open questions or deferred decisions
 
-Follow [templates/session.md](templates/session.md) for structure and frontmatter schema.
+Use [templates/session.md](templates/session.md) only as the rendered journal
+format reference; do not hand-author session markdown as the source of truth.
 
 ### 4. Next Steps
 

--- a/content/skills/brainstorm/SKILL.md
+++ b/content/skills/brainstorm/SKILL.md
@@ -17,7 +17,8 @@ Generative thinking — expanding possibilities before narrowing through structu
 - Diverge before converging — generate options before judging
 - Connect exploration to VISION.md and STRATEGY.md context
 - Document discarded options — they hold valuable reasoning
-- Capture sparks (speculative byproducts) in a dedicated section — brainstorm documents are the canonical home for sparks
+- Log invocation first: `loaf session log "skill(brainstorm): <topic>"`
+- Capture sparks (speculative byproducts) with `loaf spark capture --scope <scope> --text <text>`; brainstorm documents may render or summarize them
 - Set boundaries on exploration time
 - Log outcome to session journal: `loaf session log "decision(scope): direction chosen and rationale"`
 
@@ -31,7 +32,7 @@ Generative thinking — expanding possibilities before narrowing through structu
 
 After work completes, verify:
 - Brainstorm document created at `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
-- `## Sparks` section present with speculative byproducts
+- Sparks captured with `loaf spark capture` and optionally summarized in `## Sparks`
 - Spark lifecycle documented: unprocessed → promoted/discarded
 - Brainstorm references strategic context from VISION/STRATEGY
 
@@ -56,7 +57,7 @@ After work completes, verify:
 
 Sparks are: lightweight, byproducts, worth remembering. Mark as `*(promoted)*` or `*(abandoned)*` after processing.
 
-Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value.
+Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value. SQLite spark state is the lifecycle source; draft markdown is a projection or narrative summary.
 
 ## Suggests Next
 

--- a/content/skills/brainstorm/templates/brainstorm.md
+++ b/content/skills/brainstorm/templates/brainstorm.md
@@ -11,7 +11,7 @@ type: brainstorm
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active (has unprocessed sparks) | archived
 tags: []
-related: []            # Optional: idea files, spec IDs, session files
+related: []            # Optional: idea aliases, spec IDs, session aliases, report refs
 ---
 
 # Brainstorm: [Topic]

--- a/content/skills/handoff/templates/handoff.md
+++ b/content/skills/handoff/templates/handoff.md
@@ -8,7 +8,7 @@ title: "[Handoff Title]"
 created: YYYY-MM-DDTHH:MM:SSZ
 status: draft | final | deprecated
 source: session | branch | task | ad-hoc
-session: .agents/sessions/YYYYMMDD-HHMMSS-session.md
+session: session alias or loaf session show reference
 branch: branch-name
 deprecated_at: YYYY-MM-DDTHH:MM:SSZ  # Set only when confirmed obsolete
 deprecated_by: orchestrator

--- a/content/skills/housekeeping/SKILL.md
+++ b/content/skills/housekeeping/SKILL.md
@@ -15,10 +15,11 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Critical Rules
 
 **Always**
+- Log invocation as the first action: `loaf session log "skill(housekeeping): <scope or trigger>"`
 - Review EVERY file individually — never sample or average
 - Check Linear issue status before archiving sessions
 - Extract lessons learned and decisions before archiving
-- Use CLI (`loaf session housekeeping`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
+- Use CLI (`loaf housekeeping`, `loaf session archive`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
 - Treat `.agents/handoffs/` as first-class but disposable: keep active/final handoffs, delete only after confirmed deprecated status
 - Check report `status` is `processed` and linked session is archived before archiving reports (see [templates/report.md](templates/report.md))
 - Check state assessment `session:` field before flagging for cleanup — only flag when linked session is archived
@@ -33,7 +34,7 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Verification
 
 After work completes, verify:
-- Session files archived with proper metadata (status, archived_at, archived_by)
+- Session lifecycle state is visible through `loaf session list --json`
 - Tasks archived via `loaf task archive`
 - Specs archived via `loaf spec archive`
 - SQLite-backed task/spec/report state reflects lifecycle changes when initialized
@@ -46,10 +47,11 @@ After work completes, verify:
 ### CLI Commands
 
 ```bash
-loaf session housekeeping --dry-run  # Preview all actions
-loaf session housekeeping            # Run all checks and fixes
+loaf housekeeping --dry-run          # Preview recommendations
+loaf housekeeping                    # Run artifact scanner
+loaf housekeeping --sessions         # Review sessions only
 loaf session archive                 # Archive single session
-loaf session enrich <file>           # Enrich a session's journal from JSONL
+loaf session enrich --json           # Compatibility diagnostic for legacy enrichment
 loaf task archive TASK-XXX           # Archive single task
 loaf spec archive SPEC-XXX           # Archive single spec
 loaf task sync                       # Compatibility: repair Markdown task index drift
@@ -59,7 +61,7 @@ loaf task sync                       # Compatibility: repair Markdown task index
 
 | Artifact | Active Location | Archive | Action |
 |----------|-----------------|---------|--------|
-| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf session archive` / `loaf session housekeeping` |
+| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf housekeeping --sessions` / `loaf session archive` |
 | Tasks (local mode only) | SQLite state + `.agents/tasks/` source prose | `archive/` | `loaf task archive` |
 | Specs | SQLite state + `.agents/specs/` authored prose | `archive/` | `loaf spec archive` |
 | Drafts (state assessments) | `.agents/drafts/` | delete | Flag for cleanup when linked session is archived |
@@ -76,7 +78,10 @@ every mode.
 
 ## Session Enrichment
 
-For each session with status `stopped` or `done` that has a `claude_session_id` in frontmatter, run `loaf session enrich <file>` to catch up on journal entries that weren't logged during the session.
+In SQLite-backed projects, `loaf session log` is the canonical journal writer and
+`wrap` owns end-of-session checks. `loaf session enrich --json` is a compatibility
+diagnostic for legacy markdown enrichment; it is not part of the normal
+housekeeping flow.
 
 Do NOT enrich `active` sessions — those are handled by the wrap skill when the session ends.
 

--- a/content/skills/implement/SKILL.md
+++ b/content/skills/implement/SKILL.md
@@ -3,7 +3,7 @@ name: implement
 description: >-
   Orchestrates implementation sessions through agent delegation and batch execution.
   Use for all implementation work — features, bug fixes, refactors, and code changes.
-  Produces session files, agent spawn plans, and progress tracking.
+  Produces SQLite-backed session journals, agent spawn plans, and progress tracking.
   Not for shaping (use shape), breakdown (use breakdown), research, or review.
 ---
 
@@ -36,7 +36,7 @@ You are the coordinator. Start by understanding the task:
 **You are the ORCHESTRATOR, not the implementer.**
 
 ### Orchestrator Can Do Directly
-- Create/edit session files, council files
+- Start/log/show sessions, create council files
 - Use TodoWrite/TodoRead; **if `integrations.linear.enabled` is `true` in `.agents/loaf.json`**, use Linear MCP tools when helpful
 - Read any file for context
 - Ask clarifying questions
@@ -46,11 +46,11 @@ You are the coordinator. Start by understanding the task:
 
 ## Verification
 
-- Session file exists before any implementation work begins
+- `loaf session start` has created or resumed an active SQLite-backed session before implementation work begins
 - All code changes delegated via Task tool -- no direct edits by orchestrator
-- Session file is continuously updated with spawns, progress, and current state
+- Session journal is continuously updated with spawns, progress, and current state
 - Spec artifacts closed out on branch before PR creation
-- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session file is created; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
+- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session is started; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
 
 ## Quick Reference
 
@@ -78,7 +78,7 @@ Before starting, evaluate context suitability.
 | Just completed a different task/spec | Suggest clear |
 | About to start multi-file implementation | Check depth |
 
-If restart needed: capture state in session file, generate resumption prompt, ask user to restart.
+If restart needed: log current state with `loaf session log`, generate resumption prompt, ask user to restart.
 
 ## Input Detection
 
@@ -86,7 +86,7 @@ Parse `$ARGUMENTS` to determine session type:
 
 | Input Pattern | Type | Action |
 |---------------|------|--------|
-| `TASK-XXX` | Local task | Load via `loaf task show`, auto-create session |
+| `TASK-XXX` | Local task | Load via `loaf task show`, start/resume session |
 | `SPEC-XXX` | Spec orchestration | If spec frontmatter has `linear_parent`, resolve to that Linear parent and follow Linear-Native Routing. Otherwise resolve local tasks and build dependency waves |
 | `TASK-XXX..YYY` | Task range | Expand range, build dependency waves |
 | `TASK-XXX,YYY,ZZZ` | Task list | Parse list, build dependency waves |
@@ -98,8 +98,8 @@ Parse `$ARGUMENTS` to determine session type:
 When starting from `TASK-XXX`:
 
 1. Load task metadata via `loaf task show TASK-XXX --json`; read `.agents/TASKS.json` only as a Markdown-compatibility fallback
-2. Auto-generate session: `YYYYMMDD-HHMMSS-task-XXX.md`
-3. Create session file, update task with session reference: `loaf task update TASK-XXX --session <session-file>`
+2. Run `loaf session start` to find or create the active session for the branch
+3. Log the task coupling: `loaf session log "decision(implement): implementing TASK-XXX"`
 4. Load parent spec if task has `spec:` field
 
 **No user interaction required for session naming.**
@@ -185,7 +185,7 @@ The issue is an actual task. Implement it directly — with a pre-flight gate.
    - Resolve branch name from the sub-issue's `branchName` field (Linear
      auto-generates one) — see
      [session-management.md](references/session-management.md).
-   - Create session file, continue with the standard Startup Checklist.
+   - Run `loaf session start`, then continue with the standard Startup Checklist.
 
 ### Completion (after implementer + reviewer finish cleanly)
 
@@ -222,8 +222,8 @@ When the sub-issue's implementation passes review and tests:
   implementation reveals a missing task, surface it to the user; they
   decide whether to run `/breakdown` again or add an ad-hoc sub-issue.
 - Does not sync in-progress state bidirectionally. Source of truth at any
-  moment: Linear for issue state, local files for spec content, session
-  file for current handoff.
+  moment: Linear for issue state, local files for spec content, SQLite session
+  journal for current handoff.
 
 ---
 
@@ -246,19 +246,19 @@ Use the **Task tool** with appropriate `subagent_type`:
 
 ---
 
-## Session Creation
+## Session Start
 
-**MANDATORY: Create session file BEFORE any other work.**
+**MANDATORY: Run `loaf session start` BEFORE any implementation work.**
 
-1. Generate timestamps: `date -u +"%Y%m%d-%H%M%S"` and `date -u +"%Y-%m-%dT%H:%M:%SZ"`
-2. Create session file following [session template](templates/session.md)
-3. Verify session file exists with valid frontmatter
+1. Run `loaf session start` from the target branch/worktree.
+2. Log invocation context: `loaf session log "skill(implement): <task/spec/context>"`
+3. Verify the active session is readable with `loaf session list --json` or `loaf session show <session-ref> --json`.
 4. Suggest renaming Claude Code session with a meaningful name derived from context:
    - From spec: `Suggestion: /rename SPEC-027-session-stability`
    - From task: `Suggestion: /rename TASK-042-login-fix`
    - From ad-hoc: `Suggestion: /rename {short-slug-from-description}`
 
-**DO NOT PROCEED WITHOUT A SESSION FILE.**
+**Do not proceed until the active session is visible through `loaf session` commands.**
 
 ---
 
@@ -269,8 +269,8 @@ Use the **Task tool** with appropriate `subagent_type`:
 3. **When uncertain** -- convene council, present results, **wait for user approval**
 4. **Ensure quality** -- spawn implementer for tests, route reviews to reviewer subagents
 5. **When debugging** -- if a test failure or error isn't immediately obvious, load the **debugging** skill for structured hypothesis tracking before retrying
-6. **Update session file continuously** -- log spawns, update current_task, keep handoff-ready
-6. **Clean up** -- no ephemeral files, archive completed sessions (status + `archived_at` + `archived_by` + move to archive/)
+6. **Update session continuously** -- log spawns, progress, blockers, and next actions with `loaf session log`
+6. **Clean up** -- no ephemeral files; wrap with `loaf session end --wrap` and archive closed sessions with `loaf session archive`
 7. **When in doubt, ask the user**
 
 ## Decision Tree
@@ -279,7 +279,7 @@ Use the **Task tool** with appropriate `subagent_type`:
 Is this a code/config/doc change?
 +-- YES -> Spawn appropriate agent
 +-- NO -> Is this a planning/coordination decision?
-    +-- YES with clear path -> Proceed, update session
+    +-- YES with clear path -> Proceed, log session decision
     +-- YES but ambiguous -> Ask user
     +-- NO -> Ask user
 ```
@@ -290,18 +290,18 @@ When multiple valid approaches exist: spawn council (5-7 agents, odd), present r
 
 ## Startup Checklist
 
-After creating session file:
+After `loaf session start`:
 
 1. [ ] Parse input (task, Linear ID, or description)
-2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, update with `loaf task update TASK-XXX --session <session-file>`, load parent spec
+2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, log task coupling, load parent spec
 3. [ ] If Linear ID (or `SPEC-XXX` with `linear_parent`): follow [Linear-Native Routing](#linear-native-routing). Parent → walk sub-issues and select next. Sub-issue → verify `blockedBy` is clear, then start it as one logical Linear operation so the parent is promoted when needed
 4. [ ] If description: auto-create task (see Ad-hoc Task Auto-Creation above)
 5. [ ] Create dedicated branch (see [session-management.md](references/session-management.md))
 6. [ ] Suggest team based on task context
-7. [ ] Populate session Context section
+7. [ ] Log initial context and references with `loaf session log`
 8. [ ] Break down work using TodoWrite
 9. [ ] Identify needed specialized agents
-10. [ ] Update session Next Steps
+10. [ ] Log next steps before spawning
 11. [ ] **Get user approval** before spawning
 
 ---
@@ -309,7 +309,7 @@ After creating session file:
 ## Then Execute
 
 ### BEFORE (Planning)
-1. Create session file
+1. Run `loaf session start`
 2. Set task status: `loaf task update TASK-XXX --status in_progress`
 3. Break down work into agent-sized tasks
 4. Identify spawn order (respect dependencies)
@@ -317,10 +317,10 @@ After creating session file:
 
 ### DURING (Execution)
 1. Spawn specialized agents via Task tool
-2. Log each spawn in session `orchestration.spawned_agents`
+2. Log each spawn with `loaf session log "todo(agent): spawned <agent> for <task>"`
 3. Update Linear with progress (no emoji, no file paths)
-4. Keep session `## Current State` handoff-ready
-5. After each agent completes: update session, spawn next
+4. Keep journal entries handoff-ready
+5. After each agent completes: log outcome, spawn next
 
 ### AFTER (Completion)
 1. Code review pass (spawn `reviewer` agent)
@@ -329,13 +329,13 @@ After creating session file:
    - **Local-tasks mode:** `loaf task update TASK-XXX --status done` (per task), then `loaf task archive --spec SPEC-XXX`
    - **Linear-native mode:** `update_issue` the sub-issue to `completed`-type state. Then query the parent's sub-issues; if all are `completed`, also close the parent. If some remain, list them for the user (see [Linear-Native Routing → Completion](#completion-after-implementer--reviewer-finish-cleanly))
    - Mark spec complete and archive: `loaf spec archive SPEC-XXX` (both modes)
-   - Update session file (status: done, `archived_at`, `archived_by`)
-   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
+   - Run `loaf session end --wrap`; archive later with `loaf session archive` when appropriate
+   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session state`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
 5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
-6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
-   - `## Key Decisions` has content (not `*(none yet)*` or empty)
-   - `traceability.decisions` has entries (ADRs were recorded)
+6. **Suggest reflection:** Check the session journal for extractable learnings before closing out:
+   - `decision(...)` entries are present
+   - ADRs, report verdicts, or spec changelog entries were recorded
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
@@ -358,4 +358,4 @@ After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release`
 - **orchestration/product-development** - Full workflow hierarchy
 - **orchestration/specs** - Spec format and lifecycle
 - **orchestration/local-tasks** - Task file format including `session:` field
-- **orchestration/sessions** - Session lifecycle details
+- **orchestration/sessions** - SQLite-backed session lifecycle details

--- a/content/skills/implement/references/session-management.md
+++ b/content/skills/implement/references/session-management.md
@@ -8,7 +8,6 @@
 - Linear Status Management
 - Handoff State Requirements
 - Timestamps for User Context
-- Transcript Archival
 - Task Completion
 
 Detailed reference for session lifecycle management during implementation.
@@ -87,7 +86,7 @@ Use Linear MCP's `list_teams` (if configured) to get all workspace teams for val
 
 ## Diagram Consideration
 
-For multi-file or multi-service changes, consider adding architecture diagrams to the session file.
+For multi-file or multi-service changes, consider adding architecture diagrams to the linked spec, report, ADR, or implementation notes.
 
 ### When to Create Diagrams
 
@@ -106,7 +105,7 @@ Ask yourself:
 2. Is there a data flow that needs to be understood?
 3. Would a visual help communicate the approach?
 
-If yes to any, add an `## Architecture Diagrams` section to the session file.
+If yes to any, capture the diagram in a durable artifact such as a spec, report, ADR, or implementation note, and log the reference with `loaf session log`.
 
 ### Diagram Template
 
@@ -144,7 +143,7 @@ For complex tasks, explore before implementing:
 1. Use Task(Explore) or Task(Plan) to investigate codebase
 2. Map existing patterns and conventions
 3. Identify integration points
-4. Document findings in session file
+4. Log findings with `loaf session log` and reference durable artifacts
 5. Present approach to user for approval before spawning
 ```
 
@@ -193,12 +192,12 @@ never implement through open `blockedBy`.
 
 ## Handoff State Requirements
 
-**The session file must ALWAYS be handoff-ready.** After every significant action:
+**The session journal must ALWAYS be handoff-ready.** After every significant action:
 
-1. Update `## Current State` to reflect what just happened
-2. Update `orchestration.current_task` in frontmatter
+1. Log what just happened with `loaf session log`
+2. Reference task/spec/report/commit IDs rather than duplicating long prose
 3. Log completed agent work with outcomes
-4. Ensure anyone could pick up the work immediately
+4. Ensure anyone could pick up the work immediately from `loaf session show`
 
 ---
 
@@ -217,44 +216,6 @@ Generate with: `date -u +"%Y-%m-%d %H:%M UTC"`
 
 ---
 
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference.
-
-### Process
-
-1. **Get transcript path** from Claude Code output after compaction
-2. **Create transcripts directory** if needed:
-   ```bash
-   mkdir -p .agents/transcripts
-   ```
-3. **Copy transcript** with descriptive name:
-   ```bash
-   cp /path/to/transcript.jsonl .agents/transcripts/YYYYMMDD-HHMMSS-description.jsonl
-   ```
-4. **Update session frontmatter**:
-   ```yaml
-   transcripts:
-     - 20260123-143500-pre-compact.jsonl
-   ```
-
-### When to Archive
-
-| Event | Action |
-|-------|--------|
-| Before `/compact` | Archive current transcript |
-| Before `/clear` | Archive current transcript |
-| Session end | Archive final transcript |
-
-### Benefits
-
-- **Audit trail** - Full history of decisions and work
-- **Knowledge extraction** - Mining past sessions for patterns
-- **Debugging** - Understanding how errors occurred
-- **Training** - Learning from past sessions
-
----
-
 ## Task Completion
 
 When a task-coupled session completes:
@@ -267,7 +228,7 @@ When a task-coupled session completes:
      `list_issues` with `parent: <parent-id>`; if all are `completed`-type,
      close the parent and mark the local spec `complete`, else both stay
      in flight
-3. **Archive session** (standard process)
+3. **Wrap session** with `loaf session end --wrap`; archive with `loaf session archive` when the work is closed
 
 ### Spec Completion Check
 

--- a/content/skills/orchestration/SKILL.md
+++ b/content/skills/orchestration/SKILL.md
@@ -24,12 +24,12 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 ## Critical Rules
 
 ### Sessions
-- Create following [session template](templates/session.md) — compact inline journal format
-- Use `loaf session log` for journal entries: `decide(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
+- Start or resume with `loaf session start`; SQLite is the operational source.
+- Use `loaf session log` for journal entries: `decision(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
 - **SESSION JOURNAL NUDGE**: When you see this hook trigger, log unrecorded decisions or findings before responding. Use `loaf session log "entry(scope): description"`. Only log actions (decisions made, things discovered, conclusions reached) — not thoughts or read-only work.
-- Archive when complete (status + `archived_at` + `archived_by` + move to `.agents/sessions/archive/`)
-- PreCompact hook: appends `compact` entry with context summary
-- Post-compaction: `loaf session start` outputs recent journal entries for recovery
+- Wrap with `loaf session end --wrap`; archive with `loaf session archive` when complete.
+- PreCompact hook: flushes journal-worthy state before compaction.
+- Post-compaction: `loaf session start` and `loaf session show` expose recent journal context for recovery.
 
 ### Councils
 - Always odd number: 5 or 7 agents
@@ -54,7 +54,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 ## Verification
 
-- Validate session files with `validate-session.py` before archiving
+- Verify `loaf session list --json` / `loaf session show <ref> --json` reflect the active work before archiving
 - Validate council files with `validate-council.py` before concluding
 - Confirm Linear issue updates are self-contained (no local paths, no emoji)
 
@@ -62,7 +62,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 | Task | Action |
 |------|--------|
-| Multi-step work | Create session file, spawn agents |
+| Multi-step work | Start/resume session, spawn agents |
 | Complex decision | Convene council (5-7 agents, odd) |
 | Linear update | Checkboxes, no emoji, no local paths |
 | Feature planning | Size by complexity, shape before building |
@@ -84,7 +84,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 | Subagent Development | [references/subagent-development.md](references/subagent-development.md) | Delegating to specialized agents |
 | Background Agents | [references/background-agents.md](references/background-agents.md) | Running non-interactive work in background |
 | Council Workflow | [references/councils.md](references/councils.md) | Convening councils for complex decisions |
-| Session Management | [references/sessions.md](references/sessions.md) | Creating sessions and keeping live work resumable |
+| Session Management | [references/sessions.md](references/sessions.md) | Starting sessions and keeping live work resumable |
 | Session Resume | [references/session-resume.md](references/session-resume.md) | Resuming sessions, checkpoints, context recovery |
 | Context Management | [references/context-management.md](references/context-management.md) | Using /clear, /compact, managing context limits |
 | Linear Integration | [references/linear.md](references/linear.md) | Updating Linear issues, magic words, status conventions |
@@ -96,7 +96,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 **You are the orchestrator, not the implementer.**
 
 The orchestrator:
-1. Creates issues and session files for tracking
+1. Creates issues and starts sessions for tracking
 2. Breaks down work into delegable tasks
 3. Spawns specialized agents for implementation
 4. Coordinates outcomes and updates external systems
@@ -111,7 +111,6 @@ This skill uses paths from `.agents/loaf.json`:
 ```json
 {
   "sessions": {
-    "directory": ".agents/sessions",
     "councils_directory": ".agents/councils"
   },
   "linear": {
@@ -126,9 +125,8 @@ This skill uses paths from `.agents/loaf.json`:
 
 | Artifact | Location | Archive | Naming |
 |----------|----------|---------|--------|
-| Sessions | `.agents/sessions/` | `.agents/sessions/archive/` | `YYYYMMDD-HHMMSS-description.md` |
+| Sessions | SQLite (`loaf session show`) | `loaf session archive` | CLI alias / session ID |
 | Councils | `.agents/councils/` | `.agents/councils/archive/` | `YYYYMMDD-HHMMSS-topic.md` |
-| Transcripts | `.agents/transcripts/` | N/A | Copied from tool output |
 | Handoffs | `.agents/handoffs/` | delete after deprecated | Created by `/handoff` |
 | Reports | `.agents/reports/` | N/A | `YYYYMMDD-HHMMSS-subject.md` |
 | Tasks | `.agents/tasks/` | N/A | Per task manager conventions |
@@ -139,16 +137,16 @@ This skill uses paths from `.agents/loaf.json`:
 
 ### BEFORE (Planning)
 - Create/check external issue (Linear, GitHub)
-- Create session file following [session template](templates/session.md)
+- Run `loaf session start` and log the orchestration intent
 - Break down into tasks, identify agents, get user approval
 
 ### DURING (Execution)
 - Spawn specialized agents (never implement directly)
-- Track progress in session file and external issue
+- Track progress with `loaf session log` and external issue updates
 - Convene councils for uncertain decisions
 
 ### AFTER (Completion)
 - Code review + QA testing
 - Update external issue to Done
 - Ensure knowledge captured in permanent locations
-- Archive session (status + `archived_at` + `archived_by` + move + update links)
+- Run `loaf session end --wrap`; archive with `loaf session archive` after merge/closure

--- a/content/skills/orchestration/references/background-agents.md
+++ b/content/skills/orchestration/references/background-agents.md
@@ -1,12 +1,13 @@
 # Background Agents
 
-Background agents handle low-priority, long-running, or non-interactive work that can run independently while the user continues with other tasks.
+Background agents handle low-priority, long-running, or non-interactive work
+while the user continues with other tasks.
 
 ## Contents
 
 - When to Use Background Agents
 - Spawning Background Agents
-- Background Agent Tracking
+- Tracking
 - Result Retrieval
 - Workflow Example
 - Anti-Patterns
@@ -19,20 +20,11 @@ Background agents handle low-priority, long-running, or non-interactive work tha
 | Security audits | Interactive debugging |
 | Code coverage analysis | User-facing questions |
 | Large-scale refactoring reports | Time-sensitive fixes |
-| Codebase-wide linting reports | Tasks requiring immediate feedback |
 | Documentation audits | Work needing user decisions mid-task |
 | Dependency vulnerability scans | Blocking tasks for current work |
 
-**Good candidates:**
-- Results can be processed later
-- No user interaction required
-- Task is well-defined with clear completion criteria
-- Output is a report or artifact, not a conversation
-
-**Poor candidates:**
-- Needs clarification mid-task
-- Time-sensitive (user waiting for result)
-- Requires real-time coordination with other agents
+Good candidates have clear completion criteria, can run without clarification,
+and produce a report or durable artifact.
 
 ## Spawning Background Agents
 
@@ -51,8 +43,7 @@ Task(
     - src/services/
 
     Write report to: .agents/reports/YYYYMMDD-HHMMSS-security-audit.md
-
-    Session: .agents/sessions/20260123-143000-auth-feature.md
+    Active session: SESSION-ALIAS if available from loaf session list/show
     """,
     run_in_background=True
 )
@@ -60,187 +51,57 @@ Task(
 
 ### Cursor
 
-Background agents are configured via the `is_background: true` YAML property. When spawning:
+Background agents are configured via the `is_background: true` YAML property.
+When spawning, specify the report destination and any task/spec/session IDs:
 
 ```
 @background-runner Run security audit on backend codebase.
-Write report to .agents/reports/
+Write report to .agents/reports/.
+Reference TASK-123 and the active session alias if available.
 ```
 
-## Background Agent Tracking
+## Tracking
 
-Track background agents in session frontmatter:
+Track background work with durable references:
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security-scan"
-    agent: background-runner
-    task: "Full security audit of backend"
-    status: running  # running | completed | failed
-    result_location: null
-  - id: "bg-20260123-144500-coverage"
-    agent: background-runner
-    task: "Test coverage analysis"
-    status: completed
-    result_location: ".agents/reports/20260123-144500-coverage-report.md"
-```
+1. Log the spawn with `loaf session log "todo(background): started <id> for <task>"`.
+2. Ask the background agent to write a report under `.agents/reports/`.
+3. When complete, log `discover(background): <id> wrote <report>`.
+4. Process findings into tasks, specs, ADRs, or report verdicts as appropriate.
 
-### Status Values
-
-| Status | Meaning |
-|--------|---------|
-| `running` | Agent still executing |
-| `completed` | Work finished, results available |
-| `failed` | Agent encountered error |
-
-### ID Convention
-
-Background agent IDs follow: `bg-YYYYMMDD-HHMMSS-<description>`
-
-Generate with:
-```bash
-echo "bg-$(date -u +"%Y%m%d-%H%M%S")-<description>"
-```
+Use a stable ID such as `bg-YYYYMMDD-HHMMSS-description` in the prompt and
+journal entries.
 
 ## Result Retrieval
 
-Background agents write results to `.agents/reports/` with standard frontmatter:
-
-```yaml
----
-report:
-  title: "Security Audit Report"
-  type: background-agent-output
-  status: unprocessed  # unprocessed | processed | archived
-  created: "2026-01-23T14:30:00Z"
-  background_agent_id: "bg-20260123-143000-security-scan"
-  session_reference: "20260123-140000-auth-feature.md"
----
-```
-
-### Processing Results
-
-1. SessionStart hook alerts user to completed background work
-2. User or orchestrator reviews report in `.agents/reports/`
-3. Orchestrator updates session frontmatter:
-   - Change `status` from `running` to `completed`
-   - Set `result_location` to report path
-4. Process findings as needed (spawn agents, create issues)
-5. Set report `status` to `processed`
+Background agents write results to `.agents/reports/` with enough metadata to
+identify the source task and report status. In SQLite-backed projects, use
+`loaf report list`, `loaf report show`, and `loaf report archive` when report
+state is available.
 
 ## Workflow Example
 
-### 1. Orchestrator Identifies Low-Priority Work
-
-During auth feature implementation, orchestrator identifies need for security audit but it is not blocking current work.
-
-### 2. Orchestrator Spawns Background Agent
-
-```python
-Task(
-    subagent_type="background-runner",
-    prompt="""
-    Run comprehensive security audit on auth implementation.
-
-    Files to audit:
-    - src/auth/endpoints.py
-    - src/auth/token.py
-    - src/auth/middleware.py
-
-    Check for:
-    - OWASP Top 10 vulnerabilities
-    - Secrets in code
-    - SQL injection risks
-    - Authentication bypasses
-
-    Write report to: .agents/reports/20260123-143000-auth-security.md
-
-    Session: .agents/sessions/20260123-140000-auth-feature.md
-    """,
-    run_in_background=True
-)
-```
-
-### 3. Orchestrator Updates Session Frontmatter
-
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-auth-security"
-    agent: background-runner
-    task: "Auth security audit"
-    status: running
-    result_location: null
-```
-
-### 4. Work Continues
-
-Orchestrator and other agents continue with main implementation while background agent works.
-
-### 5. Session Resumes Later
-
-SessionStart hook detects completed background work:
-
-```
-# Background Work Completed
-
-The following background agents have completed:
-
-- **bg-20260123-143000-auth-security** (background-runner)
-  - Task: Auth security audit
-  - Result: .agents/reports/20260123-143000-auth-security.md
-
-Review reports and update session frontmatter after processing.
-```
-
-### 6. Results Processed
-
-Orchestrator reads report, creates issues for findings, updates session.
+1. Orchestrator identifies non-blocking security audit work.
+2. Orchestrator logs the background spawn in the active session.
+3. Background agent writes `.agents/reports/YYYYMMDD-HHMMSS-auth-security.md`.
+4. Orchestrator reviews the report, creates follow-up tasks, and logs the
+   outcome.
+5. Report state is finalized or archived through the report lifecycle.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
 | Use for blocking work | Keep blocking work in foreground |
-| Spawn without tracking | Always update session frontmatter |
-| Ignore completed results | Process results when alerted |
+| Spawn without tracking | Log the spawn and require a report path |
+| Ignore completed results | Process reports into tasks, findings, or decisions |
 | Use for interactive tasks | Reserve for autonomous work |
-| Spawn many concurrent background agents | Limit to 2-3 to avoid resource contention |
-| Skip result location in prompt | Always specify where to write output |
+| Spawn many concurrent background agents | Limit concurrency to avoid resource contention |
+| Skip result location in prompt | Always specify where output belongs |
 
 ## Integration Points
 
-### SessionStart Hook
-
-Checks session frontmatter for `background_agents` with `status: completed`. Alerts user to review results.
-
-### PreCompact Hook
-
-Includes background agent state in preservation. PreCompact hook captures:
-- Active background agent list
-- Current status of each
-- Result locations for completed agents
-
-### Session Frontmatter
-
-Full template with background agents:
-
-```yaml
----
-session:
-  title: "Feature implementation"
-  status: in_progress
-  # ... other session fields ...
-
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: completed
-    result_location: ".agents/reports/20260123-143000-security.md"
-  - id: "bg-20260123-150000-coverage"
-    agent: background-runner
-    task: "Coverage analysis"
-    status: running
-    result_location: null
----
-```
+- `loaf session log` records spawn and completion facts.
+- `loaf session show` exposes recent background-work journal entries.
+- `loaf report` commands own durable report lifecycle when available.
+- `/wrap` should mention unprocessed background reports before ending a session.

--- a/content/skills/orchestration/references/context-management.md
+++ b/content/skills/orchestration/references/context-management.md
@@ -1,54 +1,34 @@
 # Context Management
 
-Patterns for managing context efficiently across sessions and agent spawns.
+Patterns for keeping long work resumable while using SQLite-backed session
+journals as the external memory.
 
 ## Contents
 
 - Design for Compaction
-- Overview
 - Context Commands
 - When to Clear Context
-- The 2-Correction Rule
-- Context Compaction
-- Session Files as Context Anchors
+- Compaction Lifecycle
 - Subagents for Context Isolation
 - Context Budget Guidelines
-- Preventing Context Bloat
-- Session Context Patterns
 - Warning Signs
 - Best Practices
 
 ## Design for Compaction
 
-Compaction is a normal part of long workflows, not an emergency measure. Any workflow expected to exceed 15-20 exchanges should be designed with compaction in mind from the start.
+Compaction is a normal part of long workflows. Design any workflow expected to
+span many exchanges so important state is already outside chat context.
 
 ### Compaction-First Principles
 
-1. **The journal IS external memory** — Session journal entries (decisions, discoveries, progress) survive compaction. Compaction can be lossy because all important state is already on disk.
-2. **`## Current State` is the resumption context** — Keep this section handoff-ready at all times. The PreCompact hook requires writing a state summary here before compaction.
-3. **Decisions go to disk, not context** — Record key decisions in the session journal immediately via `loaf session log`. Context may be compressed; journal entries persist.
-4. **Subagents absorb exploration** — Investigation and exploration should happen in subagents. Only the summary returns to the main context.
-
-### Compaction Lifecycle
-
-```
-PreCompact:
-  1. Flush all unrecorded journal entries (decisions, discoveries, progress)
-  2. Write condensed state summary to session file's ## Current State
-  3. compact.sh writes compact(session) marker to journal
-
-PostCompact:
-  1. PostCompact nudge fires — tells model to read session file
-  2. Model reads ## Current State for resumption context
-  3. Model reads ## Journal for decision trail
-  4. Work resumes without "where were we?"
-```
-
-This makes compaction invisible to workflow continuity. The session file's `## Current State` section is the resumption prompt — written by the model before compaction, read by the model after.
-
-## Overview
-
-Context is finite. Long conversations accumulate irrelevant information that degrades performance. Active context management keeps conversations focused and effective.
+1. **The journal is external memory.** Record decisions, discoveries, blockers,
+   and next actions with `loaf session log`.
+2. **Artifacts carry detail.** Specs, tasks, reports, ADRs, and commits hold rich
+   detail; journal entries point to them.
+3. **Subagents absorb exploration.** Use subagents for broad investigation and
+   return concise findings to the main context.
+4. **`wrap` closes the loop.** End meaningful work with `loaf session end --wrap`
+   so the session lifecycle matches the journal.
 
 ## Context Commands
 
@@ -60,191 +40,78 @@ Context is finite. Long conversations accumulate irrelevant information that deg
 
 ## When to Clear Context
 
-### Clear Between Tasks
-
 Use `/clear` when:
 
 - Starting a completely new task
-- Previous task is fully complete
-- Context has become cluttered with failed attempts
+- Previous task is complete
+- Debugging noise is crowding out the current objective
 - Switching between unrelated codebases
 
-### Don't Clear When
+Avoid clearing mid-task until you have logged enough state for recovery.
 
-- Mid-task and need previous context
-- Debugging requires understanding of prior attempts
-- Session file provides necessary handoff information
-
-## The 2-Correction Rule
-
-**If Claude makes the same mistake twice after correction, the context may be polluted.**
-
-Signs of context pollution:
-- Repeating errors you've already corrected
-- Ignoring instructions you've given
-- Reverting to patterns you've explicitly rejected
-- Confusion about current task state
-
-**Action:** Consider `/clear` and restart with fresh context, referencing session file for state.
-
-## Context Compaction
-
-Use `/compact` when:
-- Conversation is long but task continues
-- Need to preserve key decisions while reducing noise
-- Approaching context limits
-
-**Journal entries are compaction insurance.** Every `loaf session log` call writes state to disk that survives compaction. Don't defer journaling — entries not flushed before compaction are lost.
-
-### What Compaction Preserves (via session file)
-
-- Journal entries: decisions, discoveries, progress, commits
-- `## Current State` summary (written by PreCompact)
-- All externalized artifacts: specs, tasks, ideas, code
-
-### What Compaction Discards
-
-- Intermediate exploration steps
-- Failed attempts and debugging noise
-- Verbose tool output
-- Redundant explanations
-
-## Session Files as Context Anchors
-
-Session files provide persistent context that survives `/clear`:
-
-```markdown
-## Current State
-[Always handoff-ready summary]
-
-## Key Decisions
-- Chose X over Y because Z
-
-## Next Steps
-- Immediate action items
-```
-
-### Pattern: Clear + Resume
+## Compaction Lifecycle
 
 ```
-1. Update session file with current state
-2. /clear to reset context
-3. /resume to reload from session file
-4. Continue with clean context
+PreCompact:
+  1. Flush unrecorded decisions, discoveries, blockers, and next actions
+  2. Reference specs, tasks, reports, commits, and files by stable ID/path
+  3. Let the hook persist the compact marker
+
+PostCompact:
+  1. Run or inspect `loaf session start` output for the active branch
+  2. Use `loaf session show <session-ref> --json` when more context is needed
+  3. Continue from the journal and linked artifacts
 ```
+
+This makes compaction survivable without relying on hand-maintained markdown
+state. Any state not logged or captured in a durable artifact can be lost.
 
 ## Subagents for Context Isolation
 
-Use subagents (Task tool) to investigate without polluting main context:
-
-```
-# Instead of exploring in main conversation:
-Let me look at how auth works...
-[reads 10 files, fills context]
-
-# Use subagent for investigation:
-Task(Explore, "How does authentication work in this codebase?")
-[returns focused summary, main context stays clean]
-```
-
-### When to Use Subagents
+Use subagents to investigate without filling the main context:
 
 | Situation | Approach |
 |-----------|----------|
-| Quick file lookup | Direct Read tool |
-| Multi-file exploration | Task(Explore) |
-| Implementation work | Task(implementer) |
-| Complex investigation | Task(Plan) then implement |
+| Quick file lookup | Direct read/search tool |
+| Multi-file exploration | Explorer/research subagent |
+| Implementation work | Implementer or task-focused agent |
+| Long audit | Background agent with report output |
+
+Pass stable references to subagents: task IDs, spec IDs, branch names, report
+paths, and the active session alias when available.
 
 ## Context Budget Guidelines
 
-### Short Conversations (< 10 exchanges)
+### Short Conversations
 
-- No management needed
-- Context stays fresh naturally
+No special management is usually needed.
 
-### Medium Conversations (10-30 exchanges)
+### Medium Conversations
 
-- Consider `/compact` at midpoint
-- Delegate investigations to subagents
-- Keep session file updated
+- Log decisions as they happen.
+- Delegate broad searches.
+- Keep tool output scoped.
 
-### Long Conversations (30+ exchanges)
+### Long Conversations
 
-- `/compact` every 15-20 exchanges
-- Heavy use of subagents for exploration
-- Session file as primary state holder
-- Consider `/clear` + restart if degraded
-
-## Preventing Context Bloat
-
-### Minimize Tool Output
-
-```
-# Instead of reading entire large files:
-Read(file, limit=50)  # Read first 50 lines
-
-# Instead of globbing everything:
-Glob("src/**/*.py", path="src/auth/")  # Scoped search
-```
-
-### Focused Queries
-
-```
-# Instead of "show me all the code":
-"Find where user authentication is validated"
-
-# Instead of exploring blindly:
-"What files handle the /api/users endpoint?"
-```
-
-### Progressive Disclosure
-
-1. Get overview first (symbols, structure)
-2. Drill into specific areas
-3. Read full content only when needed
-
-## Session Context Patterns
-
-### Starting a Session
-
-```
-1. Create session file (minimal context recorded)
-2. Break down task (decisions recorded)
-3. Spawn first agent (isolated context)
-4. Update session (state persisted)
-```
-
-### Mid-Session Context Check
-
-Every 10-15 exchanges, assess:
-- [ ] Is context still focused on current task?
-- [ ] Are previous decisions still relevant?
-- [ ] Has debugging noise accumulated?
-- [ ] Would `/compact` help?
-
-### Session Handoff
-
-When pausing or handing off:
-1. Update session file with complete state
-2. Include "resumption notes" for context
-3. Reference key files and decisions
-4. Clear main context if long
+- Expect compaction.
+- Keep the journal current.
+- Use reports or handoffs for rich summaries rather than stuffing prose into the
+  session journal.
 
 ## Warning Signs
 
 | Symptom | Likely Cause | Action |
 |---------|--------------|--------|
-| Repeating same mistakes | Context pollution | `/clear` + restart |
-| Forgetting recent decisions | Overcrowded context | `/compact` |
-| Slow responses | Large context | Use subagents |
-| Confusion about task | Too many pivots | Update session, `/clear` |
+| Repeating same mistakes | Context pollution | Log current facts, then clear or compact |
+| Forgetting recent decisions | Overcrowded context | Inspect `loaf session show` and continue from journal |
+| Slow responses | Large context | Delegate exploration |
+| Confusion about task | Too many pivots | Re-anchor on task/spec/session IDs |
 
 ## Best Practices
 
-1. **Update session files continuously** - they survive context resets
-2. **Use subagents for exploration** - keep main context clean
-3. **Clear between unrelated tasks** - fresh start beats polluted context
-4. **Compact mid-task if needed** - preserve decisions, discard noise
-5. **Monitor for pollution** - 2-correction rule catches degradation early
-6. **Scope tool calls** - don't read entire codebases into context
+1. Log durable facts early with `loaf session log`.
+2. Use subagents for exploration-heavy work.
+3. Clear between unrelated tasks.
+4. Compact mid-task when the journal and artifacts are current.
+5. Scope tool calls so context stays focused.

--- a/content/skills/orchestration/references/cross-session.md
+++ b/content/skills/orchestration/references/cross-session.md
@@ -135,7 +135,7 @@ When sessions are archived, decisions are extracted to Serena memory:
 
 1. `loaf session end --wrap` persists decisions to spec changelog
 2. Session stays in `sessions/` with `status: done` — no immediate archive
-3. `loaf session housekeeping` archives complete sessions after 7-day age threshold
+3. `loaf housekeeping` reports stale compatibility artifacts, and `loaf session archive` archives closed SQLite sessions when work is complete
 
 ### At Reference Time (spec changelog)
 

--- a/content/skills/orchestration/references/product-development.md
+++ b/content/skills/orchestration/references/product-development.md
@@ -11,7 +11,6 @@ A Research → Vision → Architecture → Requirements → Specs → Tasks → 
 - Configuration
 - Workflow Examples
 - Feedback Loops
-- Transcript Archival
 - Flexibility Preserved
 - Critical Files
 
@@ -33,10 +32,9 @@ docs/                               # Permanent project knowledge
 
 .agents/                            # Ephemeral orchestration
 ├── loaf.yaml                       # Project config (task backend, etc.)
-├── sessions/                       # Active work contexts
+├── sessions/                       # Compatibility/rendered session views
 ├── plans/                          # Implementation plans
 ├── councils/                       # Deliberation records
-├── transcripts/                    # Archived conversation transcripts
 ├── tasks/                          # Local tasks (when not using Linear)
 │   ├── active/
 │   │   └── TASK-001-oauth-provider.md
@@ -71,7 +69,7 @@ RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS → SE
 | `/architecture` | Decision question | ARCHITECTURE.md + ADR | Technical decisions |
 | `/shape` | Feature area or requirement | Spec in .agents/specs/ | Implementation-ready specification with boundaries |
 | `/breakdown` | Spec | Tasks in .agents/tasks/ | Atomic work items for agents |
-| `/implement` | TASK-ID | Session file | Execute a task |
+| `/implement` | TASK-ID | SQLite session + implementation commits | Execute a task |
 
 ## Document Formats
 
@@ -187,7 +185,7 @@ docs:
 
 # 6. Work on tasks
 /implement TASK-001
-# → Session → Implementation → Done
+# → SQLite session → Implementation → Done
 ```
 
 ### Quick Fix (Ad-hoc)
@@ -197,7 +195,7 @@ docs:
 /implement TASK-099
 # Orchestrator: "No parent spec. Proceed?"
 # User: "Yes, small fix"
-# → Session → Fix → Done
+# → SQLite session → Fix → Done
 ```
 
 ## Feedback Loops
@@ -210,23 +208,6 @@ The workflow is not rigid. Each level can feed back to higher levels:
 | Edge case invalidates requirement | Update REQUIREMENTS.md |
 | Spec too complex for its size | Re-scope or split |
 | Task reveals missing requirement | Add to REQUIREMENTS.md |
-
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference:
-
-1. **Copy transcript** to `.agents/transcripts/`
-2. **Link from session file** in frontmatter:
-
-```yaml
-session:
-  title: "Feature Implementation"
-  transcripts:
-    - 20260123-143500-pre-compact.jsonl
-    - 20260123-160000-final.jsonl
-```
-
-This preserves full context for debugging, knowledge extraction, and audit trails.
 
 ## Flexibility Preserved
 

--- a/content/skills/orchestration/references/session-resume.md
+++ b/content/skills/orchestration/references/session-resume.md
@@ -1,15 +1,15 @@
 # Session Resume Patterns
 
-Patterns for resuming work across Claude Code sessions using CLI flags and session files.
+Patterns for resuming work with CLI conversation history plus SQLite-backed
+Loaf session state.
 
 ## Contents
 
 - CLI Resume Flags
 - Resume Methods
 - When to Use Each Method
-- Session File as Resume Checkpoint
+- SQLite Session as Resume Checkpoint
 - Checkpoint Pattern
-- Naming Sessions Descriptively
 - Context Recovery Strategies
 - Handling Stale Sessions
 - Multi-Session Coordination
@@ -17,7 +17,7 @@ Patterns for resuming work across Claude Code sessions using CLI flags and sessi
 
 ## CLI Resume Flags
 
-Claude Code provides built-in session continuation:
+Some harnesses provide built-in conversation continuation:
 
 | Flag | Purpose |
 |------|---------|
@@ -25,217 +25,113 @@ Claude Code provides built-in session continuation:
 | `--resume <id>` | Resume a specific conversation by ID |
 | `/resume` | In-session command to list and resume |
 
+Use harness resume for chat history. Use `loaf session` for operational state.
+
 ## Resume Methods
 
-### Method 1: CLI Continue
+### Method 1: Conversation Continue
+
+Resume the exact conversation when you need full chat history.
+
+### Method 2: SQLite Session Resume
+
+Start fresh and recover operational state:
 
 ```bash
-# Continue most recent conversation
-claude --continue
-
-# Resume specific conversation
-claude --resume abc123
+loaf session start
+loaf session list --all --json
+loaf session show <session-ref> --json
 ```
 
-**Best for:** Picking up exactly where you left off with full context.
-
-### Method 2: Session File Resume
-
-```bash
-# Start new conversation, resume from session file
-claude
-> /resume 20250123-143000-feature-auth
-```
-
-**Best for:** Fresh context but task continuity from session file.
+Best for clean context with task continuity.
 
 ### Method 3: Hybrid Resume
 
-```bash
-# Continue conversation AND sync with session file
-claude --continue
-> Check session file for any updates: .agents/sessions/20250123-143000-feature-auth.md
-```
-
-**Best for:** Recovering from context pollution while preserving conversation history.
+Continue the conversation, then compare it against `loaf session show` output.
+Best when chat history matters but the journal may contain newer facts.
 
 ## When to Use Each Method
 
 | Situation | Recommended Method |
 |-----------|-------------------|
-| Short break, same task | `--continue` |
-| Long break, clean state needed | Session file resume |
+| Short break, same task | Conversation continue |
+| Long break, clean state needed | SQLite session resume |
 | Context polluted but need history | Hybrid resume |
-| Different machine | Session file resume |
-| Handoff to another person | Session file resume |
+| Different machine | SQLite session resume |
+| Handoff to another person | SQLite session + handoff/report |
 
-## Session File as Resume Checkpoint
+## SQLite Session as Resume Checkpoint
 
-### Writing Resume-Ready State
+Before ending or compacting:
 
-Before ending a session, ensure session file contains:
-
-```markdown
-## Current State
-**Last Action:** Completed API endpoint implementation
-**Pending:** Tests need to be written
-
-## Resumption Notes
-- Branch: feature/auth-endpoints
-- Key files modified: src/auth/routes.py, src/auth/models.py
-- Tests to write: test_login, test_logout, test_refresh
-- Blocker: None
-
-## Next Steps
-1. Spawn QA agent for test implementation
-2. Run full test suite
-3. Update API documentation
-```
-
-### Reading Resume State
+1. Log last action, blockers, and next steps with `loaf session log`.
+2. Reference tasks, specs, reports, commits, and branch names by stable ID/path.
+3. Run `loaf session end --wrap` when work is complete.
 
 When resuming:
 
-1. Read session file for context
-2. Check `## Current State` for where you left off
-3. Check `## Resumption Notes` for key details
-4. Check `## Next Steps` for immediate actions
-5. Verify branch and file state match expectations
+1. Run `loaf session start` on the branch/worktree.
+2. Inspect `loaf session show <session-ref> --json`.
+3. Verify branch and file state match expectations.
+4. Continue from the next logged action.
 
 ## Checkpoint Pattern
 
-For long-running tasks, create explicit checkpoints:
-
-```markdown
-## Checkpoints
-
-### Checkpoint 1: Schema Complete
-**Timestamp:** 2025-01-23T14:30:00Z
-**State:** Database schema implemented and migrated
-**Can resume from:** This checkpoint if later work fails
-
-### Checkpoint 2: API Complete
-**Timestamp:** 2025-01-23T15:45:00Z
-**State:** All endpoints implemented, passing basic tests
-**Can resume from:** This checkpoint for test expansion
-```
-
-### Rewind to Checkpoint
-
-If work goes wrong:
-
-1. Identify safe checkpoint
-2. `git checkout <commit>` to restore code state
-3. Update session file to checkpoint state
-4. `/clear` to reset context
-5. Resume from checkpoint
-
-## Naming Sessions Descriptively
-
-Good session names aid resume:
-
-```
-# Good - descriptive, searchable
-20250123-143000-auth-jwt-implementation.md
-20250123-160000-api-rate-limiting.md
-
-# Bad - generic, hard to find
-20250123-143000-feature.md
-20250123-160000-fix.md
-```
-
-### Rename Pattern
+For long-running tasks, create explicit journal checkpoints:
 
 ```bash
-# If session name becomes unclear, rename for clarity
-mv .agents/sessions/20250123-143000-feature.md \
-   .agents/sessions/20250123-143000-user-auth-oauth.md
+loaf session log "decision(checkpoint): schema complete at <commit>"
+loaf session log "decision(checkpoint): API complete; next write tests"
 ```
 
-Update any references in Linear or other sessions.
+If work goes wrong, use Git to restore code state and log the reconciliation:
+
+```bash
+loaf session log "decision(recovery): rewound to <commit>; replaying tests"
+```
 
 ## Context Recovery Strategies
 
-### Strategy 1: Full Replay
+### Full Replay
 
-For complex state, replay key decisions:
+Use `loaf session show` plus ADR/spec/report links for complex state.
 
-```markdown
-## Decision Replay
+### Minimal Context
 
-When resuming, recall these decisions:
-1. Chose JWT over sessions (see ADR-007)
-2. Using Redis for token storage
-3. 15-minute access token expiry
-```
+Use the last few journal entries when the next action is obvious.
 
-### Strategy 2: Minimal Context
+### Reference Chain
 
-For simple continuation:
+For multi-session work, log relationships:
 
-```markdown
-## Minimal Resume Context
-
-Branch: feature/auth
-Last commit: "feat: add login endpoint"
-Next: Write tests for login endpoint
-```
-
-### Strategy 3: Reference Chain
-
-For multi-session work:
-
-```markdown
-## Session Chain
-
-Previous sessions:
-- 20250122-100000-auth-design.md (planning)
-- 20250122-143000-auth-schema.md (database)
-- This session: API implementation
+```bash
+loaf session log "discover(context): previous design captured in SPEC-123 and ADR-007"
 ```
 
 ## Handling Stale Sessions
 
-### Signs of Stale Session
+Signs of stale session state:
 
-- Code has changed since session was active
-- Other sessions modified same files
+- Code changed after the last journal entry
 - Branch was rebased or merged
+- Another task/spec superseded the work
 
-### Stale Session Recovery
+Recovery:
 
-```
-1. Read session file for intended state
-2. Compare with actual code state (git diff)
-3. Identify conflicts or drift
-4. Update session file to reflect reality
-5. Plan reconciliation if needed
-```
+1. Inspect `loaf session show`.
+2. Compare with `git status`, `git log`, and relevant specs/tasks.
+3. Log the drift and reconciliation plan.
 
 ## Multi-Session Coordination
 
-When multiple sessions touch same codebase:
-
-```markdown
-## Related Sessions
-
-| Session | Status | Overlaps |
-|---------|--------|----------|
-| auth-backend | completed | src/auth/ |
-| auth-frontend | in_progress | src/components/auth/ |
-| This session | in_progress | src/auth/models.py (shared) |
-
-## Coordination Notes
-- Wait for auth-backend completion before modifying models
-- Sync with auth-frontend on API contract changes
-```
+When multiple sessions touch related areas, use specs/tasks/reports as the shared
+coordination layer. Session journals should point to those durable artifacts
+rather than becoming the only place a dependency is described.
 
 ## Best Practices
 
-1. **Update session before stopping** - capture state while fresh
-2. **Use descriptive names** - aid future resume
-3. **Create checkpoints** - safe rollback points
-4. **Note dependencies** - what must complete first
-5. **Clear stale context** - don't resume into pollution
-6. **Verify state on resume** - code may have changed
-7. **Document decision context** - not just decisions
+1. Log before stopping.
+2. Prefer stable IDs over pasted summaries.
+3. Use `loaf session show` as the operational resume surface.
+4. Keep chat-history resume separate from Loaf session state.
+5. Verify code state on resume.

--- a/content/skills/orchestration/references/sessions.md
+++ b/content/skills/orchestration/references/sessions.md
@@ -1,523 +1,116 @@
 # Session Management
 
-Sessions are coordination artifacts for active work. They are archived (set status, `archived_at`, `archived_by`, move to `.agents/sessions/archive/`) when work completes to preserve an audit trail.
+Sessions are SQLite-backed coordination records for active work. Markdown is a
+rendered view for reading or compatibility export; agents persist new facts with
+`loaf session` commands.
 
 ## Contents
 
-- Compact vs New Session
+- Core Model
 - When to Use Sessions
-- Session Types
-- Session File Format
-- Lifecycle States
-- Updating During Work
-- Session Continuity Protocol
-- Completing a Session
-- Start Protocol
+- Lifecycle
+- Journal Protocol
+- Continuity
+- Completion
 - Hook Integration
 - Anti-Patterns
 
-## Compact vs New Session
+## Core Model
 
-| Scenario | Action |
-|----------|--------|
-| Picking up previous work, same scope | Compact or resume existing conversation |
-| Switching to entirely different scope | New conversation (new session) |
-| Finished and archived a spec | New conversation |
-| Context full mid-task | Auto-compact (journal survives) |
-| Quick unrelated question | New conversation (don't pollute working session) |
+Use the `wrap` skill as the canonical session model:
 
-**Rule of thumb:** if you'd need the same session file, compact. If you'd need a different one, start fresh.
+1. `loaf session start` finds or creates the active session for the current branch
+   and prints resumption context.
+2. `loaf session log "type(scope): description"` writes durable journal rows.
+3. `loaf session show <session-ref> --json` reads the SQLite-backed session view.
+4. `loaf session end --wrap` persists the wrapped end state.
+5. `loaf session archive` archives closed sessions when the branch/work is done.
+
+The render format is documented in `templates/session.md`; it is not an
+instruction to author markdown directly.
 
 ## When to Use Sessions
 
-- Multi-step work requiring agent coordination
+- Multi-step work requiring coordination
 - Handoffs between agents
-- Tracking progress during implementation
-- Context preservation across agent spawns
+- Implementation or release work that must survive compaction
+- Long research, architecture, council, or review efforts
 
-## Session Types
+For quick unrelated questions, start a fresh conversation so the active session
+stays focused.
 
-### Implementation Sessions (Invisible)
+## Lifecycle
 
-When implementing tasks via `{{IMPLEMENT_CMD}} TASK-XXX`:
+The interim runtime lifecycle before SPEC-049 is:
 
-- Session created automatically with filename `YYYYMMDD-HHMMSS-session.md`
-- Task file updated with `session:` field linking to session
-- No user interaction needed for session naming
-- Resume via `loaf session start` then `{{IMPLEMENT_CMD}} TASK-XXX`
+| State | Source | Meaning |
+|-------|--------|---------|
+| `active` | `loaf session start` | Current work may receive journal entries |
+| `stopped` | `loaf session end` | Work paused or closed without wrap |
+| `done` | `loaf session end --wrap` | Wrapped work is complete |
+| `archived` | `loaf session archive` | Closed session preserved outside active list |
 
-Users work with tasks; sessions are an implementation detail.
+Do not introduce additional session vocabulary in guidance. SPEC-049 owns the
+durable status vocabulary.
 
-### Explicit Sessions
+## Journal Protocol
 
-For non-task work, sessions are still created explicitly:
-
-- Research sessions (`/research`)
-- Architecture decisions (`/architecture`)
-- Council deliberations (`/council`)
-
-These sessions may not have a linked task but still follow standard session format.
-
-## Session File Format
-
-**Link policy**: Documents outside `.agents/` must not reference `.agents/` files. Keep `.agents/` links contained within `.agents/` artifacts, and update them when files move to `.agents/<type>/archive/`.
-
-### Location & Naming
-
-```
-.agents/sessions/YYYYMMDD-HHMMSS-session.md
-```
-
-**Archive location:** `.agents/sessions/archive/`
-
-**Transcripts location:** `.agents/transcripts/`
-
-Transcripts are Claude Code conversation exports (`.jsonl` files) archived after context compaction. They preserve the full audit trail of agent interactions.
-
-```
-.agents/
-├── sessions/
-│   ├── YYYYMMDD-HHMMSS-session.md
-│   └── archive/
-└── transcripts/              # Claude Code transcripts
-    ├── 2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl
-    └── archive/
-```
-
-**Why keep original filenames:** The UUID-like hash is unique and matches Claude Code's internal reference, making correlation easier if needed.
-
-**Generate timestamps:**
+Log compact, factual entries:
 
 ```bash
-# Filename timestamp
-date -u +"%Y%m%d-%H%M%S"
-
-# ISO timestamp (for YAML)
-date -u +"%Y-%m-%dT%H:%M:%SZ"
+loaf session log "decision(scope): chose X because Y"
+loaf session log "discover(scope): learned Z from file/path"
+loaf session log "block(scope): waiting on external approval"
+loaf session log "unblock(scope): approval received"
+loaf session log "spark(scope): possible follow-up idea"
+loaf session log "todo(scope): concrete follow-up action"
 ```
 
-### Naming Convention
+Log durable facts, not thoughts. The journal should let another agent resume
+without reading the whole conversation.
 
-All session files use the fixed format: `YYYYMMDD-HHMMSS-session.md`
+## Continuity
 
-The timestamp is the unique identifier. Descriptions, spec links, and branch names belong in frontmatter and the `# Session:` heading, not the filename. This keeps references stable — spec and task files can point to session filenames without them ever breaking.
+Before compaction, branch switches, or agent handoff:
 
-### Required Frontmatter
+1. Flush unrecorded decisions, discoveries, blockers, and next actions with
+   `loaf session log`.
+2. Use `loaf session show <session-ref> --json` to confirm the journal has the
+   required resumption context.
+3. Pass task IDs, spec IDs, report IDs, and commit refs rather than duplicating
+   large prose into the journal.
 
-```yaml
----
-session:
-  title: "Clear description of work"           # REQUIRED
-  status: in_progress                          # REQUIRED: in_progress|paused|completed|archived
-  created: "2025-12-04T14:30:00Z"              # REQUIRED: ISO 8601
-  last_updated: "2025-12-04T14:30:00Z"         # REQUIRED: ISO 8601
-  last_archived: "2025-12-04T16:00:00Z"        # Set by PreCompact hook before compaction
-  archive_reason: "pre-compact"                # Why archived (pre-compact, manual, etc.)
-  archived_at: "2025-12-04T18:10:00Z"          # Required when archived
-  task: TASK-001                               # If implementation work (links to .agents/tasks/)
-  linear_issue: "BACK-123"                     # Optional
-  linear_url: "https://linear.app/..."         # Optional
-  branch: "username/back-123-feature"          # Optional: working branch
-  transcripts: []                              # Archived Claude Code transcripts (filenames only)
-                                               # Example: ["2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl"]
-  referenced_sessions: []                      # Cross-session references (see below)
+Background and delegated agents should receive the relevant task/spec/report
+references plus the active session alias when the caller has one.
 
-orchestration:
-  current_task: "What's actively being worked" # REQUIRED
-  spawned_agents:
-    - agent: implementer
-      task: "Brief task description"
-      status: completed                        # pending|in_progress|completed
-      summary: "Outcome summary"
+## Completion
 
-background_agents:                             # Background work running independently
-  - id: "bg-20260123-143000-security-scan"     # ID: bg-YYYYMMDD-HHMMSS-description
-    agent: background-runner                              # Agent type
-    task: "Full security audit"                # Brief description
-    status: running                            # running|completed|failed
-    result_location: null                      # Path to report when complete
----
-```
+When work is complete:
 
-### Cross-Session References
+1. Ensure decisions and discoveries are captured in durable homes such as ADRs,
+   specs, reports, or docs.
+2. Run `loaf session end --wrap` so the CLI persists the wrapped state.
+3. After merge or closure, use `loaf session archive` if the session should leave
+   the active list.
 
-Track decisions imported from past sessions via Serena memory:
-
-```yaml
-session:
-  # ... other fields ...
-  referenced_sessions:
-    - session: "20250115-140000-auth-jwt.md"     # Source session filename
-      imported_at: "2025-01-23T14:30:00Z"        # When imported
-      content_type: decisions                     # decisions|context|all
-      decisions_imported:                         # List of decision titles
-        - "JWT token rotation strategy"
-        - "Refresh token storage approach"
-    - session: "20250110-090000-auth-oauth.md"
-      imported_at: "2025-01-23T14:35:00Z"
-      content_type: context
-      summary: "OAuth provider integration patterns"
-```
-
-**Why track references:**
-
-- Audit trail of where context came from
-- Avoids re-importing same decisions
-- Enables tracing decision lineage across sessions
-
-See `references/cross-session.md` for full patterns.
-
-### Required Sections
-
-Every session file MUST have:
-
-1. **`## Context`** - Background for anyone picking up this work
-2. **`## Current State`** - Where we are now (MUST be handoff-ready)
-3. **`## Next Steps`** - Immediate actions for continuation
-
-### Session Template
-
-```markdown
-# Session: [Title]
-
-## Context
-Background for anyone picking up this work.
-What problem are we solving? Why now?
-
-## Current State
-Where we are right now. What just happened.
-**This section should ALWAYS be handoff-ready.**
-
-## Resumption Prompt
-
-<!-- Generated by PreCompact hook before compaction -->
-<!-- Provides self-contained context for post-compaction continuation -->
-
-> **Context**: [Brief description of work being done]
->
-> **Last Action**: [What just happened]
->
-> **Immediate Next**: [Concrete next step]
->
-> **Key Files**: [Relevant file paths]
->
-> **Blockers**: [Any blockers, or "None"]
->
-> **Transcript Archive**: If Claude Code provided a transcript path after compaction,
-> copy it to `.agents/transcripts/` and add the filename to this session's
-> `transcripts:` array in frontmatter.
-
-## Execution Progress
-
-### Wave 1: [Name] (ACTIVE)
-- [ ] BACK-123 - Brief description
-- [x] BACK-124 - Brief description (completed)
-
-### Wave 2: [Name] (blocked by Wave 1)
-- [ ] BACK-125 - Brief description
-
-## Technical Context
-
-### Files to Update
-- `path/to/file.py` - What needs to change
-
-### Key Commands
-```bash
-pytest path/to/tests/ -v
-mypy path/to/code/
-```
-
-## Acceptance Criteria
-
-- [ ] Criterion 1
-- [ ] Criterion 2
-
-## Decisions
-
-### Decision 1: [Title]
-
-**Decision**: What was decided
-**Rationale**: Why
-
-## Architecture Diagrams
-
-### [Diagram Name]
-
-```mermaid
-[diagram content]
-```
-
-**Purpose**: Why this diagram helps understand the work
-**Files involved**: List of related file paths
-**Created**: When diagram was created (update if modified)
-
-<!--
-When to add diagrams:
-- Multi-service changes: Show interaction points
-- Data flow changes: Trace data through system
-- Schema modifications: Visualize relationships
-- API design: Document request/response flows
-
-For reusable diagrams, store in .agents/diagrams/ instead.
-See foundations skill reference/diagrams.md for Mermaid syntax.
--->
-
-## Council Outcomes
-
-### Council: [Topic]
-
-**Outcome**: Decision summary
-**Council File**: `.agents/councils/YYYYMMDD-HHMMSS-topic.md`
-**Next Steps**: Action items captured
-**Archive**: After this summary is captured, set council status to `archived`, set `archived_at`, set `archived_by`, and move to `.agents/councils/archive/` (archive indefinitely).
-
-## Reports Processed
-
-### Report: [Title]
-
-**Key Conclusions**: Summary of findings
-**Action Items**: What changed or will change
-**Report Output**: generated with `loaf report generate ...` or stored as an authored report when durable prose is needed.
-**Archive**: After report is processed and the linked session is archived, use `loaf report archive <report>` for SQLite-backed report state. Markdown report movement is compatibility/export handling.
-**Metadata**: Require enough state or frontmatter to identify status, linked session, and processing time. In SQLite-backed projects, CLI state is authoritative.
-**Note**: Reports without state/frontmatter metadata are treated as unprocessed compatibility artifacts.
-
-## Handoffs
-
-Explicit transfer packets belong to `/handoff`, which writes
-`.agents/handoffs/YYYYMMDD-HHMMSS-title.md`. Orchestration keeps live session
-state resumable; `/handoff` packages context for another agent, branch, task,
-or future session. `/housekeeping` deletes deprecated handoffs after
-confirmation.
-
-## Blockers
-
-- Current blocker (if any)
-
----
-
-## Session Log (Compact Inline Journal)
-
-Sessions use an **append-only structured journal** format — a running log of what happened, what was decided, and what's next. Think "conventional commits meets bullet journal."
-
-### Format
-
-```markdown
-## Journal
-
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-[YYYY-MM-DD HH:MM] decision(scope): description of decision
-[YYYY-MM-DD HH:MM] discover(scope): something learned
-
-[YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
-[YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
-[YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
-```
-
-### Entry Types
-
-| Type | Use For | Written By | Scope Convention |
-|------|---------|------------|------------------|
-| `resume(scope)` | Session started/resumed | Hook (auto) | Branch name |
-| `pause` | Session ended | Hook (auto) | — |
-| `commit(SHA)` | Code committed | Hook (auto) | Short SHA |
-| `pr(#N)` | PR created/updated | Hook (auto) | PR number |
-| `merge(#N)` | PR merged | Hook (auto) | PR number |
-| `decision(scope)` | Key decisions | Agent | Topic |
-| `discover(scope)` | Something learned | Agent | Topic |
-| `block(scope)` | Blocker encountered | Agent | Topic |
-| `unblock(scope)` | Blocker resolved | Agent | Topic |
-| `spark(scope)` | Ideas to promote | Agent | Topic |
-| `resolve(spark)` | Spark triaged via `/idea` | Agent/User | Spark slug → disposition [timestamp] |
-| `todo(scope)` | Action items | Agent | Topic |
-| `finding(scope)` | Findings from analysis | Agent | Topic |
-| `hypothesis` | Theory being tested | Agent | — |
-| `try` | Approach attempted | Agent | — |
-| `reject` | Approach abandoned | Agent | — |
-| `skill(name)` | Skill invoked with context | Skill (self-log) | Skill name |
-| `idea(slug)` | Idea captured or promoted | Agent/Skill | Idea slug or `.agents/ideas/` ref |
-| `spec(id)` | Spec created, updated, or approved | Agent/Skill | Spec ID (e.g. `SPEC-024`) |
-| `handoff(slug)` | Handoff created or deprecated | Agent/Skill | Handoff slug or `.agents/handoffs/` ref |
-| `report(slug)` | Report generated | Agent/Skill | Report slug or `.agents/reports/` ref |
-| `council(slug)` | Council convened or concluded | Agent/Skill | Council slug or `.agents/councils/` ref |
-| `brainstorm(slug)` | Brainstorm session held | Agent/Skill | Draft slug or topic |
-| `plan(slug)` | Plan created or updated | Agent/Skill | Plan slug or topic |
-| `draft(slug)` | Draft document created | Agent/Skill | Draft slug or `.agents/drafts/` ref |
-
-### Format Rules
-
-1. **Timestamp:** `YYYY-MM-DD HH:MM` (no seconds)
-2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank line separator:** Insert when:
-   - Gap ≥ 5 minutes since last entry, OR
-   - State transition (block/unblock/pause/resume)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated by `loaf session end`)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-### Example Session
-
-```markdown
----
-spec: SPEC-020
-branch: feat/target-convergence
-status: active
-created: 2026-03-31T14:30:00Z
-last_entry: 2026-04-02T09:15:00Z
----
-
-# Session: Target Convergence
-
-## Journal
-
-[2026-03-31 14:30] resume(feat/target-convergence): from commit abc1234, 3 tasks pending
-[2026-03-31 14:30] decision(hooks): remove bash wrappers, go direct
-[2026-03-31 14:32] discover(cursor): prompt hooks filtered at line 269
-
-[2026-03-31 15:10] block(parity): Codex output differs by trailing newline
-[2026-03-31 15:11] hypothesis: gray-matter serialization adds trailing \n
-
-[2026-03-31 16:45] unblock(parity): confirmed gray-matter quirk, fixed with trim
-[2026-03-31 16:46] commit(def5678): fix: trim frontmatter for Codex byte parity
-
---- PAUSE 2026-03-31 17:00 ---
-
-[2026-04-02 09:15] resume(feat/target-convergence): 16 hours paused, last: verification
-```
-
-### CLI Commands
-
-```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decide(scope): desc"
-loaf session archive  # Move to archive when branch merges
-```
-
-### Consistency
-
-- **`loaf session log`** validates and appends entries in correct format
-- **Read-only agents** (reviewer, researcher) CAN write journal entries via `loaf session log` (Bash command, not file edit)
-- **Concurrent writes** are safe: atomic append, timestamps provide ordering
-
-## Lifecycle States
-
-| State | Description |
-|-------|-------------|
-| `in_progress` | Work actively happening |
-| `paused` | Temporarily stopped |
-| `completed` | Work finished; ready to archive (set status, `archived_at`, `archived_by`, move) after extraction |
-| `archived` | Closed and preserved for audit (set `archived_at`/`archived_by`, status set + moved to `.agents/sessions/archive/`) |
-
-## Updating During Work
-
-After each significant action, append entries to the session journal:
-
-1. **Use `loaf session log`** to append entries in the correct format
-2. **Add `decision`, `discover`, `block`, `spark`, `wrap` entries** during normal work
-3. **Hooks auto-append:** `resume`, `commit(SHA)`, `pr(#N)`, `merge(#N)`, `pause`
-4. **Blank line rules:** Inserted automatically by `loaf session log` based on time gaps and state transitions
-
-**Cross-agent protocol:** When any agent starts work on a branch, `loaf session start` outputs the last 15-20 journal entries. The agent reads context, continues work, appends entries.
-
-## Session Continuity Protocol
-
-### Before Pausing or Switching Agents
-
-1. Update session file with completed work
-2. Update `Current State` with where you stopped
-3. Update `Next Steps` with immediate actions
-4. Include `Files Modified` for context
-
-### Session as Continuity Medium
-
-Each agent:
-1. Reads current state from session
-2. Performs assigned work
-3. Updates session with outcomes
-4. Sets up context for next agent
-
-## Completing a Session
-
-Sessions are **archived, not deleted** when complete to preserve audit trail (set status to `archived`, set `archived_at` and `archived_by`, and move into `.agents/sessions/archive/`). Archive indefinitely (no deletion policy).
-
-**Archive timing:** only after extraction and council/report summaries are captured.
-
-### Knowledge Extraction Checklist
-
-| Information Type | Where It Belongs |
-|------------------|------------------|
-| Work tracking | External issue (Linear, GitHub) |
-| Implementation details | Git commits/PRs |
-| Architectural decisions | ADRs (`docs/decisions/`) |
-| API contracts | API documentation |
-| Remaining work | External issue backlog |
-| Council outcomes | Session summary + council file link |
-| Report conclusions | Session summary + report file link |
-| Archived artifacts | SQLite lifecycle state plus compatibility archive metadata when Markdown files exist |
-
-### Archival Checklist
-
-- [ ] External issue updated with final status
-- [ ] Decisions captured as ADRs (if architectural)
-- [ ] Lessons learned added to relevant docs
-- [ ] Remaining work created as issues
-- [ ] Council outcomes summarized in this session (link council file)
-- [ ] Reports processed and summarized in this session (link report file)
-- [ ] Reports archived only after session is archived (`loaf report archive` for SQLite-backed state)
-- [ ] Handoffs reviewed; deprecated handoffs marked for `/housekeeping` deletion
-- [ ] No orphaned references to session file
-- [ ] Set session status to `archived`
-- [ ] Set `archived_at` and `archived_by`
-- [ ] Move compatibility session file to `.agents/sessions/archive/` when one exists
-- [ ] Linked councils moved to `.agents/councils/archive/` after session summary
-- [ ] Linked report state archived after session archived + conclusions captured
-- [ ] Deprecated handoffs deleted by `/housekeeping` after confirmation
-- [ ] Update `.agents/` references to archived paths (no `.agents` links outside `.agents/`)
-- [ ] Archive indefinitely (no deletion policy)
-- [ ] Use `/housekeeping` for auto-move + link updates after confirmation
-
-## Start Protocol
-
-When starting a new orchestration context:
-
-1. Check for existing active sessions
-2. If found, ask user which to resume or start fresh
-3. If resuming, read session for context
-4. If starting fresh, create new session file
+Reports, councils, and handoffs have their own archive or finalization commands.
+Do not use session archival as a substitute for those lifecycles.
 
 ## Hook Integration
 
-### SessionStart Hook
-- Lists active sessions
-- Provides agent-specific context
-- Suggests session review/resume
-
-### SessionEnd Hook
-- Displays completion checklist
-- Reminds about session file updates
-- Shows count of active sessions
-
-### PreCompact Hook
-- `loaf session context for-compact` logs compact marker and injects flush instructions
-- Model flushes unrecorded decisions/discoveries to journal
-- Model writes structured `## Current State` summary
-- After compaction: `loaf session context for-resumption` prints rich resumption context (session, spec, journal, git)
+- Session start hooks should surface recent journal entries from SQLite.
+- Session-end hooks should nudge for missing durable journal entries before wrap.
+- Pre-compaction hooks should ask the agent to flush facts through
+  `loaf session log`.
+- Post-compaction recovery should use `loaf session start` and
+  `loaf session show`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Archive without extraction | Extract outcomes before archiving |
-| Use sessions as permanent records | Use proper documentation locations |
-| Reference stale sessions | Keep sessions current or archive (status + move) when done |
-| Store decisions only in sessions | Create ADRs for important decisions |
-| Archive without council/report summaries | Summarize outcomes in session before archive |
-| Archive but leave in active folder | Move file to `.agents/sessions/archive/` after setting status |
-| Batch session updates | Update after each significant event |
-| Keep status as `in_progress` when paused | Update status when state changes |
+| Hand-author session markdown as source | Use `loaf session start/log/show/end` |
+| Store decisions only in chat context | Log them and promote durable decisions to ADR/spec/report/docs |
+| Invent status values | Cite the runtime lifecycle until SPEC-049 lands |
+| Archive before extracting outcomes | Promote outcomes first, then wrap/archive |
+| Batch all journal entries at the end | Log significant facts as they happen |

--- a/content/skills/reflect/SKILL.md
+++ b/content/skills/reflect/SKILL.md
@@ -31,12 +31,13 @@ Update VISION, STRATEGY, and ARCHITECTURE based on proven implementation.
 - **Post-implementation only** -- reflect after shipping, not before or during planning
 - **Get explicit approval** -- never update strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) without user confirmation
 - **Consolidate** -- batch related learnings into coherent updates, avoid micro-updates
-- **Link back** -- always reference the specs/sessions that informed each update
+- **Log first** -- log invocation before gathering evidence: `loaf session log "skill(reflect): <scope>"`
+- **Link back** -- always reference the specs, SQLite sessions, reports, and commits that informed each update
 - **Log updates** -- log each strategic document update to session journal: `loaf session log "decision(scope): updated STRATEGY.md with learning"`
 
 ## Verification
 
-- Proposals cite specific specs, sessions, or commits as evidence
+- Proposals cite specific specs, SQLite sessions, reports, or commits as evidence
 - No strategic document was modified without explicit user approval
 - Completed specs referenced in updates are archived after reflection
 
@@ -84,7 +85,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 
 Sources:
 1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
-2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
+2. **SQLite sessions** (`loaf session list --all --json`, then `loaf session show <ref> --json`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?
 

--- a/content/skills/research/SKILL.md
+++ b/content/skills/research/SKILL.md
@@ -31,6 +31,7 @@ Patterns for zooming out, investigating topics, and evolving project direction.
 - Cite sources with confidence levels
 - Present options, let user decide
 - Get approval before editing VISION
+- Log invocation first: `loaf session log "skill(research): <topic or mode>"`
 - Log findings to session journal: `loaf session log "discover(scope): summary of finding"`
 
 ### Never
@@ -77,7 +78,7 @@ Parse `$ARGUMENTS` to determine mode:
 
 Prioritize sources in this order:
 
-1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, session files, codebase patterns
+1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, SQLite sessions, codebase patterns
 2. **Authoritative docs** -- Context7, official docs, RFCs
 3. **Community knowledge** -- Stack Overflow (verified), GitHub issues, expert blogs
 4. **General web** (lowest) -- Search results, unverified sources
@@ -92,7 +93,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 
 1. Read project documents: VISION.md, STRATEGY.md, ARCHITECTURE.md
 2. Check ideas (`.agents/ideas/`) and specs (`docs/specs/`)
-3. Review recent sessions (`.agents/sessions/`)
+3. Review recent sessions with `loaf session list --all --json` and `loaf session show <ref> --json`
 4. Check recent commits: `git log --oneline -20`
 5. Synthesize following [state-assessment template](templates/state-assessment.md)
 
@@ -101,7 +102,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 **Trigger:** Specific topic or question
 
 1. **Interview** with AskUserQuestion: what are you trying to understand? What context do you have? What decision will this inform?
-2. Check project context first (ADRs, ARCHITECTURE, sessions)
+2. Check project context first (ADRs, ARCHITECTURE, SQLite sessions)
 3. Apply confidence hierarchy for external sources
 4. For a transient review artifact, use `loaf report generate` when an existing
    SQLite-backed export kind fits; for authored long-form research, create a

--- a/content/skills/research/templates/state-assessment.md
+++ b/content/skills/research/templates/state-assessment.md
@@ -12,7 +12,7 @@ title: "State Assessment: [YYYY-MM-DD]"
 type: state-assessment
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active | archived
-session: ".agents/sessions/YYYYMMDD-HHMMSS-description.md"  # Session that produced this assessment
+session: "session alias or loaf session show reference"  # Session that produced this assessment
 tags: []
 ---
 

--- a/content/templates/session.md
+++ b/content/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/amp/skills/bootstrap/SKILL.md
+++ b/dist/amp/skills/bootstrap/SKILL.md
@@ -41,6 +41,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - **BRIEF is input, not output** -- the BRIEF is raw intake. Extract every useful fact into VISION/STRATEGY/ARCHITECTURE/AGENTS during bootstrap.
 - **BRIEF is archeological after bootstrap** -- once extraction completes, the BRIEF is a frozen historical snapshot. No skill, agent, command, or template should reference `docs/BRIEF.md` post-bootstrap. Operating documents must stand on their own.
 - **Suggest, don't execute** -- recommend next skills at the end, never auto-run them
+- **Log first** -- log invocation before interviewing: `loaf session log "skill(bootstrap): <project or intake>"`
 - **Log outcome** -- log bootstrap completion to session journal: `loaf session log "decision(bootstrap): project bootstrapped, mode detected"`
 
 ---
@@ -50,7 +51,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - All expected operating documents (`docs/VISION.md`, `.agents/AGENTS.md` at minimum) exist and contain populated content
 - Useful BRIEF content has been extracted into operating documents (no future reader should need to open the BRIEF)
 - Symlinks are correct: `.agents/AGENTS.md` and `./AGENTS.md -> .agents/AGENTS.md`
-- A session file was saved in `.agents/sessions/` capturing key decisions and interview exchanges
+- Key decisions and interview outcomes were logged with `loaf session log` and are readable with `loaf session show`
 
 ---
 
@@ -369,13 +370,13 @@ If symlinks already exist and point to the right targets, skip silently. If they
 
 ### 3. Session Recording
 
-Save the bootstrap interview as a session file:
+Record the bootstrap interview in the active SQLite-backed session:
 
-```
-.agents/sessions/{YYYYMMDD}-{HHMMSS}-bootstrap.md
-```
+1. Run `loaf session start` if there is no active session.
+2. Log mode detection and key interview decisions with `loaf session log`.
+3. Use `loaf session show <session-ref>` to inspect the rendered session view.
 
-The session should capture:
+The session journal should capture:
 - Mode detected and why
 - Key decisions made during the interview
 - Key interview exchanges that informed those decisions
@@ -383,7 +384,8 @@ The session should capture:
 - The original problem framing and user intent
 - Any open questions or deferred decisions
 
-Follow [templates/session.md](templates/session.md) for structure and frontmatter schema.
+Use [templates/session.md](templates/session.md) only as the rendered journal
+format reference; do not hand-author session markdown as the source of truth.
 
 ### 4. Next Steps
 

--- a/dist/amp/skills/bootstrap/templates/session.md
+++ b/dist/amp/skills/bootstrap/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/amp/skills/brainstorm/SKILL.md
+++ b/dist/amp/skills/brainstorm/SKILL.md
@@ -18,7 +18,8 @@ Generative thinking — expanding possibilities before narrowing through structu
 - Diverge before converging — generate options before judging
 - Connect exploration to VISION.md and STRATEGY.md context
 - Document discarded options — they hold valuable reasoning
-- Capture sparks (speculative byproducts) in a dedicated section — brainstorm documents are the canonical home for sparks
+- Log invocation first: `loaf session log "skill(brainstorm): <topic>"`
+- Capture sparks (speculative byproducts) with `loaf spark capture --scope <scope> --text <text>`; brainstorm documents may render or summarize them
 - Set boundaries on exploration time
 - Log outcome to session journal: `loaf session log "decision(scope): direction chosen and rationale"`
 
@@ -32,7 +33,7 @@ Generative thinking — expanding possibilities before narrowing through structu
 
 After work completes, verify:
 - Brainstorm document created at `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
-- `## Sparks` section present with speculative byproducts
+- Sparks captured with `loaf spark capture` and optionally summarized in `## Sparks`
 - Spark lifecycle documented: unprocessed → promoted/discarded
 - Brainstorm references strategic context from VISION/STRATEGY
 
@@ -57,7 +58,7 @@ After work completes, verify:
 
 Sparks are: lightweight, byproducts, worth remembering. Mark as `*(promoted)*` or `*(abandoned)*` after processing.
 
-Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value.
+Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value. SQLite spark state is the lifecycle source; draft markdown is a projection or narrative summary.
 
 ## Suggests Next
 

--- a/dist/amp/skills/brainstorm/templates/brainstorm.md
+++ b/dist/amp/skills/brainstorm/templates/brainstorm.md
@@ -11,7 +11,7 @@ type: brainstorm
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active (has unprocessed sparks) | archived
 tags: []
-related: []            # Optional: idea files, spec IDs, session files
+related: []            # Optional: idea aliases, spec IDs, session aliases, report refs
 ---
 
 # Brainstorm: [Topic]

--- a/dist/amp/skills/handoff/templates/handoff.md
+++ b/dist/amp/skills/handoff/templates/handoff.md
@@ -8,7 +8,7 @@ title: "[Handoff Title]"
 created: YYYY-MM-DDTHH:MM:SSZ
 status: draft | final | deprecated
 source: session | branch | task | ad-hoc
-session: .agents/sessions/YYYYMMDD-HHMMSS-session.md
+session: session alias or loaf session show reference
 branch: branch-name
 deprecated_at: YYYY-MM-DDTHH:MM:SSZ  # Set only when confirmed obsolete
 deprecated_by: orchestrator

--- a/dist/amp/skills/housekeeping/SKILL.md
+++ b/dist/amp/skills/housekeeping/SKILL.md
@@ -17,10 +17,11 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Critical Rules
 
 **Always**
+- Log invocation as the first action: `loaf session log "skill(housekeeping): <scope or trigger>"`
 - Review EVERY file individually — never sample or average
 - Check Linear issue status before archiving sessions
 - Extract lessons learned and decisions before archiving
-- Use CLI (`loaf session housekeeping`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
+- Use CLI (`loaf housekeeping`, `loaf session archive`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
 - Treat `.agents/handoffs/` as first-class but disposable: keep active/final handoffs, delete only after confirmed deprecated status
 - Check report `status` is `processed` and linked session is archived before archiving reports (see [templates/report.md](templates/report.md))
 - Check state assessment `session:` field before flagging for cleanup — only flag when linked session is archived
@@ -35,7 +36,7 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Verification
 
 After work completes, verify:
-- Session files archived with proper metadata (status, archived_at, archived_by)
+- Session lifecycle state is visible through `loaf session list --json`
 - Tasks archived via `loaf task archive`
 - Specs archived via `loaf spec archive`
 - SQLite-backed task/spec/report state reflects lifecycle changes when initialized
@@ -48,10 +49,11 @@ After work completes, verify:
 ### CLI Commands
 
 ```bash
-loaf session housekeeping --dry-run  # Preview all actions
-loaf session housekeeping            # Run all checks and fixes
+loaf housekeeping --dry-run          # Preview recommendations
+loaf housekeeping                    # Run artifact scanner
+loaf housekeeping --sessions         # Review sessions only
 loaf session archive                 # Archive single session
-loaf session enrich <file>           # Enrich a session's journal from JSONL
+loaf session enrich --json           # Compatibility diagnostic for legacy enrichment
 loaf task archive TASK-XXX           # Archive single task
 loaf spec archive SPEC-XXX           # Archive single spec
 loaf task sync                       # Compatibility: repair Markdown task index drift
@@ -61,7 +63,7 @@ loaf task sync                       # Compatibility: repair Markdown task index
 
 | Artifact | Active Location | Archive | Action |
 |----------|-----------------|---------|--------|
-| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf session archive` / `loaf session housekeeping` |
+| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf housekeeping --sessions` / `loaf session archive` |
 | Tasks (local mode only) | SQLite state + `.agents/tasks/` source prose | `archive/` | `loaf task archive` |
 | Specs | SQLite state + `.agents/specs/` authored prose | `archive/` | `loaf spec archive` |
 | Drafts (state assessments) | `.agents/drafts/` | delete | Flag for cleanup when linked session is archived |
@@ -78,7 +80,10 @@ every mode.
 
 ## Session Enrichment
 
-For each session with status `stopped` or `done` that has a `claude_session_id` in frontmatter, run `loaf session enrich <file>` to catch up on journal entries that weren't logged during the session.
+In SQLite-backed projects, `loaf session log` is the canonical journal writer and
+`wrap` owns end-of-session checks. `loaf session enrich --json` is a compatibility
+diagnostic for legacy markdown enrichment; it is not part of the normal
+housekeeping flow.
 
 Do NOT enrich `active` sessions — those are handled by the wrap skill when the session ends.
 

--- a/dist/amp/skills/housekeeping/templates/session.md
+++ b/dist/amp/skills/housekeeping/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/amp/skills/implement/SKILL.md
+++ b/dist/amp/skills/implement/SKILL.md
@@ -3,9 +3,9 @@ name: implement
 description: >-
   Orchestrates implementation sessions through agent delegation and batch
   execution. Use for all implementation work — features, bug fixes, refactors,
-  and code changes. Produces session files, agent spawn plans, and progress
-  tracking. Not for shaping (use shape), breakdown (use breakdown), research, or
-  review.
+  and code changes. Produces SQLite-backed session journals, agent spawn plans,
+  and progress tracking. Not for shaping (use shape), breakdown (use breakdown),
+  research, or review.
 version: 2.0.0-pre.20260614235428
 ---
 
@@ -38,7 +38,7 @@ You are the coordinator. Start by understanding the task:
 **You are the ORCHESTRATOR, not the implementer.**
 
 ### Orchestrator Can Do Directly
-- Create/edit session files, council files
+- Start/log/show sessions, create council files
 - Use Amp thread checklist; **if `integrations.linear.enabled` is `true` in `.agents/loaf.json`**, use Linear MCP tools when helpful
 - Read any file for context
 - Ask clarifying questions
@@ -48,11 +48,11 @@ You are the coordinator. Start by understanding the task:
 
 ## Verification
 
-- Session file exists before any implementation work begins
+- `loaf session start` has created or resumed an active SQLite-backed session before implementation work begins
 - All code changes delegated via Amp check/agent mode or new thread -- no direct edits by orchestrator
-- Session file is continuously updated with spawns, progress, and current state
+- Session journal is continuously updated with spawns, progress, and current state
 - Spec artifacts closed out on branch before PR creation
-- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session file is created; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
+- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session is started; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
 
 ## Quick Reference
 
@@ -80,7 +80,7 @@ Before starting, evaluate context suitability.
 | Just completed a different task/spec | Suggest clear |
 | About to start multi-file implementation | Check depth |
 
-If restart needed: capture state in session file, generate resumption prompt, ask user to restart.
+If restart needed: log current state with `loaf session log`, generate resumption prompt, ask user to restart.
 
 ## Input Detection
 
@@ -88,7 +88,7 @@ Parse `$ARGUMENTS` to determine session type:
 
 | Input Pattern | Type | Action |
 |---------------|------|--------|
-| `TASK-XXX` | Local task | Load via `loaf task show`, auto-create session |
+| `TASK-XXX` | Local task | Load via `loaf task show`, start/resume session |
 | `SPEC-XXX` | Spec orchestration | If spec frontmatter has `linear_parent`, resolve to that Linear parent and follow Linear-Native Routing. Otherwise resolve local tasks and build dependency waves |
 | `TASK-XXX..YYY` | Task range | Expand range, build dependency waves |
 | `TASK-XXX,YYY,ZZZ` | Task list | Parse list, build dependency waves |
@@ -100,8 +100,8 @@ Parse `$ARGUMENTS` to determine session type:
 When starting from `TASK-XXX`:
 
 1. Load task metadata via `loaf task show TASK-XXX --json`; read `.agents/TASKS.json` only as a Markdown-compatibility fallback
-2. Auto-generate session: `YYYYMMDD-HHMMSS-task-XXX.md`
-3. Create session file, update task with session reference: `loaf task update TASK-XXX --session <session-file>`
+2. Run `loaf session start` to find or create the active session for the branch
+3. Log the task coupling: `loaf session log "decision(implement): implementing TASK-XXX"`
 4. Load parent spec if task has `spec:` field
 
 **No user interaction required for session naming.**
@@ -187,7 +187,7 @@ The issue is an actual task. Implement it directly — with a pre-flight gate.
    - Resolve branch name from the sub-issue's `branchName` field (Linear
      auto-generates one) — see
      [session-management.md](references/session-management.md).
-   - Create session file, continue with the standard Startup Checklist.
+   - Run `loaf session start`, then continue with the standard Startup Checklist.
 
 ### Completion (after implementer + reviewer finish cleanly)
 
@@ -224,8 +224,8 @@ When the sub-issue's implementation passes review and tests:
   implementation reveals a missing task, surface it to the user; they
   decide whether to run `/breakdown` again or add an ad-hoc sub-issue.
 - Does not sync in-progress state bidirectionally. Source of truth at any
-  moment: Linear for issue state, local files for spec content, session
-  file for current handoff.
+  moment: Linear for issue state, local files for spec content, SQLite session
+  journal for current handoff.
 
 ---
 
@@ -248,19 +248,19 @@ Use the **Amp check/agent mode or new thread** with appropriate `agent_type`:
 
 ---
 
-## Session Creation
+## Session Start
 
-**MANDATORY: Create session file BEFORE any other work.**
+**MANDATORY: Run `loaf session start` BEFORE any implementation work.**
 
-1. Generate timestamps: `date -u +"%Y%m%d-%H%M%S"` and `date -u +"%Y-%m-%dT%H:%M:%SZ"`
-2. Create session file following [session template](templates/session.md)
-3. Verify session file exists with valid frontmatter
+1. Run `loaf session start` from the target branch/worktree.
+2. Log invocation context: `loaf session log "skill(implement): <task/spec/context>"`
+3. Verify the active session is readable with `loaf session list --json` or `loaf session show <session-ref> --json`.
 4. Suggest renaming Amp session with a meaningful name derived from context:
    - From spec: `Suggestion: /rename SPEC-027-session-stability`
    - From task: `Suggestion: /rename TASK-042-login-fix`
    - From ad-hoc: `Suggestion: /rename {short-slug-from-description}`
 
-**DO NOT PROCEED WITHOUT A SESSION FILE.**
+**Do not proceed until the active session is visible through `loaf session` commands.**
 
 ---
 
@@ -271,8 +271,8 @@ Use the **Amp check/agent mode or new thread** with appropriate `agent_type`:
 3. **When uncertain** -- convene council, present results, **wait for user approval**
 4. **Ensure quality** -- spawn implementer for tests, route reviews to reviewer Amp check/agent mode or new thread
 5. **When debugging** -- if a test failure or error isn't immediately obvious, load the **debugging** skill for structured hypothesis tracking before retrying
-6. **Update session file continuously** -- log spawns, update current_task, keep handoff-ready
-6. **Clean up** -- no ephemeral files, archive completed sessions (status + `archived_at` + `archived_by` + move to archive/)
+6. **Update session continuously** -- log spawns, progress, blockers, and next actions with `loaf session log`
+6. **Clean up** -- no ephemeral files; wrap with `loaf session end --wrap` and archive closed sessions with `loaf session archive`
 7. **When in doubt, ask the user**
 
 ## Decision Tree
@@ -281,7 +281,7 @@ Use the **Amp check/agent mode or new thread** with appropriate `agent_type`:
 Is this a code/config/doc change?
 +-- YES -> Spawn appropriate agent
 +-- NO -> Is this a planning/coordination decision?
-    +-- YES with clear path -> Proceed, update session
+    +-- YES with clear path -> Proceed, log session decision
     +-- YES but ambiguous -> Ask user
     +-- NO -> Ask user
 ```
@@ -292,18 +292,18 @@ When multiple valid approaches exist: spawn council (5-7 agents, odd), present r
 
 ## Startup Checklist
 
-After creating session file:
+After `loaf session start`:
 
 1. [ ] Parse input (task, Linear ID, or description)
-2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, update with `loaf task update TASK-XXX --session <session-file>`, load parent spec
+2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, log task coupling, load parent spec
 3. [ ] If Linear ID (or `SPEC-XXX` with `linear_parent`): follow [Linear-Native Routing](#linear-native-routing). Parent → walk sub-issues and select next. Sub-issue → verify `blockedBy` is clear, then start it as one logical Linear operation so the parent is promoted when needed
 4. [ ] If description: auto-create task (see Ad-hoc Task Auto-Creation above)
 5. [ ] Create dedicated branch (see [session-management.md](references/session-management.md))
 6. [ ] Suggest team based on task context
-7. [ ] Populate session Context section
+7. [ ] Log initial context and references with `loaf session log`
 8. [ ] Break down work using Amp thread checklist
 9. [ ] Identify needed specialized agents
-10. [ ] Update session Next Steps
+10. [ ] Log next steps before spawning
 11. [ ] **Get user approval** before spawning
 
 ---
@@ -311,7 +311,7 @@ After creating session file:
 ## Then Execute
 
 ### BEFORE (Planning)
-1. Create session file
+1. Run `loaf session start`
 2. Set task status: `loaf task update TASK-XXX --status in_progress`
 3. Break down work into agent-sized tasks
 4. Identify spawn order (respect dependencies)
@@ -319,10 +319,10 @@ After creating session file:
 
 ### DURING (Execution)
 1. Spawn specialized agents via Amp check/agent mode or new thread
-2. Log each spawn in session `orchestration.spawned_agents`
+2. Log each spawn with `loaf session log "todo(agent): spawned <agent> for <task>"`
 3. Update Linear with progress (no emoji, no file paths)
-4. Keep session `## Current State` handoff-ready
-5. After each agent completes: update session, spawn next
+4. Keep journal entries handoff-ready
+5. After each agent completes: log outcome, spawn next
 
 ### AFTER (Completion)
 1. Code review pass (spawn `reviewer` agent)
@@ -331,13 +331,13 @@ After creating session file:
    - **Local-tasks mode:** `loaf task update TASK-XXX --status done` (per task), then `loaf task archive --spec SPEC-XXX`
    - **Linear-native mode:** `update_issue` the sub-issue to `completed`-type state. Then query the parent's sub-issues; if all are `completed`, also close the parent. If some remain, list them for the user (see [Linear-Native Routing → Completion](#completion-after-implementer--reviewer-finish-cleanly))
    - Mark spec complete and archive: `loaf spec archive SPEC-XXX` (both modes)
-   - Update session file (status: done, `archived_at`, `archived_by`)
-   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
+   - Run `loaf session end --wrap`; archive later with `loaf session archive` when appropriate
+   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session state`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
 5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
-6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
-   - `## Key Decisions` has content (not `*(none yet)*` or empty)
-   - `traceability.decisions` has entries (ADRs were recorded)
+6. **Suggest reflection:** Check the session journal for extractable learnings before closing out:
+   - `decision(...)` entries are present
+   - ADRs, report verdicts, or spec changelog entries were recorded
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
@@ -360,4 +360,4 @@ After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release`
 - **orchestration/product-development** - Full workflow hierarchy
 - **orchestration/specs** - Spec format and lifecycle
 - **orchestration/local-tasks** - Task file format including `session:` field
-- **orchestration/sessions** - Session lifecycle details
+- **orchestration/sessions** - SQLite-backed session lifecycle details

--- a/dist/amp/skills/implement/references/session-management.md
+++ b/dist/amp/skills/implement/references/session-management.md
@@ -8,7 +8,6 @@
 - Linear Status Management
 - Handoff State Requirements
 - Timestamps for User Context
-- Transcript Archival
 - Task Completion
 
 Detailed reference for session lifecycle management during implementation.
@@ -87,7 +86,7 @@ Use Linear MCP's `list_teams` (if configured) to get all workspace teams for val
 
 ## Diagram Consideration
 
-For multi-file or multi-service changes, consider adding architecture diagrams to the session file.
+For multi-file or multi-service changes, consider adding architecture diagrams to the linked spec, report, ADR, or implementation notes.
 
 ### When to Create Diagrams
 
@@ -106,7 +105,7 @@ Ask yourself:
 2. Is there a data flow that needs to be understood?
 3. Would a visual help communicate the approach?
 
-If yes to any, add an `## Architecture Diagrams` section to the session file.
+If yes to any, capture the diagram in a durable artifact such as a spec, report, ADR, or implementation note, and log the reference with `loaf session log`.
 
 ### Diagram Template
 
@@ -144,7 +143,7 @@ For complex tasks, explore before implementing:
 1. Use Task(Explore) or Task(Plan) to investigate codebase
 2. Map existing patterns and conventions
 3. Identify integration points
-4. Document findings in session file
+4. Log findings with `loaf session log` and reference durable artifacts
 5. Present approach to user for approval before spawning
 ```
 
@@ -193,12 +192,12 @@ never implement through open `blockedBy`.
 
 ## Handoff State Requirements
 
-**The session file must ALWAYS be handoff-ready.** After every significant action:
+**The session journal must ALWAYS be handoff-ready.** After every significant action:
 
-1. Update `## Current State` to reflect what just happened
-2. Update `orchestration.current_task` in frontmatter
+1. Log what just happened with `loaf session log`
+2. Reference task/spec/report/commit IDs rather than duplicating long prose
 3. Log completed agent work with outcomes
-4. Ensure anyone could pick up the work immediately
+4. Ensure anyone could pick up the work immediately from `loaf session show`
 
 ---
 
@@ -217,44 +216,6 @@ Generate with: `date -u +"%Y-%m-%d %H:%M UTC"`
 
 ---
 
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference.
-
-### Process
-
-1. **Get transcript path** from Amp output after compaction
-2. **Create transcripts directory** if needed:
-   ```bash
-   mkdir -p .agents/transcripts
-   ```
-3. **Copy transcript** with descriptive name:
-   ```bash
-   cp /path/to/transcript.jsonl .agents/transcripts/YYYYMMDD-HHMMSS-description.jsonl
-   ```
-4. **Update session frontmatter**:
-   ```yaml
-   transcripts:
-     - 20260123-143500-pre-compact.jsonl
-   ```
-
-### When to Archive
-
-| Event | Action |
-|-------|--------|
-| Before `/compact` | Archive current transcript |
-| Before `/clear` | Archive current transcript |
-| Session end | Archive final transcript |
-
-### Benefits
-
-- **Audit trail** - Full history of decisions and work
-- **Knowledge extraction** - Mining past sessions for patterns
-- **Debugging** - Understanding how errors occurred
-- **Training** - Learning from past sessions
-
----
-
 ## Task Completion
 
 When a task-coupled session completes:
@@ -267,7 +228,7 @@ When a task-coupled session completes:
      `list_issues` with `parent: <parent-id>`; if all are `completed`-type,
      close the parent and mark the local spec `complete`, else both stay
      in flight
-3. **Archive session** (standard process)
+3. **Wrap session** with `loaf session end --wrap`; archive with `loaf session archive` when the work is closed
 
 ### Spec Completion Check
 

--- a/dist/amp/skills/implement/templates/session.md
+++ b/dist/amp/skills/implement/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/amp/skills/orchestration/SKILL.md
+++ b/dist/amp/skills/orchestration/SKILL.md
@@ -26,12 +26,12 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 ## Critical Rules
 
 ### Sessions
-- Create following [session template](templates/session.md) — compact inline journal format
-- Use `loaf session log` for journal entries: `decide(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
+- Start or resume with `loaf session start`; SQLite is the operational source.
+- Use `loaf session log` for journal entries: `decision(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
 - **SESSION JOURNAL NUDGE**: When you see this hook trigger, log unrecorded decisions or findings before responding. Use `loaf session log "entry(scope): description"`. Only log actions (decisions made, things discovered, conclusions reached) — not thoughts or read-only work.
-- Archive when complete (status + `archived_at` + `archived_by` + move to `.agents/sessions/archive/`)
-- PreCompact hook: appends `compact` entry with context summary
-- Post-compaction: `loaf session start` outputs recent journal entries for recovery
+- Wrap with `loaf session end --wrap`; archive with `loaf session archive` when complete.
+- PreCompact hook: flushes journal-worthy state before compaction.
+- Post-compaction: `loaf session start` and `loaf session show` expose recent journal context for recovery.
 
 ### Councils
 - Always odd number: 5 or 7 agents
@@ -56,7 +56,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 ## Verification
 
-- Validate session files with `validate-session.py` before archiving
+- Verify `loaf session list --json` / `loaf session show <ref> --json` reflect the active work before archiving
 - Validate council files with `validate-council.py` before concluding
 - Confirm Linear issue updates are self-contained (no local paths, no emoji)
 
@@ -64,7 +64,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 | Task | Action |
 |------|--------|
-| Multi-step work | Create session file, spawn agents |
+| Multi-step work | Start/resume session, spawn agents |
 | Complex decision | Convene council (5-7 agents, odd) |
 | Linear update | Checkboxes, no emoji, no local paths |
 | Feature planning | Size by complexity, shape before building |
@@ -86,7 +86,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 | Amp check/agent mode or new thread Development | [references/Amp check/agent mode or new thread-development.md](references/Amp check/agent mode or new thread-development.md) | Delegating to specialized agents |
 | Background Agents | [references/background-agents.md](references/background-agents.md) | Running non-interactive work in background |
 | Council Workflow | [references/councils.md](references/councils.md) | Convening councils for complex decisions |
-| Session Management | [references/sessions.md](references/sessions.md) | Creating sessions and keeping live work resumable |
+| Session Management | [references/sessions.md](references/sessions.md) | Starting sessions and keeping live work resumable |
 | Session Resume | [references/session-resume.md](references/session-resume.md) | Resuming sessions, checkpoints, context recovery |
 | Context Management | [references/context-management.md](references/context-management.md) | Using /clear, /compact, managing context limits |
 | Linear Integration | [references/linear.md](references/linear.md) | Updating Linear issues, magic words, status conventions |
@@ -98,7 +98,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 **You are the orchestrator, not the implementer.**
 
 The orchestrator:
-1. Creates issues and session files for tracking
+1. Creates issues and starts sessions for tracking
 2. Breaks down work into delegable tasks
 3. Spawns specialized agents for implementation
 4. Coordinates outcomes and updates external systems
@@ -113,7 +113,6 @@ This skill uses paths from `.agents/loaf.json`:
 ```json
 {
   "sessions": {
-    "directory": ".agents/sessions",
     "councils_directory": ".agents/councils"
   },
   "linear": {
@@ -128,9 +127,8 @@ This skill uses paths from `.agents/loaf.json`:
 
 | Artifact | Location | Archive | Naming |
 |----------|----------|---------|--------|
-| Sessions | `.agents/sessions/` | `.agents/sessions/archive/` | `YYYYMMDD-HHMMSS-description.md` |
+| Sessions | SQLite (`loaf session show`) | `loaf session archive` | CLI alias / session ID |
 | Councils | `.agents/councils/` | `.agents/councils/archive/` | `YYYYMMDD-HHMMSS-topic.md` |
-| Transcripts | `.agents/transcripts/` | N/A | Copied from tool output |
 | Handoffs | `.agents/handoffs/` | delete after deprecated | Created by `/handoff` |
 | Reports | `.agents/reports/` | N/A | `YYYYMMDD-HHMMSS-subject.md` |
 | Tasks | `.agents/tasks/` | N/A | Per task manager conventions |
@@ -141,16 +139,16 @@ This skill uses paths from `.agents/loaf.json`:
 
 ### BEFORE (Planning)
 - Create/check external issue (Linear, GitHub)
-- Create session file following [session template](templates/session.md)
+- Run `loaf session start` and log the orchestration intent
 - Break down into tasks, identify agents, get user approval
 
 ### DURING (Execution)
 - Spawn specialized agents (never implement directly)
-- Track progress in session file and external issue
+- Track progress with `loaf session log` and external issue updates
 - Convene councils for uncertain decisions
 
 ### AFTER (Completion)
 - Code review + QA testing
 - Update external issue to Done
 - Ensure knowledge captured in permanent locations
-- Archive session (status + `archived_at` + `archived_by` + move + update links)
+- Run `loaf session end --wrap`; archive with `loaf session archive` after merge/closure

--- a/dist/amp/skills/orchestration/references/background-agents.md
+++ b/dist/amp/skills/orchestration/references/background-agents.md
@@ -1,12 +1,13 @@
 # Background Agents
 
-Background agents handle low-priority, long-running, or non-interactive work that can run independently while the user continues with other tasks.
+Background agents handle low-priority, long-running, or non-interactive work
+while the user continues with other tasks.
 
 ## Contents
 
 - When to Use Background Agents
 - Spawning Background Agents
-- Background Agent Tracking
+- Tracking
 - Result Retrieval
 - Workflow Example
 - Anti-Patterns
@@ -19,20 +20,11 @@ Background agents handle low-priority, long-running, or non-interactive work tha
 | Security audits | Interactive debugging |
 | Code coverage analysis | User-facing questions |
 | Large-scale refactoring reports | Time-sensitive fixes |
-| Codebase-wide linting reports | Tasks requiring immediate feedback |
 | Documentation audits | Work needing user decisions mid-task |
 | Dependency vulnerability scans | Blocking tasks for current work |
 
-**Good candidates:**
-- Results can be processed later
-- No user interaction required
-- Task is well-defined with clear completion criteria
-- Output is a report or artifact, not a conversation
-
-**Poor candidates:**
-- Needs clarification mid-task
-- Time-sensitive (user waiting for result)
-- Requires real-time coordination with other agents
+Good candidates have clear completion criteria, can run without clarification,
+and produce a report or durable artifact.
 
 ## Spawning Background Agents
 
@@ -51,8 +43,7 @@ Task(
     - src/services/
 
     Write report to: .agents/reports/YYYYMMDD-HHMMSS-security-audit.md
-
-    Session: .agents/sessions/20260123-143000-auth-feature.md
+    Active session: SESSION-ALIAS if available from loaf session list/show
     """,
     run_in_background=True
 )
@@ -60,187 +51,57 @@ Task(
 
 ### Cursor
 
-Background agents are configured via the `is_background: true` YAML property. When spawning:
+Background agents are configured via the `is_background: true` YAML property.
+When spawning, specify the report destination and any task/spec/session IDs:
 
 ```
 @background-runner Run security audit on backend codebase.
-Write report to .agents/reports/
+Write report to .agents/reports/.
+Reference TASK-123 and the active session alias if available.
 ```
 
-## Background Agent Tracking
+## Tracking
 
-Track background agents in session frontmatter:
+Track background work with durable references:
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security-scan"
-    agent: background-runner
-    task: "Full security audit of backend"
-    status: running  # running | completed | failed
-    result_location: null
-  - id: "bg-20260123-144500-coverage"
-    agent: background-runner
-    task: "Test coverage analysis"
-    status: completed
-    result_location: ".agents/reports/20260123-144500-coverage-report.md"
-```
+1. Log the spawn with `loaf session log "todo(background): started <id> for <task>"`.
+2. Ask the background agent to write a report under `.agents/reports/`.
+3. When complete, log `discover(background): <id> wrote <report>`.
+4. Process findings into tasks, specs, ADRs, or report verdicts as appropriate.
 
-### Status Values
-
-| Status | Meaning |
-|--------|---------|
-| `running` | Agent still executing |
-| `completed` | Work finished, results available |
-| `failed` | Agent encountered error |
-
-### ID Convention
-
-Background agent IDs follow: `bg-YYYYMMDD-HHMMSS-<description>`
-
-Generate with:
-```bash
-echo "bg-$(date -u +"%Y%m%d-%H%M%S")-<description>"
-```
+Use a stable ID such as `bg-YYYYMMDD-HHMMSS-description` in the prompt and
+journal entries.
 
 ## Result Retrieval
 
-Background agents write results to `.agents/reports/` with standard frontmatter:
-
-```yaml
----
-report:
-  title: "Security Audit Report"
-  type: background-agent-output
-  status: unprocessed  # unprocessed | processed | archived
-  created: "2026-01-23T14:30:00Z"
-  background_agent_id: "bg-20260123-143000-security-scan"
-  session_reference: "20260123-140000-auth-feature.md"
----
-```
-
-### Processing Results
-
-1. SessionStart hook alerts user to completed background work
-2. User or orchestrator reviews report in `.agents/reports/`
-3. Orchestrator updates session frontmatter:
-   - Change `status` from `running` to `completed`
-   - Set `result_location` to report path
-4. Process findings as needed (spawn agents, create issues)
-5. Set report `status` to `processed`
+Background agents write results to `.agents/reports/` with enough metadata to
+identify the source task and report status. In SQLite-backed projects, use
+`loaf report list`, `loaf report show`, and `loaf report archive` when report
+state is available.
 
 ## Workflow Example
 
-### 1. Orchestrator Identifies Low-Priority Work
-
-During auth feature implementation, orchestrator identifies need for security audit but it is not blocking current work.
-
-### 2. Orchestrator Spawns Background Agent
-
-```python
-Task(
-    agent_type="background-runner",
-    prompt="""
-    Run comprehensive security audit on auth implementation.
-
-    Files to audit:
-    - src/auth/endpoints.py
-    - src/auth/token.py
-    - src/auth/middleware.py
-
-    Check for:
-    - OWASP Top 10 vulnerabilities
-    - Secrets in code
-    - SQL injection risks
-    - Authentication bypasses
-
-    Write report to: .agents/reports/20260123-143000-auth-security.md
-
-    Session: .agents/sessions/20260123-140000-auth-feature.md
-    """,
-    run_in_background=True
-)
-```
-
-### 3. Orchestrator Updates Session Frontmatter
-
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-auth-security"
-    agent: background-runner
-    task: "Auth security audit"
-    status: running
-    result_location: null
-```
-
-### 4. Work Continues
-
-Orchestrator and other agents continue with main implementation while background agent works.
-
-### 5. Session Resumes Later
-
-SessionStart hook detects completed background work:
-
-```
-# Background Work Completed
-
-The following background agents have completed:
-
-- **bg-20260123-143000-auth-security** (background-runner)
-  - Task: Auth security audit
-  - Result: .agents/reports/20260123-143000-auth-security.md
-
-Review reports and update session frontmatter after processing.
-```
-
-### 6. Results Processed
-
-Orchestrator reads report, creates issues for findings, updates session.
+1. Orchestrator identifies non-blocking security audit work.
+2. Orchestrator logs the background spawn in the active session.
+3. Background agent writes `.agents/reports/YYYYMMDD-HHMMSS-auth-security.md`.
+4. Orchestrator reviews the report, creates follow-up tasks, and logs the
+   outcome.
+5. Report state is finalized or archived through the report lifecycle.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
 | Use for blocking work | Keep blocking work in foreground |
-| Spawn without tracking | Always update session frontmatter |
-| Ignore completed results | Process results when alerted |
+| Spawn without tracking | Log the spawn and require a report path |
+| Ignore completed results | Process reports into tasks, findings, or decisions |
 | Use for interactive tasks | Reserve for autonomous work |
-| Spawn many concurrent background agents | Limit to 2-3 to avoid resource contention |
-| Skip result location in prompt | Always specify where to write output |
+| Spawn many concurrent background agents | Limit concurrency to avoid resource contention |
+| Skip result location in prompt | Always specify where output belongs |
 
 ## Integration Points
 
-### SessionStart Hook
-
-Checks session frontmatter for `background_agents` with `status: completed`. Alerts user to review results.
-
-### PreCompact Hook
-
-Includes background agent state in preservation. PreCompact hook captures:
-- Active background agent list
-- Current status of each
-- Result locations for completed agents
-
-### Session Frontmatter
-
-Full template with background agents:
-
-```yaml
----
-session:
-  title: "Feature implementation"
-  status: in_progress
-  # ... other session fields ...
-
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: completed
-    result_location: ".agents/reports/20260123-143000-security.md"
-  - id: "bg-20260123-150000-coverage"
-    agent: background-runner
-    task: "Coverage analysis"
-    status: running
-    result_location: null
----
-```
+- `loaf session log` records spawn and completion facts.
+- `loaf session show` exposes recent background-work journal entries.
+- `loaf report` commands own durable report lifecycle when available.
+- `/wrap` should mention unprocessed background reports before ending a session.

--- a/dist/amp/skills/orchestration/references/context-management.md
+++ b/dist/amp/skills/orchestration/references/context-management.md
@@ -1,54 +1,34 @@
 # Context Management
 
-Patterns for managing context efficiently across sessions and agent spawns.
+Patterns for keeping long work resumable while using SQLite-backed session
+journals as the external memory.
 
 ## Contents
 
 - Design for Compaction
-- Overview
 - Context Commands
 - When to Clear Context
-- The 2-Correction Rule
-- Context Compaction
-- Session Files as Context Anchors
+- Compaction Lifecycle
 - Amp check/agent mode or new thread for Context Isolation
 - Context Budget Guidelines
-- Preventing Context Bloat
-- Session Context Patterns
 - Warning Signs
 - Best Practices
 
 ## Design for Compaction
 
-Compaction is a normal part of long workflows, not an emergency measure. Any workflow expected to exceed 15-20 exchanges should be designed with compaction in mind from the start.
+Compaction is a normal part of long workflows. Design any workflow expected to
+span many exchanges so important state is already outside chat context.
 
 ### Compaction-First Principles
 
-1. **The journal IS external memory** — Session journal entries (decisions, discoveries, progress) survive compaction. Compaction can be lossy because all important state is already on disk.
-2. **`## Current State` is the resumption context** — Keep this section handoff-ready at all times. The PreCompact hook requires writing a state summary here before compaction.
-3. **Decisions go to disk, not context** — Record key decisions in the session journal immediately via `loaf session log`. Context may be compressed; journal entries persist.
-4. **Amp check/agent mode or new thread absorb exploration** — Investigation and exploration should happen in Amp check/agent mode or new thread. Only the summary returns to the main context.
-
-### Compaction Lifecycle
-
-```
-PreCompact:
-  1. Flush all unrecorded journal entries (decisions, discoveries, progress)
-  2. Write condensed state summary to session file's ## Current State
-  3. compact.sh writes compact(session) marker to journal
-
-PostCompact:
-  1. PostCompact nudge fires — tells model to read session file
-  2. Model reads ## Current State for resumption context
-  3. Model reads ## Journal for decision trail
-  4. Work resumes without "where were we?"
-```
-
-This makes compaction invisible to workflow continuity. The session file's `## Current State` section is the resumption prompt — written by the model before compaction, read by the model after.
-
-## Overview
-
-Context is finite. Long conversations accumulate irrelevant information that degrades performance. Active context management keeps conversations focused and effective.
+1. **The journal is external memory.** Record decisions, discoveries, blockers,
+   and next actions with `loaf session log`.
+2. **Artifacts carry detail.** Specs, tasks, reports, ADRs, and commits hold rich
+   detail; journal entries point to them.
+3. **Amp check/agent mode or new thread absorb exploration.** Use Amp check/agent mode or new thread for broad investigation and
+   return concise findings to the main context.
+4. **`wrap` closes the loop.** End meaningful work with `loaf session end --wrap`
+   so the session lifecycle matches the journal.
 
 ## Context Commands
 
@@ -60,191 +40,78 @@ Context is finite. Long conversations accumulate irrelevant information that deg
 
 ## When to Clear Context
 
-### Clear Between Tasks
-
 Use `/clear` when:
 
 - Starting a completely new task
-- Previous task is fully complete
-- Context has become cluttered with failed attempts
+- Previous task is complete
+- Debugging noise is crowding out the current objective
 - Switching between unrelated codebases
 
-### Don't Clear When
+Avoid clearing mid-task until you have logged enough state for recovery.
 
-- Mid-task and need previous context
-- Debugging requires understanding of prior attempts
-- Session file provides necessary handoff information
-
-## The 2-Correction Rule
-
-**If Claude makes the same mistake twice after correction, the context may be polluted.**
-
-Signs of context pollution:
-- Repeating errors you've already corrected
-- Ignoring instructions you've given
-- Reverting to patterns you've explicitly rejected
-- Confusion about current task state
-
-**Action:** Consider `/clear` and restart with fresh context, referencing session file for state.
-
-## Context Compaction
-
-Use `/compact` when:
-- Conversation is long but task continues
-- Need to preserve key decisions while reducing noise
-- Approaching context limits
-
-**Journal entries are compaction insurance.** Every `loaf session log` call writes state to disk that survives compaction. Don't defer journaling — entries not flushed before compaction are lost.
-
-### What Compaction Preserves (via session file)
-
-- Journal entries: decisions, discoveries, progress, commits
-- `## Current State` summary (written by PreCompact)
-- All externalized artifacts: specs, tasks, ideas, code
-
-### What Compaction Discards
-
-- Intermediate exploration steps
-- Failed attempts and debugging noise
-- Verbose tool output
-- Redundant explanations
-
-## Session Files as Context Anchors
-
-Session files provide persistent context that survives `/clear`:
-
-```markdown
-## Current State
-[Always handoff-ready summary]
-
-## Key Decisions
-- Chose X over Y because Z
-
-## Next Steps
-- Immediate action items
-```
-
-### Pattern: Clear + Resume
+## Compaction Lifecycle
 
 ```
-1. Update session file with current state
-2. /clear to reset context
-3. /resume to reload from session file
-4. Continue with clean context
+PreCompact:
+  1. Flush unrecorded decisions, discoveries, blockers, and next actions
+  2. Reference specs, tasks, reports, commits, and files by stable ID/path
+  3. Let the hook persist the compact marker
+
+PostCompact:
+  1. Run or inspect `loaf session start` output for the active branch
+  2. Use `loaf session show <session-ref> --json` when more context is needed
+  3. Continue from the journal and linked artifacts
 ```
+
+This makes compaction survivable without relying on hand-maintained markdown
+state. Any state not logged or captured in a durable artifact can be lost.
 
 ## Amp check/agent mode or new thread for Context Isolation
 
-Use Amp check/agent mode or new thread (Amp check/agent mode or new thread) to investigate without polluting main context:
-
-```
-# Instead of exploring in main conversation:
-Let me look at how auth works...
-[reads 10 files, fills context]
-
-# Use Amp check/agent mode or new thread for investigation:
-Task(Explore, "How does authentication work in this codebase?")
-[returns focused summary, main context stays clean]
-```
-
-### When to Use Amp check/agent mode or new thread
+Use Amp check/agent mode or new thread to investigate without filling the main context:
 
 | Situation | Approach |
 |-----------|----------|
-| Quick file lookup | Direct Read tool |
-| Multi-file exploration | Task(Explore) |
-| Implementation work | Task(implementer) |
-| Complex investigation | Task(Plan) then implement |
+| Quick file lookup | Direct read/search tool |
+| Multi-file exploration | Explorer/research Amp check/agent mode or new thread |
+| Implementation work | Implementer or task-focused agent |
+| Long audit | Background agent with report output |
+
+Pass stable references to Amp check/agent mode or new thread: task IDs, spec IDs, branch names, report
+paths, and the active session alias when available.
 
 ## Context Budget Guidelines
 
-### Short Conversations (< 10 exchanges)
+### Short Conversations
 
-- No management needed
-- Context stays fresh naturally
+No special management is usually needed.
 
-### Medium Conversations (10-30 exchanges)
+### Medium Conversations
 
-- Consider `/compact` at midpoint
-- Delegate investigations to Amp check/agent mode or new thread
-- Keep session file updated
+- Log decisions as they happen.
+- Delegate broad searches.
+- Keep tool output scoped.
 
-### Long Conversations (30+ exchanges)
+### Long Conversations
 
-- `/compact` every 15-20 exchanges
-- Heavy use of Amp check/agent mode or new thread for exploration
-- Session file as primary state holder
-- Consider `/clear` + restart if degraded
-
-## Preventing Context Bloat
-
-### Minimize Tool Output
-
-```
-# Instead of reading entire large files:
-Read(file, limit=50)  # Read first 50 lines
-
-# Instead of globbing everything:
-Glob("src/**/*.py", path="src/auth/")  # Scoped search
-```
-
-### Focused Queries
-
-```
-# Instead of "show me all the code":
-"Find where user authentication is validated"
-
-# Instead of exploring blindly:
-"What files handle the /api/users endpoint?"
-```
-
-### Progressive Disclosure
-
-1. Get overview first (symbols, structure)
-2. Drill into specific areas
-3. Read full content only when needed
-
-## Session Context Patterns
-
-### Starting a Session
-
-```
-1. Create session file (minimal context recorded)
-2. Break down task (decisions recorded)
-3. Spawn first agent (isolated context)
-4. Update session (state persisted)
-```
-
-### Mid-Session Context Check
-
-Every 10-15 exchanges, assess:
-- [ ] Is context still focused on current task?
-- [ ] Are previous decisions still relevant?
-- [ ] Has debugging noise accumulated?
-- [ ] Would `/compact` help?
-
-### Session Handoff
-
-When pausing or handing off:
-1. Update session file with complete state
-2. Include "resumption notes" for context
-3. Reference key files and decisions
-4. Clear main context if long
+- Expect compaction.
+- Keep the journal current.
+- Use reports or handoffs for rich summaries rather than stuffing prose into the
+  session journal.
 
 ## Warning Signs
 
 | Symptom | Likely Cause | Action |
 |---------|--------------|--------|
-| Repeating same mistakes | Context pollution | `/clear` + restart |
-| Forgetting recent decisions | Overcrowded context | `/compact` |
-| Slow responses | Large context | Use Amp check/agent mode or new thread |
-| Confusion about task | Too many pivots | Update session, `/clear` |
+| Repeating same mistakes | Context pollution | Log current facts, then clear or compact |
+| Forgetting recent decisions | Overcrowded context | Inspect `loaf session show` and continue from journal |
+| Slow responses | Large context | Delegate exploration |
+| Confusion about task | Too many pivots | Re-anchor on task/spec/session IDs |
 
 ## Best Practices
 
-1. **Update session files continuously** - they survive context resets
-2. **Use Amp check/agent mode or new thread for exploration** - keep main context clean
-3. **Clear between unrelated tasks** - fresh start beats polluted context
-4. **Compact mid-task if needed** - preserve decisions, discard noise
-5. **Monitor for pollution** - 2-correction rule catches degradation early
-6. **Scope tool calls** - don't read entire codebases into context
+1. Log durable facts early with `loaf session log`.
+2. Use Amp check/agent mode or new thread for exploration-heavy work.
+3. Clear between unrelated tasks.
+4. Compact mid-task when the journal and artifacts are current.
+5. Scope tool calls so context stays focused.

--- a/dist/amp/skills/orchestration/references/cross-session.md
+++ b/dist/amp/skills/orchestration/references/cross-session.md
@@ -135,7 +135,7 @@ When sessions are archived, decisions are extracted to Serena memory:
 
 1. `loaf session end --wrap` persists decisions to spec changelog
 2. Session stays in `sessions/` with `status: done` — no immediate archive
-3. `loaf session housekeeping` archives complete sessions after 7-day age threshold
+3. `loaf housekeeping` reports stale compatibility artifacts, and `loaf session archive` archives closed SQLite sessions when work is complete
 
 ### At Reference Time (spec changelog)
 

--- a/dist/amp/skills/orchestration/references/product-development.md
+++ b/dist/amp/skills/orchestration/references/product-development.md
@@ -11,7 +11,6 @@ A Research → Vision → Architecture → Requirements → Specs → Tasks → 
 - Configuration
 - Workflow Examples
 - Feedback Loops
-- Transcript Archival
 - Flexibility Preserved
 - Critical Files
 
@@ -33,10 +32,9 @@ docs/                               # Permanent project knowledge
 
 .agents/                            # Ephemeral orchestration
 ├── loaf.yaml                       # Project config (task backend, etc.)
-├── sessions/                       # Active work contexts
+├── sessions/                       # Compatibility/rendered session views
 ├── plans/                          # Implementation plans
 ├── councils/                       # Deliberation records
-├── transcripts/                    # Archived conversation transcripts
 ├── tasks/                          # Local tasks (when not using Linear)
 │   ├── active/
 │   │   └── TASK-001-oauth-provider.md
@@ -71,7 +69,7 @@ RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS → SE
 | `/architecture` | Decision question | ARCHITECTURE.md + ADR | Technical decisions |
 | `/shape` | Feature area or requirement | Spec in .agents/specs/ | Implementation-ready specification with boundaries |
 | `/breakdown` | Spec | Tasks in .agents/tasks/ | Atomic work items for agents |
-| `/implement` | TASK-ID | Session file | Execute a task |
+| `/implement` | TASK-ID | SQLite session + implementation commits | Execute a task |
 
 ## Document Formats
 
@@ -187,7 +185,7 @@ docs:
 
 # 6. Work on tasks
 /implement TASK-001
-# → Session → Implementation → Done
+# → SQLite session → Implementation → Done
 ```
 
 ### Quick Fix (Ad-hoc)
@@ -197,7 +195,7 @@ docs:
 /implement TASK-099
 # Orchestrator: "No parent spec. Proceed?"
 # User: "Yes, small fix"
-# → Session → Fix → Done
+# → SQLite session → Fix → Done
 ```
 
 ## Feedback Loops
@@ -210,23 +208,6 @@ The workflow is not rigid. Each level can feed back to higher levels:
 | Edge case invalidates requirement | Update REQUIREMENTS.md |
 | Spec too complex for its size | Re-scope or split |
 | Task reveals missing requirement | Add to REQUIREMENTS.md |
-
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference:
-
-1. **Copy transcript** to `.agents/transcripts/`
-2. **Link from session file** in frontmatter:
-
-```yaml
-session:
-  title: "Feature Implementation"
-  transcripts:
-    - 20260123-143500-pre-compact.jsonl
-    - 20260123-160000-final.jsonl
-```
-
-This preserves full context for debugging, knowledge extraction, and audit trails.
 
 ## Flexibility Preserved
 

--- a/dist/amp/skills/orchestration/references/session-resume.md
+++ b/dist/amp/skills/orchestration/references/session-resume.md
@@ -1,15 +1,15 @@
 # Session Resume Patterns
 
-Patterns for resuming work across Amp sessions using CLI flags and session files.
+Patterns for resuming work with CLI conversation history plus SQLite-backed
+Loaf session state.
 
 ## Contents
 
 - CLI Resume Flags
 - Resume Methods
 - When to Use Each Method
-- Session File as Resume Checkpoint
+- SQLite Session as Resume Checkpoint
 - Checkpoint Pattern
-- Naming Sessions Descriptively
 - Context Recovery Strategies
 - Handling Stale Sessions
 - Multi-Session Coordination
@@ -17,7 +17,7 @@ Patterns for resuming work across Amp sessions using CLI flags and session files
 
 ## CLI Resume Flags
 
-Amp provides built-in session continuation:
+Some harnesses provide built-in conversation continuation:
 
 | Flag | Purpose |
 |------|---------|
@@ -25,217 +25,113 @@ Amp provides built-in session continuation:
 | `--resume <id>` | Resume a specific conversation by ID |
 | `/resume` | In-session command to list and resume |
 
+Use harness resume for chat history. Use `loaf session` for operational state.
+
 ## Resume Methods
 
-### Method 1: CLI Continue
+### Method 1: Conversation Continue
+
+Resume the exact conversation when you need full chat history.
+
+### Method 2: SQLite Session Resume
+
+Start fresh and recover operational state:
 
 ```bash
-# Continue most recent conversation
-claude --continue
-
-# Resume specific conversation
-claude --resume abc123
+loaf session start
+loaf session list --all --json
+loaf session show <session-ref> --json
 ```
 
-**Best for:** Picking up exactly where you left off with full context.
-
-### Method 2: Session File Resume
-
-```bash
-# Start new conversation, resume from session file
-claude
-> /resume 20250123-143000-feature-auth
-```
-
-**Best for:** Fresh context but task continuity from session file.
+Best for clean context with task continuity.
 
 ### Method 3: Hybrid Resume
 
-```bash
-# Continue conversation AND sync with session file
-claude --continue
-> Check session file for any updates: .agents/sessions/20250123-143000-feature-auth.md
-```
-
-**Best for:** Recovering from context pollution while preserving conversation history.
+Continue the conversation, then compare it against `loaf session show` output.
+Best when chat history matters but the journal may contain newer facts.
 
 ## When to Use Each Method
 
 | Situation | Recommended Method |
 |-----------|-------------------|
-| Short break, same task | `--continue` |
-| Long break, clean state needed | Session file resume |
+| Short break, same task | Conversation continue |
+| Long break, clean state needed | SQLite session resume |
 | Context polluted but need history | Hybrid resume |
-| Different machine | Session file resume |
-| Handoff to another person | Session file resume |
+| Different machine | SQLite session resume |
+| Handoff to another person | SQLite session + handoff/report |
 
-## Session File as Resume Checkpoint
+## SQLite Session as Resume Checkpoint
 
-### Writing Resume-Ready State
+Before ending or compacting:
 
-Before ending a session, ensure session file contains:
-
-```markdown
-## Current State
-**Last Action:** Completed API endpoint implementation
-**Pending:** Tests need to be written
-
-## Resumption Notes
-- Branch: feature/auth-endpoints
-- Key files modified: src/auth/routes.py, src/auth/models.py
-- Tests to write: test_login, test_logout, test_refresh
-- Blocker: None
-
-## Next Steps
-1. Spawn QA agent for test implementation
-2. Run full test suite
-3. Update API documentation
-```
-
-### Reading Resume State
+1. Log last action, blockers, and next steps with `loaf session log`.
+2. Reference tasks, specs, reports, commits, and branch names by stable ID/path.
+3. Run `loaf session end --wrap` when work is complete.
 
 When resuming:
 
-1. Read session file for context
-2. Check `## Current State` for where you left off
-3. Check `## Resumption Notes` for key details
-4. Check `## Next Steps` for immediate actions
-5. Verify branch and file state match expectations
+1. Run `loaf session start` on the branch/worktree.
+2. Inspect `loaf session show <session-ref> --json`.
+3. Verify branch and file state match expectations.
+4. Continue from the next logged action.
 
 ## Checkpoint Pattern
 
-For long-running tasks, create explicit checkpoints:
-
-```markdown
-## Checkpoints
-
-### Checkpoint 1: Schema Complete
-**Timestamp:** 2025-01-23T14:30:00Z
-**State:** Database schema implemented and migrated
-**Can resume from:** This checkpoint if later work fails
-
-### Checkpoint 2: API Complete
-**Timestamp:** 2025-01-23T15:45:00Z
-**State:** All endpoints implemented, passing basic tests
-**Can resume from:** This checkpoint for test expansion
-```
-
-### Rewind to Checkpoint
-
-If work goes wrong:
-
-1. Identify safe checkpoint
-2. `git checkout <commit>` to restore code state
-3. Update session file to checkpoint state
-4. `/clear` to reset context
-5. Resume from checkpoint
-
-## Naming Sessions Descriptively
-
-Good session names aid resume:
-
-```
-# Good - descriptive, searchable
-20250123-143000-auth-jwt-implementation.md
-20250123-160000-api-rate-limiting.md
-
-# Bad - generic, hard to find
-20250123-143000-feature.md
-20250123-160000-fix.md
-```
-
-### Rename Pattern
+For long-running tasks, create explicit journal checkpoints:
 
 ```bash
-# If session name becomes unclear, rename for clarity
-mv .agents/sessions/20250123-143000-feature.md \
-   .agents/sessions/20250123-143000-user-auth-oauth.md
+loaf session log "decision(checkpoint): schema complete at <commit>"
+loaf session log "decision(checkpoint): API complete; next write tests"
 ```
 
-Update any references in Linear or other sessions.
+If work goes wrong, use Git to restore code state and log the reconciliation:
+
+```bash
+loaf session log "decision(recovery): rewound to <commit>; replaying tests"
+```
 
 ## Context Recovery Strategies
 
-### Strategy 1: Full Replay
+### Full Replay
 
-For complex state, replay key decisions:
+Use `loaf session show` plus ADR/spec/report links for complex state.
 
-```markdown
-## Decision Replay
+### Minimal Context
 
-When resuming, recall these decisions:
-1. Chose JWT over sessions (see ADR-007)
-2. Using Redis for token storage
-3. 15-minute access token expiry
-```
+Use the last few journal entries when the next action is obvious.
 
-### Strategy 2: Minimal Context
+### Reference Chain
 
-For simple continuation:
+For multi-session work, log relationships:
 
-```markdown
-## Minimal Resume Context
-
-Branch: feature/auth
-Last commit: "feat: add login endpoint"
-Next: Write tests for login endpoint
-```
-
-### Strategy 3: Reference Chain
-
-For multi-session work:
-
-```markdown
-## Session Chain
-
-Previous sessions:
-- 20250122-100000-auth-design.md (planning)
-- 20250122-143000-auth-schema.md (database)
-- This session: API implementation
+```bash
+loaf session log "discover(context): previous design captured in SPEC-123 and ADR-007"
 ```
 
 ## Handling Stale Sessions
 
-### Signs of Stale Session
+Signs of stale session state:
 
-- Code has changed since session was active
-- Other sessions modified same files
+- Code changed after the last journal entry
 - Branch was rebased or merged
+- Another task/spec superseded the work
 
-### Stale Session Recovery
+Recovery:
 
-```
-1. Read session file for intended state
-2. Compare with actual code state (git diff)
-3. Identify conflicts or drift
-4. Update session file to reflect reality
-5. Plan reconciliation if needed
-```
+1. Inspect `loaf session show`.
+2. Compare with `git status`, `git log`, and relevant specs/tasks.
+3. Log the drift and reconciliation plan.
 
 ## Multi-Session Coordination
 
-When multiple sessions touch same codebase:
-
-```markdown
-## Related Sessions
-
-| Session | Status | Overlaps |
-|---------|--------|----------|
-| auth-backend | completed | src/auth/ |
-| auth-frontend | in_progress | src/components/auth/ |
-| This session | in_progress | src/auth/models.py (shared) |
-
-## Coordination Notes
-- Wait for auth-backend completion before modifying models
-- Sync with auth-frontend on API contract changes
-```
+When multiple sessions touch related areas, use specs/tasks/reports as the shared
+coordination layer. Session journals should point to those durable artifacts
+rather than becoming the only place a dependency is described.
 
 ## Best Practices
 
-1. **Update session before stopping** - capture state while fresh
-2. **Use descriptive names** - aid future resume
-3. **Create checkpoints** - safe rollback points
-4. **Note dependencies** - what must complete first
-5. **Clear stale context** - don't resume into pollution
-6. **Verify state on resume** - code may have changed
-7. **Document decision context** - not just decisions
+1. Log before stopping.
+2. Prefer stable IDs over pasted summaries.
+3. Use `loaf session show` as the operational resume surface.
+4. Keep chat-history resume separate from Loaf session state.
+5. Verify code state on resume.

--- a/dist/amp/skills/orchestration/references/sessions.md
+++ b/dist/amp/skills/orchestration/references/sessions.md
@@ -1,523 +1,116 @@
 # Session Management
 
-Sessions are coordination artifacts for active work. They are archived (set status, `archived_at`, `archived_by`, move to `.agents/sessions/archive/`) when work completes to preserve an audit trail.
+Sessions are SQLite-backed coordination records for active work. Markdown is a
+rendered view for reading or compatibility export; agents persist new facts with
+`loaf session` commands.
 
 ## Contents
 
-- Compact vs New Session
+- Core Model
 - When to Use Sessions
-- Session Types
-- Session File Format
-- Lifecycle States
-- Updating During Work
-- Session Continuity Protocol
-- Completing a Session
-- Start Protocol
+- Lifecycle
+- Journal Protocol
+- Continuity
+- Completion
 - Hook Integration
 - Anti-Patterns
 
-## Compact vs New Session
+## Core Model
 
-| Scenario | Action |
-|----------|--------|
-| Picking up previous work, same scope | Compact or resume existing conversation |
-| Switching to entirely different scope | New conversation (new session) |
-| Finished and archived a spec | New conversation |
-| Context full mid-task | Auto-compact (journal survives) |
-| Quick unrelated question | New conversation (don't pollute working session) |
+Use the `wrap` skill as the canonical session model:
 
-**Rule of thumb:** if you'd need the same session file, compact. If you'd need a different one, start fresh.
+1. `loaf session start` finds or creates the active session for the current branch
+   and prints resumption context.
+2. `loaf session log "type(scope): description"` writes durable journal rows.
+3. `loaf session show <session-ref> --json` reads the SQLite-backed session view.
+4. `loaf session end --wrap` persists the wrapped end state.
+5. `loaf session archive` archives closed sessions when the branch/work is done.
+
+The render format is documented in `templates/session.md`; it is not an
+instruction to author markdown directly.
 
 ## When to Use Sessions
 
-- Multi-step work requiring agent coordination
+- Multi-step work requiring coordination
 - Handoffs between agents
-- Tracking progress during implementation
-- Context preservation across agent spawns
+- Implementation or release work that must survive compaction
+- Long research, architecture, council, or review efforts
 
-## Session Types
+For quick unrelated questions, start a fresh conversation so the active session
+stays focused.
 
-### Implementation Sessions (Invisible)
+## Lifecycle
 
-When implementing tasks via `/implement TASK-XXX`:
+The interim runtime lifecycle before SPEC-049 is:
 
-- Session created automatically with filename `YYYYMMDD-HHMMSS-session.md`
-- Task file updated with `session:` field linking to session
-- No user interaction needed for session naming
-- Resume via `loaf session start` then `/implement TASK-XXX`
+| State | Source | Meaning |
+|-------|--------|---------|
+| `active` | `loaf session start` | Current work may receive journal entries |
+| `stopped` | `loaf session end` | Work paused or closed without wrap |
+| `done` | `loaf session end --wrap` | Wrapped work is complete |
+| `archived` | `loaf session archive` | Closed session preserved outside active list |
 
-Users work with tasks; sessions are an implementation detail.
+Do not introduce additional session vocabulary in guidance. SPEC-049 owns the
+durable status vocabulary.
 
-### Explicit Sessions
+## Journal Protocol
 
-For non-task work, sessions are still created explicitly:
-
-- Research sessions (`/research`)
-- Architecture decisions (`/architecture`)
-- Council deliberations (`/council`)
-
-These sessions may not have a linked task but still follow standard session format.
-
-## Session File Format
-
-**Link policy**: Documents outside `.agents/` must not reference `.agents/` files. Keep `.agents/` links contained within `.agents/` artifacts, and update them when files move to `.agents/<type>/archive/`.
-
-### Location & Naming
-
-```
-.agents/sessions/YYYYMMDD-HHMMSS-session.md
-```
-
-**Archive location:** `.agents/sessions/archive/`
-
-**Transcripts location:** `.agents/transcripts/`
-
-Transcripts are Amp conversation exports (`.jsonl` files) archived after context compaction. They preserve the full audit trail of agent interactions.
-
-```
-.agents/
-├── sessions/
-│   ├── YYYYMMDD-HHMMSS-session.md
-│   └── archive/
-└── transcripts/              # Amp transcripts
-    ├── 2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl
-    └── archive/
-```
-
-**Why keep original filenames:** The UUID-like hash is unique and matches Amp's internal reference, making correlation easier if needed.
-
-**Generate timestamps:**
+Log compact, factual entries:
 
 ```bash
-# Filename timestamp
-date -u +"%Y%m%d-%H%M%S"
-
-# ISO timestamp (for YAML)
-date -u +"%Y-%m-%dT%H:%M:%SZ"
+loaf session log "decision(scope): chose X because Y"
+loaf session log "discover(scope): learned Z from file/path"
+loaf session log "block(scope): waiting on external approval"
+loaf session log "unblock(scope): approval received"
+loaf session log "spark(scope): possible follow-up idea"
+loaf session log "todo(scope): concrete follow-up action"
 ```
 
-### Naming Convention
+Log durable facts, not thoughts. The journal should let another agent resume
+without reading the whole conversation.
 
-All session files use the fixed format: `YYYYMMDD-HHMMSS-session.md`
+## Continuity
 
-The timestamp is the unique identifier. Descriptions, spec links, and branch names belong in frontmatter and the `# Session:` heading, not the filename. This keeps references stable — spec and task files can point to session filenames without them ever breaking.
+Before compaction, branch switches, or agent handoff:
 
-### Required Frontmatter
+1. Flush unrecorded decisions, discoveries, blockers, and next actions with
+   `loaf session log`.
+2. Use `loaf session show <session-ref> --json` to confirm the journal has the
+   required resumption context.
+3. Pass task IDs, spec IDs, report IDs, and commit refs rather than duplicating
+   large prose into the journal.
 
-```yaml
----
-session:
-  title: "Clear description of work"           # REQUIRED
-  status: in_progress                          # REQUIRED: in_progress|paused|completed|archived
-  created: "2025-12-04T14:30:00Z"              # REQUIRED: ISO 8601
-  last_updated: "2025-12-04T14:30:00Z"         # REQUIRED: ISO 8601
-  last_archived: "2025-12-04T16:00:00Z"        # Set by PreCompact hook before compaction
-  archive_reason: "pre-compact"                # Why archived (pre-compact, manual, etc.)
-  archived_at: "2025-12-04T18:10:00Z"          # Required when archived
-  task: TASK-001                               # If implementation work (links to .agents/tasks/)
-  linear_issue: "BACK-123"                     # Optional
-  linear_url: "https://linear.app/..."         # Optional
-  branch: "username/back-123-feature"          # Optional: working branch
-  transcripts: []                              # Archived Amp transcripts (filenames only)
-                                               # Example: ["2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl"]
-  referenced_sessions: []                      # Cross-session references (see below)
+Background and delegated agents should receive the relevant task/spec/report
+references plus the active session alias when the caller has one.
 
-orchestration:
-  current_task: "What's actively being worked" # REQUIRED
-  spawned_agents:
-    - agent: implementer
-      task: "Brief task description"
-      status: completed                        # pending|in_progress|completed
-      summary: "Outcome summary"
+## Completion
 
-background_agents:                             # Background work running independently
-  - id: "bg-20260123-143000-security-scan"     # ID: bg-YYYYMMDD-HHMMSS-description
-    agent: background-runner                              # Agent type
-    task: "Full security audit"                # Brief description
-    status: running                            # running|completed|failed
-    result_location: null                      # Path to report when complete
----
-```
+When work is complete:
 
-### Cross-Session References
+1. Ensure decisions and discoveries are captured in durable homes such as ADRs,
+   specs, reports, or docs.
+2. Run `loaf session end --wrap` so the CLI persists the wrapped state.
+3. After merge or closure, use `loaf session archive` if the session should leave
+   the active list.
 
-Track decisions imported from past sessions via Serena memory:
-
-```yaml
-session:
-  # ... other fields ...
-  referenced_sessions:
-    - session: "20250115-140000-auth-jwt.md"     # Source session filename
-      imported_at: "2025-01-23T14:30:00Z"        # When imported
-      content_type: decisions                     # decisions|context|all
-      decisions_imported:                         # List of decision titles
-        - "JWT token rotation strategy"
-        - "Refresh token storage approach"
-    - session: "20250110-090000-auth-oauth.md"
-      imported_at: "2025-01-23T14:35:00Z"
-      content_type: context
-      summary: "OAuth provider integration patterns"
-```
-
-**Why track references:**
-
-- Audit trail of where context came from
-- Avoids re-importing same decisions
-- Enables tracing decision lineage across sessions
-
-See `references/cross-session.md` for full patterns.
-
-### Required Sections
-
-Every session file MUST have:
-
-1. **`## Context`** - Background for anyone picking up this work
-2. **`## Current State`** - Where we are now (MUST be handoff-ready)
-3. **`## Next Steps`** - Immediate actions for continuation
-
-### Session Template
-
-```markdown
-# Session: [Title]
-
-## Context
-Background for anyone picking up this work.
-What problem are we solving? Why now?
-
-## Current State
-Where we are right now. What just happened.
-**This section should ALWAYS be handoff-ready.**
-
-## Resumption Prompt
-
-<!-- Generated by PreCompact hook before compaction -->
-<!-- Provides self-contained context for post-compaction continuation -->
-
-> **Context**: [Brief description of work being done]
->
-> **Last Action**: [What just happened]
->
-> **Immediate Next**: [Concrete next step]
->
-> **Key Files**: [Relevant file paths]
->
-> **Blockers**: [Any blockers, or "None"]
->
-> **Transcript Archive**: If Amp provided a transcript path after compaction,
-> copy it to `.agents/transcripts/` and add the filename to this session's
-> `transcripts:` array in frontmatter.
-
-## Execution Progress
-
-### Wave 1: [Name] (ACTIVE)
-- [ ] BACK-123 - Brief description
-- [x] BACK-124 - Brief description (completed)
-
-### Wave 2: [Name] (blocked by Wave 1)
-- [ ] BACK-125 - Brief description
-
-## Technical Context
-
-### Files to Update
-- `path/to/file.py` - What needs to change
-
-### Key Commands
-```bash
-pytest path/to/tests/ -v
-mypy path/to/code/
-```
-
-## Acceptance Criteria
-
-- [ ] Criterion 1
-- [ ] Criterion 2
-
-## Decisions
-
-### Decision 1: [Title]
-
-**Decision**: What was decided
-**Rationale**: Why
-
-## Architecture Diagrams
-
-### [Diagram Name]
-
-```mermaid
-[diagram content]
-```
-
-**Purpose**: Why this diagram helps understand the work
-**Files involved**: List of related file paths
-**Created**: When diagram was created (update if modified)
-
-<!--
-When to add diagrams:
-- Multi-service changes: Show interaction points
-- Data flow changes: Trace data through system
-- Schema modifications: Visualize relationships
-- API design: Document request/response flows
-
-For reusable diagrams, store in .agents/diagrams/ instead.
-See foundations skill reference/diagrams.md for Mermaid syntax.
--->
-
-## Council Outcomes
-
-### Council: [Topic]
-
-**Outcome**: Decision summary
-**Council File**: `.agents/councils/YYYYMMDD-HHMMSS-topic.md`
-**Next Steps**: Action items captured
-**Archive**: After this summary is captured, set council status to `archived`, set `archived_at`, set `archived_by`, and move to `.agents/councils/archive/` (archive indefinitely).
-
-## Reports Processed
-
-### Report: [Title]
-
-**Key Conclusions**: Summary of findings
-**Action Items**: What changed or will change
-**Report Output**: generated with `loaf report generate ...` or stored as an authored report when durable prose is needed.
-**Archive**: After report is processed and the linked session is archived, use `loaf report archive <report>` for SQLite-backed report state. Markdown report movement is compatibility/export handling.
-**Metadata**: Require enough state or frontmatter to identify status, linked session, and processing time. In SQLite-backed projects, CLI state is authoritative.
-**Note**: Reports without state/frontmatter metadata are treated as unprocessed compatibility artifacts.
-
-## Handoffs
-
-Explicit transfer packets belong to `/handoff`, which writes
-`.agents/handoffs/YYYYMMDD-HHMMSS-title.md`. Orchestration keeps live session
-state resumable; `/handoff` packages context for another agent, branch, task,
-or future session. `/housekeeping` deletes deprecated handoffs after
-confirmation.
-
-## Blockers
-
-- Current blocker (if any)
-
----
-
-## Session Log (Compact Inline Journal)
-
-Sessions use an **append-only structured journal** format — a running log of what happened, what was decided, and what's next. Think "conventional commits meets bullet journal."
-
-### Format
-
-```markdown
-## Journal
-
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-[YYYY-MM-DD HH:MM] decision(scope): description of decision
-[YYYY-MM-DD HH:MM] discover(scope): something learned
-
-[YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
-[YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
-[YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
-```
-
-### Entry Types
-
-| Type | Use For | Written By | Scope Convention |
-|------|---------|------------|------------------|
-| `resume(scope)` | Session started/resumed | Hook (auto) | Branch name |
-| `pause` | Session ended | Hook (auto) | — |
-| `commit(SHA)` | Code committed | Hook (auto) | Short SHA |
-| `pr(#N)` | PR created/updated | Hook (auto) | PR number |
-| `merge(#N)` | PR merged | Hook (auto) | PR number |
-| `decision(scope)` | Key decisions | Agent | Topic |
-| `discover(scope)` | Something learned | Agent | Topic |
-| `block(scope)` | Blocker encountered | Agent | Topic |
-| `unblock(scope)` | Blocker resolved | Agent | Topic |
-| `spark(scope)` | Ideas to promote | Agent | Topic |
-| `resolve(spark)` | Spark triaged via `/idea` | Agent/User | Spark slug → disposition [timestamp] |
-| `todo(scope)` | Action items | Agent | Topic |
-| `finding(scope)` | Findings from analysis | Agent | Topic |
-| `hypothesis` | Theory being tested | Agent | — |
-| `try` | Approach attempted | Agent | — |
-| `reject` | Approach abandoned | Agent | — |
-| `skill(name)` | Skill invoked with context | Skill (self-log) | Skill name |
-| `idea(slug)` | Idea captured or promoted | Agent/Skill | Idea slug or `.agents/ideas/` ref |
-| `spec(id)` | Spec created, updated, or approved | Agent/Skill | Spec ID (e.g. `SPEC-024`) |
-| `handoff(slug)` | Handoff created or deprecated | Agent/Skill | Handoff slug or `.agents/handoffs/` ref |
-| `report(slug)` | Report generated | Agent/Skill | Report slug or `.agents/reports/` ref |
-| `council(slug)` | Council convened or concluded | Agent/Skill | Council slug or `.agents/councils/` ref |
-| `brainstorm(slug)` | Brainstorm session held | Agent/Skill | Draft slug or topic |
-| `plan(slug)` | Plan created or updated | Agent/Skill | Plan slug or topic |
-| `draft(slug)` | Draft document created | Agent/Skill | Draft slug or `.agents/drafts/` ref |
-
-### Format Rules
-
-1. **Timestamp:** `YYYY-MM-DD HH:MM` (no seconds)
-2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank line separator:** Insert when:
-   - Gap ≥ 5 minutes since last entry, OR
-   - State transition (block/unblock/pause/resume)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated by `loaf session end`)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-### Example Session
-
-```markdown
----
-spec: SPEC-020
-branch: feat/target-convergence
-status: active
-created: 2026-03-31T14:30:00Z
-last_entry: 2026-04-02T09:15:00Z
----
-
-# Session: Target Convergence
-
-## Journal
-
-[2026-03-31 14:30] resume(feat/target-convergence): from commit abc1234, 3 tasks pending
-[2026-03-31 14:30] decision(hooks): remove bash wrappers, go direct
-[2026-03-31 14:32] discover(cursor): prompt hooks filtered at line 269
-
-[2026-03-31 15:10] block(parity): Codex output differs by trailing newline
-[2026-03-31 15:11] hypothesis: gray-matter serialization adds trailing \n
-
-[2026-03-31 16:45] unblock(parity): confirmed gray-matter quirk, fixed with trim
-[2026-03-31 16:46] commit(def5678): fix: trim frontmatter for Codex byte parity
-
---- PAUSE 2026-03-31 17:00 ---
-
-[2026-04-02 09:15] resume(feat/target-convergence): 16 hours paused, last: verification
-```
-
-### CLI Commands
-
-```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decide(scope): desc"
-loaf session archive  # Move to archive when branch merges
-```
-
-### Consistency
-
-- **`loaf session log`** validates and appends entries in correct format
-- **Read-only agents** (reviewer, researcher) CAN write journal entries via `loaf session log` (Bash command, not file edit)
-- **Concurrent writes** are safe: atomic append, timestamps provide ordering
-
-## Lifecycle States
-
-| State | Description |
-|-------|-------------|
-| `in_progress` | Work actively happening |
-| `paused` | Temporarily stopped |
-| `completed` | Work finished; ready to archive (set status, `archived_at`, `archived_by`, move) after extraction |
-| `archived` | Closed and preserved for audit (set `archived_at`/`archived_by`, status set + moved to `.agents/sessions/archive/`) |
-
-## Updating During Work
-
-After each significant action, append entries to the session journal:
-
-1. **Use `loaf session log`** to append entries in the correct format
-2. **Add `decision`, `discover`, `block`, `spark`, `wrap` entries** during normal work
-3. **Hooks auto-append:** `resume`, `commit(SHA)`, `pr(#N)`, `merge(#N)`, `pause`
-4. **Blank line rules:** Inserted automatically by `loaf session log` based on time gaps and state transitions
-
-**Cross-agent protocol:** When any agent starts work on a branch, `loaf session start` outputs the last 15-20 journal entries. The agent reads context, continues work, appends entries.
-
-## Session Continuity Protocol
-
-### Before Pausing or Switching Agents
-
-1. Update session file with completed work
-2. Update `Current State` with where you stopped
-3. Update `Next Steps` with immediate actions
-4. Include `Files Modified` for context
-
-### Session as Continuity Medium
-
-Each agent:
-1. Reads current state from session
-2. Performs assigned work
-3. Updates session with outcomes
-4. Sets up context for next agent
-
-## Completing a Session
-
-Sessions are **archived, not deleted** when complete to preserve audit trail (set status to `archived`, set `archived_at` and `archived_by`, and move into `.agents/sessions/archive/`). Archive indefinitely (no deletion policy).
-
-**Archive timing:** only after extraction and council/report summaries are captured.
-
-### Knowledge Extraction Checklist
-
-| Information Type | Where It Belongs |
-|------------------|------------------|
-| Work tracking | External issue (Linear, GitHub) |
-| Implementation details | Git commits/PRs |
-| Architectural decisions | ADRs (`docs/decisions/`) |
-| API contracts | API documentation |
-| Remaining work | External issue backlog |
-| Council outcomes | Session summary + council file link |
-| Report conclusions | Session summary + report file link |
-| Archived artifacts | SQLite lifecycle state plus compatibility archive metadata when Markdown files exist |
-
-### Archival Checklist
-
-- [ ] External issue updated with final status
-- [ ] Decisions captured as ADRs (if architectural)
-- [ ] Lessons learned added to relevant docs
-- [ ] Remaining work created as issues
-- [ ] Council outcomes summarized in this session (link council file)
-- [ ] Reports processed and summarized in this session (link report file)
-- [ ] Reports archived only after session is archived (`loaf report archive` for SQLite-backed state)
-- [ ] Handoffs reviewed; deprecated handoffs marked for `/housekeeping` deletion
-- [ ] No orphaned references to session file
-- [ ] Set session status to `archived`
-- [ ] Set `archived_at` and `archived_by`
-- [ ] Move compatibility session file to `.agents/sessions/archive/` when one exists
-- [ ] Linked councils moved to `.agents/councils/archive/` after session summary
-- [ ] Linked report state archived after session archived + conclusions captured
-- [ ] Deprecated handoffs deleted by `/housekeeping` after confirmation
-- [ ] Update `.agents/` references to archived paths (no `.agents` links outside `.agents/`)
-- [ ] Archive indefinitely (no deletion policy)
-- [ ] Use `/housekeeping` for auto-move + link updates after confirmation
-
-## Start Protocol
-
-When starting a new orchestration context:
-
-1. Check for existing active sessions
-2. If found, ask user which to resume or start fresh
-3. If resuming, read session for context
-4. If starting fresh, create new session file
+Reports, councils, and handoffs have their own archive or finalization commands.
+Do not use session archival as a substitute for those lifecycles.
 
 ## Hook Integration
 
-### SessionStart Hook
-- Lists active sessions
-- Provides agent-specific context
-- Suggests session review/resume
-
-### SessionEnd Hook
-- Displays completion checklist
-- Reminds about session file updates
-- Shows count of active sessions
-
-### PreCompact Hook
-- `loaf session context for-compact` logs compact marker and injects flush instructions
-- Model flushes unrecorded decisions/discoveries to journal
-- Model writes structured `## Current State` summary
-- After compaction: `loaf session context for-resumption` prints rich resumption context (session, spec, journal, git)
+- Session start hooks should surface recent journal entries from SQLite.
+- Session-end hooks should nudge for missing durable journal entries before wrap.
+- Pre-compaction hooks should ask the agent to flush facts through
+  `loaf session log`.
+- Post-compaction recovery should use `loaf session start` and
+  `loaf session show`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Archive without extraction | Extract outcomes before archiving |
-| Use sessions as permanent records | Use proper documentation locations |
-| Reference stale sessions | Keep sessions current or archive (status + move) when done |
-| Store decisions only in sessions | Create ADRs for important decisions |
-| Archive without council/report summaries | Summarize outcomes in session before archive |
-| Archive but leave in active folder | Move file to `.agents/sessions/archive/` after setting status |
-| Batch session updates | Update after each significant event |
-| Keep status as `in_progress` when paused | Update status when state changes |
+| Hand-author session markdown as source | Use `loaf session start/log/show/end` |
+| Store decisions only in chat context | Log them and promote durable decisions to ADR/spec/report/docs |
+| Invent status values | Cite the runtime lifecycle until SPEC-049 lands |
+| Archive before extracting outcomes | Promote outcomes first, then wrap/archive |
+| Batch all journal entries at the end | Log significant facts as they happen |

--- a/dist/amp/skills/orchestration/templates/session.md
+++ b/dist/amp/skills/orchestration/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/amp/skills/reflect/SKILL.md
+++ b/dist/amp/skills/reflect/SKILL.md
@@ -33,12 +33,13 @@ Update VISION, STRATEGY, and ARCHITECTURE based on proven implementation.
 - **Post-implementation only** -- reflect after shipping, not before or during planning
 - **Get explicit approval** -- never update strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) without user confirmation
 - **Consolidate** -- batch related learnings into coherent updates, avoid micro-updates
-- **Link back** -- always reference the specs/sessions that informed each update
+- **Log first** -- log invocation before gathering evidence: `loaf session log "skill(reflect): <scope>"`
+- **Link back** -- always reference the specs, SQLite sessions, reports, and commits that informed each update
 - **Log updates** -- log each strategic document update to session journal: `loaf session log "decision(scope): updated STRATEGY.md with learning"`
 
 ## Verification
 
-- Proposals cite specific specs, sessions, or commits as evidence
+- Proposals cite specific specs, SQLite sessions, reports, or commits as evidence
 - No strategic document was modified without explicit user approval
 - Completed specs referenced in updates are archived after reflection
 
@@ -86,7 +87,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 
 Sources:
 1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
-2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
+2. **SQLite sessions** (`loaf session list --all --json`, then `loaf session show <ref> --json`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?
 

--- a/dist/amp/skills/research/SKILL.md
+++ b/dist/amp/skills/research/SKILL.md
@@ -33,6 +33,7 @@ Patterns for zooming out, investigating topics, and evolving project direction.
 - Cite sources with confidence levels
 - Present options, let user decide
 - Get approval before editing VISION
+- Log invocation first: `loaf session log "skill(research): <topic or mode>"`
 - Log findings to session journal: `loaf session log "discover(scope): summary of finding"`
 
 ### Never
@@ -79,7 +80,7 @@ Parse `$ARGUMENTS` to determine mode:
 
 Prioritize sources in this order:
 
-1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, session files, codebase patterns
+1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, SQLite sessions, codebase patterns
 2. **Authoritative docs** -- Context7, official docs, RFCs
 3. **Community knowledge** -- Stack Overflow (verified), GitHub issues, expert blogs
 4. **General web** (lowest) -- Search results, unverified sources
@@ -94,7 +95,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 
 1. Read project documents: VISION.md, STRATEGY.md, ARCHITECTURE.md
 2. Check ideas (`.agents/ideas/`) and specs (`docs/specs/`)
-3. Review recent sessions (`.agents/sessions/`)
+3. Review recent sessions with `loaf session list --all --json` and `loaf session show <ref> --json`
 4. Check recent commits: `git log --oneline -20`
 5. Synthesize following [state-assessment template](templates/state-assessment.md)
 
@@ -103,7 +104,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 **Trigger:** Specific topic or question
 
 1. **Interview** with Amp UI input: what are you trying to understand? What context do you have? What decision will this inform?
-2. Check project context first (ADRs, ARCHITECTURE, sessions)
+2. Check project context first (ADRs, ARCHITECTURE, SQLite sessions)
 3. Apply confidence hierarchy for external sources
 4. For a transient review artifact, use `loaf report generate` when an existing
    SQLite-backed export kind fits; for authored long-form research, create a

--- a/dist/amp/skills/research/templates/state-assessment.md
+++ b/dist/amp/skills/research/templates/state-assessment.md
@@ -12,7 +12,7 @@ title: "State Assessment: [YYYY-MM-DD]"
 type: state-assessment
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active | archived
-session: ".agents/sessions/YYYYMMDD-HHMMSS-description.md"  # Session that produced this assessment
+session: "session alias or loaf session show reference"  # Session that produced this assessment
 tags: []
 ---
 

--- a/dist/codex/skills/bootstrap/SKILL.md
+++ b/dist/codex/skills/bootstrap/SKILL.md
@@ -41,6 +41,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - **BRIEF is input, not output** -- the BRIEF is raw intake. Extract every useful fact into VISION/STRATEGY/ARCHITECTURE/AGENTS during bootstrap.
 - **BRIEF is archeological after bootstrap** -- once extraction completes, the BRIEF is a frozen historical snapshot. No skill, agent, command, or template should reference `docs/BRIEF.md` post-bootstrap. Operating documents must stand on their own.
 - **Suggest, don't execute** -- recommend next skills at the end, never auto-run them
+- **Log first** -- log invocation before interviewing: `loaf session log "skill(bootstrap): <project or intake>"`
 - **Log outcome** -- log bootstrap completion to session journal: `loaf session log "decision(bootstrap): project bootstrapped, mode detected"`
 
 ---
@@ -50,7 +51,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - All expected operating documents (`docs/VISION.md`, `.agents/AGENTS.md` at minimum) exist and contain populated content
 - Useful BRIEF content has been extracted into operating documents (no future reader should need to open the BRIEF)
 - Symlinks are correct: `.agents/AGENTS.md` and `./AGENTS.md -> .agents/AGENTS.md`
-- A session file was saved in `.agents/sessions/` capturing key decisions and interview exchanges
+- Key decisions and interview outcomes were logged with `loaf session log` and are readable with `loaf session show`
 
 ---
 
@@ -369,13 +370,13 @@ If symlinks already exist and point to the right targets, skip silently. If they
 
 ### 3. Session Recording
 
-Save the bootstrap interview as a session file:
+Record the bootstrap interview in the active SQLite-backed session:
 
-```
-.agents/sessions/{YYYYMMDD}-{HHMMSS}-bootstrap.md
-```
+1. Run `loaf session start` if there is no active session.
+2. Log mode detection and key interview decisions with `loaf session log`.
+3. Use `loaf session show <session-ref>` to inspect the rendered session view.
 
-The session should capture:
+The session journal should capture:
 - Mode detected and why
 - Key decisions made during the interview
 - Key interview exchanges that informed those decisions
@@ -383,7 +384,8 @@ The session should capture:
 - The original problem framing and user intent
 - Any open questions or deferred decisions
 
-Follow [templates/session.md](templates/session.md) for structure and frontmatter schema.
+Use [templates/session.md](templates/session.md) only as the rendered journal
+format reference; do not hand-author session markdown as the source of truth.
 
 ### 4. Next Steps
 

--- a/dist/codex/skills/bootstrap/templates/session.md
+++ b/dist/codex/skills/bootstrap/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/codex/skills/brainstorm/SKILL.md
+++ b/dist/codex/skills/brainstorm/SKILL.md
@@ -18,7 +18,8 @@ Generative thinking — expanding possibilities before narrowing through structu
 - Diverge before converging — generate options before judging
 - Connect exploration to VISION.md and STRATEGY.md context
 - Document discarded options — they hold valuable reasoning
-- Capture sparks (speculative byproducts) in a dedicated section — brainstorm documents are the canonical home for sparks
+- Log invocation first: `loaf session log "skill(brainstorm): <topic>"`
+- Capture sparks (speculative byproducts) with `loaf spark capture --scope <scope> --text <text>`; brainstorm documents may render or summarize them
 - Set boundaries on exploration time
 - Log outcome to session journal: `loaf session log "decision(scope): direction chosen and rationale"`
 
@@ -32,7 +33,7 @@ Generative thinking — expanding possibilities before narrowing through structu
 
 After work completes, verify:
 - Brainstorm document created at `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
-- `## Sparks` section present with speculative byproducts
+- Sparks captured with `loaf spark capture` and optionally summarized in `## Sparks`
 - Spark lifecycle documented: unprocessed → promoted/discarded
 - Brainstorm references strategic context from VISION/STRATEGY
 
@@ -57,7 +58,7 @@ After work completes, verify:
 
 Sparks are: lightweight, byproducts, worth remembering. Mark as `*(promoted)*` or `*(abandoned)*` after processing.
 
-Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value.
+Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value. SQLite spark state is the lifecycle source; draft markdown is a projection or narrative summary.
 
 ## Suggests Next
 

--- a/dist/codex/skills/brainstorm/templates/brainstorm.md
+++ b/dist/codex/skills/brainstorm/templates/brainstorm.md
@@ -11,7 +11,7 @@ type: brainstorm
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active (has unprocessed sparks) | archived
 tags: []
-related: []            # Optional: idea files, spec IDs, session files
+related: []            # Optional: idea aliases, spec IDs, session aliases, report refs
 ---
 
 # Brainstorm: [Topic]

--- a/dist/codex/skills/handoff/templates/handoff.md
+++ b/dist/codex/skills/handoff/templates/handoff.md
@@ -8,7 +8,7 @@ title: "[Handoff Title]"
 created: YYYY-MM-DDTHH:MM:SSZ
 status: draft | final | deprecated
 source: session | branch | task | ad-hoc
-session: .agents/sessions/YYYYMMDD-HHMMSS-session.md
+session: session alias or loaf session show reference
 branch: branch-name
 deprecated_at: YYYY-MM-DDTHH:MM:SSZ  # Set only when confirmed obsolete
 deprecated_by: orchestrator

--- a/dist/codex/skills/housekeeping/SKILL.md
+++ b/dist/codex/skills/housekeeping/SKILL.md
@@ -17,10 +17,11 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Critical Rules
 
 **Always**
+- Log invocation as the first action: `loaf session log "skill(housekeeping): <scope or trigger>"`
 - Review EVERY file individually — never sample or average
 - Check Linear issue status before archiving sessions
 - Extract lessons learned and decisions before archiving
-- Use CLI (`loaf session housekeeping`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
+- Use CLI (`loaf housekeeping`, `loaf session archive`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
 - Treat `.agents/handoffs/` as first-class but disposable: keep active/final handoffs, delete only after confirmed deprecated status
 - Check report `status` is `processed` and linked session is archived before archiving reports (see [templates/report.md](templates/report.md))
 - Check state assessment `session:` field before flagging for cleanup — only flag when linked session is archived
@@ -35,7 +36,7 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Verification
 
 After work completes, verify:
-- Session files archived with proper metadata (status, archived_at, archived_by)
+- Session lifecycle state is visible through `loaf session list --json`
 - Tasks archived via `loaf task archive`
 - Specs archived via `loaf spec archive`
 - SQLite-backed task/spec/report state reflects lifecycle changes when initialized
@@ -48,10 +49,11 @@ After work completes, verify:
 ### CLI Commands
 
 ```bash
-loaf session housekeeping --dry-run  # Preview all actions
-loaf session housekeeping            # Run all checks and fixes
+loaf housekeeping --dry-run          # Preview recommendations
+loaf housekeeping                    # Run artifact scanner
+loaf housekeeping --sessions         # Review sessions only
 loaf session archive                 # Archive single session
-loaf session enrich <file>           # Enrich a session's journal from JSONL
+loaf session enrich --json           # Compatibility diagnostic for legacy enrichment
 loaf task archive TASK-XXX           # Archive single task
 loaf spec archive SPEC-XXX           # Archive single spec
 loaf task sync                       # Compatibility: repair Markdown task index drift
@@ -61,7 +63,7 @@ loaf task sync                       # Compatibility: repair Markdown task index
 
 | Artifact | Active Location | Archive | Action |
 |----------|-----------------|---------|--------|
-| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf session archive` / `loaf session housekeeping` |
+| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf housekeeping --sessions` / `loaf session archive` |
 | Tasks (local mode only) | SQLite state + `.agents/tasks/` source prose | `archive/` | `loaf task archive` |
 | Specs | SQLite state + `.agents/specs/` authored prose | `archive/` | `loaf spec archive` |
 | Drafts (state assessments) | `.agents/drafts/` | delete | Flag for cleanup when linked session is archived |
@@ -78,7 +80,10 @@ every mode.
 
 ## Session Enrichment
 
-For each session with status `stopped` or `done` that has a `claude_session_id` in frontmatter, run `loaf session enrich <file>` to catch up on journal entries that weren't logged during the session.
+In SQLite-backed projects, `loaf session log` is the canonical journal writer and
+`wrap` owns end-of-session checks. `loaf session enrich --json` is a compatibility
+diagnostic for legacy markdown enrichment; it is not part of the normal
+housekeeping flow.
 
 Do NOT enrich `active` sessions — those are handled by the wrap skill when the session ends.
 

--- a/dist/codex/skills/housekeeping/templates/session.md
+++ b/dist/codex/skills/housekeeping/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/codex/skills/implement/SKILL.md
+++ b/dist/codex/skills/implement/SKILL.md
@@ -3,9 +3,9 @@ name: implement
 description: >-
   Orchestrates implementation sessions through agent delegation and batch
   execution. Use for all implementation work — features, bug fixes, refactors,
-  and code changes. Produces session files, agent spawn plans, and progress
-  tracking. Not for shaping (use shape), breakdown (use breakdown), research, or
-  review.
+  and code changes. Produces SQLite-backed session journals, agent spawn plans,
+  and progress tracking. Not for shaping (use shape), breakdown (use breakdown),
+  research, or review.
 version: 2.0.0-pre.20260614235428
 ---
 
@@ -38,7 +38,7 @@ You are the coordinator. Start by understanding the task:
 **You are the ORCHESTRATOR, not the implementer.**
 
 ### Orchestrator Can Do Directly
-- Create/edit session files, council files
+- Start/log/show sessions, create council files
 - Use update_plan; **if `integrations.linear.enabled` is `true` in `.agents/loaf.json`**, use Linear MCP tools when helpful
 - Read any file for context
 - Ask clarifying questions
@@ -48,11 +48,11 @@ You are the coordinator. Start by understanding the task:
 
 ## Verification
 
-- Session file exists before any implementation work begins
+- `loaf session start` has created or resumed an active SQLite-backed session before implementation work begins
 - All code changes delegated via separate Codex thread or explicit multi-agent tool when available -- no direct edits by orchestrator
-- Session file is continuously updated with spawns, progress, and current state
+- Session journal is continuously updated with spawns, progress, and current state
 - Spec artifacts closed out on branch before PR creation
-- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session file is created; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
+- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session is started; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
 
 ## Quick Reference
 
@@ -80,7 +80,7 @@ Before starting, evaluate context suitability.
 | Just completed a different task/spec | Suggest clear |
 | About to start multi-file implementation | Check depth |
 
-If restart needed: capture state in session file, generate resumption prompt, ask user to restart.
+If restart needed: log current state with `loaf session log`, generate resumption prompt, ask user to restart.
 
 ## Input Detection
 
@@ -88,7 +88,7 @@ Parse `$ARGUMENTS` to determine session type:
 
 | Input Pattern | Type | Action |
 |---------------|------|--------|
-| `TASK-XXX` | Local task | Load via `loaf task show`, auto-create session |
+| `TASK-XXX` | Local task | Load via `loaf task show`, start/resume session |
 | `SPEC-XXX` | Spec orchestration | If spec frontmatter has `linear_parent`, resolve to that Linear parent and follow Linear-Native Routing. Otherwise resolve local tasks and build dependency waves |
 | `TASK-XXX..YYY` | Task range | Expand range, build dependency waves |
 | `TASK-XXX,YYY,ZZZ` | Task list | Parse list, build dependency waves |
@@ -100,8 +100,8 @@ Parse `$ARGUMENTS` to determine session type:
 When starting from `TASK-XXX`:
 
 1. Load task metadata via `loaf task show TASK-XXX --json`; read `.agents/TASKS.json` only as a Markdown-compatibility fallback
-2. Auto-generate session: `YYYYMMDD-HHMMSS-task-XXX.md`
-3. Create session file, update task with session reference: `loaf task update TASK-XXX --session <session-file>`
+2. Run `loaf session start` to find or create the active session for the branch
+3. Log the task coupling: `loaf session log "decision(implement): implementing TASK-XXX"`
 4. Load parent spec if task has `spec:` field
 
 **No user interaction required for session naming.**
@@ -187,7 +187,7 @@ The issue is an actual task. Implement it directly — with a pre-flight gate.
    - Resolve branch name from the sub-issue's `branchName` field (Linear
      auto-generates one) — see
      [session-management.md](references/session-management.md).
-   - Create session file, continue with the standard Startup Checklist.
+   - Run `loaf session start`, then continue with the standard Startup Checklist.
 
 ### Completion (after implementer + reviewer finish cleanly)
 
@@ -224,8 +224,8 @@ When the sub-issue's implementation passes review and tests:
   implementation reveals a missing task, surface it to the user; they
   decide whether to run `/breakdown` again or add an ad-hoc sub-issue.
 - Does not sync in-progress state bidirectionally. Source of truth at any
-  moment: Linear for issue state, local files for spec content, session
-  file for current handoff.
+  moment: Linear for issue state, local files for spec content, SQLite session
+  journal for current handoff.
 
 ---
 
@@ -248,19 +248,19 @@ Use the **separate Codex thread or explicit multi-agent tool when available** wi
 
 ---
 
-## Session Creation
+## Session Start
 
-**MANDATORY: Create session file BEFORE any other work.**
+**MANDATORY: Run `loaf session start` BEFORE any implementation work.**
 
-1. Generate timestamps: `date -u +"%Y%m%d-%H%M%S"` and `date -u +"%Y-%m-%dT%H:%M:%SZ"`
-2. Create session file following [session template](templates/session.md)
-3. Verify session file exists with valid frontmatter
+1. Run `loaf session start` from the target branch/worktree.
+2. Log invocation context: `loaf session log "skill(implement): <task/spec/context>"`
+3. Verify the active session is readable with `loaf session list --json` or `loaf session show <session-ref> --json`.
 4. Suggest renaming Codex session with a meaningful name derived from context:
    - From spec: `Suggestion: /rename SPEC-027-session-stability`
    - From task: `Suggestion: /rename TASK-042-login-fix`
    - From ad-hoc: `Suggestion: /rename {short-slug-from-description}`
 
-**DO NOT PROCEED WITHOUT A SESSION FILE.**
+**Do not proceed until the active session is visible through `loaf session` commands.**
 
 ---
 
@@ -271,8 +271,8 @@ Use the **separate Codex thread or explicit multi-agent tool when available** wi
 3. **When uncertain** -- convene council, present results, **wait for user approval**
 4. **Ensure quality** -- spawn implementer for tests, route reviews to reviewer separate Codex thread or explicit multi-agent tool when available
 5. **When debugging** -- if a test failure or error isn't immediately obvious, load the **debugging** skill for structured hypothesis tracking before retrying
-6. **Update session file continuously** -- log spawns, update current_task, keep handoff-ready
-6. **Clean up** -- no ephemeral files, archive completed sessions (status + `archived_at` + `archived_by` + move to archive/)
+6. **Update session continuously** -- log spawns, progress, blockers, and next actions with `loaf session log`
+6. **Clean up** -- no ephemeral files; wrap with `loaf session end --wrap` and archive closed sessions with `loaf session archive`
 7. **When in doubt, ask the user**
 
 ## Decision Tree
@@ -281,7 +281,7 @@ Use the **separate Codex thread or explicit multi-agent tool when available** wi
 Is this a code/config/doc change?
 +-- YES -> Spawn appropriate agent
 +-- NO -> Is this a planning/coordination decision?
-    +-- YES with clear path -> Proceed, update session
+    +-- YES with clear path -> Proceed, log session decision
     +-- YES but ambiguous -> Ask user
     +-- NO -> Ask user
 ```
@@ -292,18 +292,18 @@ When multiple valid approaches exist: spawn council (5-7 agents, odd), present r
 
 ## Startup Checklist
 
-After creating session file:
+After `loaf session start`:
 
 1. [ ] Parse input (task, Linear ID, or description)
-2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, update with `loaf task update TASK-XXX --session <session-file>`, load parent spec
+2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, log task coupling, load parent spec
 3. [ ] If Linear ID (or `SPEC-XXX` with `linear_parent`): follow [Linear-Native Routing](#linear-native-routing). Parent → walk sub-issues and select next. Sub-issue → verify `blockedBy` is clear, then start it as one logical Linear operation so the parent is promoted when needed
 4. [ ] If description: auto-create task (see Ad-hoc Task Auto-Creation above)
 5. [ ] Create dedicated branch (see [session-management.md](references/session-management.md))
 6. [ ] Suggest team based on task context
-7. [ ] Populate session Context section
+7. [ ] Log initial context and references with `loaf session log`
 8. [ ] Break down work using update_plan
 9. [ ] Identify needed specialized agents
-10. [ ] Update session Next Steps
+10. [ ] Log next steps before spawning
 11. [ ] **Get user approval** before spawning
 
 ---
@@ -311,7 +311,7 @@ After creating session file:
 ## Then Execute
 
 ### BEFORE (Planning)
-1. Create session file
+1. Run `loaf session start`
 2. Set task status: `loaf task update TASK-XXX --status in_progress`
 3. Break down work into agent-sized tasks
 4. Identify spawn order (respect dependencies)
@@ -319,10 +319,10 @@ After creating session file:
 
 ### DURING (Execution)
 1. Spawn specialized agents via separate Codex thread or explicit multi-agent tool when available
-2. Log each spawn in session `orchestration.spawned_agents`
+2. Log each spawn with `loaf session log "todo(agent): spawned <agent> for <task>"`
 3. Update Linear with progress (no emoji, no file paths)
-4. Keep session `## Current State` handoff-ready
-5. After each agent completes: update session, spawn next
+4. Keep journal entries handoff-ready
+5. After each agent completes: log outcome, spawn next
 
 ### AFTER (Completion)
 1. Code review pass (spawn `reviewer` agent)
@@ -331,13 +331,13 @@ After creating session file:
    - **Local-tasks mode:** `loaf task update TASK-XXX --status done` (per task), then `loaf task archive --spec SPEC-XXX`
    - **Linear-native mode:** `update_issue` the sub-issue to `completed`-type state. Then query the parent's sub-issues; if all are `completed`, also close the parent. If some remain, list them for the user (see [Linear-Native Routing → Completion](#completion-after-implementer--reviewer-finish-cleanly))
    - Mark spec complete and archive: `loaf spec archive SPEC-XXX` (both modes)
-   - Update session file (status: done, `archived_at`, `archived_by`)
-   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
+   - Run `loaf session end --wrap`; archive later with `loaf session archive` when appropriate
+   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session state`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
 5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
-6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
-   - `## Key Decisions` has content (not `*(none yet)*` or empty)
-   - `traceability.decisions` has entries (ADRs were recorded)
+6. **Suggest reflection:** Check the session journal for extractable learnings before closing out:
+   - `decision(...)` entries are present
+   - ADRs, report verdicts, or spec changelog entries were recorded
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
@@ -360,4 +360,4 @@ After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release`
 - **orchestration/product-development** - Full workflow hierarchy
 - **orchestration/specs** - Spec format and lifecycle
 - **orchestration/local-tasks** - Task file format including `session:` field
-- **orchestration/sessions** - Session lifecycle details
+- **orchestration/sessions** - SQLite-backed session lifecycle details

--- a/dist/codex/skills/implement/references/session-management.md
+++ b/dist/codex/skills/implement/references/session-management.md
@@ -8,7 +8,6 @@
 - Linear Status Management
 - Handoff State Requirements
 - Timestamps for User Context
-- Transcript Archival
 - Task Completion
 
 Detailed reference for session lifecycle management during implementation.
@@ -87,7 +86,7 @@ Use Linear MCP's `list_teams` (if configured) to get all workspace teams for val
 
 ## Diagram Consideration
 
-For multi-file or multi-service changes, consider adding architecture diagrams to the session file.
+For multi-file or multi-service changes, consider adding architecture diagrams to the linked spec, report, ADR, or implementation notes.
 
 ### When to Create Diagrams
 
@@ -106,7 +105,7 @@ Ask yourself:
 2. Is there a data flow that needs to be understood?
 3. Would a visual help communicate the approach?
 
-If yes to any, add an `## Architecture Diagrams` section to the session file.
+If yes to any, capture the diagram in a durable artifact such as a spec, report, ADR, or implementation note, and log the reference with `loaf session log`.
 
 ### Diagram Template
 
@@ -144,7 +143,7 @@ For complex tasks, explore before implementing:
 1. Use Task(Explore) or Task(Plan) to investigate codebase
 2. Map existing patterns and conventions
 3. Identify integration points
-4. Document findings in session file
+4. Log findings with `loaf session log` and reference durable artifacts
 5. Present approach to user for approval before spawning
 ```
 
@@ -193,12 +192,12 @@ never implement through open `blockedBy`.
 
 ## Handoff State Requirements
 
-**The session file must ALWAYS be handoff-ready.** After every significant action:
+**The session journal must ALWAYS be handoff-ready.** After every significant action:
 
-1. Update `## Current State` to reflect what just happened
-2. Update `orchestration.current_task` in frontmatter
+1. Log what just happened with `loaf session log`
+2. Reference task/spec/report/commit IDs rather than duplicating long prose
 3. Log completed agent work with outcomes
-4. Ensure anyone could pick up the work immediately
+4. Ensure anyone could pick up the work immediately from `loaf session show`
 
 ---
 
@@ -217,44 +216,6 @@ Generate with: `date -u +"%Y-%m-%d %H:%M UTC"`
 
 ---
 
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference.
-
-### Process
-
-1. **Get transcript path** from Codex output after compaction
-2. **Create transcripts directory** if needed:
-   ```bash
-   mkdir -p .agents/transcripts
-   ```
-3. **Copy transcript** with descriptive name:
-   ```bash
-   cp /path/to/transcript.jsonl .agents/transcripts/YYYYMMDD-HHMMSS-description.jsonl
-   ```
-4. **Update session frontmatter**:
-   ```yaml
-   transcripts:
-     - 20260123-143500-pre-compact.jsonl
-   ```
-
-### When to Archive
-
-| Event | Action |
-|-------|--------|
-| Before `/compact` | Archive current transcript |
-| Before `/clear` | Archive current transcript |
-| Session end | Archive final transcript |
-
-### Benefits
-
-- **Audit trail** - Full history of decisions and work
-- **Knowledge extraction** - Mining past sessions for patterns
-- **Debugging** - Understanding how errors occurred
-- **Training** - Learning from past sessions
-
----
-
 ## Task Completion
 
 When a task-coupled session completes:
@@ -267,7 +228,7 @@ When a task-coupled session completes:
      `list_issues` with `parent: <parent-id>`; if all are `completed`-type,
      close the parent and mark the local spec `complete`, else both stay
      in flight
-3. **Archive session** (standard process)
+3. **Wrap session** with `loaf session end --wrap`; archive with `loaf session archive` when the work is closed
 
 ### Spec Completion Check
 

--- a/dist/codex/skills/implement/templates/session.md
+++ b/dist/codex/skills/implement/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/codex/skills/orchestration/SKILL.md
+++ b/dist/codex/skills/orchestration/SKILL.md
@@ -26,12 +26,12 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 ## Critical Rules
 
 ### Sessions
-- Create following [session template](templates/session.md) — compact inline journal format
-- Use `loaf session log` for journal entries: `decide(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
+- Start or resume with `loaf session start`; SQLite is the operational source.
+- Use `loaf session log` for journal entries: `decision(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
 - **SESSION JOURNAL NUDGE**: When you see this hook trigger, log unrecorded decisions or findings before responding. Use `loaf session log "entry(scope): description"`. Only log actions (decisions made, things discovered, conclusions reached) — not thoughts or read-only work.
-- Archive when complete (status + `archived_at` + `archived_by` + move to `.agents/sessions/archive/`)
-- PreCompact hook: appends `compact` entry with context summary
-- Post-compaction: `loaf session start` outputs recent journal entries for recovery
+- Wrap with `loaf session end --wrap`; archive with `loaf session archive` when complete.
+- PreCompact hook: flushes journal-worthy state before compaction.
+- Post-compaction: `loaf session start` and `loaf session show` expose recent journal context for recovery.
 
 ### Councils
 - Always odd number: 5 or 7 agents
@@ -56,7 +56,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 ## Verification
 
-- Validate session files with `validate-session.py` before archiving
+- Verify `loaf session list --json` / `loaf session show <ref> --json` reflect the active work before archiving
 - Validate council files with `validate-council.py` before concluding
 - Confirm Linear issue updates are self-contained (no local paths, no emoji)
 
@@ -64,7 +64,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 | Task | Action |
 |------|--------|
-| Multi-step work | Create session file, spawn agents |
+| Multi-step work | Start/resume session, spawn agents |
 | Complex decision | Convene council (5-7 agents, odd) |
 | Linear update | Checkboxes, no emoji, no local paths |
 | Feature planning | Size by complexity, shape before building |
@@ -86,7 +86,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 | separate Codex thread or explicit multi-agent tool when available Development | [references/separate Codex thread or explicit multi-agent tool when available-development.md](references/separate Codex thread or explicit multi-agent tool when available-development.md) | Delegating to specialized agents |
 | Background Agents | [references/background-agents.md](references/background-agents.md) | Running non-interactive work in background |
 | Council Workflow | [references/councils.md](references/councils.md) | Convening councils for complex decisions |
-| Session Management | [references/sessions.md](references/sessions.md) | Creating sessions and keeping live work resumable |
+| Session Management | [references/sessions.md](references/sessions.md) | Starting sessions and keeping live work resumable |
 | Session Resume | [references/session-resume.md](references/session-resume.md) | Resuming sessions, checkpoints, context recovery |
 | Context Management | [references/context-management.md](references/context-management.md) | Using /clear, /compact, managing context limits |
 | Linear Integration | [references/linear.md](references/linear.md) | Updating Linear issues, magic words, status conventions |
@@ -98,7 +98,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 **You are the orchestrator, not the implementer.**
 
 The orchestrator:
-1. Creates issues and session files for tracking
+1. Creates issues and starts sessions for tracking
 2. Breaks down work into delegable tasks
 3. Spawns specialized agents for implementation
 4. Coordinates outcomes and updates external systems
@@ -113,7 +113,6 @@ This skill uses paths from `.agents/loaf.json`:
 ```json
 {
   "sessions": {
-    "directory": ".agents/sessions",
     "councils_directory": ".agents/councils"
   },
   "linear": {
@@ -128,9 +127,8 @@ This skill uses paths from `.agents/loaf.json`:
 
 | Artifact | Location | Archive | Naming |
 |----------|----------|---------|--------|
-| Sessions | `.agents/sessions/` | `.agents/sessions/archive/` | `YYYYMMDD-HHMMSS-description.md` |
+| Sessions | SQLite (`loaf session show`) | `loaf session archive` | CLI alias / session ID |
 | Councils | `.agents/councils/` | `.agents/councils/archive/` | `YYYYMMDD-HHMMSS-topic.md` |
-| Transcripts | `.agents/transcripts/` | N/A | Copied from tool output |
 | Handoffs | `.agents/handoffs/` | delete after deprecated | Created by `/handoff` |
 | Reports | `.agents/reports/` | N/A | `YYYYMMDD-HHMMSS-subject.md` |
 | Tasks | `.agents/tasks/` | N/A | Per task manager conventions |
@@ -141,16 +139,16 @@ This skill uses paths from `.agents/loaf.json`:
 
 ### BEFORE (Planning)
 - Create/check external issue (Linear, GitHub)
-- Create session file following [session template](templates/session.md)
+- Run `loaf session start` and log the orchestration intent
 - Break down into tasks, identify agents, get user approval
 
 ### DURING (Execution)
 - Spawn specialized agents (never implement directly)
-- Track progress in session file and external issue
+- Track progress with `loaf session log` and external issue updates
 - Convene councils for uncertain decisions
 
 ### AFTER (Completion)
 - Code review + QA testing
 - Update external issue to Done
 - Ensure knowledge captured in permanent locations
-- Archive session (status + `archived_at` + `archived_by` + move + update links)
+- Run `loaf session end --wrap`; archive with `loaf session archive` after merge/closure

--- a/dist/codex/skills/orchestration/references/background-agents.md
+++ b/dist/codex/skills/orchestration/references/background-agents.md
@@ -1,12 +1,13 @@
 # Background Agents
 
-Background agents handle low-priority, long-running, or non-interactive work that can run independently while the user continues with other tasks.
+Background agents handle low-priority, long-running, or non-interactive work
+while the user continues with other tasks.
 
 ## Contents
 
 - When to Use Background Agents
 - Spawning Background Agents
-- Background Agent Tracking
+- Tracking
 - Result Retrieval
 - Workflow Example
 - Anti-Patterns
@@ -19,20 +20,11 @@ Background agents handle low-priority, long-running, or non-interactive work tha
 | Security audits | Interactive debugging |
 | Code coverage analysis | User-facing questions |
 | Large-scale refactoring reports | Time-sensitive fixes |
-| Codebase-wide linting reports | Tasks requiring immediate feedback |
 | Documentation audits | Work needing user decisions mid-task |
 | Dependency vulnerability scans | Blocking tasks for current work |
 
-**Good candidates:**
-- Results can be processed later
-- No user interaction required
-- Task is well-defined with clear completion criteria
-- Output is a report or artifact, not a conversation
-
-**Poor candidates:**
-- Needs clarification mid-task
-- Time-sensitive (user waiting for result)
-- Requires real-time coordination with other agents
+Good candidates have clear completion criteria, can run without clarification,
+and produce a report or durable artifact.
 
 ## Spawning Background Agents
 
@@ -51,8 +43,7 @@ Task(
     - src/services/
 
     Write report to: .agents/reports/YYYYMMDD-HHMMSS-security-audit.md
-
-    Session: .agents/sessions/20260123-143000-auth-feature.md
+    Active session: SESSION-ALIAS if available from loaf session list/show
     """,
     run_in_background=True
 )
@@ -60,187 +51,57 @@ Task(
 
 ### Cursor
 
-Background agents are configured via the `is_background: true` YAML property. When spawning:
+Background agents are configured via the `is_background: true` YAML property.
+When spawning, specify the report destination and any task/spec/session IDs:
 
 ```
 @background-runner Run security audit on backend codebase.
-Write report to .agents/reports/
+Write report to .agents/reports/.
+Reference TASK-123 and the active session alias if available.
 ```
 
-## Background Agent Tracking
+## Tracking
 
-Track background agents in session frontmatter:
+Track background work with durable references:
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security-scan"
-    agent: background-runner
-    task: "Full security audit of backend"
-    status: running  # running | completed | failed
-    result_location: null
-  - id: "bg-20260123-144500-coverage"
-    agent: background-runner
-    task: "Test coverage analysis"
-    status: completed
-    result_location: ".agents/reports/20260123-144500-coverage-report.md"
-```
+1. Log the spawn with `loaf session log "todo(background): started <id> for <task>"`.
+2. Ask the background agent to write a report under `.agents/reports/`.
+3. When complete, log `discover(background): <id> wrote <report>`.
+4. Process findings into tasks, specs, ADRs, or report verdicts as appropriate.
 
-### Status Values
-
-| Status | Meaning |
-|--------|---------|
-| `running` | Agent still executing |
-| `completed` | Work finished, results available |
-| `failed` | Agent encountered error |
-
-### ID Convention
-
-Background agent IDs follow: `bg-YYYYMMDD-HHMMSS-<description>`
-
-Generate with:
-```bash
-echo "bg-$(date -u +"%Y%m%d-%H%M%S")-<description>"
-```
+Use a stable ID such as `bg-YYYYMMDD-HHMMSS-description` in the prompt and
+journal entries.
 
 ## Result Retrieval
 
-Background agents write results to `.agents/reports/` with standard frontmatter:
-
-```yaml
----
-report:
-  title: "Security Audit Report"
-  type: background-agent-output
-  status: unprocessed  # unprocessed | processed | archived
-  created: "2026-01-23T14:30:00Z"
-  background_agent_id: "bg-20260123-143000-security-scan"
-  session_reference: "20260123-140000-auth-feature.md"
----
-```
-
-### Processing Results
-
-1. SessionStart hook alerts user to completed background work
-2. User or orchestrator reviews report in `.agents/reports/`
-3. Orchestrator updates session frontmatter:
-   - Change `status` from `running` to `completed`
-   - Set `result_location` to report path
-4. Process findings as needed (spawn agents, create issues)
-5. Set report `status` to `processed`
+Background agents write results to `.agents/reports/` with enough metadata to
+identify the source task and report status. In SQLite-backed projects, use
+`loaf report list`, `loaf report show`, and `loaf report archive` when report
+state is available.
 
 ## Workflow Example
 
-### 1. Orchestrator Identifies Low-Priority Work
-
-During auth feature implementation, orchestrator identifies need for security audit but it is not blocking current work.
-
-### 2. Orchestrator Spawns Background Agent
-
-```python
-Task(
-    agent_type="background-runner",
-    prompt="""
-    Run comprehensive security audit on auth implementation.
-
-    Files to audit:
-    - src/auth/endpoints.py
-    - src/auth/token.py
-    - src/auth/middleware.py
-
-    Check for:
-    - OWASP Top 10 vulnerabilities
-    - Secrets in code
-    - SQL injection risks
-    - Authentication bypasses
-
-    Write report to: .agents/reports/20260123-143000-auth-security.md
-
-    Session: .agents/sessions/20260123-140000-auth-feature.md
-    """,
-    run_in_background=True
-)
-```
-
-### 3. Orchestrator Updates Session Frontmatter
-
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-auth-security"
-    agent: background-runner
-    task: "Auth security audit"
-    status: running
-    result_location: null
-```
-
-### 4. Work Continues
-
-Orchestrator and other agents continue with main implementation while background agent works.
-
-### 5. Session Resumes Later
-
-SessionStart hook detects completed background work:
-
-```
-# Background Work Completed
-
-The following background agents have completed:
-
-- **bg-20260123-143000-auth-security** (background-runner)
-  - Task: Auth security audit
-  - Result: .agents/reports/20260123-143000-auth-security.md
-
-Review reports and update session frontmatter after processing.
-```
-
-### 6. Results Processed
-
-Orchestrator reads report, creates issues for findings, updates session.
+1. Orchestrator identifies non-blocking security audit work.
+2. Orchestrator logs the background spawn in the active session.
+3. Background agent writes `.agents/reports/YYYYMMDD-HHMMSS-auth-security.md`.
+4. Orchestrator reviews the report, creates follow-up tasks, and logs the
+   outcome.
+5. Report state is finalized or archived through the report lifecycle.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
 | Use for blocking work | Keep blocking work in foreground |
-| Spawn without tracking | Always update session frontmatter |
-| Ignore completed results | Process results when alerted |
+| Spawn without tracking | Log the spawn and require a report path |
+| Ignore completed results | Process reports into tasks, findings, or decisions |
 | Use for interactive tasks | Reserve for autonomous work |
-| Spawn many concurrent background agents | Limit to 2-3 to avoid resource contention |
-| Skip result location in prompt | Always specify where to write output |
+| Spawn many concurrent background agents | Limit concurrency to avoid resource contention |
+| Skip result location in prompt | Always specify where output belongs |
 
 ## Integration Points
 
-### SessionStart Hook
-
-Checks session frontmatter for `background_agents` with `status: completed`. Alerts user to review results.
-
-### PreCompact Hook
-
-Includes background agent state in preservation. PreCompact hook captures:
-- Active background agent list
-- Current status of each
-- Result locations for completed agents
-
-### Session Frontmatter
-
-Full template with background agents:
-
-```yaml
----
-session:
-  title: "Feature implementation"
-  status: in_progress
-  # ... other session fields ...
-
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: completed
-    result_location: ".agents/reports/20260123-143000-security.md"
-  - id: "bg-20260123-150000-coverage"
-    agent: background-runner
-    task: "Coverage analysis"
-    status: running
-    result_location: null
----
-```
+- `loaf session log` records spawn and completion facts.
+- `loaf session show` exposes recent background-work journal entries.
+- `loaf report` commands own durable report lifecycle when available.
+- `/wrap` should mention unprocessed background reports before ending a session.

--- a/dist/codex/skills/orchestration/references/context-management.md
+++ b/dist/codex/skills/orchestration/references/context-management.md
@@ -1,54 +1,34 @@
 # Context Management
 
-Patterns for managing context efficiently across sessions and agent spawns.
+Patterns for keeping long work resumable while using SQLite-backed session
+journals as the external memory.
 
 ## Contents
 
 - Design for Compaction
-- Overview
 - Context Commands
 - When to Clear Context
-- The 2-Correction Rule
-- Context Compaction
-- Session Files as Context Anchors
+- Compaction Lifecycle
 - separate Codex thread or explicit multi-agent tool when available for Context Isolation
 - Context Budget Guidelines
-- Preventing Context Bloat
-- Session Context Patterns
 - Warning Signs
 - Best Practices
 
 ## Design for Compaction
 
-Compaction is a normal part of long workflows, not an emergency measure. Any workflow expected to exceed 15-20 exchanges should be designed with compaction in mind from the start.
+Compaction is a normal part of long workflows. Design any workflow expected to
+span many exchanges so important state is already outside chat context.
 
 ### Compaction-First Principles
 
-1. **The journal IS external memory** — Session journal entries (decisions, discoveries, progress) survive compaction. Compaction can be lossy because all important state is already on disk.
-2. **`## Current State` is the resumption context** — Keep this section handoff-ready at all times. The PreCompact hook requires writing a state summary here before compaction.
-3. **Decisions go to disk, not context** — Record key decisions in the session journal immediately via `loaf session log`. Context may be compressed; journal entries persist.
-4. **separate Codex thread or explicit multi-agent tool when available absorb exploration** — Investigation and exploration should happen in separate Codex thread or explicit multi-agent tool when available. Only the summary returns to the main context.
-
-### Compaction Lifecycle
-
-```
-PreCompact:
-  1. Flush all unrecorded journal entries (decisions, discoveries, progress)
-  2. Write condensed state summary to session file's ## Current State
-  3. compact.sh writes compact(session) marker to journal
-
-PostCompact:
-  1. PostCompact nudge fires — tells model to read session file
-  2. Model reads ## Current State for resumption context
-  3. Model reads ## Journal for decision trail
-  4. Work resumes without "where were we?"
-```
-
-This makes compaction invisible to workflow continuity. The session file's `## Current State` section is the resumption prompt — written by the model before compaction, read by the model after.
-
-## Overview
-
-Context is finite. Long conversations accumulate irrelevant information that degrades performance. Active context management keeps conversations focused and effective.
+1. **The journal is external memory.** Record decisions, discoveries, blockers,
+   and next actions with `loaf session log`.
+2. **Artifacts carry detail.** Specs, tasks, reports, ADRs, and commits hold rich
+   detail; journal entries point to them.
+3. **separate Codex thread or explicit multi-agent tool when available absorb exploration.** Use separate Codex thread or explicit multi-agent tool when available for broad investigation and
+   return concise findings to the main context.
+4. **`wrap` closes the loop.** End meaningful work with `loaf session end --wrap`
+   so the session lifecycle matches the journal.
 
 ## Context Commands
 
@@ -60,191 +40,78 @@ Context is finite. Long conversations accumulate irrelevant information that deg
 
 ## When to Clear Context
 
-### Clear Between Tasks
-
 Use `/clear` when:
 
 - Starting a completely new task
-- Previous task is fully complete
-- Context has become cluttered with failed attempts
+- Previous task is complete
+- Debugging noise is crowding out the current objective
 - Switching between unrelated codebases
 
-### Don't Clear When
+Avoid clearing mid-task until you have logged enough state for recovery.
 
-- Mid-task and need previous context
-- Debugging requires understanding of prior attempts
-- Session file provides necessary handoff information
-
-## The 2-Correction Rule
-
-**If Claude makes the same mistake twice after correction, the context may be polluted.**
-
-Signs of context pollution:
-- Repeating errors you've already corrected
-- Ignoring instructions you've given
-- Reverting to patterns you've explicitly rejected
-- Confusion about current task state
-
-**Action:** Consider `/clear` and restart with fresh context, referencing session file for state.
-
-## Context Compaction
-
-Use `/compact` when:
-- Conversation is long but task continues
-- Need to preserve key decisions while reducing noise
-- Approaching context limits
-
-**Journal entries are compaction insurance.** Every `loaf session log` call writes state to disk that survives compaction. Don't defer journaling — entries not flushed before compaction are lost.
-
-### What Compaction Preserves (via session file)
-
-- Journal entries: decisions, discoveries, progress, commits
-- `## Current State` summary (written by PreCompact)
-- All externalized artifacts: specs, tasks, ideas, code
-
-### What Compaction Discards
-
-- Intermediate exploration steps
-- Failed attempts and debugging noise
-- Verbose tool output
-- Redundant explanations
-
-## Session Files as Context Anchors
-
-Session files provide persistent context that survives `/clear`:
-
-```markdown
-## Current State
-[Always handoff-ready summary]
-
-## Key Decisions
-- Chose X over Y because Z
-
-## Next Steps
-- Immediate action items
-```
-
-### Pattern: Clear + Resume
+## Compaction Lifecycle
 
 ```
-1. Update session file with current state
-2. /clear to reset context
-3. /resume to reload from session file
-4. Continue with clean context
+PreCompact:
+  1. Flush unrecorded decisions, discoveries, blockers, and next actions
+  2. Reference specs, tasks, reports, commits, and files by stable ID/path
+  3. Let the hook persist the compact marker
+
+PostCompact:
+  1. Run or inspect `loaf session start` output for the active branch
+  2. Use `loaf session show <session-ref> --json` when more context is needed
+  3. Continue from the journal and linked artifacts
 ```
+
+This makes compaction survivable without relying on hand-maintained markdown
+state. Any state not logged or captured in a durable artifact can be lost.
 
 ## separate Codex thread or explicit multi-agent tool when available for Context Isolation
 
-Use separate Codex thread or explicit multi-agent tool when available (separate Codex thread or explicit multi-agent tool when available) to investigate without polluting main context:
-
-```
-# Instead of exploring in main conversation:
-Let me look at how auth works...
-[reads 10 files, fills context]
-
-# Use separate Codex thread or explicit multi-agent tool when available for investigation:
-Task(Explore, "How does authentication work in this codebase?")
-[returns focused summary, main context stays clean]
-```
-
-### When to Use separate Codex thread or explicit multi-agent tool when available
+Use separate Codex thread or explicit multi-agent tool when available to investigate without filling the main context:
 
 | Situation | Approach |
 |-----------|----------|
-| Quick file lookup | Direct Read tool |
-| Multi-file exploration | Task(Explore) |
-| Implementation work | Task(implementer) |
-| Complex investigation | Task(Plan) then implement |
+| Quick file lookup | Direct read/search tool |
+| Multi-file exploration | Explorer/research separate Codex thread or explicit multi-agent tool when available |
+| Implementation work | Implementer or task-focused agent |
+| Long audit | Background agent with report output |
+
+Pass stable references to separate Codex thread or explicit multi-agent tool when available: task IDs, spec IDs, branch names, report
+paths, and the active session alias when available.
 
 ## Context Budget Guidelines
 
-### Short Conversations (< 10 exchanges)
+### Short Conversations
 
-- No management needed
-- Context stays fresh naturally
+No special management is usually needed.
 
-### Medium Conversations (10-30 exchanges)
+### Medium Conversations
 
-- Consider `/compact` at midpoint
-- Delegate investigations to separate Codex thread or explicit multi-agent tool when available
-- Keep session file updated
+- Log decisions as they happen.
+- Delegate broad searches.
+- Keep tool output scoped.
 
-### Long Conversations (30+ exchanges)
+### Long Conversations
 
-- `/compact` every 15-20 exchanges
-- Heavy use of separate Codex thread or explicit multi-agent tool when available for exploration
-- Session file as primary state holder
-- Consider `/clear` + restart if degraded
-
-## Preventing Context Bloat
-
-### Minimize Tool Output
-
-```
-# Instead of reading entire large files:
-Read(file, limit=50)  # Read first 50 lines
-
-# Instead of globbing everything:
-Glob("src/**/*.py", path="src/auth/")  # Scoped search
-```
-
-### Focused Queries
-
-```
-# Instead of "show me all the code":
-"Find where user authentication is validated"
-
-# Instead of exploring blindly:
-"What files handle the /api/users endpoint?"
-```
-
-### Progressive Disclosure
-
-1. Get overview first (symbols, structure)
-2. Drill into specific areas
-3. Read full content only when needed
-
-## Session Context Patterns
-
-### Starting a Session
-
-```
-1. Create session file (minimal context recorded)
-2. Break down task (decisions recorded)
-3. Spawn first agent (isolated context)
-4. Update session (state persisted)
-```
-
-### Mid-Session Context Check
-
-Every 10-15 exchanges, assess:
-- [ ] Is context still focused on current task?
-- [ ] Are previous decisions still relevant?
-- [ ] Has debugging noise accumulated?
-- [ ] Would `/compact` help?
-
-### Session Handoff
-
-When pausing or handing off:
-1. Update session file with complete state
-2. Include "resumption notes" for context
-3. Reference key files and decisions
-4. Clear main context if long
+- Expect compaction.
+- Keep the journal current.
+- Use reports or handoffs for rich summaries rather than stuffing prose into the
+  session journal.
 
 ## Warning Signs
 
 | Symptom | Likely Cause | Action |
 |---------|--------------|--------|
-| Repeating same mistakes | Context pollution | `/clear` + restart |
-| Forgetting recent decisions | Overcrowded context | `/compact` |
-| Slow responses | Large context | Use separate Codex thread or explicit multi-agent tool when available |
-| Confusion about task | Too many pivots | Update session, `/clear` |
+| Repeating same mistakes | Context pollution | Log current facts, then clear or compact |
+| Forgetting recent decisions | Overcrowded context | Inspect `loaf session show` and continue from journal |
+| Slow responses | Large context | Delegate exploration |
+| Confusion about task | Too many pivots | Re-anchor on task/spec/session IDs |
 
 ## Best Practices
 
-1. **Update session files continuously** - they survive context resets
-2. **Use separate Codex thread or explicit multi-agent tool when available for exploration** - keep main context clean
-3. **Clear between unrelated tasks** - fresh start beats polluted context
-4. **Compact mid-task if needed** - preserve decisions, discard noise
-5. **Monitor for pollution** - 2-correction rule catches degradation early
-6. **Scope tool calls** - don't read entire codebases into context
+1. Log durable facts early with `loaf session log`.
+2. Use separate Codex thread or explicit multi-agent tool when available for exploration-heavy work.
+3. Clear between unrelated tasks.
+4. Compact mid-task when the journal and artifacts are current.
+5. Scope tool calls so context stays focused.

--- a/dist/codex/skills/orchestration/references/cross-session.md
+++ b/dist/codex/skills/orchestration/references/cross-session.md
@@ -135,7 +135,7 @@ When sessions are archived, decisions are extracted to Serena memory:
 
 1. `loaf session end --wrap` persists decisions to spec changelog
 2. Session stays in `sessions/` with `status: done` — no immediate archive
-3. `loaf session housekeeping` archives complete sessions after 7-day age threshold
+3. `loaf housekeeping` reports stale compatibility artifacts, and `loaf session archive` archives closed SQLite sessions when work is complete
 
 ### At Reference Time (spec changelog)
 

--- a/dist/codex/skills/orchestration/references/product-development.md
+++ b/dist/codex/skills/orchestration/references/product-development.md
@@ -11,7 +11,6 @@ A Research → Vision → Architecture → Requirements → Specs → Tasks → 
 - Configuration
 - Workflow Examples
 - Feedback Loops
-- Transcript Archival
 - Flexibility Preserved
 - Critical Files
 
@@ -33,10 +32,9 @@ docs/                               # Permanent project knowledge
 
 .agents/                            # Ephemeral orchestration
 ├── loaf.yaml                       # Project config (task backend, etc.)
-├── sessions/                       # Active work contexts
+├── sessions/                       # Compatibility/rendered session views
 ├── plans/                          # Implementation plans
 ├── councils/                       # Deliberation records
-├── transcripts/                    # Archived conversation transcripts
 ├── tasks/                          # Local tasks (when not using Linear)
 │   ├── active/
 │   │   └── TASK-001-oauth-provider.md
@@ -71,7 +69,7 @@ RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS → SE
 | `/architecture` | Decision question | ARCHITECTURE.md + ADR | Technical decisions |
 | `/shape` | Feature area or requirement | Spec in .agents/specs/ | Implementation-ready specification with boundaries |
 | `/breakdown` | Spec | Tasks in .agents/tasks/ | Atomic work items for agents |
-| `/implement` | TASK-ID | Session file | Execute a task |
+| `/implement` | TASK-ID | SQLite session + implementation commits | Execute a task |
 
 ## Document Formats
 
@@ -187,7 +185,7 @@ docs:
 
 # 6. Work on tasks
 /implement TASK-001
-# → Session → Implementation → Done
+# → SQLite session → Implementation → Done
 ```
 
 ### Quick Fix (Ad-hoc)
@@ -197,7 +195,7 @@ docs:
 /implement TASK-099
 # Orchestrator: "No parent spec. Proceed?"
 # User: "Yes, small fix"
-# → Session → Fix → Done
+# → SQLite session → Fix → Done
 ```
 
 ## Feedback Loops
@@ -210,23 +208,6 @@ The workflow is not rigid. Each level can feed back to higher levels:
 | Edge case invalidates requirement | Update REQUIREMENTS.md |
 | Spec too complex for its size | Re-scope or split |
 | Task reveals missing requirement | Add to REQUIREMENTS.md |
-
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference:
-
-1. **Copy transcript** to `.agents/transcripts/`
-2. **Link from session file** in frontmatter:
-
-```yaml
-session:
-  title: "Feature Implementation"
-  transcripts:
-    - 20260123-143500-pre-compact.jsonl
-    - 20260123-160000-final.jsonl
-```
-
-This preserves full context for debugging, knowledge extraction, and audit trails.
 
 ## Flexibility Preserved
 

--- a/dist/codex/skills/orchestration/references/session-resume.md
+++ b/dist/codex/skills/orchestration/references/session-resume.md
@@ -1,15 +1,15 @@
 # Session Resume Patterns
 
-Patterns for resuming work across Codex sessions using CLI flags and session files.
+Patterns for resuming work with CLI conversation history plus SQLite-backed
+Loaf session state.
 
 ## Contents
 
 - CLI Resume Flags
 - Resume Methods
 - When to Use Each Method
-- Session File as Resume Checkpoint
+- SQLite Session as Resume Checkpoint
 - Checkpoint Pattern
-- Naming Sessions Descriptively
 - Context Recovery Strategies
 - Handling Stale Sessions
 - Multi-Session Coordination
@@ -17,7 +17,7 @@ Patterns for resuming work across Codex sessions using CLI flags and session fil
 
 ## CLI Resume Flags
 
-Codex provides built-in session continuation:
+Some harnesses provide built-in conversation continuation:
 
 | Flag | Purpose |
 |------|---------|
@@ -25,217 +25,113 @@ Codex provides built-in session continuation:
 | `--resume <id>` | Resume a specific conversation by ID |
 | `/resume` | In-session command to list and resume |
 
+Use harness resume for chat history. Use `loaf session` for operational state.
+
 ## Resume Methods
 
-### Method 1: CLI Continue
+### Method 1: Conversation Continue
+
+Resume the exact conversation when you need full chat history.
+
+### Method 2: SQLite Session Resume
+
+Start fresh and recover operational state:
 
 ```bash
-# Continue most recent conversation
-claude --continue
-
-# Resume specific conversation
-claude --resume abc123
+loaf session start
+loaf session list --all --json
+loaf session show <session-ref> --json
 ```
 
-**Best for:** Picking up exactly where you left off with full context.
-
-### Method 2: Session File Resume
-
-```bash
-# Start new conversation, resume from session file
-claude
-> /resume 20250123-143000-feature-auth
-```
-
-**Best for:** Fresh context but task continuity from session file.
+Best for clean context with task continuity.
 
 ### Method 3: Hybrid Resume
 
-```bash
-# Continue conversation AND sync with session file
-claude --continue
-> Check session file for any updates: .agents/sessions/20250123-143000-feature-auth.md
-```
-
-**Best for:** Recovering from context pollution while preserving conversation history.
+Continue the conversation, then compare it against `loaf session show` output.
+Best when chat history matters but the journal may contain newer facts.
 
 ## When to Use Each Method
 
 | Situation | Recommended Method |
 |-----------|-------------------|
-| Short break, same task | `--continue` |
-| Long break, clean state needed | Session file resume |
+| Short break, same task | Conversation continue |
+| Long break, clean state needed | SQLite session resume |
 | Context polluted but need history | Hybrid resume |
-| Different machine | Session file resume |
-| Handoff to another person | Session file resume |
+| Different machine | SQLite session resume |
+| Handoff to another person | SQLite session + handoff/report |
 
-## Session File as Resume Checkpoint
+## SQLite Session as Resume Checkpoint
 
-### Writing Resume-Ready State
+Before ending or compacting:
 
-Before ending a session, ensure session file contains:
-
-```markdown
-## Current State
-**Last Action:** Completed API endpoint implementation
-**Pending:** Tests need to be written
-
-## Resumption Notes
-- Branch: feature/auth-endpoints
-- Key files modified: src/auth/routes.py, src/auth/models.py
-- Tests to write: test_login, test_logout, test_refresh
-- Blocker: None
-
-## Next Steps
-1. Spawn QA agent for test implementation
-2. Run full test suite
-3. Update API documentation
-```
-
-### Reading Resume State
+1. Log last action, blockers, and next steps with `loaf session log`.
+2. Reference tasks, specs, reports, commits, and branch names by stable ID/path.
+3. Run `loaf session end --wrap` when work is complete.
 
 When resuming:
 
-1. Read session file for context
-2. Check `## Current State` for where you left off
-3. Check `## Resumption Notes` for key details
-4. Check `## Next Steps` for immediate actions
-5. Verify branch and file state match expectations
+1. Run `loaf session start` on the branch/worktree.
+2. Inspect `loaf session show <session-ref> --json`.
+3. Verify branch and file state match expectations.
+4. Continue from the next logged action.
 
 ## Checkpoint Pattern
 
-For long-running tasks, create explicit checkpoints:
-
-```markdown
-## Checkpoints
-
-### Checkpoint 1: Schema Complete
-**Timestamp:** 2025-01-23T14:30:00Z
-**State:** Database schema implemented and migrated
-**Can resume from:** This checkpoint if later work fails
-
-### Checkpoint 2: API Complete
-**Timestamp:** 2025-01-23T15:45:00Z
-**State:** All endpoints implemented, passing basic tests
-**Can resume from:** This checkpoint for test expansion
-```
-
-### Rewind to Checkpoint
-
-If work goes wrong:
-
-1. Identify safe checkpoint
-2. `git checkout <commit>` to restore code state
-3. Update session file to checkpoint state
-4. `/clear` to reset context
-5. Resume from checkpoint
-
-## Naming Sessions Descriptively
-
-Good session names aid resume:
-
-```
-# Good - descriptive, searchable
-20250123-143000-auth-jwt-implementation.md
-20250123-160000-api-rate-limiting.md
-
-# Bad - generic, hard to find
-20250123-143000-feature.md
-20250123-160000-fix.md
-```
-
-### Rename Pattern
+For long-running tasks, create explicit journal checkpoints:
 
 ```bash
-# If session name becomes unclear, rename for clarity
-mv .agents/sessions/20250123-143000-feature.md \
-   .agents/sessions/20250123-143000-user-auth-oauth.md
+loaf session log "decision(checkpoint): schema complete at <commit>"
+loaf session log "decision(checkpoint): API complete; next write tests"
 ```
 
-Update any references in Linear or other sessions.
+If work goes wrong, use Git to restore code state and log the reconciliation:
+
+```bash
+loaf session log "decision(recovery): rewound to <commit>; replaying tests"
+```
 
 ## Context Recovery Strategies
 
-### Strategy 1: Full Replay
+### Full Replay
 
-For complex state, replay key decisions:
+Use `loaf session show` plus ADR/spec/report links for complex state.
 
-```markdown
-## Decision Replay
+### Minimal Context
 
-When resuming, recall these decisions:
-1. Chose JWT over sessions (see ADR-007)
-2. Using Redis for token storage
-3. 15-minute access token expiry
-```
+Use the last few journal entries when the next action is obvious.
 
-### Strategy 2: Minimal Context
+### Reference Chain
 
-For simple continuation:
+For multi-session work, log relationships:
 
-```markdown
-## Minimal Resume Context
-
-Branch: feature/auth
-Last commit: "feat: add login endpoint"
-Next: Write tests for login endpoint
-```
-
-### Strategy 3: Reference Chain
-
-For multi-session work:
-
-```markdown
-## Session Chain
-
-Previous sessions:
-- 20250122-100000-auth-design.md (planning)
-- 20250122-143000-auth-schema.md (database)
-- This session: API implementation
+```bash
+loaf session log "discover(context): previous design captured in SPEC-123 and ADR-007"
 ```
 
 ## Handling Stale Sessions
 
-### Signs of Stale Session
+Signs of stale session state:
 
-- Code has changed since session was active
-- Other sessions modified same files
+- Code changed after the last journal entry
 - Branch was rebased or merged
+- Another task/spec superseded the work
 
-### Stale Session Recovery
+Recovery:
 
-```
-1. Read session file for intended state
-2. Compare with actual code state (git diff)
-3. Identify conflicts or drift
-4. Update session file to reflect reality
-5. Plan reconciliation if needed
-```
+1. Inspect `loaf session show`.
+2. Compare with `git status`, `git log`, and relevant specs/tasks.
+3. Log the drift and reconciliation plan.
 
 ## Multi-Session Coordination
 
-When multiple sessions touch same codebase:
-
-```markdown
-## Related Sessions
-
-| Session | Status | Overlaps |
-|---------|--------|----------|
-| auth-backend | completed | src/auth/ |
-| auth-frontend | in_progress | src/components/auth/ |
-| This session | in_progress | src/auth/models.py (shared) |
-
-## Coordination Notes
-- Wait for auth-backend completion before modifying models
-- Sync with auth-frontend on API contract changes
-```
+When multiple sessions touch related areas, use specs/tasks/reports as the shared
+coordination layer. Session journals should point to those durable artifacts
+rather than becoming the only place a dependency is described.
 
 ## Best Practices
 
-1. **Update session before stopping** - capture state while fresh
-2. **Use descriptive names** - aid future resume
-3. **Create checkpoints** - safe rollback points
-4. **Note dependencies** - what must complete first
-5. **Clear stale context** - don't resume into pollution
-6. **Verify state on resume** - code may have changed
-7. **Document decision context** - not just decisions
+1. Log before stopping.
+2. Prefer stable IDs over pasted summaries.
+3. Use `loaf session show` as the operational resume surface.
+4. Keep chat-history resume separate from Loaf session state.
+5. Verify code state on resume.

--- a/dist/codex/skills/orchestration/references/sessions.md
+++ b/dist/codex/skills/orchestration/references/sessions.md
@@ -1,523 +1,116 @@
 # Session Management
 
-Sessions are coordination artifacts for active work. They are archived (set status, `archived_at`, `archived_by`, move to `.agents/sessions/archive/`) when work completes to preserve an audit trail.
+Sessions are SQLite-backed coordination records for active work. Markdown is a
+rendered view for reading or compatibility export; agents persist new facts with
+`loaf session` commands.
 
 ## Contents
 
-- Compact vs New Session
+- Core Model
 - When to Use Sessions
-- Session Types
-- Session File Format
-- Lifecycle States
-- Updating During Work
-- Session Continuity Protocol
-- Completing a Session
-- Start Protocol
+- Lifecycle
+- Journal Protocol
+- Continuity
+- Completion
 - Hook Integration
 - Anti-Patterns
 
-## Compact vs New Session
+## Core Model
 
-| Scenario | Action |
-|----------|--------|
-| Picking up previous work, same scope | Compact or resume existing conversation |
-| Switching to entirely different scope | New conversation (new session) |
-| Finished and archived a spec | New conversation |
-| Context full mid-task | Auto-compact (journal survives) |
-| Quick unrelated question | New conversation (don't pollute working session) |
+Use the `wrap` skill as the canonical session model:
 
-**Rule of thumb:** if you'd need the same session file, compact. If you'd need a different one, start fresh.
+1. `loaf session start` finds or creates the active session for the current branch
+   and prints resumption context.
+2. `loaf session log "type(scope): description"` writes durable journal rows.
+3. `loaf session show <session-ref> --json` reads the SQLite-backed session view.
+4. `loaf session end --wrap` persists the wrapped end state.
+5. `loaf session archive` archives closed sessions when the branch/work is done.
+
+The render format is documented in `templates/session.md`; it is not an
+instruction to author markdown directly.
 
 ## When to Use Sessions
 
-- Multi-step work requiring agent coordination
+- Multi-step work requiring coordination
 - Handoffs between agents
-- Tracking progress during implementation
-- Context preservation across agent spawns
+- Implementation or release work that must survive compaction
+- Long research, architecture, council, or review efforts
 
-## Session Types
+For quick unrelated questions, start a fresh conversation so the active session
+stays focused.
 
-### Implementation Sessions (Invisible)
+## Lifecycle
 
-When implementing tasks via `/implement TASK-XXX`:
+The interim runtime lifecycle before SPEC-049 is:
 
-- Session created automatically with filename `YYYYMMDD-HHMMSS-session.md`
-- Task file updated with `session:` field linking to session
-- No user interaction needed for session naming
-- Resume via `loaf session start` then `/implement TASK-XXX`
+| State | Source | Meaning |
+|-------|--------|---------|
+| `active` | `loaf session start` | Current work may receive journal entries |
+| `stopped` | `loaf session end` | Work paused or closed without wrap |
+| `done` | `loaf session end --wrap` | Wrapped work is complete |
+| `archived` | `loaf session archive` | Closed session preserved outside active list |
 
-Users work with tasks; sessions are an implementation detail.
+Do not introduce additional session vocabulary in guidance. SPEC-049 owns the
+durable status vocabulary.
 
-### Explicit Sessions
+## Journal Protocol
 
-For non-task work, sessions are still created explicitly:
-
-- Research sessions (`/research`)
-- Architecture decisions (`/architecture`)
-- Council deliberations (`/council`)
-
-These sessions may not have a linked task but still follow standard session format.
-
-## Session File Format
-
-**Link policy**: Documents outside `.agents/` must not reference `.agents/` files. Keep `.agents/` links contained within `.agents/` artifacts, and update them when files move to `.agents/<type>/archive/`.
-
-### Location & Naming
-
-```
-.agents/sessions/YYYYMMDD-HHMMSS-session.md
-```
-
-**Archive location:** `.agents/sessions/archive/`
-
-**Transcripts location:** `.agents/transcripts/`
-
-Transcripts are Codex conversation exports (`.jsonl` files) archived after context compaction. They preserve the full audit trail of agent interactions.
-
-```
-.agents/
-├── sessions/
-│   ├── YYYYMMDD-HHMMSS-session.md
-│   └── archive/
-└── transcripts/              # Codex transcripts
-    ├── 2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl
-    └── archive/
-```
-
-**Why keep original filenames:** The UUID-like hash is unique and matches Codex's internal reference, making correlation easier if needed.
-
-**Generate timestamps:**
+Log compact, factual entries:
 
 ```bash
-# Filename timestamp
-date -u +"%Y%m%d-%H%M%S"
-
-# ISO timestamp (for YAML)
-date -u +"%Y-%m-%dT%H:%M:%SZ"
+loaf session log "decision(scope): chose X because Y"
+loaf session log "discover(scope): learned Z from file/path"
+loaf session log "block(scope): waiting on external approval"
+loaf session log "unblock(scope): approval received"
+loaf session log "spark(scope): possible follow-up idea"
+loaf session log "todo(scope): concrete follow-up action"
 ```
 
-### Naming Convention
+Log durable facts, not thoughts. The journal should let another agent resume
+without reading the whole conversation.
 
-All session files use the fixed format: `YYYYMMDD-HHMMSS-session.md`
+## Continuity
 
-The timestamp is the unique identifier. Descriptions, spec links, and branch names belong in frontmatter and the `# Session:` heading, not the filename. This keeps references stable — spec and task files can point to session filenames without them ever breaking.
+Before compaction, branch switches, or agent handoff:
 
-### Required Frontmatter
+1. Flush unrecorded decisions, discoveries, blockers, and next actions with
+   `loaf session log`.
+2. Use `loaf session show <session-ref> --json` to confirm the journal has the
+   required resumption context.
+3. Pass task IDs, spec IDs, report IDs, and commit refs rather than duplicating
+   large prose into the journal.
 
-```yaml
----
-session:
-  title: "Clear description of work"           # REQUIRED
-  status: in_progress                          # REQUIRED: in_progress|paused|completed|archived
-  created: "2025-12-04T14:30:00Z"              # REQUIRED: ISO 8601
-  last_updated: "2025-12-04T14:30:00Z"         # REQUIRED: ISO 8601
-  last_archived: "2025-12-04T16:00:00Z"        # Set by PreCompact hook before compaction
-  archive_reason: "pre-compact"                # Why archived (pre-compact, manual, etc.)
-  archived_at: "2025-12-04T18:10:00Z"          # Required when archived
-  task: TASK-001                               # If implementation work (links to .agents/tasks/)
-  linear_issue: "BACK-123"                     # Optional
-  linear_url: "https://linear.app/..."         # Optional
-  branch: "username/back-123-feature"          # Optional: working branch
-  transcripts: []                              # Archived Codex transcripts (filenames only)
-                                               # Example: ["2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl"]
-  referenced_sessions: []                      # Cross-session references (see below)
+Background and delegated agents should receive the relevant task/spec/report
+references plus the active session alias when the caller has one.
 
-orchestration:
-  current_task: "What's actively being worked" # REQUIRED
-  spawned_agents:
-    - agent: implementer
-      task: "Brief task description"
-      status: completed                        # pending|in_progress|completed
-      summary: "Outcome summary"
+## Completion
 
-background_agents:                             # Background work running independently
-  - id: "bg-20260123-143000-security-scan"     # ID: bg-YYYYMMDD-HHMMSS-description
-    agent: background-runner                              # Agent type
-    task: "Full security audit"                # Brief description
-    status: running                            # running|completed|failed
-    result_location: null                      # Path to report when complete
----
-```
+When work is complete:
 
-### Cross-Session References
+1. Ensure decisions and discoveries are captured in durable homes such as ADRs,
+   specs, reports, or docs.
+2. Run `loaf session end --wrap` so the CLI persists the wrapped state.
+3. After merge or closure, use `loaf session archive` if the session should leave
+   the active list.
 
-Track decisions imported from past sessions via Serena memory:
-
-```yaml
-session:
-  # ... other fields ...
-  referenced_sessions:
-    - session: "20250115-140000-auth-jwt.md"     # Source session filename
-      imported_at: "2025-01-23T14:30:00Z"        # When imported
-      content_type: decisions                     # decisions|context|all
-      decisions_imported:                         # List of decision titles
-        - "JWT token rotation strategy"
-        - "Refresh token storage approach"
-    - session: "20250110-090000-auth-oauth.md"
-      imported_at: "2025-01-23T14:35:00Z"
-      content_type: context
-      summary: "OAuth provider integration patterns"
-```
-
-**Why track references:**
-
-- Audit trail of where context came from
-- Avoids re-importing same decisions
-- Enables tracing decision lineage across sessions
-
-See `references/cross-session.md` for full patterns.
-
-### Required Sections
-
-Every session file MUST have:
-
-1. **`## Context`** - Background for anyone picking up this work
-2. **`## Current State`** - Where we are now (MUST be handoff-ready)
-3. **`## Next Steps`** - Immediate actions for continuation
-
-### Session Template
-
-```markdown
-# Session: [Title]
-
-## Context
-Background for anyone picking up this work.
-What problem are we solving? Why now?
-
-## Current State
-Where we are right now. What just happened.
-**This section should ALWAYS be handoff-ready.**
-
-## Resumption Prompt
-
-<!-- Generated by PreCompact hook before compaction -->
-<!-- Provides self-contained context for post-compaction continuation -->
-
-> **Context**: [Brief description of work being done]
->
-> **Last Action**: [What just happened]
->
-> **Immediate Next**: [Concrete next step]
->
-> **Key Files**: [Relevant file paths]
->
-> **Blockers**: [Any blockers, or "None"]
->
-> **Transcript Archive**: If Codex provided a transcript path after compaction,
-> copy it to `.agents/transcripts/` and add the filename to this session's
-> `transcripts:` array in frontmatter.
-
-## Execution Progress
-
-### Wave 1: [Name] (ACTIVE)
-- [ ] BACK-123 - Brief description
-- [x] BACK-124 - Brief description (completed)
-
-### Wave 2: [Name] (blocked by Wave 1)
-- [ ] BACK-125 - Brief description
-
-## Technical Context
-
-### Files to Update
-- `path/to/file.py` - What needs to change
-
-### Key Commands
-```bash
-pytest path/to/tests/ -v
-mypy path/to/code/
-```
-
-## Acceptance Criteria
-
-- [ ] Criterion 1
-- [ ] Criterion 2
-
-## Decisions
-
-### Decision 1: [Title]
-
-**Decision**: What was decided
-**Rationale**: Why
-
-## Architecture Diagrams
-
-### [Diagram Name]
-
-```mermaid
-[diagram content]
-```
-
-**Purpose**: Why this diagram helps understand the work
-**Files involved**: List of related file paths
-**Created**: When diagram was created (update if modified)
-
-<!--
-When to add diagrams:
-- Multi-service changes: Show interaction points
-- Data flow changes: Trace data through system
-- Schema modifications: Visualize relationships
-- API design: Document request/response flows
-
-For reusable diagrams, store in .agents/diagrams/ instead.
-See foundations skill reference/diagrams.md for Mermaid syntax.
--->
-
-## Council Outcomes
-
-### Council: [Topic]
-
-**Outcome**: Decision summary
-**Council File**: `.agents/councils/YYYYMMDD-HHMMSS-topic.md`
-**Next Steps**: Action items captured
-**Archive**: After this summary is captured, set council status to `archived`, set `archived_at`, set `archived_by`, and move to `.agents/councils/archive/` (archive indefinitely).
-
-## Reports Processed
-
-### Report: [Title]
-
-**Key Conclusions**: Summary of findings
-**Action Items**: What changed or will change
-**Report Output**: generated with `loaf report generate ...` or stored as an authored report when durable prose is needed.
-**Archive**: After report is processed and the linked session is archived, use `loaf report archive <report>` for SQLite-backed report state. Markdown report movement is compatibility/export handling.
-**Metadata**: Require enough state or frontmatter to identify status, linked session, and processing time. In SQLite-backed projects, CLI state is authoritative.
-**Note**: Reports without state/frontmatter metadata are treated as unprocessed compatibility artifacts.
-
-## Handoffs
-
-Explicit transfer packets belong to `/handoff`, which writes
-`.agents/handoffs/YYYYMMDD-HHMMSS-title.md`. Orchestration keeps live session
-state resumable; `/handoff` packages context for another agent, branch, task,
-or future session. `/housekeeping` deletes deprecated handoffs after
-confirmation.
-
-## Blockers
-
-- Current blocker (if any)
-
----
-
-## Session Log (Compact Inline Journal)
-
-Sessions use an **append-only structured journal** format — a running log of what happened, what was decided, and what's next. Think "conventional commits meets bullet journal."
-
-### Format
-
-```markdown
-## Journal
-
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-[YYYY-MM-DD HH:MM] decision(scope): description of decision
-[YYYY-MM-DD HH:MM] discover(scope): something learned
-
-[YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
-[YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
-[YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
-```
-
-### Entry Types
-
-| Type | Use For | Written By | Scope Convention |
-|------|---------|------------|------------------|
-| `resume(scope)` | Session started/resumed | Hook (auto) | Branch name |
-| `pause` | Session ended | Hook (auto) | — |
-| `commit(SHA)` | Code committed | Hook (auto) | Short SHA |
-| `pr(#N)` | PR created/updated | Hook (auto) | PR number |
-| `merge(#N)` | PR merged | Hook (auto) | PR number |
-| `decision(scope)` | Key decisions | Agent | Topic |
-| `discover(scope)` | Something learned | Agent | Topic |
-| `block(scope)` | Blocker encountered | Agent | Topic |
-| `unblock(scope)` | Blocker resolved | Agent | Topic |
-| `spark(scope)` | Ideas to promote | Agent | Topic |
-| `resolve(spark)` | Spark triaged via `/idea` | Agent/User | Spark slug → disposition [timestamp] |
-| `todo(scope)` | Action items | Agent | Topic |
-| `finding(scope)` | Findings from analysis | Agent | Topic |
-| `hypothesis` | Theory being tested | Agent | — |
-| `try` | Approach attempted | Agent | — |
-| `reject` | Approach abandoned | Agent | — |
-| `skill(name)` | Skill invoked with context | Skill (self-log) | Skill name |
-| `idea(slug)` | Idea captured or promoted | Agent/Skill | Idea slug or `.agents/ideas/` ref |
-| `spec(id)` | Spec created, updated, or approved | Agent/Skill | Spec ID (e.g. `SPEC-024`) |
-| `handoff(slug)` | Handoff created or deprecated | Agent/Skill | Handoff slug or `.agents/handoffs/` ref |
-| `report(slug)` | Report generated | Agent/Skill | Report slug or `.agents/reports/` ref |
-| `council(slug)` | Council convened or concluded | Agent/Skill | Council slug or `.agents/councils/` ref |
-| `brainstorm(slug)` | Brainstorm session held | Agent/Skill | Draft slug or topic |
-| `plan(slug)` | Plan created or updated | Agent/Skill | Plan slug or topic |
-| `draft(slug)` | Draft document created | Agent/Skill | Draft slug or `.agents/drafts/` ref |
-
-### Format Rules
-
-1. **Timestamp:** `YYYY-MM-DD HH:MM` (no seconds)
-2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank line separator:** Insert when:
-   - Gap ≥ 5 minutes since last entry, OR
-   - State transition (block/unblock/pause/resume)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated by `loaf session end`)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-### Example Session
-
-```markdown
----
-spec: SPEC-020
-branch: feat/target-convergence
-status: active
-created: 2026-03-31T14:30:00Z
-last_entry: 2026-04-02T09:15:00Z
----
-
-# Session: Target Convergence
-
-## Journal
-
-[2026-03-31 14:30] resume(feat/target-convergence): from commit abc1234, 3 tasks pending
-[2026-03-31 14:30] decision(hooks): remove bash wrappers, go direct
-[2026-03-31 14:32] discover(cursor): prompt hooks filtered at line 269
-
-[2026-03-31 15:10] block(parity): Codex output differs by trailing newline
-[2026-03-31 15:11] hypothesis: gray-matter serialization adds trailing \n
-
-[2026-03-31 16:45] unblock(parity): confirmed gray-matter quirk, fixed with trim
-[2026-03-31 16:46] commit(def5678): fix: trim frontmatter for Codex byte parity
-
---- PAUSE 2026-03-31 17:00 ---
-
-[2026-04-02 09:15] resume(feat/target-convergence): 16 hours paused, last: verification
-```
-
-### CLI Commands
-
-```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decide(scope): desc"
-loaf session archive  # Move to archive when branch merges
-```
-
-### Consistency
-
-- **`loaf session log`** validates and appends entries in correct format
-- **Read-only agents** (reviewer, researcher) CAN write journal entries via `loaf session log` (Bash command, not file edit)
-- **Concurrent writes** are safe: atomic append, timestamps provide ordering
-
-## Lifecycle States
-
-| State | Description |
-|-------|-------------|
-| `in_progress` | Work actively happening |
-| `paused` | Temporarily stopped |
-| `completed` | Work finished; ready to archive (set status, `archived_at`, `archived_by`, move) after extraction |
-| `archived` | Closed and preserved for audit (set `archived_at`/`archived_by`, status set + moved to `.agents/sessions/archive/`) |
-
-## Updating During Work
-
-After each significant action, append entries to the session journal:
-
-1. **Use `loaf session log`** to append entries in the correct format
-2. **Add `decision`, `discover`, `block`, `spark`, `wrap` entries** during normal work
-3. **Hooks auto-append:** `resume`, `commit(SHA)`, `pr(#N)`, `merge(#N)`, `pause`
-4. **Blank line rules:** Inserted automatically by `loaf session log` based on time gaps and state transitions
-
-**Cross-agent protocol:** When any agent starts work on a branch, `loaf session start` outputs the last 15-20 journal entries. The agent reads context, continues work, appends entries.
-
-## Session Continuity Protocol
-
-### Before Pausing or Switching Agents
-
-1. Update session file with completed work
-2. Update `Current State` with where you stopped
-3. Update `Next Steps` with immediate actions
-4. Include `Files Modified` for context
-
-### Session as Continuity Medium
-
-Each agent:
-1. Reads current state from session
-2. Performs assigned work
-3. Updates session with outcomes
-4. Sets up context for next agent
-
-## Completing a Session
-
-Sessions are **archived, not deleted** when complete to preserve audit trail (set status to `archived`, set `archived_at` and `archived_by`, and move into `.agents/sessions/archive/`). Archive indefinitely (no deletion policy).
-
-**Archive timing:** only after extraction and council/report summaries are captured.
-
-### Knowledge Extraction Checklist
-
-| Information Type | Where It Belongs |
-|------------------|------------------|
-| Work tracking | External issue (Linear, GitHub) |
-| Implementation details | Git commits/PRs |
-| Architectural decisions | ADRs (`docs/decisions/`) |
-| API contracts | API documentation |
-| Remaining work | External issue backlog |
-| Council outcomes | Session summary + council file link |
-| Report conclusions | Session summary + report file link |
-| Archived artifacts | SQLite lifecycle state plus compatibility archive metadata when Markdown files exist |
-
-### Archival Checklist
-
-- [ ] External issue updated with final status
-- [ ] Decisions captured as ADRs (if architectural)
-- [ ] Lessons learned added to relevant docs
-- [ ] Remaining work created as issues
-- [ ] Council outcomes summarized in this session (link council file)
-- [ ] Reports processed and summarized in this session (link report file)
-- [ ] Reports archived only after session is archived (`loaf report archive` for SQLite-backed state)
-- [ ] Handoffs reviewed; deprecated handoffs marked for `/housekeeping` deletion
-- [ ] No orphaned references to session file
-- [ ] Set session status to `archived`
-- [ ] Set `archived_at` and `archived_by`
-- [ ] Move compatibility session file to `.agents/sessions/archive/` when one exists
-- [ ] Linked councils moved to `.agents/councils/archive/` after session summary
-- [ ] Linked report state archived after session archived + conclusions captured
-- [ ] Deprecated handoffs deleted by `/housekeeping` after confirmation
-- [ ] Update `.agents/` references to archived paths (no `.agents` links outside `.agents/`)
-- [ ] Archive indefinitely (no deletion policy)
-- [ ] Use `/housekeeping` for auto-move + link updates after confirmation
-
-## Start Protocol
-
-When starting a new orchestration context:
-
-1. Check for existing active sessions
-2. If found, ask user which to resume or start fresh
-3. If resuming, read session for context
-4. If starting fresh, create new session file
+Reports, councils, and handoffs have their own archive or finalization commands.
+Do not use session archival as a substitute for those lifecycles.
 
 ## Hook Integration
 
-### SessionStart Hook
-- Lists active sessions
-- Provides agent-specific context
-- Suggests session review/resume
-
-### SessionEnd Hook
-- Displays completion checklist
-- Reminds about session file updates
-- Shows count of active sessions
-
-### PreCompact Hook
-- `loaf session context for-compact` logs compact marker and injects flush instructions
-- Model flushes unrecorded decisions/discoveries to journal
-- Model writes structured `## Current State` summary
-- After compaction: `loaf session context for-resumption` prints rich resumption context (session, spec, journal, git)
+- Session start hooks should surface recent journal entries from SQLite.
+- Session-end hooks should nudge for missing durable journal entries before wrap.
+- Pre-compaction hooks should ask the agent to flush facts through
+  `loaf session log`.
+- Post-compaction recovery should use `loaf session start` and
+  `loaf session show`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Archive without extraction | Extract outcomes before archiving |
-| Use sessions as permanent records | Use proper documentation locations |
-| Reference stale sessions | Keep sessions current or archive (status + move) when done |
-| Store decisions only in sessions | Create ADRs for important decisions |
-| Archive without council/report summaries | Summarize outcomes in session before archive |
-| Archive but leave in active folder | Move file to `.agents/sessions/archive/` after setting status |
-| Batch session updates | Update after each significant event |
-| Keep status as `in_progress` when paused | Update status when state changes |
+| Hand-author session markdown as source | Use `loaf session start/log/show/end` |
+| Store decisions only in chat context | Log them and promote durable decisions to ADR/spec/report/docs |
+| Invent status values | Cite the runtime lifecycle until SPEC-049 lands |
+| Archive before extracting outcomes | Promote outcomes first, then wrap/archive |
+| Batch all journal entries at the end | Log significant facts as they happen |

--- a/dist/codex/skills/orchestration/templates/session.md
+++ b/dist/codex/skills/orchestration/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/codex/skills/reflect/SKILL.md
+++ b/dist/codex/skills/reflect/SKILL.md
@@ -33,12 +33,13 @@ Update VISION, STRATEGY, and ARCHITECTURE based on proven implementation.
 - **Post-implementation only** -- reflect after shipping, not before or during planning
 - **Get explicit approval** -- never update strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) without user confirmation
 - **Consolidate** -- batch related learnings into coherent updates, avoid micro-updates
-- **Link back** -- always reference the specs/sessions that informed each update
+- **Log first** -- log invocation before gathering evidence: `loaf session log "skill(reflect): <scope>"`
+- **Link back** -- always reference the specs, SQLite sessions, reports, and commits that informed each update
 - **Log updates** -- log each strategic document update to session journal: `loaf session log "decision(scope): updated STRATEGY.md with learning"`
 
 ## Verification
 
-- Proposals cite specific specs, sessions, or commits as evidence
+- Proposals cite specific specs, SQLite sessions, reports, or commits as evidence
 - No strategic document was modified without explicit user approval
 - Completed specs referenced in updates are archived after reflection
 
@@ -86,7 +87,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 
 Sources:
 1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
-2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
+2. **SQLite sessions** (`loaf session list --all --json`, then `loaf session show <ref> --json`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?
 

--- a/dist/codex/skills/research/SKILL.md
+++ b/dist/codex/skills/research/SKILL.md
@@ -33,6 +33,7 @@ Patterns for zooming out, investigating topics, and evolving project direction.
 - Cite sources with confidence levels
 - Present options, let user decide
 - Get approval before editing VISION
+- Log invocation first: `loaf session log "skill(research): <topic or mode>"`
 - Log findings to session journal: `loaf session log "discover(scope): summary of finding"`
 
 ### Never
@@ -79,7 +80,7 @@ Parse `$ARGUMENTS` to determine mode:
 
 Prioritize sources in this order:
 
-1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, session files, codebase patterns
+1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, SQLite sessions, codebase patterns
 2. **Authoritative docs** -- Context7, official docs, RFCs
 3. **Community knowledge** -- Stack Overflow (verified), GitHub issues, expert blogs
 4. **General web** (lowest) -- Search results, unverified sources
@@ -94,7 +95,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 
 1. Read project documents: VISION.md, STRATEGY.md, ARCHITECTURE.md
 2. Check ideas (`.agents/ideas/`) and specs (`docs/specs/`)
-3. Review recent sessions (`.agents/sessions/`)
+3. Review recent sessions with `loaf session list --all --json` and `loaf session show <ref> --json`
 4. Check recent commits: `git log --oneline -20`
 5. Synthesize following [state-assessment template](templates/state-assessment.md)
 
@@ -103,7 +104,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 **Trigger:** Specific topic or question
 
 1. **Interview** with request_user_input: what are you trying to understand? What context do you have? What decision will this inform?
-2. Check project context first (ADRs, ARCHITECTURE, sessions)
+2. Check project context first (ADRs, ARCHITECTURE, SQLite sessions)
 3. Apply confidence hierarchy for external sources
 4. For a transient review artifact, use `loaf report generate` when an existing
    SQLite-backed export kind fits; for authored long-form research, create a

--- a/dist/codex/skills/research/templates/state-assessment.md
+++ b/dist/codex/skills/research/templates/state-assessment.md
@@ -12,7 +12,7 @@ title: "State Assessment: [YYYY-MM-DD]"
 type: state-assessment
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active | archived
-session: ".agents/sessions/YYYYMMDD-HHMMSS-description.md"  # Session that produced this assessment
+session: "session alias or loaf session show reference"  # Session that produced this assessment
 tags: []
 ---
 

--- a/dist/cursor/agents/background-runner.md
+++ b/dist/cursor/agents/background-runner.md
@@ -26,7 +26,7 @@ You execute specific tasks in the background, writing results to a specified loc
 
 1. **Execute assigned task** - Security audits, coverage analysis, code reviews, etc.
 2. **Write results** - Output to specified `.agents/reports/` location
-3. **Update session** - Mark your background agent entry as complete
+3. **Report completion** - Write completion status in the report and log a concise session entry when session context is available
 
 ## Input You Receive
 
@@ -34,7 +34,7 @@ The spawning agent provides:
 - Specific task to execute
 - Files or scope to analyze
 - Output location (`.agents/reports/YYYYMMDD-HHMMSS-<name>.md`)
-- Session reference
+- Session alias or task/spec reference when available
 
 ## Execution Process
 
@@ -44,7 +44,7 @@ Extract from prompt:
 - What to do (audit, analyze, review)
 - Scope (files, directories)
 - Output location
-- Session file path
+- Session alias, task ID, or spec ID when provided
 
 ### 2. Execute Work
 
@@ -66,7 +66,7 @@ report:
   status: unprocessed
   created: "2026-01-23T14:30:00Z"
   background_agent_id: "bg-YYYYMMDD-HHMMSS-description"
-  session_reference: "YYYYMMDD-HHMMSS-session-name.md"
+  session_reference: "session alias or task/spec reference"
 ---
 
 # Report Title
@@ -93,17 +93,13 @@ Prioritized list of actions.
 - `path/to/file2.py`
 ```
 
-### 4. Update Session Frontmatter
+### 4. Report Completion
 
-Read session file and update your background agent entry:
+If the prompt supplied an active session alias and the `loaf` CLI is available,
+log the result:
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: completed  # Changed from running
-    result_location: ".agents/reports/20260123-143000-security.md"  # Set path
+```bash
+loaf session log "discover(background): bg-YYYYMMDD-HHMMSS-description completed; report .agents/reports/..."
 ```
 
 ## Constraints
@@ -120,8 +116,7 @@ Before completing:
 - [ ] Task executed per prompt instructions
 - [ ] Report written to specified location
 - [ ] Report has valid frontmatter with `background_agent_id`
-- [ ] Session frontmatter updated with `status: completed`
-- [ ] Session frontmatter updated with `result_location`
+- [ ] Completion logged to session journal when session context was provided
 - [ ] No user interaction attempted
 
 ## Error Handling
@@ -130,16 +125,11 @@ If task cannot be completed:
 
 1. Write partial report with what was accomplished
 2. Document blockers in report
-3. Update session frontmatter with `status: failed`
+3. Log failure to session journal when session context was provided
 4. Include error details in report
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: failed
-    result_location: ".agents/reports/20260123-143000-security-partial.md"
+```bash
+loaf session log "block(background): bg-YYYYMMDD-HHMMSS-description failed; partial report .agents/reports/..."
 ```
 
 ## Example Task
@@ -156,7 +146,7 @@ Check for OWASP Top 10 vulnerabilities.
 
 Write report to: .agents/reports/20260123-143000-auth-security.md
 
-Session: .agents/sessions/20260123-140000-auth-feature.md
+Session: active session alias if available
 Background Agent ID: bg-20260123-143000-auth-security
 ```
 
@@ -164,7 +154,7 @@ Background Agent ID: bg-20260123-143000-auth-security
 1. Read `src/auth/endpoints.py` and `src/auth/token.py`
 2. Analyze for OWASP vulnerabilities
 3. Write findings to `.agents/reports/20260123-143000-auth-security.md`
-4. Update `.agents/sessions/20260123-140000-auth-feature.md` frontmatter
+4. Log completion to the session journal if session context was provided
 
 ---
 version: 2.0.0-pre.20260614235428

--- a/dist/cursor/agents/implementer.md
+++ b/dist/cursor/agents/implementer.md
@@ -21,7 +21,7 @@ You are an implementer. You have full write access to the codebase: code, tests,
 ## Behavioral Contract
 
 - Your domain speciality comes from the skills loaded at spawn time, not from this profile. An implementer with Python skills implements Python; an implementer with infrastructure skills writes Terraform. The role is the same; the material differs.
-- Work within an active session. If no session file was provided in your spawn prompt, say so immediately.
+- Work within an active session. If no session alias, task ID, or branch context was provided in your spawn prompt, say so immediately.
 - Follow the conventions defined in your loaded skills. They are your blueprints.
 - Write tests alongside implementation, never after.
 - Run verification commands (linters, type checkers, test suites) before reporting completion.

--- a/dist/cursor/agents/librarian.md
+++ b/dist/cursor/agents/librarian.md
@@ -6,21 +6,21 @@ description: librarian agent for specialized tasks
 ---
 # Librarian
 
-You are a librarian. You shepherd session files through their lifecycle and tend the operational artifacts under `.agents/`. You have read access to the repository and edit access scoped to `.agents/` only.
+You are a librarian. You shepherd SQLite-backed session journals through their lifecycle and tend operational artifacts under `.agents/`. You have read access to the repository and edit access scoped to `.agents/` only.
 
 ## Behavioral Contract
 
-- Tend session files: Current State summaries, journal quality, wrap summaries, lifecycle transitions.
+- Tend session journals: journal quality, wrap summaries, and lifecycle transitions.
 - Never modify code, tests, or configuration — only `.agents/` artifacts.
 - Never research, review, or orchestrate — those are other profiles' work.
 - Work quickly and silently. The user should not notice you unless something is wrong.
-- Read before writing — always check the current state of a session file before modifying it.
+- Read before writing — always check the current state with `loaf session show` before modifying related artifacts.
 
 ## What You Tend
 
-- **Session files** in `.agents/sessions/` — frontmatter, Current State, journal entries
+- **SQLite sessions** — inspect with `loaf session list --json` and `loaf session show <ref> --json`
 - **Session lifecycle** — status transitions (active → stopped → done → archived)
-- **Pre-compaction preservation** — flush journal entries, write Current State before context compaction
+- **Pre-compaction preservation** — flush journal entries before context compaction
 - **Knowledge artifacts** in `.agents/knowledge/` — staleness markers, coverage notes
 - **Wrap summaries** — end-of-session distillation when invoked by `/wrap`
 - **Decision persistence** — extract decisions to spec changelog via `loaf session end --wrap`

--- a/dist/cursor/skills/bootstrap/SKILL.md
+++ b/dist/cursor/skills/bootstrap/SKILL.md
@@ -41,6 +41,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - **BRIEF is input, not output** -- the BRIEF is raw intake. Extract every useful fact into VISION/STRATEGY/ARCHITECTURE/AGENTS during bootstrap.
 - **BRIEF is archeological after bootstrap** -- once extraction completes, the BRIEF is a frozen historical snapshot. No skill, agent, command, or template should reference `docs/BRIEF.md` post-bootstrap. Operating documents must stand on their own.
 - **Suggest, don't execute** -- recommend next skills at the end, never auto-run them
+- **Log first** -- log invocation before interviewing: `loaf session log "skill(bootstrap): <project or intake>"`
 - **Log outcome** -- log bootstrap completion to session journal: `loaf session log "decision(bootstrap): project bootstrapped, mode detected"`
 
 ---
@@ -50,7 +51,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - All expected operating documents (`docs/VISION.md`, `.agents/AGENTS.md` at minimum) exist and contain populated content
 - Useful BRIEF content has been extracted into operating documents (no future reader should need to open the BRIEF)
 - Symlinks are correct: `.agents/AGENTS.md` and `./AGENTS.md -> .agents/AGENTS.md`
-- A session file was saved in `.agents/sessions/` capturing key decisions and interview exchanges
+- Key decisions and interview outcomes were logged with `loaf session log` and are readable with `loaf session show`
 
 ---
 
@@ -369,13 +370,13 @@ If symlinks already exist and point to the right targets, skip silently. If they
 
 ### 3. Session Recording
 
-Save the bootstrap interview as a session file:
+Record the bootstrap interview in the active SQLite-backed session:
 
-```
-.agents/sessions/{YYYYMMDD}-{HHMMSS}-bootstrap.md
-```
+1. Run `loaf session start` if there is no active session.
+2. Log mode detection and key interview decisions with `loaf session log`.
+3. Use `loaf session show <session-ref>` to inspect the rendered session view.
 
-The session should capture:
+The session journal should capture:
 - Mode detected and why
 - Key decisions made during the interview
 - Key interview exchanges that informed those decisions
@@ -383,7 +384,8 @@ The session should capture:
 - The original problem framing and user intent
 - Any open questions or deferred decisions
 
-Follow [templates/session.md](templates/session.md) for structure and frontmatter schema.
+Use [templates/session.md](templates/session.md) only as the rendered journal
+format reference; do not hand-author session markdown as the source of truth.
 
 ### 4. Next Steps
 

--- a/dist/cursor/skills/bootstrap/templates/session.md
+++ b/dist/cursor/skills/bootstrap/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/cursor/skills/brainstorm/SKILL.md
+++ b/dist/cursor/skills/brainstorm/SKILL.md
@@ -18,7 +18,8 @@ Generative thinking — expanding possibilities before narrowing through structu
 - Diverge before converging — generate options before judging
 - Connect exploration to VISION.md and STRATEGY.md context
 - Document discarded options — they hold valuable reasoning
-- Capture sparks (speculative byproducts) in a dedicated section — brainstorm documents are the canonical home for sparks
+- Log invocation first: `loaf session log "skill(brainstorm): <topic>"`
+- Capture sparks (speculative byproducts) with `loaf spark capture --scope <scope> --text <text>`; brainstorm documents may render or summarize them
 - Set boundaries on exploration time
 - Log outcome to session journal: `loaf session log "decision(scope): direction chosen and rationale"`
 
@@ -32,7 +33,7 @@ Generative thinking — expanding possibilities before narrowing through structu
 
 After work completes, verify:
 - Brainstorm document created at `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
-- `## Sparks` section present with speculative byproducts
+- Sparks captured with `loaf spark capture` and optionally summarized in `## Sparks`
 - Spark lifecycle documented: unprocessed → promoted/discarded
 - Brainstorm references strategic context from VISION/STRATEGY
 
@@ -57,7 +58,7 @@ After work completes, verify:
 
 Sparks are: lightweight, byproducts, worth remembering. Mark as `*(promoted)*` or `*(abandoned)*` after processing.
 
-Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value.
+Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value. SQLite spark state is the lifecycle source; draft markdown is a projection or narrative summary.
 
 ## Suggests Next
 

--- a/dist/cursor/skills/brainstorm/templates/brainstorm.md
+++ b/dist/cursor/skills/brainstorm/templates/brainstorm.md
@@ -11,7 +11,7 @@ type: brainstorm
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active (has unprocessed sparks) | archived
 tags: []
-related: []            # Optional: idea files, spec IDs, session files
+related: []            # Optional: idea aliases, spec IDs, session aliases, report refs
 ---
 
 # Brainstorm: [Topic]

--- a/dist/cursor/skills/handoff/templates/handoff.md
+++ b/dist/cursor/skills/handoff/templates/handoff.md
@@ -8,7 +8,7 @@ title: "[Handoff Title]"
 created: YYYY-MM-DDTHH:MM:SSZ
 status: draft | final | deprecated
 source: session | branch | task | ad-hoc
-session: .agents/sessions/YYYYMMDD-HHMMSS-session.md
+session: session alias or loaf session show reference
 branch: branch-name
 deprecated_at: YYYY-MM-DDTHH:MM:SSZ  # Set only when confirmed obsolete
 deprecated_by: orchestrator

--- a/dist/cursor/skills/housekeeping/SKILL.md
+++ b/dist/cursor/skills/housekeeping/SKILL.md
@@ -17,10 +17,11 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Critical Rules
 
 **Always**
+- Log invocation as the first action: `loaf session log "skill(housekeeping): <scope or trigger>"`
 - Review EVERY file individually — never sample or average
 - Check Linear issue status before archiving sessions
 - Extract lessons learned and decisions before archiving
-- Use CLI (`loaf session housekeeping`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
+- Use CLI (`loaf housekeeping`, `loaf session archive`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
 - Treat `.agents/handoffs/` as first-class but disposable: keep active/final handoffs, delete only after confirmed deprecated status
 - Check report `status` is `processed` and linked session is archived before archiving reports (see [templates/report.md](templates/report.md))
 - Check state assessment `session:` field before flagging for cleanup — only flag when linked session is archived
@@ -35,7 +36,7 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Verification
 
 After work completes, verify:
-- Session files archived with proper metadata (status, archived_at, archived_by)
+- Session lifecycle state is visible through `loaf session list --json`
 - Tasks archived via `loaf task archive`
 - Specs archived via `loaf spec archive`
 - SQLite-backed task/spec/report state reflects lifecycle changes when initialized
@@ -48,10 +49,11 @@ After work completes, verify:
 ### CLI Commands
 
 ```bash
-loaf session housekeeping --dry-run  # Preview all actions
-loaf session housekeeping            # Run all checks and fixes
+loaf housekeeping --dry-run          # Preview recommendations
+loaf housekeeping                    # Run artifact scanner
+loaf housekeeping --sessions         # Review sessions only
 loaf session archive                 # Archive single session
-loaf session enrich <file>           # Enrich a session's journal from JSONL
+loaf session enrich --json           # Compatibility diagnostic for legacy enrichment
 loaf task archive TASK-XXX           # Archive single task
 loaf spec archive SPEC-XXX           # Archive single spec
 loaf task sync                       # Compatibility: repair Markdown task index drift
@@ -61,7 +63,7 @@ loaf task sync                       # Compatibility: repair Markdown task index
 
 | Artifact | Active Location | Archive | Action |
 |----------|-----------------|---------|--------|
-| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf session archive` / `loaf session housekeeping` |
+| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf housekeeping --sessions` / `loaf session archive` |
 | Tasks (local mode only) | SQLite state + `.agents/tasks/` source prose | `archive/` | `loaf task archive` |
 | Specs | SQLite state + `.agents/specs/` authored prose | `archive/` | `loaf spec archive` |
 | Drafts (state assessments) | `.agents/drafts/` | delete | Flag for cleanup when linked session is archived |
@@ -78,7 +80,10 @@ every mode.
 
 ## Session Enrichment
 
-For each session with status `stopped` or `done` that has a `claude_session_id` in frontmatter, run `loaf session enrich <file>` to catch up on journal entries that weren't logged during the session.
+In SQLite-backed projects, `loaf session log` is the canonical journal writer and
+`wrap` owns end-of-session checks. `loaf session enrich --json` is a compatibility
+diagnostic for legacy markdown enrichment; it is not part of the normal
+housekeeping flow.
 
 Do NOT enrich `active` sessions — those are handled by the wrap skill when the session ends.
 

--- a/dist/cursor/skills/housekeeping/templates/session.md
+++ b/dist/cursor/skills/housekeeping/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/cursor/skills/implement/SKILL.md
+++ b/dist/cursor/skills/implement/SKILL.md
@@ -3,9 +3,9 @@ name: implement
 description: >-
   Orchestrates implementation sessions through agent delegation and batch
   execution. Use for all implementation work — features, bug fixes, refactors,
-  and code changes. Produces session files, agent spawn plans, and progress
-  tracking. Not for shaping (use shape), breakdown (use breakdown), research, or
-  review.
+  and code changes. Produces SQLite-backed session journals, agent spawn plans,
+  and progress tracking. Not for shaping (use shape), breakdown (use breakdown),
+  research, or review.
 version: 2.0.0-pre.20260614235428
 ---
 
@@ -38,7 +38,7 @@ You are the coordinator. Start by understanding the task:
 **You are the ORCHESTRATOR, not the implementer.**
 
 ### Orchestrator Can Do Directly
-- Create/edit session files, council files
+- Start/log/show sessions, create council files
 - Use task list or chat checklist; **if `integrations.linear.enabled` is `true` in `.agents/loaf.json`**, use Linear MCP tools when helpful
 - Read any file for context
 - Ask clarifying questions
@@ -48,11 +48,11 @@ You are the coordinator. Start by understanding the task:
 
 ## Verification
 
-- Session file exists before any implementation work begins
+- `loaf session start` has created or resumed an active SQLite-backed session before implementation work begins
 - All code changes delegated via background agent -- no direct edits by orchestrator
-- Session file is continuously updated with spawns, progress, and current state
+- Session journal is continuously updated with spawns, progress, and current state
 - Spec artifacts closed out on branch before PR creation
-- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session file is created; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
+- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session is started; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
 
 ## Quick Reference
 
@@ -80,7 +80,7 @@ Before starting, evaluate context suitability.
 | Just completed a different task/spec | Suggest clear |
 | About to start multi-file implementation | Check depth |
 
-If restart needed: capture state in session file, generate resumption prompt, ask user to restart.
+If restart needed: log current state with `loaf session log`, generate resumption prompt, ask user to restart.
 
 ## Input Detection
 
@@ -88,7 +88,7 @@ Parse `$ARGUMENTS` to determine session type:
 
 | Input Pattern | Type | Action |
 |---------------|------|--------|
-| `TASK-XXX` | Local task | Load via `loaf task show`, auto-create session |
+| `TASK-XXX` | Local task | Load via `loaf task show`, start/resume session |
 | `SPEC-XXX` | Spec orchestration | If spec frontmatter has `linear_parent`, resolve to that Linear parent and follow Linear-Native Routing. Otherwise resolve local tasks and build dependency waves |
 | `TASK-XXX..YYY` | Task range | Expand range, build dependency waves |
 | `TASK-XXX,YYY,ZZZ` | Task list | Parse list, build dependency waves |
@@ -100,8 +100,8 @@ Parse `$ARGUMENTS` to determine session type:
 When starting from `TASK-XXX`:
 
 1. Load task metadata via `loaf task show TASK-XXX --json`; read `.agents/TASKS.json` only as a Markdown-compatibility fallback
-2. Auto-generate session: `YYYYMMDD-HHMMSS-task-XXX.md`
-3. Create session file, update task with session reference: `loaf task update TASK-XXX --session <session-file>`
+2. Run `loaf session start` to find or create the active session for the branch
+3. Log the task coupling: `loaf session log "decision(implement): implementing TASK-XXX"`
 4. Load parent spec if task has `spec:` field
 
 **No user interaction required for session naming.**
@@ -187,7 +187,7 @@ The issue is an actual task. Implement it directly — with a pre-flight gate.
    - Resolve branch name from the sub-issue's `branchName` field (Linear
      auto-generates one) — see
      [session-management.md](references/session-management.md).
-   - Create session file, continue with the standard Startup Checklist.
+   - Run `loaf session start`, then continue with the standard Startup Checklist.
 
 ### Completion (after implementer + reviewer finish cleanly)
 
@@ -224,8 +224,8 @@ When the sub-issue's implementation passes review and tests:
   implementation reveals a missing task, surface it to the user; they
   decide whether to run `/breakdown` again or add an ad-hoc sub-issue.
 - Does not sync in-progress state bidirectionally. Source of truth at any
-  moment: Linear for issue state, local files for spec content, session
-  file for current handoff.
+  moment: Linear for issue state, local files for spec content, SQLite session
+  journal for current handoff.
 
 ---
 
@@ -248,19 +248,19 @@ Use the **background agent** with appropriate `agent_type`:
 
 ---
 
-## Session Creation
+## Session Start
 
-**MANDATORY: Create session file BEFORE any other work.**
+**MANDATORY: Run `loaf session start` BEFORE any implementation work.**
 
-1. Generate timestamps: `date -u +"%Y%m%d-%H%M%S"` and `date -u +"%Y-%m-%dT%H:%M:%SZ"`
-2. Create session file following [session template](templates/session.md)
-3. Verify session file exists with valid frontmatter
+1. Run `loaf session start` from the target branch/worktree.
+2. Log invocation context: `loaf session log "skill(implement): <task/spec/context>"`
+3. Verify the active session is readable with `loaf session list --json` or `loaf session show <session-ref> --json`.
 4. Suggest renaming Cursor session with a meaningful name derived from context:
    - From spec: `Suggestion: /rename SPEC-027-session-stability`
    - From task: `Suggestion: /rename TASK-042-login-fix`
    - From ad-hoc: `Suggestion: /rename {short-slug-from-description}`
 
-**DO NOT PROCEED WITHOUT A SESSION FILE.**
+**Do not proceed until the active session is visible through `loaf session` commands.**
 
 ---
 
@@ -271,8 +271,8 @@ Use the **background agent** with appropriate `agent_type`:
 3. **When uncertain** -- convene council, present results, **wait for user approval**
 4. **Ensure quality** -- spawn implementer for tests, route reviews to reviewer background agent
 5. **When debugging** -- if a test failure or error isn't immediately obvious, load the **debugging** skill for structured hypothesis tracking before retrying
-6. **Update session file continuously** -- log spawns, update current_task, keep handoff-ready
-6. **Clean up** -- no ephemeral files, archive completed sessions (status + `archived_at` + `archived_by` + move to archive/)
+6. **Update session continuously** -- log spawns, progress, blockers, and next actions with `loaf session log`
+6. **Clean up** -- no ephemeral files; wrap with `loaf session end --wrap` and archive closed sessions with `loaf session archive`
 7. **When in doubt, ask the user**
 
 ## Decision Tree
@@ -281,7 +281,7 @@ Use the **background agent** with appropriate `agent_type`:
 Is this a code/config/doc change?
 +-- YES -> Spawn appropriate agent
 +-- NO -> Is this a planning/coordination decision?
-    +-- YES with clear path -> Proceed, update session
+    +-- YES with clear path -> Proceed, log session decision
     +-- YES but ambiguous -> Ask user
     +-- NO -> Ask user
 ```
@@ -292,18 +292,18 @@ When multiple valid approaches exist: spawn council (5-7 agents, odd), present r
 
 ## Startup Checklist
 
-After creating session file:
+After `loaf session start`:
 
 1. [ ] Parse input (task, Linear ID, or description)
-2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, update with `loaf task update TASK-XXX --session <session-file>`, load parent spec
+2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, log task coupling, load parent spec
 3. [ ] If Linear ID (or `SPEC-XXX` with `linear_parent`): follow [Linear-Native Routing](#linear-native-routing). Parent → walk sub-issues and select next. Sub-issue → verify `blockedBy` is clear, then start it as one logical Linear operation so the parent is promoted when needed
 4. [ ] If description: auto-create task (see Ad-hoc Task Auto-Creation above)
 5. [ ] Create dedicated branch (see [session-management.md](references/session-management.md))
 6. [ ] Suggest team based on task context
-7. [ ] Populate session Context section
+7. [ ] Log initial context and references with `loaf session log`
 8. [ ] Break down work using task list or chat checklist
 9. [ ] Identify needed specialized agents
-10. [ ] Update session Next Steps
+10. [ ] Log next steps before spawning
 11. [ ] **Get user approval** before spawning
 
 ---
@@ -311,7 +311,7 @@ After creating session file:
 ## Then Execute
 
 ### BEFORE (Planning)
-1. Create session file
+1. Run `loaf session start`
 2. Set task status: `loaf task update TASK-XXX --status in_progress`
 3. Break down work into agent-sized tasks
 4. Identify spawn order (respect dependencies)
@@ -319,10 +319,10 @@ After creating session file:
 
 ### DURING (Execution)
 1. Spawn specialized agents via background agent
-2. Log each spawn in session `orchestration.spawned_agents`
+2. Log each spawn with `loaf session log "todo(agent): spawned <agent> for <task>"`
 3. Update Linear with progress (no emoji, no file paths)
-4. Keep session `## Current State` handoff-ready
-5. After each agent completes: update session, spawn next
+4. Keep journal entries handoff-ready
+5. After each agent completes: log outcome, spawn next
 
 ### AFTER (Completion)
 1. Code review pass (spawn `reviewer` agent)
@@ -331,13 +331,13 @@ After creating session file:
    - **Local-tasks mode:** `loaf task update TASK-XXX --status done` (per task), then `loaf task archive --spec SPEC-XXX`
    - **Linear-native mode:** `update_issue` the sub-issue to `completed`-type state. Then query the parent's sub-issues; if all are `completed`, also close the parent. If some remain, list them for the user (see [Linear-Native Routing → Completion](#completion-after-implementer--reviewer-finish-cleanly))
    - Mark spec complete and archive: `loaf spec archive SPEC-XXX` (both modes)
-   - Update session file (status: done, `archived_at`, `archived_by`)
-   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
+   - Run `loaf session end --wrap`; archive later with `loaf session archive` when appropriate
+   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session state`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
 5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
-6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
-   - `## Key Decisions` has content (not `*(none yet)*` or empty)
-   - `traceability.decisions` has entries (ADRs were recorded)
+6. **Suggest reflection:** Check the session journal for extractable learnings before closing out:
+   - `decision(...)` entries are present
+   - ADRs, report verdicts, or spec changelog entries were recorded
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
@@ -360,4 +360,4 @@ After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release`
 - **orchestration/product-development** - Full workflow hierarchy
 - **orchestration/specs** - Spec format and lifecycle
 - **orchestration/local-tasks** - Task file format including `session:` field
-- **orchestration/sessions** - Session lifecycle details
+- **orchestration/sessions** - SQLite-backed session lifecycle details

--- a/dist/cursor/skills/implement/references/session-management.md
+++ b/dist/cursor/skills/implement/references/session-management.md
@@ -8,7 +8,6 @@
 - Linear Status Management
 - Handoff State Requirements
 - Timestamps for User Context
-- Transcript Archival
 - Task Completion
 
 Detailed reference for session lifecycle management during implementation.
@@ -87,7 +86,7 @@ Use Linear MCP's `list_teams` (if configured) to get all workspace teams for val
 
 ## Diagram Consideration
 
-For multi-file or multi-service changes, consider adding architecture diagrams to the session file.
+For multi-file or multi-service changes, consider adding architecture diagrams to the linked spec, report, ADR, or implementation notes.
 
 ### When to Create Diagrams
 
@@ -106,7 +105,7 @@ Ask yourself:
 2. Is there a data flow that needs to be understood?
 3. Would a visual help communicate the approach?
 
-If yes to any, add an `## Architecture Diagrams` section to the session file.
+If yes to any, capture the diagram in a durable artifact such as a spec, report, ADR, or implementation note, and log the reference with `loaf session log`.
 
 ### Diagram Template
 
@@ -144,7 +143,7 @@ For complex tasks, explore before implementing:
 1. Use Task(Explore) or Task(Plan) to investigate codebase
 2. Map existing patterns and conventions
 3. Identify integration points
-4. Document findings in session file
+4. Log findings with `loaf session log` and reference durable artifacts
 5. Present approach to user for approval before spawning
 ```
 
@@ -193,12 +192,12 @@ never implement through open `blockedBy`.
 
 ## Handoff State Requirements
 
-**The session file must ALWAYS be handoff-ready.** After every significant action:
+**The session journal must ALWAYS be handoff-ready.** After every significant action:
 
-1. Update `## Current State` to reflect what just happened
-2. Update `orchestration.current_task` in frontmatter
+1. Log what just happened with `loaf session log`
+2. Reference task/spec/report/commit IDs rather than duplicating long prose
 3. Log completed agent work with outcomes
-4. Ensure anyone could pick up the work immediately
+4. Ensure anyone could pick up the work immediately from `loaf session show`
 
 ---
 
@@ -217,44 +216,6 @@ Generate with: `date -u +"%Y-%m-%d %H:%M UTC"`
 
 ---
 
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference.
-
-### Process
-
-1. **Get transcript path** from Cursor output after compaction
-2. **Create transcripts directory** if needed:
-   ```bash
-   mkdir -p .agents/transcripts
-   ```
-3. **Copy transcript** with descriptive name:
-   ```bash
-   cp /path/to/transcript.jsonl .agents/transcripts/YYYYMMDD-HHMMSS-description.jsonl
-   ```
-4. **Update session frontmatter**:
-   ```yaml
-   transcripts:
-     - 20260123-143500-pre-compact.jsonl
-   ```
-
-### When to Archive
-
-| Event | Action |
-|-------|--------|
-| Before `/compact` | Archive current transcript |
-| Before `/clear` | Archive current transcript |
-| Session end | Archive final transcript |
-
-### Benefits
-
-- **Audit trail** - Full history of decisions and work
-- **Knowledge extraction** - Mining past sessions for patterns
-- **Debugging** - Understanding how errors occurred
-- **Training** - Learning from past sessions
-
----
-
 ## Task Completion
 
 When a task-coupled session completes:
@@ -267,7 +228,7 @@ When a task-coupled session completes:
      `list_issues` with `parent: <parent-id>`; if all are `completed`-type,
      close the parent and mark the local spec `complete`, else both stay
      in flight
-3. **Archive session** (standard process)
+3. **Wrap session** with `loaf session end --wrap`; archive with `loaf session archive` when the work is closed
 
 ### Spec Completion Check
 

--- a/dist/cursor/skills/implement/templates/session.md
+++ b/dist/cursor/skills/implement/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/cursor/skills/orchestration/SKILL.md
+++ b/dist/cursor/skills/orchestration/SKILL.md
@@ -26,12 +26,12 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 ## Critical Rules
 
 ### Sessions
-- Create following [session template](templates/session.md) — compact inline journal format
-- Use `loaf session log` for journal entries: `decide(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
+- Start or resume with `loaf session start`; SQLite is the operational source.
+- Use `loaf session log` for journal entries: `decision(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
 - **SESSION JOURNAL NUDGE**: When you see this hook trigger, log unrecorded decisions or findings before responding. Use `loaf session log "entry(scope): description"`. Only log actions (decisions made, things discovered, conclusions reached) — not thoughts or read-only work.
-- Archive when complete (status + `archived_at` + `archived_by` + move to `.agents/sessions/archive/`)
-- PreCompact hook: appends `compact` entry with context summary
-- Post-compaction: `loaf session start` outputs recent journal entries for recovery
+- Wrap with `loaf session end --wrap`; archive with `loaf session archive` when complete.
+- PreCompact hook: flushes journal-worthy state before compaction.
+- Post-compaction: `loaf session start` and `loaf session show` expose recent journal context for recovery.
 
 ### Councils
 - Always odd number: 5 or 7 agents
@@ -56,7 +56,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 ## Verification
 
-- Validate session files with `validate-session.py` before archiving
+- Verify `loaf session list --json` / `loaf session show <ref> --json` reflect the active work before archiving
 - Validate council files with `validate-council.py` before concluding
 - Confirm Linear issue updates are self-contained (no local paths, no emoji)
 
@@ -64,7 +64,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 | Task | Action |
 |------|--------|
-| Multi-step work | Create session file, spawn agents |
+| Multi-step work | Start/resume session, spawn agents |
 | Complex decision | Convene council (5-7 agents, odd) |
 | Linear update | Checkboxes, no emoji, no local paths |
 | Feature planning | Size by complexity, shape before building |
@@ -86,7 +86,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 | background agent Development | [references/background agent-development.md](references/background agent-development.md) | Delegating to specialized agents |
 | Background Agents | [references/background-agents.md](references/background-agents.md) | Running non-interactive work in background |
 | Council Workflow | [references/councils.md](references/councils.md) | Convening councils for complex decisions |
-| Session Management | [references/sessions.md](references/sessions.md) | Creating sessions and keeping live work resumable |
+| Session Management | [references/sessions.md](references/sessions.md) | Starting sessions and keeping live work resumable |
 | Session Resume | [references/session-resume.md](references/session-resume.md) | Resuming sessions, checkpoints, context recovery |
 | Context Management | [references/context-management.md](references/context-management.md) | Using /clear, /compact, managing context limits |
 | Linear Integration | [references/linear.md](references/linear.md) | Updating Linear issues, magic words, status conventions |
@@ -98,7 +98,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 **You are the orchestrator, not the implementer.**
 
 The orchestrator:
-1. Creates issues and session files for tracking
+1. Creates issues and starts sessions for tracking
 2. Breaks down work into delegable tasks
 3. Spawns specialized agents for implementation
 4. Coordinates outcomes and updates external systems
@@ -113,7 +113,6 @@ This skill uses paths from `.agents/loaf.json`:
 ```json
 {
   "sessions": {
-    "directory": ".agents/sessions",
     "councils_directory": ".agents/councils"
   },
   "linear": {
@@ -128,9 +127,8 @@ This skill uses paths from `.agents/loaf.json`:
 
 | Artifact | Location | Archive | Naming |
 |----------|----------|---------|--------|
-| Sessions | `.agents/sessions/` | `.agents/sessions/archive/` | `YYYYMMDD-HHMMSS-description.md` |
+| Sessions | SQLite (`loaf session show`) | `loaf session archive` | CLI alias / session ID |
 | Councils | `.agents/councils/` | `.agents/councils/archive/` | `YYYYMMDD-HHMMSS-topic.md` |
-| Transcripts | `.agents/transcripts/` | N/A | Copied from tool output |
 | Handoffs | `.agents/handoffs/` | delete after deprecated | Created by `/handoff` |
 | Reports | `.agents/reports/` | N/A | `YYYYMMDD-HHMMSS-subject.md` |
 | Tasks | `.agents/tasks/` | N/A | Per task manager conventions |
@@ -141,16 +139,16 @@ This skill uses paths from `.agents/loaf.json`:
 
 ### BEFORE (Planning)
 - Create/check external issue (Linear, GitHub)
-- Create session file following [session template](templates/session.md)
+- Run `loaf session start` and log the orchestration intent
 - Break down into tasks, identify agents, get user approval
 
 ### DURING (Execution)
 - Spawn specialized agents (never implement directly)
-- Track progress in session file and external issue
+- Track progress with `loaf session log` and external issue updates
 - Convene councils for uncertain decisions
 
 ### AFTER (Completion)
 - Code review + QA testing
 - Update external issue to Done
 - Ensure knowledge captured in permanent locations
-- Archive session (status + `archived_at` + `archived_by` + move + update links)
+- Run `loaf session end --wrap`; archive with `loaf session archive` after merge/closure

--- a/dist/cursor/skills/orchestration/references/background-agents.md
+++ b/dist/cursor/skills/orchestration/references/background-agents.md
@@ -1,12 +1,13 @@
 # Background Agents
 
-Background agents handle low-priority, long-running, or non-interactive work that can run independently while the user continues with other tasks.
+Background agents handle low-priority, long-running, or non-interactive work
+while the user continues with other tasks.
 
 ## Contents
 
 - When to Use Background Agents
 - Spawning Background Agents
-- Background Agent Tracking
+- Tracking
 - Result Retrieval
 - Workflow Example
 - Anti-Patterns
@@ -19,20 +20,11 @@ Background agents handle low-priority, long-running, or non-interactive work tha
 | Security audits | Interactive debugging |
 | Code coverage analysis | User-facing questions |
 | Large-scale refactoring reports | Time-sensitive fixes |
-| Codebase-wide linting reports | Tasks requiring immediate feedback |
 | Documentation audits | Work needing user decisions mid-task |
 | Dependency vulnerability scans | Blocking tasks for current work |
 
-**Good candidates:**
-- Results can be processed later
-- No user interaction required
-- Task is well-defined with clear completion criteria
-- Output is a report or artifact, not a conversation
-
-**Poor candidates:**
-- Needs clarification mid-task
-- Time-sensitive (user waiting for result)
-- Requires real-time coordination with other agents
+Good candidates have clear completion criteria, can run without clarification,
+and produce a report or durable artifact.
 
 ## Spawning Background Agents
 
@@ -51,8 +43,7 @@ Task(
     - src/services/
 
     Write report to: .agents/reports/YYYYMMDD-HHMMSS-security-audit.md
-
-    Session: .agents/sessions/20260123-143000-auth-feature.md
+    Active session: SESSION-ALIAS if available from loaf session list/show
     """,
     run_in_background=True
 )
@@ -60,187 +51,57 @@ Task(
 
 ### Cursor
 
-Background agents are configured via the `is_background: true` YAML property. When spawning:
+Background agents are configured via the `is_background: true` YAML property.
+When spawning, specify the report destination and any task/spec/session IDs:
 
 ```
 @background-runner Run security audit on backend codebase.
-Write report to .agents/reports/
+Write report to .agents/reports/.
+Reference TASK-123 and the active session alias if available.
 ```
 
-## Background Agent Tracking
+## Tracking
 
-Track background agents in session frontmatter:
+Track background work with durable references:
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security-scan"
-    agent: background-runner
-    task: "Full security audit of backend"
-    status: running  # running | completed | failed
-    result_location: null
-  - id: "bg-20260123-144500-coverage"
-    agent: background-runner
-    task: "Test coverage analysis"
-    status: completed
-    result_location: ".agents/reports/20260123-144500-coverage-report.md"
-```
+1. Log the spawn with `loaf session log "todo(background): started <id> for <task>"`.
+2. Ask the background agent to write a report under `.agents/reports/`.
+3. When complete, log `discover(background): <id> wrote <report>`.
+4. Process findings into tasks, specs, ADRs, or report verdicts as appropriate.
 
-### Status Values
-
-| Status | Meaning |
-|--------|---------|
-| `running` | Agent still executing |
-| `completed` | Work finished, results available |
-| `failed` | Agent encountered error |
-
-### ID Convention
-
-Background agent IDs follow: `bg-YYYYMMDD-HHMMSS-<description>`
-
-Generate with:
-```bash
-echo "bg-$(date -u +"%Y%m%d-%H%M%S")-<description>"
-```
+Use a stable ID such as `bg-YYYYMMDD-HHMMSS-description` in the prompt and
+journal entries.
 
 ## Result Retrieval
 
-Background agents write results to `.agents/reports/` with standard frontmatter:
-
-```yaml
----
-report:
-  title: "Security Audit Report"
-  type: background-agent-output
-  status: unprocessed  # unprocessed | processed | archived
-  created: "2026-01-23T14:30:00Z"
-  background_agent_id: "bg-20260123-143000-security-scan"
-  session_reference: "20260123-140000-auth-feature.md"
----
-```
-
-### Processing Results
-
-1. SessionStart hook alerts user to completed background work
-2. User or orchestrator reviews report in `.agents/reports/`
-3. Orchestrator updates session frontmatter:
-   - Change `status` from `running` to `completed`
-   - Set `result_location` to report path
-4. Process findings as needed (spawn agents, create issues)
-5. Set report `status` to `processed`
+Background agents write results to `.agents/reports/` with enough metadata to
+identify the source task and report status. In SQLite-backed projects, use
+`loaf report list`, `loaf report show`, and `loaf report archive` when report
+state is available.
 
 ## Workflow Example
 
-### 1. Orchestrator Identifies Low-Priority Work
-
-During auth feature implementation, orchestrator identifies need for security audit but it is not blocking current work.
-
-### 2. Orchestrator Spawns Background Agent
-
-```python
-Task(
-    agent_type="background-runner",
-    prompt="""
-    Run comprehensive security audit on auth implementation.
-
-    Files to audit:
-    - src/auth/endpoints.py
-    - src/auth/token.py
-    - src/auth/middleware.py
-
-    Check for:
-    - OWASP Top 10 vulnerabilities
-    - Secrets in code
-    - SQL injection risks
-    - Authentication bypasses
-
-    Write report to: .agents/reports/20260123-143000-auth-security.md
-
-    Session: .agents/sessions/20260123-140000-auth-feature.md
-    """,
-    run_in_background=True
-)
-```
-
-### 3. Orchestrator Updates Session Frontmatter
-
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-auth-security"
-    agent: background-runner
-    task: "Auth security audit"
-    status: running
-    result_location: null
-```
-
-### 4. Work Continues
-
-Orchestrator and other agents continue with main implementation while background agent works.
-
-### 5. Session Resumes Later
-
-SessionStart hook detects completed background work:
-
-```
-# Background Work Completed
-
-The following background agents have completed:
-
-- **bg-20260123-143000-auth-security** (background-runner)
-  - Task: Auth security audit
-  - Result: .agents/reports/20260123-143000-auth-security.md
-
-Review reports and update session frontmatter after processing.
-```
-
-### 6. Results Processed
-
-Orchestrator reads report, creates issues for findings, updates session.
+1. Orchestrator identifies non-blocking security audit work.
+2. Orchestrator logs the background spawn in the active session.
+3. Background agent writes `.agents/reports/YYYYMMDD-HHMMSS-auth-security.md`.
+4. Orchestrator reviews the report, creates follow-up tasks, and logs the
+   outcome.
+5. Report state is finalized or archived through the report lifecycle.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
 | Use for blocking work | Keep blocking work in foreground |
-| Spawn without tracking | Always update session frontmatter |
-| Ignore completed results | Process results when alerted |
+| Spawn without tracking | Log the spawn and require a report path |
+| Ignore completed results | Process reports into tasks, findings, or decisions |
 | Use for interactive tasks | Reserve for autonomous work |
-| Spawn many concurrent background agents | Limit to 2-3 to avoid resource contention |
-| Skip result location in prompt | Always specify where to write output |
+| Spawn many concurrent background agents | Limit concurrency to avoid resource contention |
+| Skip result location in prompt | Always specify where output belongs |
 
 ## Integration Points
 
-### SessionStart Hook
-
-Checks session frontmatter for `background_agents` with `status: completed`. Alerts user to review results.
-
-### PreCompact Hook
-
-Includes background agent state in preservation. PreCompact hook captures:
-- Active background agent list
-- Current status of each
-- Result locations for completed agents
-
-### Session Frontmatter
-
-Full template with background agents:
-
-```yaml
----
-session:
-  title: "Feature implementation"
-  status: in_progress
-  # ... other session fields ...
-
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: completed
-    result_location: ".agents/reports/20260123-143000-security.md"
-  - id: "bg-20260123-150000-coverage"
-    agent: background-runner
-    task: "Coverage analysis"
-    status: running
-    result_location: null
----
-```
+- `loaf session log` records spawn and completion facts.
+- `loaf session show` exposes recent background-work journal entries.
+- `loaf report` commands own durable report lifecycle when available.
+- `/wrap` should mention unprocessed background reports before ending a session.

--- a/dist/cursor/skills/orchestration/references/context-management.md
+++ b/dist/cursor/skills/orchestration/references/context-management.md
@@ -1,54 +1,34 @@
 # Context Management
 
-Patterns for managing context efficiently across sessions and agent spawns.
+Patterns for keeping long work resumable while using SQLite-backed session
+journals as the external memory.
 
 ## Contents
 
 - Design for Compaction
-- Overview
 - Context Commands
 - When to Clear Context
-- The 2-Correction Rule
-- Context Compaction
-- Session Files as Context Anchors
+- Compaction Lifecycle
 - background agent for Context Isolation
 - Context Budget Guidelines
-- Preventing Context Bloat
-- Session Context Patterns
 - Warning Signs
 - Best Practices
 
 ## Design for Compaction
 
-Compaction is a normal part of long workflows, not an emergency measure. Any workflow expected to exceed 15-20 exchanges should be designed with compaction in mind from the start.
+Compaction is a normal part of long workflows. Design any workflow expected to
+span many exchanges so important state is already outside chat context.
 
 ### Compaction-First Principles
 
-1. **The journal IS external memory** — Session journal entries (decisions, discoveries, progress) survive compaction. Compaction can be lossy because all important state is already on disk.
-2. **`## Current State` is the resumption context** — Keep this section handoff-ready at all times. The PreCompact hook requires writing a state summary here before compaction.
-3. **Decisions go to disk, not context** — Record key decisions in the session journal immediately via `loaf session log`. Context may be compressed; journal entries persist.
-4. **background agent absorb exploration** — Investigation and exploration should happen in background agent. Only the summary returns to the main context.
-
-### Compaction Lifecycle
-
-```
-PreCompact:
-  1. Flush all unrecorded journal entries (decisions, discoveries, progress)
-  2. Write condensed state summary to session file's ## Current State
-  3. compact.sh writes compact(session) marker to journal
-
-PostCompact:
-  1. PostCompact nudge fires — tells model to read session file
-  2. Model reads ## Current State for resumption context
-  3. Model reads ## Journal for decision trail
-  4. Work resumes without "where were we?"
-```
-
-This makes compaction invisible to workflow continuity. The session file's `## Current State` section is the resumption prompt — written by the model before compaction, read by the model after.
-
-## Overview
-
-Context is finite. Long conversations accumulate irrelevant information that degrades performance. Active context management keeps conversations focused and effective.
+1. **The journal is external memory.** Record decisions, discoveries, blockers,
+   and next actions with `loaf session log`.
+2. **Artifacts carry detail.** Specs, tasks, reports, ADRs, and commits hold rich
+   detail; journal entries point to them.
+3. **background agent absorb exploration.** Use background agent for broad investigation and
+   return concise findings to the main context.
+4. **`wrap` closes the loop.** End meaningful work with `loaf session end --wrap`
+   so the session lifecycle matches the journal.
 
 ## Context Commands
 
@@ -60,191 +40,78 @@ Context is finite. Long conversations accumulate irrelevant information that deg
 
 ## When to Clear Context
 
-### Clear Between Tasks
-
 Use `/clear` when:
 
 - Starting a completely new task
-- Previous task is fully complete
-- Context has become cluttered with failed attempts
+- Previous task is complete
+- Debugging noise is crowding out the current objective
 - Switching between unrelated codebases
 
-### Don't Clear When
+Avoid clearing mid-task until you have logged enough state for recovery.
 
-- Mid-task and need previous context
-- Debugging requires understanding of prior attempts
-- Session file provides necessary handoff information
-
-## The 2-Correction Rule
-
-**If Claude makes the same mistake twice after correction, the context may be polluted.**
-
-Signs of context pollution:
-- Repeating errors you've already corrected
-- Ignoring instructions you've given
-- Reverting to patterns you've explicitly rejected
-- Confusion about current task state
-
-**Action:** Consider `/clear` and restart with fresh context, referencing session file for state.
-
-## Context Compaction
-
-Use `/compact` when:
-- Conversation is long but task continues
-- Need to preserve key decisions while reducing noise
-- Approaching context limits
-
-**Journal entries are compaction insurance.** Every `loaf session log` call writes state to disk that survives compaction. Don't defer journaling — entries not flushed before compaction are lost.
-
-### What Compaction Preserves (via session file)
-
-- Journal entries: decisions, discoveries, progress, commits
-- `## Current State` summary (written by PreCompact)
-- All externalized artifacts: specs, tasks, ideas, code
-
-### What Compaction Discards
-
-- Intermediate exploration steps
-- Failed attempts and debugging noise
-- Verbose tool output
-- Redundant explanations
-
-## Session Files as Context Anchors
-
-Session files provide persistent context that survives `/clear`:
-
-```markdown
-## Current State
-[Always handoff-ready summary]
-
-## Key Decisions
-- Chose X over Y because Z
-
-## Next Steps
-- Immediate action items
-```
-
-### Pattern: Clear + Resume
+## Compaction Lifecycle
 
 ```
-1. Update session file with current state
-2. /clear to reset context
-3. /resume to reload from session file
-4. Continue with clean context
+PreCompact:
+  1. Flush unrecorded decisions, discoveries, blockers, and next actions
+  2. Reference specs, tasks, reports, commits, and files by stable ID/path
+  3. Let the hook persist the compact marker
+
+PostCompact:
+  1. Run or inspect `loaf session start` output for the active branch
+  2. Use `loaf session show <session-ref> --json` when more context is needed
+  3. Continue from the journal and linked artifacts
 ```
+
+This makes compaction survivable without relying on hand-maintained markdown
+state. Any state not logged or captured in a durable artifact can be lost.
 
 ## background agent for Context Isolation
 
-Use background agent (background agent) to investigate without polluting main context:
-
-```
-# Instead of exploring in main conversation:
-Let me look at how auth works...
-[reads 10 files, fills context]
-
-# Use background agent for investigation:
-Task(Explore, "How does authentication work in this codebase?")
-[returns focused summary, main context stays clean]
-```
-
-### When to Use background agent
+Use background agent to investigate without filling the main context:
 
 | Situation | Approach |
 |-----------|----------|
-| Quick file lookup | Direct Read tool |
-| Multi-file exploration | Task(Explore) |
-| Implementation work | Task(implementer) |
-| Complex investigation | Task(Plan) then implement |
+| Quick file lookup | Direct read/search tool |
+| Multi-file exploration | Explorer/research background agent |
+| Implementation work | Implementer or task-focused agent |
+| Long audit | Background agent with report output |
+
+Pass stable references to background agent: task IDs, spec IDs, branch names, report
+paths, and the active session alias when available.
 
 ## Context Budget Guidelines
 
-### Short Conversations (< 10 exchanges)
+### Short Conversations
 
-- No management needed
-- Context stays fresh naturally
+No special management is usually needed.
 
-### Medium Conversations (10-30 exchanges)
+### Medium Conversations
 
-- Consider `/compact` at midpoint
-- Delegate investigations to background agent
-- Keep session file updated
+- Log decisions as they happen.
+- Delegate broad searches.
+- Keep tool output scoped.
 
-### Long Conversations (30+ exchanges)
+### Long Conversations
 
-- `/compact` every 15-20 exchanges
-- Heavy use of background agent for exploration
-- Session file as primary state holder
-- Consider `/clear` + restart if degraded
-
-## Preventing Context Bloat
-
-### Minimize Tool Output
-
-```
-# Instead of reading entire large files:
-Read(file, limit=50)  # Read first 50 lines
-
-# Instead of globbing everything:
-Glob("src/**/*.py", path="src/auth/")  # Scoped search
-```
-
-### Focused Queries
-
-```
-# Instead of "show me all the code":
-"Find where user authentication is validated"
-
-# Instead of exploring blindly:
-"What files handle the /api/users endpoint?"
-```
-
-### Progressive Disclosure
-
-1. Get overview first (symbols, structure)
-2. Drill into specific areas
-3. Read full content only when needed
-
-## Session Context Patterns
-
-### Starting a Session
-
-```
-1. Create session file (minimal context recorded)
-2. Break down task (decisions recorded)
-3. Spawn first agent (isolated context)
-4. Update session (state persisted)
-```
-
-### Mid-Session Context Check
-
-Every 10-15 exchanges, assess:
-- [ ] Is context still focused on current task?
-- [ ] Are previous decisions still relevant?
-- [ ] Has debugging noise accumulated?
-- [ ] Would `/compact` help?
-
-### Session Handoff
-
-When pausing or handing off:
-1. Update session file with complete state
-2. Include "resumption notes" for context
-3. Reference key files and decisions
-4. Clear main context if long
+- Expect compaction.
+- Keep the journal current.
+- Use reports or handoffs for rich summaries rather than stuffing prose into the
+  session journal.
 
 ## Warning Signs
 
 | Symptom | Likely Cause | Action |
 |---------|--------------|--------|
-| Repeating same mistakes | Context pollution | `/clear` + restart |
-| Forgetting recent decisions | Overcrowded context | `/compact` |
-| Slow responses | Large context | Use background agent |
-| Confusion about task | Too many pivots | Update session, `/clear` |
+| Repeating same mistakes | Context pollution | Log current facts, then clear or compact |
+| Forgetting recent decisions | Overcrowded context | Inspect `loaf session show` and continue from journal |
+| Slow responses | Large context | Delegate exploration |
+| Confusion about task | Too many pivots | Re-anchor on task/spec/session IDs |
 
 ## Best Practices
 
-1. **Update session files continuously** - they survive context resets
-2. **Use background agent for exploration** - keep main context clean
-3. **Clear between unrelated tasks** - fresh start beats polluted context
-4. **Compact mid-task if needed** - preserve decisions, discard noise
-5. **Monitor for pollution** - 2-correction rule catches degradation early
-6. **Scope tool calls** - don't read entire codebases into context
+1. Log durable facts early with `loaf session log`.
+2. Use background agent for exploration-heavy work.
+3. Clear between unrelated tasks.
+4. Compact mid-task when the journal and artifacts are current.
+5. Scope tool calls so context stays focused.

--- a/dist/cursor/skills/orchestration/references/cross-session.md
+++ b/dist/cursor/skills/orchestration/references/cross-session.md
@@ -135,7 +135,7 @@ When sessions are archived, decisions are extracted to Serena memory:
 
 1. `loaf session end --wrap` persists decisions to spec changelog
 2. Session stays in `sessions/` with `status: done` — no immediate archive
-3. `loaf session housekeeping` archives complete sessions after 7-day age threshold
+3. `loaf housekeeping` reports stale compatibility artifacts, and `loaf session archive` archives closed SQLite sessions when work is complete
 
 ### At Reference Time (spec changelog)
 

--- a/dist/cursor/skills/orchestration/references/product-development.md
+++ b/dist/cursor/skills/orchestration/references/product-development.md
@@ -11,7 +11,6 @@ A Research → Vision → Architecture → Requirements → Specs → Tasks → 
 - Configuration
 - Workflow Examples
 - Feedback Loops
-- Transcript Archival
 - Flexibility Preserved
 - Critical Files
 
@@ -33,10 +32,9 @@ docs/                               # Permanent project knowledge
 
 .agents/                            # Ephemeral orchestration
 ├── loaf.yaml                       # Project config (task backend, etc.)
-├── sessions/                       # Active work contexts
+├── sessions/                       # Compatibility/rendered session views
 ├── plans/                          # Implementation plans
 ├── councils/                       # Deliberation records
-├── transcripts/                    # Archived conversation transcripts
 ├── tasks/                          # Local tasks (when not using Linear)
 │   ├── active/
 │   │   └── TASK-001-oauth-provider.md
@@ -71,7 +69,7 @@ RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS → SE
 | `/architecture` | Decision question | ARCHITECTURE.md + ADR | Technical decisions |
 | `/shape` | Feature area or requirement | Spec in .agents/specs/ | Implementation-ready specification with boundaries |
 | `/breakdown` | Spec | Tasks in .agents/tasks/ | Atomic work items for agents |
-| `/implement` | TASK-ID | Session file | Execute a task |
+| `/implement` | TASK-ID | SQLite session + implementation commits | Execute a task |
 
 ## Document Formats
 
@@ -187,7 +185,7 @@ docs:
 
 # 6. Work on tasks
 /implement TASK-001
-# → Session → Implementation → Done
+# → SQLite session → Implementation → Done
 ```
 
 ### Quick Fix (Ad-hoc)
@@ -197,7 +195,7 @@ docs:
 /implement TASK-099
 # Orchestrator: "No parent spec. Proceed?"
 # User: "Yes, small fix"
-# → Session → Fix → Done
+# → SQLite session → Fix → Done
 ```
 
 ## Feedback Loops
@@ -210,23 +208,6 @@ The workflow is not rigid. Each level can feed back to higher levels:
 | Edge case invalidates requirement | Update REQUIREMENTS.md |
 | Spec too complex for its size | Re-scope or split |
 | Task reveals missing requirement | Add to REQUIREMENTS.md |
-
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference:
-
-1. **Copy transcript** to `.agents/transcripts/`
-2. **Link from session file** in frontmatter:
-
-```yaml
-session:
-  title: "Feature Implementation"
-  transcripts:
-    - 20260123-143500-pre-compact.jsonl
-    - 20260123-160000-final.jsonl
-```
-
-This preserves full context for debugging, knowledge extraction, and audit trails.
 
 ## Flexibility Preserved
 

--- a/dist/cursor/skills/orchestration/references/session-resume.md
+++ b/dist/cursor/skills/orchestration/references/session-resume.md
@@ -1,15 +1,15 @@
 # Session Resume Patterns
 
-Patterns for resuming work across Cursor sessions using CLI flags and session files.
+Patterns for resuming work with CLI conversation history plus SQLite-backed
+Loaf session state.
 
 ## Contents
 
 - CLI Resume Flags
 - Resume Methods
 - When to Use Each Method
-- Session File as Resume Checkpoint
+- SQLite Session as Resume Checkpoint
 - Checkpoint Pattern
-- Naming Sessions Descriptively
 - Context Recovery Strategies
 - Handling Stale Sessions
 - Multi-Session Coordination
@@ -17,7 +17,7 @@ Patterns for resuming work across Cursor sessions using CLI flags and session fi
 
 ## CLI Resume Flags
 
-Cursor provides built-in session continuation:
+Some harnesses provide built-in conversation continuation:
 
 | Flag | Purpose |
 |------|---------|
@@ -25,217 +25,113 @@ Cursor provides built-in session continuation:
 | `--resume <id>` | Resume a specific conversation by ID |
 | `/resume` | In-session command to list and resume |
 
+Use harness resume for chat history. Use `loaf session` for operational state.
+
 ## Resume Methods
 
-### Method 1: CLI Continue
+### Method 1: Conversation Continue
+
+Resume the exact conversation when you need full chat history.
+
+### Method 2: SQLite Session Resume
+
+Start fresh and recover operational state:
 
 ```bash
-# Continue most recent conversation
-claude --continue
-
-# Resume specific conversation
-claude --resume abc123
+loaf session start
+loaf session list --all --json
+loaf session show <session-ref> --json
 ```
 
-**Best for:** Picking up exactly where you left off with full context.
-
-### Method 2: Session File Resume
-
-```bash
-# Start new conversation, resume from session file
-claude
-> /resume 20250123-143000-feature-auth
-```
-
-**Best for:** Fresh context but task continuity from session file.
+Best for clean context with task continuity.
 
 ### Method 3: Hybrid Resume
 
-```bash
-# Continue conversation AND sync with session file
-claude --continue
-> Check session file for any updates: .agents/sessions/20250123-143000-feature-auth.md
-```
-
-**Best for:** Recovering from context pollution while preserving conversation history.
+Continue the conversation, then compare it against `loaf session show` output.
+Best when chat history matters but the journal may contain newer facts.
 
 ## When to Use Each Method
 
 | Situation | Recommended Method |
 |-----------|-------------------|
-| Short break, same task | `--continue` |
-| Long break, clean state needed | Session file resume |
+| Short break, same task | Conversation continue |
+| Long break, clean state needed | SQLite session resume |
 | Context polluted but need history | Hybrid resume |
-| Different machine | Session file resume |
-| Handoff to another person | Session file resume |
+| Different machine | SQLite session resume |
+| Handoff to another person | SQLite session + handoff/report |
 
-## Session File as Resume Checkpoint
+## SQLite Session as Resume Checkpoint
 
-### Writing Resume-Ready State
+Before ending or compacting:
 
-Before ending a session, ensure session file contains:
-
-```markdown
-## Current State
-**Last Action:** Completed API endpoint implementation
-**Pending:** Tests need to be written
-
-## Resumption Notes
-- Branch: feature/auth-endpoints
-- Key files modified: src/auth/routes.py, src/auth/models.py
-- Tests to write: test_login, test_logout, test_refresh
-- Blocker: None
-
-## Next Steps
-1. Spawn QA agent for test implementation
-2. Run full test suite
-3. Update API documentation
-```
-
-### Reading Resume State
+1. Log last action, blockers, and next steps with `loaf session log`.
+2. Reference tasks, specs, reports, commits, and branch names by stable ID/path.
+3. Run `loaf session end --wrap` when work is complete.
 
 When resuming:
 
-1. Read session file for context
-2. Check `## Current State` for where you left off
-3. Check `## Resumption Notes` for key details
-4. Check `## Next Steps` for immediate actions
-5. Verify branch and file state match expectations
+1. Run `loaf session start` on the branch/worktree.
+2. Inspect `loaf session show <session-ref> --json`.
+3. Verify branch and file state match expectations.
+4. Continue from the next logged action.
 
 ## Checkpoint Pattern
 
-For long-running tasks, create explicit checkpoints:
-
-```markdown
-## Checkpoints
-
-### Checkpoint 1: Schema Complete
-**Timestamp:** 2025-01-23T14:30:00Z
-**State:** Database schema implemented and migrated
-**Can resume from:** This checkpoint if later work fails
-
-### Checkpoint 2: API Complete
-**Timestamp:** 2025-01-23T15:45:00Z
-**State:** All endpoints implemented, passing basic tests
-**Can resume from:** This checkpoint for test expansion
-```
-
-### Rewind to Checkpoint
-
-If work goes wrong:
-
-1. Identify safe checkpoint
-2. `git checkout <commit>` to restore code state
-3. Update session file to checkpoint state
-4. `/clear` to reset context
-5. Resume from checkpoint
-
-## Naming Sessions Descriptively
-
-Good session names aid resume:
-
-```
-# Good - descriptive, searchable
-20250123-143000-auth-jwt-implementation.md
-20250123-160000-api-rate-limiting.md
-
-# Bad - generic, hard to find
-20250123-143000-feature.md
-20250123-160000-fix.md
-```
-
-### Rename Pattern
+For long-running tasks, create explicit journal checkpoints:
 
 ```bash
-# If session name becomes unclear, rename for clarity
-mv .agents/sessions/20250123-143000-feature.md \
-   .agents/sessions/20250123-143000-user-auth-oauth.md
+loaf session log "decision(checkpoint): schema complete at <commit>"
+loaf session log "decision(checkpoint): API complete; next write tests"
 ```
 
-Update any references in Linear or other sessions.
+If work goes wrong, use Git to restore code state and log the reconciliation:
+
+```bash
+loaf session log "decision(recovery): rewound to <commit>; replaying tests"
+```
 
 ## Context Recovery Strategies
 
-### Strategy 1: Full Replay
+### Full Replay
 
-For complex state, replay key decisions:
+Use `loaf session show` plus ADR/spec/report links for complex state.
 
-```markdown
-## Decision Replay
+### Minimal Context
 
-When resuming, recall these decisions:
-1. Chose JWT over sessions (see ADR-007)
-2. Using Redis for token storage
-3. 15-minute access token expiry
-```
+Use the last few journal entries when the next action is obvious.
 
-### Strategy 2: Minimal Context
+### Reference Chain
 
-For simple continuation:
+For multi-session work, log relationships:
 
-```markdown
-## Minimal Resume Context
-
-Branch: feature/auth
-Last commit: "feat: add login endpoint"
-Next: Write tests for login endpoint
-```
-
-### Strategy 3: Reference Chain
-
-For multi-session work:
-
-```markdown
-## Session Chain
-
-Previous sessions:
-- 20250122-100000-auth-design.md (planning)
-- 20250122-143000-auth-schema.md (database)
-- This session: API implementation
+```bash
+loaf session log "discover(context): previous design captured in SPEC-123 and ADR-007"
 ```
 
 ## Handling Stale Sessions
 
-### Signs of Stale Session
+Signs of stale session state:
 
-- Code has changed since session was active
-- Other sessions modified same files
+- Code changed after the last journal entry
 - Branch was rebased or merged
+- Another task/spec superseded the work
 
-### Stale Session Recovery
+Recovery:
 
-```
-1. Read session file for intended state
-2. Compare with actual code state (git diff)
-3. Identify conflicts or drift
-4. Update session file to reflect reality
-5. Plan reconciliation if needed
-```
+1. Inspect `loaf session show`.
+2. Compare with `git status`, `git log`, and relevant specs/tasks.
+3. Log the drift and reconciliation plan.
 
 ## Multi-Session Coordination
 
-When multiple sessions touch same codebase:
-
-```markdown
-## Related Sessions
-
-| Session | Status | Overlaps |
-|---------|--------|----------|
-| auth-backend | completed | src/auth/ |
-| auth-frontend | in_progress | src/components/auth/ |
-| This session | in_progress | src/auth/models.py (shared) |
-
-## Coordination Notes
-- Wait for auth-backend completion before modifying models
-- Sync with auth-frontend on API contract changes
-```
+When multiple sessions touch related areas, use specs/tasks/reports as the shared
+coordination layer. Session journals should point to those durable artifacts
+rather than becoming the only place a dependency is described.
 
 ## Best Practices
 
-1. **Update session before stopping** - capture state while fresh
-2. **Use descriptive names** - aid future resume
-3. **Create checkpoints** - safe rollback points
-4. **Note dependencies** - what must complete first
-5. **Clear stale context** - don't resume into pollution
-6. **Verify state on resume** - code may have changed
-7. **Document decision context** - not just decisions
+1. Log before stopping.
+2. Prefer stable IDs over pasted summaries.
+3. Use `loaf session show` as the operational resume surface.
+4. Keep chat-history resume separate from Loaf session state.
+5. Verify code state on resume.

--- a/dist/cursor/skills/orchestration/references/sessions.md
+++ b/dist/cursor/skills/orchestration/references/sessions.md
@@ -1,523 +1,116 @@
 # Session Management
 
-Sessions are coordination artifacts for active work. They are archived (set status, `archived_at`, `archived_by`, move to `.agents/sessions/archive/`) when work completes to preserve an audit trail.
+Sessions are SQLite-backed coordination records for active work. Markdown is a
+rendered view for reading or compatibility export; agents persist new facts with
+`loaf session` commands.
 
 ## Contents
 
-- Compact vs New Session
+- Core Model
 - When to Use Sessions
-- Session Types
-- Session File Format
-- Lifecycle States
-- Updating During Work
-- Session Continuity Protocol
-- Completing a Session
-- Start Protocol
+- Lifecycle
+- Journal Protocol
+- Continuity
+- Completion
 - Hook Integration
 - Anti-Patterns
 
-## Compact vs New Session
+## Core Model
 
-| Scenario | Action |
-|----------|--------|
-| Picking up previous work, same scope | Compact or resume existing conversation |
-| Switching to entirely different scope | New conversation (new session) |
-| Finished and archived a spec | New conversation |
-| Context full mid-task | Auto-compact (journal survives) |
-| Quick unrelated question | New conversation (don't pollute working session) |
+Use the `wrap` skill as the canonical session model:
 
-**Rule of thumb:** if you'd need the same session file, compact. If you'd need a different one, start fresh.
+1. `loaf session start` finds or creates the active session for the current branch
+   and prints resumption context.
+2. `loaf session log "type(scope): description"` writes durable journal rows.
+3. `loaf session show <session-ref> --json` reads the SQLite-backed session view.
+4. `loaf session end --wrap` persists the wrapped end state.
+5. `loaf session archive` archives closed sessions when the branch/work is done.
+
+The render format is documented in `templates/session.md`; it is not an
+instruction to author markdown directly.
 
 ## When to Use Sessions
 
-- Multi-step work requiring agent coordination
+- Multi-step work requiring coordination
 - Handoffs between agents
-- Tracking progress during implementation
-- Context preservation across agent spawns
+- Implementation or release work that must survive compaction
+- Long research, architecture, council, or review efforts
 
-## Session Types
+For quick unrelated questions, start a fresh conversation so the active session
+stays focused.
 
-### Implementation Sessions (Invisible)
+## Lifecycle
 
-When implementing tasks via `/implement TASK-XXX`:
+The interim runtime lifecycle before SPEC-049 is:
 
-- Session created automatically with filename `YYYYMMDD-HHMMSS-session.md`
-- Task file updated with `session:` field linking to session
-- No user interaction needed for session naming
-- Resume via `loaf session start` then `/implement TASK-XXX`
+| State | Source | Meaning |
+|-------|--------|---------|
+| `active` | `loaf session start` | Current work may receive journal entries |
+| `stopped` | `loaf session end` | Work paused or closed without wrap |
+| `done` | `loaf session end --wrap` | Wrapped work is complete |
+| `archived` | `loaf session archive` | Closed session preserved outside active list |
 
-Users work with tasks; sessions are an implementation detail.
+Do not introduce additional session vocabulary in guidance. SPEC-049 owns the
+durable status vocabulary.
 
-### Explicit Sessions
+## Journal Protocol
 
-For non-task work, sessions are still created explicitly:
-
-- Research sessions (`/research`)
-- Architecture decisions (`/architecture`)
-- Council deliberations (`/council`)
-
-These sessions may not have a linked task but still follow standard session format.
-
-## Session File Format
-
-**Link policy**: Documents outside `.agents/` must not reference `.agents/` files. Keep `.agents/` links contained within `.agents/` artifacts, and update them when files move to `.agents/<type>/archive/`.
-
-### Location & Naming
-
-```
-.agents/sessions/YYYYMMDD-HHMMSS-session.md
-```
-
-**Archive location:** `.agents/sessions/archive/`
-
-**Transcripts location:** `.agents/transcripts/`
-
-Transcripts are Cursor conversation exports (`.jsonl` files) archived after context compaction. They preserve the full audit trail of agent interactions.
-
-```
-.agents/
-├── sessions/
-│   ├── YYYYMMDD-HHMMSS-session.md
-│   └── archive/
-└── transcripts/              # Cursor transcripts
-    ├── 2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl
-    └── archive/
-```
-
-**Why keep original filenames:** The UUID-like hash is unique and matches Cursor's internal reference, making correlation easier if needed.
-
-**Generate timestamps:**
+Log compact, factual entries:
 
 ```bash
-# Filename timestamp
-date -u +"%Y%m%d-%H%M%S"
-
-# ISO timestamp (for YAML)
-date -u +"%Y-%m-%dT%H:%M:%SZ"
+loaf session log "decision(scope): chose X because Y"
+loaf session log "discover(scope): learned Z from file/path"
+loaf session log "block(scope): waiting on external approval"
+loaf session log "unblock(scope): approval received"
+loaf session log "spark(scope): possible follow-up idea"
+loaf session log "todo(scope): concrete follow-up action"
 ```
 
-### Naming Convention
+Log durable facts, not thoughts. The journal should let another agent resume
+without reading the whole conversation.
 
-All session files use the fixed format: `YYYYMMDD-HHMMSS-session.md`
+## Continuity
 
-The timestamp is the unique identifier. Descriptions, spec links, and branch names belong in frontmatter and the `# Session:` heading, not the filename. This keeps references stable — spec and task files can point to session filenames without them ever breaking.
+Before compaction, branch switches, or agent handoff:
 
-### Required Frontmatter
+1. Flush unrecorded decisions, discoveries, blockers, and next actions with
+   `loaf session log`.
+2. Use `loaf session show <session-ref> --json` to confirm the journal has the
+   required resumption context.
+3. Pass task IDs, spec IDs, report IDs, and commit refs rather than duplicating
+   large prose into the journal.
 
-```yaml
----
-session:
-  title: "Clear description of work"           # REQUIRED
-  status: in_progress                          # REQUIRED: in_progress|paused|completed|archived
-  created: "2025-12-04T14:30:00Z"              # REQUIRED: ISO 8601
-  last_updated: "2025-12-04T14:30:00Z"         # REQUIRED: ISO 8601
-  last_archived: "2025-12-04T16:00:00Z"        # Set by PreCompact hook before compaction
-  archive_reason: "pre-compact"                # Why archived (pre-compact, manual, etc.)
-  archived_at: "2025-12-04T18:10:00Z"          # Required when archived
-  task: TASK-001                               # If implementation work (links to .agents/tasks/)
-  linear_issue: "BACK-123"                     # Optional
-  linear_url: "https://linear.app/..."         # Optional
-  branch: "username/back-123-feature"          # Optional: working branch
-  transcripts: []                              # Archived Cursor transcripts (filenames only)
-                                               # Example: ["2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl"]
-  referenced_sessions: []                      # Cross-session references (see below)
+Background and delegated agents should receive the relevant task/spec/report
+references plus the active session alias when the caller has one.
 
-orchestration:
-  current_task: "What's actively being worked" # REQUIRED
-  spawned_agents:
-    - agent: implementer
-      task: "Brief task description"
-      status: completed                        # pending|in_progress|completed
-      summary: "Outcome summary"
+## Completion
 
-background_agents:                             # Background work running independently
-  - id: "bg-20260123-143000-security-scan"     # ID: bg-YYYYMMDD-HHMMSS-description
-    agent: background-runner                              # Agent type
-    task: "Full security audit"                # Brief description
-    status: running                            # running|completed|failed
-    result_location: null                      # Path to report when complete
----
-```
+When work is complete:
 
-### Cross-Session References
+1. Ensure decisions and discoveries are captured in durable homes such as ADRs,
+   specs, reports, or docs.
+2. Run `loaf session end --wrap` so the CLI persists the wrapped state.
+3. After merge or closure, use `loaf session archive` if the session should leave
+   the active list.
 
-Track decisions imported from past sessions via Serena memory:
-
-```yaml
-session:
-  # ... other fields ...
-  referenced_sessions:
-    - session: "20250115-140000-auth-jwt.md"     # Source session filename
-      imported_at: "2025-01-23T14:30:00Z"        # When imported
-      content_type: decisions                     # decisions|context|all
-      decisions_imported:                         # List of decision titles
-        - "JWT token rotation strategy"
-        - "Refresh token storage approach"
-    - session: "20250110-090000-auth-oauth.md"
-      imported_at: "2025-01-23T14:35:00Z"
-      content_type: context
-      summary: "OAuth provider integration patterns"
-```
-
-**Why track references:**
-
-- Audit trail of where context came from
-- Avoids re-importing same decisions
-- Enables tracing decision lineage across sessions
-
-See `references/cross-session.md` for full patterns.
-
-### Required Sections
-
-Every session file MUST have:
-
-1. **`## Context`** - Background for anyone picking up this work
-2. **`## Current State`** - Where we are now (MUST be handoff-ready)
-3. **`## Next Steps`** - Immediate actions for continuation
-
-### Session Template
-
-```markdown
-# Session: [Title]
-
-## Context
-Background for anyone picking up this work.
-What problem are we solving? Why now?
-
-## Current State
-Where we are right now. What just happened.
-**This section should ALWAYS be handoff-ready.**
-
-## Resumption Prompt
-
-<!-- Generated by PreCompact hook before compaction -->
-<!-- Provides self-contained context for post-compaction continuation -->
-
-> **Context**: [Brief description of work being done]
->
-> **Last Action**: [What just happened]
->
-> **Immediate Next**: [Concrete next step]
->
-> **Key Files**: [Relevant file paths]
->
-> **Blockers**: [Any blockers, or "None"]
->
-> **Transcript Archive**: If Cursor provided a transcript path after compaction,
-> copy it to `.agents/transcripts/` and add the filename to this session's
-> `transcripts:` array in frontmatter.
-
-## Execution Progress
-
-### Wave 1: [Name] (ACTIVE)
-- [ ] BACK-123 - Brief description
-- [x] BACK-124 - Brief description (completed)
-
-### Wave 2: [Name] (blocked by Wave 1)
-- [ ] BACK-125 - Brief description
-
-## Technical Context
-
-### Files to Update
-- `path/to/file.py` - What needs to change
-
-### Key Commands
-```bash
-pytest path/to/tests/ -v
-mypy path/to/code/
-```
-
-## Acceptance Criteria
-
-- [ ] Criterion 1
-- [ ] Criterion 2
-
-## Decisions
-
-### Decision 1: [Title]
-
-**Decision**: What was decided
-**Rationale**: Why
-
-## Architecture Diagrams
-
-### [Diagram Name]
-
-```mermaid
-[diagram content]
-```
-
-**Purpose**: Why this diagram helps understand the work
-**Files involved**: List of related file paths
-**Created**: When diagram was created (update if modified)
-
-<!--
-When to add diagrams:
-- Multi-service changes: Show interaction points
-- Data flow changes: Trace data through system
-- Schema modifications: Visualize relationships
-- API design: Document request/response flows
-
-For reusable diagrams, store in .agents/diagrams/ instead.
-See foundations skill reference/diagrams.md for Mermaid syntax.
--->
-
-## Council Outcomes
-
-### Council: [Topic]
-
-**Outcome**: Decision summary
-**Council File**: `.agents/councils/YYYYMMDD-HHMMSS-topic.md`
-**Next Steps**: Action items captured
-**Archive**: After this summary is captured, set council status to `archived`, set `archived_at`, set `archived_by`, and move to `.agents/councils/archive/` (archive indefinitely).
-
-## Reports Processed
-
-### Report: [Title]
-
-**Key Conclusions**: Summary of findings
-**Action Items**: What changed or will change
-**Report Output**: generated with `loaf report generate ...` or stored as an authored report when durable prose is needed.
-**Archive**: After report is processed and the linked session is archived, use `loaf report archive <report>` for SQLite-backed report state. Markdown report movement is compatibility/export handling.
-**Metadata**: Require enough state or frontmatter to identify status, linked session, and processing time. In SQLite-backed projects, CLI state is authoritative.
-**Note**: Reports without state/frontmatter metadata are treated as unprocessed compatibility artifacts.
-
-## Handoffs
-
-Explicit transfer packets belong to `/handoff`, which writes
-`.agents/handoffs/YYYYMMDD-HHMMSS-title.md`. Orchestration keeps live session
-state resumable; `/handoff` packages context for another agent, branch, task,
-or future session. `/housekeeping` deletes deprecated handoffs after
-confirmation.
-
-## Blockers
-
-- Current blocker (if any)
-
----
-
-## Session Log (Compact Inline Journal)
-
-Sessions use an **append-only structured journal** format — a running log of what happened, what was decided, and what's next. Think "conventional commits meets bullet journal."
-
-### Format
-
-```markdown
-## Journal
-
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-[YYYY-MM-DD HH:MM] decision(scope): description of decision
-[YYYY-MM-DD HH:MM] discover(scope): something learned
-
-[YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
-[YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
-[YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
-```
-
-### Entry Types
-
-| Type | Use For | Written By | Scope Convention |
-|------|---------|------------|------------------|
-| `resume(scope)` | Session started/resumed | Hook (auto) | Branch name |
-| `pause` | Session ended | Hook (auto) | — |
-| `commit(SHA)` | Code committed | Hook (auto) | Short SHA |
-| `pr(#N)` | PR created/updated | Hook (auto) | PR number |
-| `merge(#N)` | PR merged | Hook (auto) | PR number |
-| `decision(scope)` | Key decisions | Agent | Topic |
-| `discover(scope)` | Something learned | Agent | Topic |
-| `block(scope)` | Blocker encountered | Agent | Topic |
-| `unblock(scope)` | Blocker resolved | Agent | Topic |
-| `spark(scope)` | Ideas to promote | Agent | Topic |
-| `resolve(spark)` | Spark triaged via `/idea` | Agent/User | Spark slug → disposition [timestamp] |
-| `todo(scope)` | Action items | Agent | Topic |
-| `finding(scope)` | Findings from analysis | Agent | Topic |
-| `hypothesis` | Theory being tested | Agent | — |
-| `try` | Approach attempted | Agent | — |
-| `reject` | Approach abandoned | Agent | — |
-| `skill(name)` | Skill invoked with context | Skill (self-log) | Skill name |
-| `idea(slug)` | Idea captured or promoted | Agent/Skill | Idea slug or `.agents/ideas/` ref |
-| `spec(id)` | Spec created, updated, or approved | Agent/Skill | Spec ID (e.g. `SPEC-024`) |
-| `handoff(slug)` | Handoff created or deprecated | Agent/Skill | Handoff slug or `.agents/handoffs/` ref |
-| `report(slug)` | Report generated | Agent/Skill | Report slug or `.agents/reports/` ref |
-| `council(slug)` | Council convened or concluded | Agent/Skill | Council slug or `.agents/councils/` ref |
-| `brainstorm(slug)` | Brainstorm session held | Agent/Skill | Draft slug or topic |
-| `plan(slug)` | Plan created or updated | Agent/Skill | Plan slug or topic |
-| `draft(slug)` | Draft document created | Agent/Skill | Draft slug or `.agents/drafts/` ref |
-
-### Format Rules
-
-1. **Timestamp:** `YYYY-MM-DD HH:MM` (no seconds)
-2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank line separator:** Insert when:
-   - Gap ≥ 5 minutes since last entry, OR
-   - State transition (block/unblock/pause/resume)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated by `loaf session end`)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-### Example Session
-
-```markdown
----
-spec: SPEC-020
-branch: feat/target-convergence
-status: active
-created: 2026-03-31T14:30:00Z
-last_entry: 2026-04-02T09:15:00Z
----
-
-# Session: Target Convergence
-
-## Journal
-
-[2026-03-31 14:30] resume(feat/target-convergence): from commit abc1234, 3 tasks pending
-[2026-03-31 14:30] decision(hooks): remove bash wrappers, go direct
-[2026-03-31 14:32] discover(cursor): prompt hooks filtered at line 269
-
-[2026-03-31 15:10] block(parity): Codex output differs by trailing newline
-[2026-03-31 15:11] hypothesis: gray-matter serialization adds trailing \n
-
-[2026-03-31 16:45] unblock(parity): confirmed gray-matter quirk, fixed with trim
-[2026-03-31 16:46] commit(def5678): fix: trim frontmatter for Codex byte parity
-
---- PAUSE 2026-03-31 17:00 ---
-
-[2026-04-02 09:15] resume(feat/target-convergence): 16 hours paused, last: verification
-```
-
-### CLI Commands
-
-```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decide(scope): desc"
-loaf session archive  # Move to archive when branch merges
-```
-
-### Consistency
-
-- **`loaf session log`** validates and appends entries in correct format
-- **Read-only agents** (reviewer, researcher) CAN write journal entries via `loaf session log` (Bash command, not file edit)
-- **Concurrent writes** are safe: atomic append, timestamps provide ordering
-
-## Lifecycle States
-
-| State | Description |
-|-------|-------------|
-| `in_progress` | Work actively happening |
-| `paused` | Temporarily stopped |
-| `completed` | Work finished; ready to archive (set status, `archived_at`, `archived_by`, move) after extraction |
-| `archived` | Closed and preserved for audit (set `archived_at`/`archived_by`, status set + moved to `.agents/sessions/archive/`) |
-
-## Updating During Work
-
-After each significant action, append entries to the session journal:
-
-1. **Use `loaf session log`** to append entries in the correct format
-2. **Add `decision`, `discover`, `block`, `spark`, `wrap` entries** during normal work
-3. **Hooks auto-append:** `resume`, `commit(SHA)`, `pr(#N)`, `merge(#N)`, `pause`
-4. **Blank line rules:** Inserted automatically by `loaf session log` based on time gaps and state transitions
-
-**Cross-agent protocol:** When any agent starts work on a branch, `loaf session start` outputs the last 15-20 journal entries. The agent reads context, continues work, appends entries.
-
-## Session Continuity Protocol
-
-### Before Pausing or Switching Agents
-
-1. Update session file with completed work
-2. Update `Current State` with where you stopped
-3. Update `Next Steps` with immediate actions
-4. Include `Files Modified` for context
-
-### Session as Continuity Medium
-
-Each agent:
-1. Reads current state from session
-2. Performs assigned work
-3. Updates session with outcomes
-4. Sets up context for next agent
-
-## Completing a Session
-
-Sessions are **archived, not deleted** when complete to preserve audit trail (set status to `archived`, set `archived_at` and `archived_by`, and move into `.agents/sessions/archive/`). Archive indefinitely (no deletion policy).
-
-**Archive timing:** only after extraction and council/report summaries are captured.
-
-### Knowledge Extraction Checklist
-
-| Information Type | Where It Belongs |
-|------------------|------------------|
-| Work tracking | External issue (Linear, GitHub) |
-| Implementation details | Git commits/PRs |
-| Architectural decisions | ADRs (`docs/decisions/`) |
-| API contracts | API documentation |
-| Remaining work | External issue backlog |
-| Council outcomes | Session summary + council file link |
-| Report conclusions | Session summary + report file link |
-| Archived artifacts | SQLite lifecycle state plus compatibility archive metadata when Markdown files exist |
-
-### Archival Checklist
-
-- [ ] External issue updated with final status
-- [ ] Decisions captured as ADRs (if architectural)
-- [ ] Lessons learned added to relevant docs
-- [ ] Remaining work created as issues
-- [ ] Council outcomes summarized in this session (link council file)
-- [ ] Reports processed and summarized in this session (link report file)
-- [ ] Reports archived only after session is archived (`loaf report archive` for SQLite-backed state)
-- [ ] Handoffs reviewed; deprecated handoffs marked for `/housekeeping` deletion
-- [ ] No orphaned references to session file
-- [ ] Set session status to `archived`
-- [ ] Set `archived_at` and `archived_by`
-- [ ] Move compatibility session file to `.agents/sessions/archive/` when one exists
-- [ ] Linked councils moved to `.agents/councils/archive/` after session summary
-- [ ] Linked report state archived after session archived + conclusions captured
-- [ ] Deprecated handoffs deleted by `/housekeeping` after confirmation
-- [ ] Update `.agents/` references to archived paths (no `.agents` links outside `.agents/`)
-- [ ] Archive indefinitely (no deletion policy)
-- [ ] Use `/housekeeping` for auto-move + link updates after confirmation
-
-## Start Protocol
-
-When starting a new orchestration context:
-
-1. Check for existing active sessions
-2. If found, ask user which to resume or start fresh
-3. If resuming, read session for context
-4. If starting fresh, create new session file
+Reports, councils, and handoffs have their own archive or finalization commands.
+Do not use session archival as a substitute for those lifecycles.
 
 ## Hook Integration
 
-### SessionStart Hook
-- Lists active sessions
-- Provides agent-specific context
-- Suggests session review/resume
-
-### SessionEnd Hook
-- Displays completion checklist
-- Reminds about session file updates
-- Shows count of active sessions
-
-### PreCompact Hook
-- `loaf session context for-compact` logs compact marker and injects flush instructions
-- Model flushes unrecorded decisions/discoveries to journal
-- Model writes structured `## Current State` summary
-- After compaction: `loaf session context for-resumption` prints rich resumption context (session, spec, journal, git)
+- Session start hooks should surface recent journal entries from SQLite.
+- Session-end hooks should nudge for missing durable journal entries before wrap.
+- Pre-compaction hooks should ask the agent to flush facts through
+  `loaf session log`.
+- Post-compaction recovery should use `loaf session start` and
+  `loaf session show`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Archive without extraction | Extract outcomes before archiving |
-| Use sessions as permanent records | Use proper documentation locations |
-| Reference stale sessions | Keep sessions current or archive (status + move) when done |
-| Store decisions only in sessions | Create ADRs for important decisions |
-| Archive without council/report summaries | Summarize outcomes in session before archive |
-| Archive but leave in active folder | Move file to `.agents/sessions/archive/` after setting status |
-| Batch session updates | Update after each significant event |
-| Keep status as `in_progress` when paused | Update status when state changes |
+| Hand-author session markdown as source | Use `loaf session start/log/show/end` |
+| Store decisions only in chat context | Log them and promote durable decisions to ADR/spec/report/docs |
+| Invent status values | Cite the runtime lifecycle until SPEC-049 lands |
+| Archive before extracting outcomes | Promote outcomes first, then wrap/archive |
+| Batch all journal entries at the end | Log significant facts as they happen |

--- a/dist/cursor/skills/orchestration/templates/session.md
+++ b/dist/cursor/skills/orchestration/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/cursor/skills/reflect/SKILL.md
+++ b/dist/cursor/skills/reflect/SKILL.md
@@ -33,12 +33,13 @@ Update VISION, STRATEGY, and ARCHITECTURE based on proven implementation.
 - **Post-implementation only** -- reflect after shipping, not before or during planning
 - **Get explicit approval** -- never update strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) without user confirmation
 - **Consolidate** -- batch related learnings into coherent updates, avoid micro-updates
-- **Link back** -- always reference the specs/sessions that informed each update
+- **Log first** -- log invocation before gathering evidence: `loaf session log "skill(reflect): <scope>"`
+- **Link back** -- always reference the specs, SQLite sessions, reports, and commits that informed each update
 - **Log updates** -- log each strategic document update to session journal: `loaf session log "decision(scope): updated STRATEGY.md with learning"`
 
 ## Verification
 
-- Proposals cite specific specs, sessions, or commits as evidence
+- Proposals cite specific specs, SQLite sessions, reports, or commits as evidence
 - No strategic document was modified without explicit user approval
 - Completed specs referenced in updates are archived after reflection
 
@@ -86,7 +87,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 
 Sources:
 1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
-2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
+2. **SQLite sessions** (`loaf session list --all --json`, then `loaf session show <ref> --json`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?
 

--- a/dist/cursor/skills/research/SKILL.md
+++ b/dist/cursor/skills/research/SKILL.md
@@ -33,6 +33,7 @@ Patterns for zooming out, investigating topics, and evolving project direction.
 - Cite sources with confidence levels
 - Present options, let user decide
 - Get approval before editing VISION
+- Log invocation first: `loaf session log "skill(research): <topic or mode>"`
 - Log findings to session journal: `loaf session log "discover(scope): summary of finding"`
 
 ### Never
@@ -79,7 +80,7 @@ Parse `$ARGUMENTS` to determine mode:
 
 Prioritize sources in this order:
 
-1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, session files, codebase patterns
+1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, SQLite sessions, codebase patterns
 2. **Authoritative docs** -- Context7, official docs, RFCs
 3. **Community knowledge** -- Stack Overflow (verified), GitHub issues, expert blogs
 4. **General web** (lowest) -- Search results, unverified sources
@@ -94,7 +95,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 
 1. Read project documents: VISION.md, STRATEGY.md, ARCHITECTURE.md
 2. Check ideas (`.agents/ideas/`) and specs (`docs/specs/`)
-3. Review recent sessions (`.agents/sessions/`)
+3. Review recent sessions with `loaf session list --all --json` and `loaf session show <ref> --json`
 4. Check recent commits: `git log --oneline -20`
 5. Synthesize following [state-assessment template](templates/state-assessment.md)
 
@@ -103,7 +104,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 **Trigger:** Specific topic or question
 
 1. **Interview** with built-in chat clarification: what are you trying to understand? What context do you have? What decision will this inform?
-2. Check project context first (ADRs, ARCHITECTURE, sessions)
+2. Check project context first (ADRs, ARCHITECTURE, SQLite sessions)
 3. Apply confidence hierarchy for external sources
 4. For a transient review artifact, use `loaf report generate` when an existing
    SQLite-backed export kind fits; for authored long-form research, create a

--- a/dist/cursor/skills/research/templates/state-assessment.md
+++ b/dist/cursor/skills/research/templates/state-assessment.md
@@ -12,7 +12,7 @@ title: "State Assessment: [YYYY-MM-DD]"
 type: state-assessment
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active | archived
-session: ".agents/sessions/YYYYMMDD-HHMMSS-description.md"  # Session that produced this assessment
+session: "session alias or loaf session show reference"  # Session that produced this assessment
 tags: []
 ---
 

--- a/dist/opencode/agents/background-runner.md
+++ b/dist/opencode/agents/background-runner.md
@@ -27,7 +27,7 @@ You execute specific tasks in the background, writing results to a specified loc
 
 1. **Execute assigned task** - Security audits, coverage analysis, code reviews, etc.
 2. **Write results** - Output to specified `.agents/reports/` location
-3. **Update session** - Mark your background agent entry as complete
+3. **Report completion** - Write completion status in the report and log a concise session entry when session context is available
 
 ## Input You Receive
 
@@ -35,7 +35,7 @@ The spawning agent provides:
 - Specific task to execute
 - Files or scope to analyze
 - Output location (`.agents/reports/YYYYMMDD-HHMMSS-<name>.md`)
-- Session reference
+- Session alias or task/spec reference when available
 
 ## Execution Process
 
@@ -45,7 +45,7 @@ Extract from prompt:
 - What to do (audit, analyze, review)
 - Scope (files, directories)
 - Output location
-- Session file path
+- Session alias, task ID, or spec ID when provided
 
 ### 2. Execute Work
 
@@ -67,7 +67,7 @@ report:
   status: unprocessed
   created: "2026-01-23T14:30:00Z"
   background_agent_id: "bg-YYYYMMDD-HHMMSS-description"
-  session_reference: "YYYYMMDD-HHMMSS-session-name.md"
+  session_reference: "session alias or task/spec reference"
 ---
 
 # Report Title
@@ -94,17 +94,13 @@ Prioritized list of actions.
 - `path/to/file2.py`
 ```
 
-### 4. Update Session Frontmatter
+### 4. Report Completion
 
-Read session file and update your background agent entry:
+If the prompt supplied an active session alias and the `loaf` CLI is available,
+log the result:
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: completed  # Changed from running
-    result_location: ".agents/reports/20260123-143000-security.md"  # Set path
+```bash
+loaf session log "discover(background): bg-YYYYMMDD-HHMMSS-description completed; report .agents/reports/..."
 ```
 
 ## Constraints
@@ -121,8 +117,7 @@ Before completing:
 - [ ] Task executed per prompt instructions
 - [ ] Report written to specified location
 - [ ] Report has valid frontmatter with `background_agent_id`
-- [ ] Session frontmatter updated with `status: completed`
-- [ ] Session frontmatter updated with `result_location`
+- [ ] Completion logged to session journal when session context was provided
 - [ ] No user interaction attempted
 
 ## Error Handling
@@ -131,16 +126,11 @@ If task cannot be completed:
 
 1. Write partial report with what was accomplished
 2. Document blockers in report
-3. Update session frontmatter with `status: failed`
+3. Log failure to session journal when session context was provided
 4. Include error details in report
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: failed
-    result_location: ".agents/reports/20260123-143000-security-partial.md"
+```bash
+loaf session log "block(background): bg-YYYYMMDD-HHMMSS-description failed; partial report .agents/reports/..."
 ```
 
 ## Example Task
@@ -157,7 +147,7 @@ Check for OWASP Top 10 vulnerabilities.
 
 Write report to: .agents/reports/20260123-143000-auth-security.md
 
-Session: .agents/sessions/20260123-140000-auth-feature.md
+Session: active session alias if available
 Background Agent ID: bg-20260123-143000-auth-security
 ```
 
@@ -165,7 +155,7 @@ Background Agent ID: bg-20260123-143000-auth-security
 1. Read `src/auth/endpoints.py` and `src/auth/token.py`
 2. Analyze for OWASP vulnerabilities
 3. Write findings to `.agents/reports/20260123-143000-auth-security.md`
-4. Update `.agents/sessions/20260123-140000-auth-feature.md` frontmatter
+4. Log completion to the session journal if session context was provided
 
 ---
 version: 2.0.0-pre.20260614235428

--- a/dist/opencode/agents/implementer.md
+++ b/dist/opencode/agents/implementer.md
@@ -20,7 +20,7 @@ You are an implementer. You have full write access to the codebase: code, tests,
 ## Behavioral Contract
 
 - Your domain speciality comes from the skills loaded at spawn time, not from this profile. An implementer with Python skills implements Python; an implementer with infrastructure skills writes Terraform. The role is the same; the material differs.
-- Work within an active session. If no session file was provided in your spawn prompt, say so immediately.
+- Work within an active session. If no session alias, task ID, or branch context was provided in your spawn prompt, say so immediately.
 - Follow the conventions defined in your loaded skills. They are your blueprints.
 - Write tests alongside implementation, never after.
 - Run verification commands (linters, type checkers, test suites) before reporting completion.

--- a/dist/opencode/agents/librarian.md
+++ b/dist/opencode/agents/librarian.md
@@ -4,21 +4,21 @@ description: librarian agent for specialized tasks
 ---
 # Librarian
 
-You are a librarian. You shepherd session files through their lifecycle and tend the operational artifacts under `.agents/`. You have read access to the repository and edit access scoped to `.agents/` only.
+You are a librarian. You shepherd SQLite-backed session journals through their lifecycle and tend operational artifacts under `.agents/`. You have read access to the repository and edit access scoped to `.agents/` only.
 
 ## Behavioral Contract
 
-- Tend session files: Current State summaries, journal quality, wrap summaries, lifecycle transitions.
+- Tend session journals: journal quality, wrap summaries, and lifecycle transitions.
 - Never modify code, tests, or configuration — only `.agents/` artifacts.
 - Never research, review, or orchestrate — those are other profiles' work.
 - Work quickly and silently. The user should not notice you unless something is wrong.
-- Read before writing — always check the current state of a session file before modifying it.
+- Read before writing — always check the current state with `loaf session show` before modifying related artifacts.
 
 ## What You Tend
 
-- **Session files** in `.agents/sessions/` — frontmatter, Current State, journal entries
+- **SQLite sessions** — inspect with `loaf session list --json` and `loaf session show <ref> --json`
 - **Session lifecycle** — status transitions (active → stopped → done → archived)
-- **Pre-compaction preservation** — flush journal entries, write Current State before context compaction
+- **Pre-compaction preservation** — flush journal entries before context compaction
 - **Knowledge artifacts** in `.agents/knowledge/` — staleness markers, coverage notes
 - **Wrap summaries** — end-of-session distillation when invoked by `/wrap`
 - **Decision persistence** — extract decisions to spec changelog via `loaf session end --wrap`

--- a/dist/opencode/commands/bootstrap.md
+++ b/dist/opencode/commands/bootstrap.md
@@ -40,6 +40,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - **BRIEF is input, not output** -- the BRIEF is raw intake. Extract every useful fact into VISION/STRATEGY/ARCHITECTURE/AGENTS during bootstrap.
 - **BRIEF is archeological after bootstrap** -- once extraction completes, the BRIEF is a frozen historical snapshot. No skill, agent, command, or template should reference `docs/BRIEF.md` post-bootstrap. Operating documents must stand on their own.
 - **Suggest, don't execute** -- recommend next skills at the end, never auto-run them
+- **Log first** -- log invocation before interviewing: `loaf session log "skill(bootstrap): <project or intake>"`
 - **Log outcome** -- log bootstrap completion to session journal: `loaf session log "decision(bootstrap): project bootstrapped, mode detected"`
 
 ---
@@ -49,7 +50,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - All expected operating documents (`docs/VISION.md`, `.agents/AGENTS.md` at minimum) exist and contain populated content
 - Useful BRIEF content has been extracted into operating documents (no future reader should need to open the BRIEF)
 - Symlinks are correct: `.agents/AGENTS.md` and `./AGENTS.md -> .agents/AGENTS.md`
-- A session file was saved in `.agents/sessions/` capturing key decisions and interview exchanges
+- Key decisions and interview outcomes were logged with `loaf session log` and are readable with `loaf session show`
 
 ---
 
@@ -368,13 +369,13 @@ If symlinks already exist and point to the right targets, skip silently. If they
 
 ### 3. Session Recording
 
-Save the bootstrap interview as a session file:
+Record the bootstrap interview in the active SQLite-backed session:
 
-```
-.agents/sessions/{YYYYMMDD}-{HHMMSS}-bootstrap.md
-```
+1. Run `loaf session start` if there is no active session.
+2. Log mode detection and key interview decisions with `loaf session log`.
+3. Use `loaf session show <session-ref>` to inspect the rendered session view.
 
-The session should capture:
+The session journal should capture:
 - Mode detected and why
 - Key decisions made during the interview
 - Key interview exchanges that informed those decisions
@@ -382,7 +383,8 @@ The session should capture:
 - The original problem framing and user intent
 - Any open questions or deferred decisions
 
-Follow [templates/session.md](../skills/bootstrap/templates/session.md) for structure and frontmatter schema.
+Use [templates/session.md](../skills/bootstrap/templates/session.md) only as the rendered journal
+format reference; do not hand-author session markdown as the source of truth.
 
 ### 4. Next Steps
 

--- a/dist/opencode/commands/brainstorm.md
+++ b/dist/opencode/commands/brainstorm.md
@@ -18,7 +18,8 @@ Generative thinking — expanding possibilities before narrowing through structu
 - Diverge before converging — generate options before judging
 - Connect exploration to VISION.md and STRATEGY.md context
 - Document discarded options — they hold valuable reasoning
-- Capture sparks (speculative byproducts) in a dedicated section — brainstorm documents are the canonical home for sparks
+- Log invocation first: `loaf session log "skill(brainstorm): <topic>"`
+- Capture sparks (speculative byproducts) with `loaf spark capture --scope <scope> --text <text>`; brainstorm documents may render or summarize them
 - Set boundaries on exploration time
 - Log outcome to session journal: `loaf session log "decision(scope): direction chosen and rationale"`
 
@@ -32,7 +33,7 @@ Generative thinking — expanding possibilities before narrowing through structu
 
 After work completes, verify:
 - Brainstorm document created at `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
-- `## Sparks` section present with speculative byproducts
+- Sparks captured with `loaf spark capture` and optionally summarized in `## Sparks`
 - Spark lifecycle documented: unprocessed → promoted/discarded
 - Brainstorm references strategic context from VISION/STRATEGY
 
@@ -57,7 +58,7 @@ After work completes, verify:
 
 Sparks are: lightweight, byproducts, worth remembering. Mark as `*(promoted)*` or `*(abandoned)*` after processing.
 
-Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value.
+Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value. SQLite spark state is the lifecycle source; draft markdown is a projection or narrative summary.
 
 ## Suggests Next
 

--- a/dist/opencode/commands/housekeeping.md
+++ b/dist/opencode/commands/housekeeping.md
@@ -17,10 +17,11 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Critical Rules
 
 **Always**
+- Log invocation as the first action: `loaf session log "skill(housekeeping): <scope or trigger>"`
 - Review EVERY file individually — never sample or average
 - Check Linear issue status before archiving sessions
 - Extract lessons learned and decisions before archiving
-- Use CLI (`loaf session housekeeping`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
+- Use CLI (`loaf housekeeping`, `loaf session archive`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
 - Treat `.agents/handoffs/` as first-class but disposable: keep active/final handoffs, delete only after confirmed deprecated status
 - Check report `status` is `processed` and linked session is archived before archiving reports (see [templates/report.md](../skills/housekeeping/templates/report.md))
 - Check state assessment `session:` field before flagging for cleanup — only flag when linked session is archived
@@ -35,7 +36,7 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Verification
 
 After work completes, verify:
-- Session files archived with proper metadata (status, archived_at, archived_by)
+- Session lifecycle state is visible through `loaf session list --json`
 - Tasks archived via `loaf task archive`
 - Specs archived via `loaf spec archive`
 - SQLite-backed task/spec/report state reflects lifecycle changes when initialized
@@ -48,10 +49,11 @@ After work completes, verify:
 ### CLI Commands
 
 ```bash
-loaf session housekeeping --dry-run  # Preview all actions
-loaf session housekeeping            # Run all checks and fixes
+loaf housekeeping --dry-run          # Preview recommendations
+loaf housekeeping                    # Run artifact scanner
+loaf housekeeping --sessions         # Review sessions only
 loaf session archive                 # Archive single session
-loaf session enrich <file>           # Enrich a session's journal from JSONL
+loaf session enrich --json           # Compatibility diagnostic for legacy enrichment
 loaf task archive TASK-XXX           # Archive single task
 loaf spec archive SPEC-XXX           # Archive single spec
 loaf task sync                       # Compatibility: repair Markdown task index drift
@@ -61,7 +63,7 @@ loaf task sync                       # Compatibility: repair Markdown task index
 
 | Artifact | Active Location | Archive | Action |
 |----------|-----------------|---------|--------|
-| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf session archive` / `loaf session housekeeping` |
+| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf housekeeping --sessions` / `loaf session archive` |
 | Tasks (local mode only) | SQLite state + `.agents/tasks/` source prose | `archive/` | `loaf task archive` |
 | Specs | SQLite state + `.agents/specs/` authored prose | `archive/` | `loaf spec archive` |
 | Drafts (state assessments) | `.agents/drafts/` | delete | Flag for cleanup when linked session is archived |
@@ -78,7 +80,10 @@ every mode.
 
 ## Session Enrichment
 
-For each session with status `stopped` or `done` that has a `claude_session_id` in frontmatter, run `loaf session enrich <file>` to catch up on journal entries that weren't logged during the session.
+In SQLite-backed projects, `loaf session log` is the canonical journal writer and
+`wrap` owns end-of-session checks. `loaf session enrich --json` is a compatibility
+diagnostic for legacy markdown enrichment; it is not part of the normal
+housekeeping flow.
 
 Do NOT enrich `active` sessions — those are handled by the wrap skill when the session ends.
 

--- a/dist/opencode/commands/implement.md
+++ b/dist/opencode/commands/implement.md
@@ -2,9 +2,9 @@
 description: >-
   Orchestrates implementation sessions through agent delegation and batch
   execution. Use for all implementation work — features, bug fixes, refactors,
-  and code changes. Produces session files, agent spawn plans, and progress
-  tracking. Not for shaping (use shape), breakdown (use breakdown), research, or
-  review.
+  and code changes. Produces SQLite-backed session journals, agent spawn plans,
+  and progress tracking. Not for shaping (use shape), breakdown (use breakdown),
+  research, or review.
 subtask: false
 version: 2.0.0-pre.20260614235428
 ---
@@ -38,7 +38,7 @@ You are the coordinator. Start by understanding the task:
 **You are the ORCHESTRATOR, not the implementer.**
 
 ### Orchestrator Can Do Directly
-- Create/edit session files, council files
+- Start/log/show sessions, create council files
 - Use native task/todo surface when available; **if `integrations.linear.enabled` is `true` in `.agents/loaf.json`**, use Linear MCP tools when helpful
 - Read any file for context
 - Ask clarifying questions
@@ -48,11 +48,11 @@ You are the coordinator. Start by understanding the task:
 
 ## Verification
 
-- Session file exists before any implementation work begins
+- `loaf session start` has created or resumed an active SQLite-backed session before implementation work begins
 - All code changes delegated via subtask agent -- no direct edits by orchestrator
-- Session file is continuously updated with spawns, progress, and current state
+- Session journal is continuously updated with spawns, progress, and current state
 - Spec artifacts closed out on branch before PR creation
-- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session file is created; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
+- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session is started; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
 
 ## Quick Reference
 
@@ -80,7 +80,7 @@ Before starting, evaluate context suitability.
 | Just completed a different task/spec | Suggest clear |
 | About to start multi-file implementation | Check depth |
 
-If restart needed: capture state in session file, generate resumption prompt, ask user to restart.
+If restart needed: log current state with `loaf session log`, generate resumption prompt, ask user to restart.
 
 ## Input Detection
 
@@ -88,7 +88,7 @@ Parse `$ARGUMENTS` to determine session type:
 
 | Input Pattern | Type | Action |
 |---------------|------|--------|
-| `TASK-XXX` | Local task | Load via `loaf task show`, auto-create session |
+| `TASK-XXX` | Local task | Load via `loaf task show`, start/resume session |
 | `SPEC-XXX` | Spec orchestration | If spec frontmatter has `linear_parent`, resolve to that Linear parent and follow Linear-Native Routing. Otherwise resolve local tasks and build dependency waves |
 | `TASK-XXX..YYY` | Task range | Expand range, build dependency waves |
 | `TASK-XXX,YYY,ZZZ` | Task list | Parse list, build dependency waves |
@@ -100,8 +100,8 @@ Parse `$ARGUMENTS` to determine session type:
 When starting from `TASK-XXX`:
 
 1. Load task metadata via `loaf task show TASK-XXX --json`; read `.agents/TASKS.json` only as a Markdown-compatibility fallback
-2. Auto-generate session: `YYYYMMDD-HHMMSS-task-XXX.md`
-3. Create session file, update task with session reference: `loaf task update TASK-XXX --session <session-file>`
+2. Run `loaf session start` to find or create the active session for the branch
+3. Log the task coupling: `loaf session log "decision(implement): implementing TASK-XXX"`
 4. Load parent spec if task has `spec:` field
 
 **No user interaction required for session naming.**
@@ -187,7 +187,7 @@ The issue is an actual task. Implement it directly — with a pre-flight gate.
    - Resolve branch name from the sub-issue's `branchName` field (Linear
      auto-generates one) — see
      [session-management.md](../skills/implement/references/session-management.md).
-   - Create session file, continue with the standard Startup Checklist.
+   - Run `loaf session start`, then continue with the standard Startup Checklist.
 
 ### Completion (after implementer + reviewer finish cleanly)
 
@@ -224,8 +224,8 @@ When the sub-issue's implementation passes review and tests:
   implementation reveals a missing task, surface it to the user; they
   decide whether to run `/breakdown` again or add an ad-hoc sub-issue.
 - Does not sync in-progress state bidirectionally. Source of truth at any
-  moment: Linear for issue state, local files for spec content, session
-  file for current handoff.
+  moment: Linear for issue state, local files for spec content, SQLite session
+  journal for current handoff.
 
 ---
 
@@ -248,19 +248,19 @@ Use the **subtask agent** with appropriate `agent_type`:
 
 ---
 
-## Session Creation
+## Session Start
 
-**MANDATORY: Create session file BEFORE any other work.**
+**MANDATORY: Run `loaf session start` BEFORE any implementation work.**
 
-1. Generate timestamps: `date -u +"%Y%m%d-%H%M%S"` and `date -u +"%Y-%m-%dT%H:%M:%SZ"`
-2. Create session file following [session template](../skills/implement/templates/session.md)
-3. Verify session file exists with valid frontmatter
+1. Run `loaf session start` from the target branch/worktree.
+2. Log invocation context: `loaf session log "skill(implement): <task/spec/context>"`
+3. Verify the active session is readable with `loaf session list --json` or `loaf session show <session-ref> --json`.
 4. Suggest renaming OpenCode session with a meaningful name derived from context:
    - From spec: `Suggestion: /rename SPEC-027-session-stability`
    - From task: `Suggestion: /rename TASK-042-login-fix`
    - From ad-hoc: `Suggestion: /rename {short-slug-from-description}`
 
-**DO NOT PROCEED WITHOUT A SESSION FILE.**
+**Do not proceed until the active session is visible through `loaf session` commands.**
 
 ---
 
@@ -271,8 +271,8 @@ Use the **subtask agent** with appropriate `agent_type`:
 3. **When uncertain** -- convene council, present results, **wait for user approval**
 4. **Ensure quality** -- spawn implementer for tests, route reviews to reviewer subtask agent
 5. **When debugging** -- if a test failure or error isn't immediately obvious, load the **debugging** skill for structured hypothesis tracking before retrying
-6. **Update session file continuously** -- log spawns, update current_task, keep handoff-ready
-6. **Clean up** -- no ephemeral files, archive completed sessions (status + `archived_at` + `archived_by` + move to archive/)
+6. **Update session continuously** -- log spawns, progress, blockers, and next actions with `loaf session log`
+6. **Clean up** -- no ephemeral files; wrap with `loaf session end --wrap` and archive closed sessions with `loaf session archive`
 7. **When in doubt, ask the user**
 
 ## Decision Tree
@@ -281,7 +281,7 @@ Use the **subtask agent** with appropriate `agent_type`:
 Is this a code/config/doc change?
 +-- YES -> Spawn appropriate agent
 +-- NO -> Is this a planning/coordination decision?
-    +-- YES with clear path -> Proceed, update session
+    +-- YES with clear path -> Proceed, log session decision
     +-- YES but ambiguous -> Ask user
     +-- NO -> Ask user
 ```
@@ -292,18 +292,18 @@ When multiple valid approaches exist: spawn council (5-7 agents, odd), present r
 
 ## Startup Checklist
 
-After creating session file:
+After `loaf session start`:
 
 1. [ ] Parse input (task, Linear ID, or description)
-2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, update with `loaf task update TASK-XXX --session <session-file>`, load parent spec
+2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, log task coupling, load parent spec
 3. [ ] If Linear ID (or `SPEC-XXX` with `linear_parent`): follow [Linear-Native Routing](#linear-native-routing). Parent → walk sub-issues and select next. Sub-issue → verify `blockedBy` is clear, then start it as one logical Linear operation so the parent is promoted when needed
 4. [ ] If description: auto-create task (see Ad-hoc Task Auto-Creation above)
 5. [ ] Create dedicated branch (see [session-management.md](../skills/implement/references/session-management.md))
 6. [ ] Suggest team based on task context
-7. [ ] Populate session Context section
+7. [ ] Log initial context and references with `loaf session log`
 8. [ ] Break down work using native task/todo surface when available
 9. [ ] Identify needed specialized agents
-10. [ ] Update session Next Steps
+10. [ ] Log next steps before spawning
 11. [ ] **Get user approval** before spawning
 
 ---
@@ -311,7 +311,7 @@ After creating session file:
 ## Then Execute
 
 ### BEFORE (Planning)
-1. Create session file
+1. Run `loaf session start`
 2. Set task status: `loaf task update TASK-XXX --status in_progress`
 3. Break down work into agent-sized tasks
 4. Identify spawn order (respect dependencies)
@@ -319,10 +319,10 @@ After creating session file:
 
 ### DURING (Execution)
 1. Spawn specialized agents via subtask agent
-2. Log each spawn in session `orchestration.spawned_agents`
+2. Log each spawn with `loaf session log "todo(agent): spawned <agent> for <task>"`
 3. Update Linear with progress (no emoji, no file paths)
-4. Keep session `## Current State` handoff-ready
-5. After each agent completes: update session, spawn next
+4. Keep journal entries handoff-ready
+5. After each agent completes: log outcome, spawn next
 
 ### AFTER (Completion)
 1. Code review pass (spawn `reviewer` agent)
@@ -331,13 +331,13 @@ After creating session file:
    - **Local-tasks mode:** `loaf task update TASK-XXX --status done` (per task), then `loaf task archive --spec SPEC-XXX`
    - **Linear-native mode:** `update_issue` the sub-issue to `completed`-type state. Then query the parent's sub-issues; if all are `completed`, also close the parent. If some remain, list them for the user (see [Linear-Native Routing → Completion](#completion-after-implementer--reviewer-finish-cleanly))
    - Mark spec complete and archive: `loaf spec archive SPEC-XXX` (both modes)
-   - Update session file (status: done, `archived_at`, `archived_by`)
-   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
+   - Run `loaf session end --wrap`; archive later with `loaf session archive` when appropriate
+   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session state`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
 5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
-6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
-   - `## Key Decisions` has content (not `*(none yet)*` or empty)
-   - `traceability.decisions` has entries (ADRs were recorded)
+6. **Suggest reflection:** Check the session journal for extractable learnings before closing out:
+   - `decision(...)` entries are present
+   - ADRs, report verdicts, or spec changelog entries were recorded
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
@@ -360,4 +360,4 @@ After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release`
 - **orchestration/product-development** - Full workflow hierarchy
 - **orchestration/specs** - Spec format and lifecycle
 - **orchestration/local-tasks** - Task file format including `session:` field
-- **orchestration/sessions** - Session lifecycle details
+- **orchestration/sessions** - SQLite-backed session lifecycle details

--- a/dist/opencode/commands/reflect.md
+++ b/dist/opencode/commands/reflect.md
@@ -33,12 +33,13 @@ Update VISION, STRATEGY, and ARCHITECTURE based on proven implementation.
 - **Post-implementation only** -- reflect after shipping, not before or during planning
 - **Get explicit approval** -- never update strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) without user confirmation
 - **Consolidate** -- batch related learnings into coherent updates, avoid micro-updates
-- **Link back** -- always reference the specs/sessions that informed each update
+- **Log first** -- log invocation before gathering evidence: `loaf session log "skill(reflect): <scope>"`
+- **Link back** -- always reference the specs, SQLite sessions, reports, and commits that informed each update
 - **Log updates** -- log each strategic document update to session journal: `loaf session log "decision(scope): updated STRATEGY.md with learning"`
 
 ## Verification
 
-- Proposals cite specific specs, sessions, or commits as evidence
+- Proposals cite specific specs, SQLite sessions, reports, or commits as evidence
 - No strategic document was modified without explicit user approval
 - Completed specs referenced in updates are archived after reflection
 
@@ -86,7 +87,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 
 Sources:
 1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
-2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
+2. **SQLite sessions** (`loaf session list --all --json`, then `loaf session show <ref> --json`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?
 

--- a/dist/opencode/commands/research.md
+++ b/dist/opencode/commands/research.md
@@ -33,6 +33,7 @@ Patterns for zooming out, investigating topics, and evolving project direction.
 - Cite sources with confidence levels
 - Present options, let user decide
 - Get approval before editing VISION
+- Log invocation first: `loaf session log "skill(research): <topic or mode>"`
 - Log findings to session journal: `loaf session log "discover(scope): summary of finding"`
 
 ### Never
@@ -79,7 +80,7 @@ Parse `$ARGUMENTS` to determine mode:
 
 Prioritize sources in this order:
 
-1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, session files, codebase patterns
+1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, SQLite sessions, codebase patterns
 2. **Authoritative docs** -- Context7, official docs, RFCs
 3. **Community knowledge** -- Stack Overflow (verified), GitHub issues, expert blogs
 4. **General web** (lowest) -- Search results, unverified sources
@@ -94,7 +95,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 
 1. Read project documents: VISION.md, STRATEGY.md, ARCHITECTURE.md
 2. Check ideas (`.agents/ideas/`) and specs (`docs/specs/`)
-3. Review recent sessions (`.agents/sessions/`)
+3. Review recent sessions with `loaf session list --all --json` and `loaf session show <ref> --json`
 4. Check recent commits: `git log --oneline -20`
 5. Synthesize following [state-assessment template](../skills/research/templates/state-assessment.md)
 
@@ -103,7 +104,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 **Trigger:** Specific topic or question
 
 1. **Interview** with prompt the user in chat: what are you trying to understand? What context do you have? What decision will this inform?
-2. Check project context first (ADRs, ARCHITECTURE, sessions)
+2. Check project context first (ADRs, ARCHITECTURE, SQLite sessions)
 3. Apply confidence hierarchy for external sources
 4. For a transient review artifact, use `loaf report generate` when an existing
    SQLite-backed export kind fits; for authored long-form research, create a

--- a/dist/opencode/skills/bootstrap/SKILL.md
+++ b/dist/opencode/skills/bootstrap/SKILL.md
@@ -41,6 +41,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - **BRIEF is input, not output** -- the BRIEF is raw intake. Extract every useful fact into VISION/STRATEGY/ARCHITECTURE/AGENTS during bootstrap.
 - **BRIEF is archeological after bootstrap** -- once extraction completes, the BRIEF is a frozen historical snapshot. No skill, agent, command, or template should reference `docs/BRIEF.md` post-bootstrap. Operating documents must stand on their own.
 - **Suggest, don't execute** -- recommend next skills at the end, never auto-run them
+- **Log first** -- log invocation before interviewing: `loaf session log "skill(bootstrap): <project or intake>"`
 - **Log outcome** -- log bootstrap completion to session journal: `loaf session log "decision(bootstrap): project bootstrapped, mode detected"`
 
 ---
@@ -50,7 +51,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - All expected operating documents (`docs/VISION.md`, `.agents/AGENTS.md` at minimum) exist and contain populated content
 - Useful BRIEF content has been extracted into operating documents (no future reader should need to open the BRIEF)
 - Symlinks are correct: `.agents/AGENTS.md` and `./AGENTS.md -> .agents/AGENTS.md`
-- A session file was saved in `.agents/sessions/` capturing key decisions and interview exchanges
+- Key decisions and interview outcomes were logged with `loaf session log` and are readable with `loaf session show`
 
 ---
 
@@ -369,13 +370,13 @@ If symlinks already exist and point to the right targets, skip silently. If they
 
 ### 3. Session Recording
 
-Save the bootstrap interview as a session file:
+Record the bootstrap interview in the active SQLite-backed session:
 
-```
-.agents/sessions/{YYYYMMDD}-{HHMMSS}-bootstrap.md
-```
+1. Run `loaf session start` if there is no active session.
+2. Log mode detection and key interview decisions with `loaf session log`.
+3. Use `loaf session show <session-ref>` to inspect the rendered session view.
 
-The session should capture:
+The session journal should capture:
 - Mode detected and why
 - Key decisions made during the interview
 - Key interview exchanges that informed those decisions
@@ -383,7 +384,8 @@ The session should capture:
 - The original problem framing and user intent
 - Any open questions or deferred decisions
 
-Follow [templates/session.md](templates/session.md) for structure and frontmatter schema.
+Use [templates/session.md](templates/session.md) only as the rendered journal
+format reference; do not hand-author session markdown as the source of truth.
 
 ### 4. Next Steps
 

--- a/dist/opencode/skills/bootstrap/templates/session.md
+++ b/dist/opencode/skills/bootstrap/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/opencode/skills/brainstorm/SKILL.md
+++ b/dist/opencode/skills/brainstorm/SKILL.md
@@ -19,7 +19,8 @@ Generative thinking — expanding possibilities before narrowing through structu
 - Diverge before converging — generate options before judging
 - Connect exploration to VISION.md and STRATEGY.md context
 - Document discarded options — they hold valuable reasoning
-- Capture sparks (speculative byproducts) in a dedicated section — brainstorm documents are the canonical home for sparks
+- Log invocation first: `loaf session log "skill(brainstorm): <topic>"`
+- Capture sparks (speculative byproducts) with `loaf spark capture --scope <scope> --text <text>`; brainstorm documents may render or summarize them
 - Set boundaries on exploration time
 - Log outcome to session journal: `loaf session log "decision(scope): direction chosen and rationale"`
 
@@ -33,7 +34,7 @@ Generative thinking — expanding possibilities before narrowing through structu
 
 After work completes, verify:
 - Brainstorm document created at `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
-- `## Sparks` section present with speculative byproducts
+- Sparks captured with `loaf spark capture` and optionally summarized in `## Sparks`
 - Spark lifecycle documented: unprocessed → promoted/discarded
 - Brainstorm references strategic context from VISION/STRATEGY
 
@@ -58,7 +59,7 @@ After work completes, verify:
 
 Sparks are: lightweight, byproducts, worth remembering. Mark as `*(promoted)*` or `*(abandoned)*` after processing.
 
-Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value.
+Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value. SQLite spark state is the lifecycle source; draft markdown is a projection or narrative summary.
 
 ## Suggests Next
 

--- a/dist/opencode/skills/brainstorm/templates/brainstorm.md
+++ b/dist/opencode/skills/brainstorm/templates/brainstorm.md
@@ -11,7 +11,7 @@ type: brainstorm
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active (has unprocessed sparks) | archived
 tags: []
-related: []            # Optional: idea files, spec IDs, session files
+related: []            # Optional: idea aliases, spec IDs, session aliases, report refs
 ---
 
 # Brainstorm: [Topic]

--- a/dist/opencode/skills/handoff/templates/handoff.md
+++ b/dist/opencode/skills/handoff/templates/handoff.md
@@ -8,7 +8,7 @@ title: "[Handoff Title]"
 created: YYYY-MM-DDTHH:MM:SSZ
 status: draft | final | deprecated
 source: session | branch | task | ad-hoc
-session: .agents/sessions/YYYYMMDD-HHMMSS-session.md
+session: session alias or loaf session show reference
 branch: branch-name
 deprecated_at: YYYY-MM-DDTHH:MM:SSZ  # Set only when confirmed obsolete
 deprecated_by: orchestrator

--- a/dist/opencode/skills/housekeeping/SKILL.md
+++ b/dist/opencode/skills/housekeeping/SKILL.md
@@ -18,10 +18,11 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Critical Rules
 
 **Always**
+- Log invocation as the first action: `loaf session log "skill(housekeeping): <scope or trigger>"`
 - Review EVERY file individually — never sample or average
 - Check Linear issue status before archiving sessions
 - Extract lessons learned and decisions before archiving
-- Use CLI (`loaf session housekeeping`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
+- Use CLI (`loaf housekeeping`, `loaf session archive`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
 - Treat `.agents/handoffs/` as first-class but disposable: keep active/final handoffs, delete only after confirmed deprecated status
 - Check report `status` is `processed` and linked session is archived before archiving reports (see [templates/report.md](templates/report.md))
 - Check state assessment `session:` field before flagging for cleanup — only flag when linked session is archived
@@ -36,7 +37,7 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Verification
 
 After work completes, verify:
-- Session files archived with proper metadata (status, archived_at, archived_by)
+- Session lifecycle state is visible through `loaf session list --json`
 - Tasks archived via `loaf task archive`
 - Specs archived via `loaf spec archive`
 - SQLite-backed task/spec/report state reflects lifecycle changes when initialized
@@ -49,10 +50,11 @@ After work completes, verify:
 ### CLI Commands
 
 ```bash
-loaf session housekeeping --dry-run  # Preview all actions
-loaf session housekeeping            # Run all checks and fixes
+loaf housekeeping --dry-run          # Preview recommendations
+loaf housekeeping                    # Run artifact scanner
+loaf housekeeping --sessions         # Review sessions only
 loaf session archive                 # Archive single session
-loaf session enrich <file>           # Enrich a session's journal from JSONL
+loaf session enrich --json           # Compatibility diagnostic for legacy enrichment
 loaf task archive TASK-XXX           # Archive single task
 loaf spec archive SPEC-XXX           # Archive single spec
 loaf task sync                       # Compatibility: repair Markdown task index drift
@@ -62,7 +64,7 @@ loaf task sync                       # Compatibility: repair Markdown task index
 
 | Artifact | Active Location | Archive | Action |
 |----------|-----------------|---------|--------|
-| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf session archive` / `loaf session housekeeping` |
+| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf housekeeping --sessions` / `loaf session archive` |
 | Tasks (local mode only) | SQLite state + `.agents/tasks/` source prose | `archive/` | `loaf task archive` |
 | Specs | SQLite state + `.agents/specs/` authored prose | `archive/` | `loaf spec archive` |
 | Drafts (state assessments) | `.agents/drafts/` | delete | Flag for cleanup when linked session is archived |
@@ -79,7 +81,10 @@ every mode.
 
 ## Session Enrichment
 
-For each session with status `stopped` or `done` that has a `claude_session_id` in frontmatter, run `loaf session enrich <file>` to catch up on journal entries that weren't logged during the session.
+In SQLite-backed projects, `loaf session log` is the canonical journal writer and
+`wrap` owns end-of-session checks. `loaf session enrich --json` is a compatibility
+diagnostic for legacy markdown enrichment; it is not part of the normal
+housekeeping flow.
 
 Do NOT enrich `active` sessions — those are handled by the wrap skill when the session ends.
 

--- a/dist/opencode/skills/housekeeping/templates/session.md
+++ b/dist/opencode/skills/housekeeping/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/opencode/skills/implement/SKILL.md
+++ b/dist/opencode/skills/implement/SKILL.md
@@ -3,9 +3,9 @@ name: implement
 description: >-
   Orchestrates implementation sessions through agent delegation and batch
   execution. Use for all implementation work — features, bug fixes, refactors,
-  and code changes. Produces session files, agent spawn plans, and progress
-  tracking. Not for shaping (use shape), breakdown (use breakdown), research, or
-  review.
+  and code changes. Produces SQLite-backed session journals, agent spawn plans,
+  and progress tracking. Not for shaping (use shape), breakdown (use breakdown),
+  research, or review.
 subtask: false
 version: 2.0.0-pre.20260614235428
 ---
@@ -39,7 +39,7 @@ You are the coordinator. Start by understanding the task:
 **You are the ORCHESTRATOR, not the implementer.**
 
 ### Orchestrator Can Do Directly
-- Create/edit session files, council files
+- Start/log/show sessions, create council files
 - Use native task/todo surface when available; **if `integrations.linear.enabled` is `true` in `.agents/loaf.json`**, use Linear MCP tools when helpful
 - Read any file for context
 - Ask clarifying questions
@@ -49,11 +49,11 @@ You are the coordinator. Start by understanding the task:
 
 ## Verification
 
-- Session file exists before any implementation work begins
+- `loaf session start` has created or resumed an active SQLite-backed session before implementation work begins
 - All code changes delegated via subtask agent -- no direct edits by orchestrator
-- Session file is continuously updated with spawns, progress, and current state
+- Session journal is continuously updated with spawns, progress, and current state
 - Spec artifacts closed out on branch before PR creation
-- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session file is created; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
+- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session is started; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
 
 ## Quick Reference
 
@@ -81,7 +81,7 @@ Before starting, evaluate context suitability.
 | Just completed a different task/spec | Suggest clear |
 | About to start multi-file implementation | Check depth |
 
-If restart needed: capture state in session file, generate resumption prompt, ask user to restart.
+If restart needed: log current state with `loaf session log`, generate resumption prompt, ask user to restart.
 
 ## Input Detection
 
@@ -89,7 +89,7 @@ Parse `$ARGUMENTS` to determine session type:
 
 | Input Pattern | Type | Action |
 |---------------|------|--------|
-| `TASK-XXX` | Local task | Load via `loaf task show`, auto-create session |
+| `TASK-XXX` | Local task | Load via `loaf task show`, start/resume session |
 | `SPEC-XXX` | Spec orchestration | If spec frontmatter has `linear_parent`, resolve to that Linear parent and follow Linear-Native Routing. Otherwise resolve local tasks and build dependency waves |
 | `TASK-XXX..YYY` | Task range | Expand range, build dependency waves |
 | `TASK-XXX,YYY,ZZZ` | Task list | Parse list, build dependency waves |
@@ -101,8 +101,8 @@ Parse `$ARGUMENTS` to determine session type:
 When starting from `TASK-XXX`:
 
 1. Load task metadata via `loaf task show TASK-XXX --json`; read `.agents/TASKS.json` only as a Markdown-compatibility fallback
-2. Auto-generate session: `YYYYMMDD-HHMMSS-task-XXX.md`
-3. Create session file, update task with session reference: `loaf task update TASK-XXX --session <session-file>`
+2. Run `loaf session start` to find or create the active session for the branch
+3. Log the task coupling: `loaf session log "decision(implement): implementing TASK-XXX"`
 4. Load parent spec if task has `spec:` field
 
 **No user interaction required for session naming.**
@@ -188,7 +188,7 @@ The issue is an actual task. Implement it directly — with a pre-flight gate.
    - Resolve branch name from the sub-issue's `branchName` field (Linear
      auto-generates one) — see
      [session-management.md](references/session-management.md).
-   - Create session file, continue with the standard Startup Checklist.
+   - Run `loaf session start`, then continue with the standard Startup Checklist.
 
 ### Completion (after implementer + reviewer finish cleanly)
 
@@ -225,8 +225,8 @@ When the sub-issue's implementation passes review and tests:
   implementation reveals a missing task, surface it to the user; they
   decide whether to run `/breakdown` again or add an ad-hoc sub-issue.
 - Does not sync in-progress state bidirectionally. Source of truth at any
-  moment: Linear for issue state, local files for spec content, session
-  file for current handoff.
+  moment: Linear for issue state, local files for spec content, SQLite session
+  journal for current handoff.
 
 ---
 
@@ -249,19 +249,19 @@ Use the **subtask agent** with appropriate `agent_type`:
 
 ---
 
-## Session Creation
+## Session Start
 
-**MANDATORY: Create session file BEFORE any other work.**
+**MANDATORY: Run `loaf session start` BEFORE any implementation work.**
 
-1. Generate timestamps: `date -u +"%Y%m%d-%H%M%S"` and `date -u +"%Y-%m-%dT%H:%M:%SZ"`
-2. Create session file following [session template](templates/session.md)
-3. Verify session file exists with valid frontmatter
+1. Run `loaf session start` from the target branch/worktree.
+2. Log invocation context: `loaf session log "skill(implement): <task/spec/context>"`
+3. Verify the active session is readable with `loaf session list --json` or `loaf session show <session-ref> --json`.
 4. Suggest renaming OpenCode session with a meaningful name derived from context:
    - From spec: `Suggestion: /rename SPEC-027-session-stability`
    - From task: `Suggestion: /rename TASK-042-login-fix`
    - From ad-hoc: `Suggestion: /rename {short-slug-from-description}`
 
-**DO NOT PROCEED WITHOUT A SESSION FILE.**
+**Do not proceed until the active session is visible through `loaf session` commands.**
 
 ---
 
@@ -272,8 +272,8 @@ Use the **subtask agent** with appropriate `agent_type`:
 3. **When uncertain** -- convene council, present results, **wait for user approval**
 4. **Ensure quality** -- spawn implementer for tests, route reviews to reviewer subtask agent
 5. **When debugging** -- if a test failure or error isn't immediately obvious, load the **debugging** skill for structured hypothesis tracking before retrying
-6. **Update session file continuously** -- log spawns, update current_task, keep handoff-ready
-6. **Clean up** -- no ephemeral files, archive completed sessions (status + `archived_at` + `archived_by` + move to archive/)
+6. **Update session continuously** -- log spawns, progress, blockers, and next actions with `loaf session log`
+6. **Clean up** -- no ephemeral files; wrap with `loaf session end --wrap` and archive closed sessions with `loaf session archive`
 7. **When in doubt, ask the user**
 
 ## Decision Tree
@@ -282,7 +282,7 @@ Use the **subtask agent** with appropriate `agent_type`:
 Is this a code/config/doc change?
 +-- YES -> Spawn appropriate agent
 +-- NO -> Is this a planning/coordination decision?
-    +-- YES with clear path -> Proceed, update session
+    +-- YES with clear path -> Proceed, log session decision
     +-- YES but ambiguous -> Ask user
     +-- NO -> Ask user
 ```
@@ -293,18 +293,18 @@ When multiple valid approaches exist: spawn council (5-7 agents, odd), present r
 
 ## Startup Checklist
 
-After creating session file:
+After `loaf session start`:
 
 1. [ ] Parse input (task, Linear ID, or description)
-2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, update with `loaf task update TASK-XXX --session <session-file>`, load parent spec
+2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, log task coupling, load parent spec
 3. [ ] If Linear ID (or `SPEC-XXX` with `linear_parent`): follow [Linear-Native Routing](#linear-native-routing). Parent → walk sub-issues and select next. Sub-issue → verify `blockedBy` is clear, then start it as one logical Linear operation so the parent is promoted when needed
 4. [ ] If description: auto-create task (see Ad-hoc Task Auto-Creation above)
 5. [ ] Create dedicated branch (see [session-management.md](references/session-management.md))
 6. [ ] Suggest team based on task context
-7. [ ] Populate session Context section
+7. [ ] Log initial context and references with `loaf session log`
 8. [ ] Break down work using native task/todo surface when available
 9. [ ] Identify needed specialized agents
-10. [ ] Update session Next Steps
+10. [ ] Log next steps before spawning
 11. [ ] **Get user approval** before spawning
 
 ---
@@ -312,7 +312,7 @@ After creating session file:
 ## Then Execute
 
 ### BEFORE (Planning)
-1. Create session file
+1. Run `loaf session start`
 2. Set task status: `loaf task update TASK-XXX --status in_progress`
 3. Break down work into agent-sized tasks
 4. Identify spawn order (respect dependencies)
@@ -320,10 +320,10 @@ After creating session file:
 
 ### DURING (Execution)
 1. Spawn specialized agents via subtask agent
-2. Log each spawn in session `orchestration.spawned_agents`
+2. Log each spawn with `loaf session log "todo(agent): spawned <agent> for <task>"`
 3. Update Linear with progress (no emoji, no file paths)
-4. Keep session `## Current State` handoff-ready
-5. After each agent completes: update session, spawn next
+4. Keep journal entries handoff-ready
+5. After each agent completes: log outcome, spawn next
 
 ### AFTER (Completion)
 1. Code review pass (spawn `reviewer` agent)
@@ -332,13 +332,13 @@ After creating session file:
    - **Local-tasks mode:** `loaf task update TASK-XXX --status done` (per task), then `loaf task archive --spec SPEC-XXX`
    - **Linear-native mode:** `update_issue` the sub-issue to `completed`-type state. Then query the parent's sub-issues; if all are `completed`, also close the parent. If some remain, list them for the user (see [Linear-Native Routing → Completion](#completion-after-implementer--reviewer-finish-cleanly))
    - Mark spec complete and archive: `loaf spec archive SPEC-XXX` (both modes)
-   - Update session file (status: done, `archived_at`, `archived_by`)
-   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
+   - Run `loaf session end --wrap`; archive later with `loaf session archive` when appropriate
+   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session state`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
 5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
-6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
-   - `## Key Decisions` has content (not `*(none yet)*` or empty)
-   - `traceability.decisions` has entries (ADRs were recorded)
+6. **Suggest reflection:** Check the session journal for extractable learnings before closing out:
+   - `decision(...)` entries are present
+   - ADRs, report verdicts, or spec changelog entries were recorded
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
@@ -361,4 +361,4 @@ After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release`
 - **orchestration/product-development** - Full workflow hierarchy
 - **orchestration/specs** - Spec format and lifecycle
 - **orchestration/local-tasks** - Task file format including `session:` field
-- **orchestration/sessions** - Session lifecycle details
+- **orchestration/sessions** - SQLite-backed session lifecycle details

--- a/dist/opencode/skills/implement/references/session-management.md
+++ b/dist/opencode/skills/implement/references/session-management.md
@@ -8,7 +8,6 @@
 - Linear Status Management
 - Handoff State Requirements
 - Timestamps for User Context
-- Transcript Archival
 - Task Completion
 
 Detailed reference for session lifecycle management during implementation.
@@ -87,7 +86,7 @@ Use Linear MCP's `list_teams` (if configured) to get all workspace teams for val
 
 ## Diagram Consideration
 
-For multi-file or multi-service changes, consider adding architecture diagrams to the session file.
+For multi-file or multi-service changes, consider adding architecture diagrams to the linked spec, report, ADR, or implementation notes.
 
 ### When to Create Diagrams
 
@@ -106,7 +105,7 @@ Ask yourself:
 2. Is there a data flow that needs to be understood?
 3. Would a visual help communicate the approach?
 
-If yes to any, add an `## Architecture Diagrams` section to the session file.
+If yes to any, capture the diagram in a durable artifact such as a spec, report, ADR, or implementation note, and log the reference with `loaf session log`.
 
 ### Diagram Template
 
@@ -144,7 +143,7 @@ For complex tasks, explore before implementing:
 1. Use Task(Explore) or Task(Plan) to investigate codebase
 2. Map existing patterns and conventions
 3. Identify integration points
-4. Document findings in session file
+4. Log findings with `loaf session log` and reference durable artifacts
 5. Present approach to user for approval before spawning
 ```
 
@@ -193,12 +192,12 @@ never implement through open `blockedBy`.
 
 ## Handoff State Requirements
 
-**The session file must ALWAYS be handoff-ready.** After every significant action:
+**The session journal must ALWAYS be handoff-ready.** After every significant action:
 
-1. Update `## Current State` to reflect what just happened
-2. Update `orchestration.current_task` in frontmatter
+1. Log what just happened with `loaf session log`
+2. Reference task/spec/report/commit IDs rather than duplicating long prose
 3. Log completed agent work with outcomes
-4. Ensure anyone could pick up the work immediately
+4. Ensure anyone could pick up the work immediately from `loaf session show`
 
 ---
 
@@ -217,44 +216,6 @@ Generate with: `date -u +"%Y-%m-%d %H:%M UTC"`
 
 ---
 
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference.
-
-### Process
-
-1. **Get transcript path** from OpenCode output after compaction
-2. **Create transcripts directory** if needed:
-   ```bash
-   mkdir -p .agents/transcripts
-   ```
-3. **Copy transcript** with descriptive name:
-   ```bash
-   cp /path/to/transcript.jsonl .agents/transcripts/YYYYMMDD-HHMMSS-description.jsonl
-   ```
-4. **Update session frontmatter**:
-   ```yaml
-   transcripts:
-     - 20260123-143500-pre-compact.jsonl
-   ```
-
-### When to Archive
-
-| Event | Action |
-|-------|--------|
-| Before `/compact` | Archive current transcript |
-| Before `/clear` | Archive current transcript |
-| Session end | Archive final transcript |
-
-### Benefits
-
-- **Audit trail** - Full history of decisions and work
-- **Knowledge extraction** - Mining past sessions for patterns
-- **Debugging** - Understanding how errors occurred
-- **Training** - Learning from past sessions
-
----
-
 ## Task Completion
 
 When a task-coupled session completes:
@@ -267,7 +228,7 @@ When a task-coupled session completes:
      `list_issues` with `parent: <parent-id>`; if all are `completed`-type,
      close the parent and mark the local spec `complete`, else both stay
      in flight
-3. **Archive session** (standard process)
+3. **Wrap session** with `loaf session end --wrap`; archive with `loaf session archive` when the work is closed
 
 ### Spec Completion Check
 

--- a/dist/opencode/skills/implement/templates/session.md
+++ b/dist/opencode/skills/implement/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/opencode/skills/orchestration/SKILL.md
+++ b/dist/opencode/skills/orchestration/SKILL.md
@@ -26,12 +26,12 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 ## Critical Rules
 
 ### Sessions
-- Create following [session template](templates/session.md) — compact inline journal format
-- Use `loaf session log` for journal entries: `decide(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
+- Start or resume with `loaf session start`; SQLite is the operational source.
+- Use `loaf session log` for journal entries: `decision(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
 - **SESSION JOURNAL NUDGE**: When you see this hook trigger, log unrecorded decisions or findings before responding. Use `loaf session log "entry(scope): description"`. Only log actions (decisions made, things discovered, conclusions reached) — not thoughts or read-only work.
-- Archive when complete (status + `archived_at` + `archived_by` + move to `.agents/sessions/archive/`)
-- PreCompact hook: appends `compact` entry with context summary
-- Post-compaction: `loaf session start` outputs recent journal entries for recovery
+- Wrap with `loaf session end --wrap`; archive with `loaf session archive` when complete.
+- PreCompact hook: flushes journal-worthy state before compaction.
+- Post-compaction: `loaf session start` and `loaf session show` expose recent journal context for recovery.
 
 ### Councils
 - Always odd number: 5 or 7 agents
@@ -56,7 +56,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 ## Verification
 
-- Validate session files with `validate-session.py` before archiving
+- Verify `loaf session list --json` / `loaf session show <ref> --json` reflect the active work before archiving
 - Validate council files with `validate-council.py` before concluding
 - Confirm Linear issue updates are self-contained (no local paths, no emoji)
 
@@ -64,7 +64,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 | Task | Action |
 |------|--------|
-| Multi-step work | Create session file, spawn agents |
+| Multi-step work | Start/resume session, spawn agents |
 | Complex decision | Convene council (5-7 agents, odd) |
 | Linear update | Checkboxes, no emoji, no local paths |
 | Feature planning | Size by complexity, shape before building |
@@ -86,7 +86,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 | subtask agent Development | [references/subtask agent-development.md](references/subtask agent-development.md) | Delegating to specialized agents |
 | Background Agents | [references/background-agents.md](references/background-agents.md) | Running non-interactive work in background |
 | Council Workflow | [references/councils.md](references/councils.md) | Convening councils for complex decisions |
-| Session Management | [references/sessions.md](references/sessions.md) | Creating sessions and keeping live work resumable |
+| Session Management | [references/sessions.md](references/sessions.md) | Starting sessions and keeping live work resumable |
 | Session Resume | [references/session-resume.md](references/session-resume.md) | Resuming sessions, checkpoints, context recovery |
 | Context Management | [references/context-management.md](references/context-management.md) | Using /clear, /compact, managing context limits |
 | Linear Integration | [references/linear.md](references/linear.md) | Updating Linear issues, magic words, status conventions |
@@ -98,7 +98,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 **You are the orchestrator, not the implementer.**
 
 The orchestrator:
-1. Creates issues and session files for tracking
+1. Creates issues and starts sessions for tracking
 2. Breaks down work into delegable tasks
 3. Spawns specialized agents for implementation
 4. Coordinates outcomes and updates external systems
@@ -113,7 +113,6 @@ This skill uses paths from `.agents/loaf.json`:
 ```json
 {
   "sessions": {
-    "directory": ".agents/sessions",
     "councils_directory": ".agents/councils"
   },
   "linear": {
@@ -128,9 +127,8 @@ This skill uses paths from `.agents/loaf.json`:
 
 | Artifact | Location | Archive | Naming |
 |----------|----------|---------|--------|
-| Sessions | `.agents/sessions/` | `.agents/sessions/archive/` | `YYYYMMDD-HHMMSS-description.md` |
+| Sessions | SQLite (`loaf session show`) | `loaf session archive` | CLI alias / session ID |
 | Councils | `.agents/councils/` | `.agents/councils/archive/` | `YYYYMMDD-HHMMSS-topic.md` |
-| Transcripts | `.agents/transcripts/` | N/A | Copied from tool output |
 | Handoffs | `.agents/handoffs/` | delete after deprecated | Created by `/handoff` |
 | Reports | `.agents/reports/` | N/A | `YYYYMMDD-HHMMSS-subject.md` |
 | Tasks | `.agents/tasks/` | N/A | Per task manager conventions |
@@ -141,16 +139,16 @@ This skill uses paths from `.agents/loaf.json`:
 
 ### BEFORE (Planning)
 - Create/check external issue (Linear, GitHub)
-- Create session file following [session template](templates/session.md)
+- Run `loaf session start` and log the orchestration intent
 - Break down into tasks, identify agents, get user approval
 
 ### DURING (Execution)
 - Spawn specialized agents (never implement directly)
-- Track progress in session file and external issue
+- Track progress with `loaf session log` and external issue updates
 - Convene councils for uncertain decisions
 
 ### AFTER (Completion)
 - Code review + QA testing
 - Update external issue to Done
 - Ensure knowledge captured in permanent locations
-- Archive session (status + `archived_at` + `archived_by` + move + update links)
+- Run `loaf session end --wrap`; archive with `loaf session archive` after merge/closure

--- a/dist/opencode/skills/orchestration/references/background-agents.md
+++ b/dist/opencode/skills/orchestration/references/background-agents.md
@@ -1,12 +1,13 @@
 # Background Agents
 
-Background agents handle low-priority, long-running, or non-interactive work that can run independently while the user continues with other tasks.
+Background agents handle low-priority, long-running, or non-interactive work
+while the user continues with other tasks.
 
 ## Contents
 
 - When to Use Background Agents
 - Spawning Background Agents
-- Background Agent Tracking
+- Tracking
 - Result Retrieval
 - Workflow Example
 - Anti-Patterns
@@ -19,20 +20,11 @@ Background agents handle low-priority, long-running, or non-interactive work tha
 | Security audits | Interactive debugging |
 | Code coverage analysis | User-facing questions |
 | Large-scale refactoring reports | Time-sensitive fixes |
-| Codebase-wide linting reports | Tasks requiring immediate feedback |
 | Documentation audits | Work needing user decisions mid-task |
 | Dependency vulnerability scans | Blocking tasks for current work |
 
-**Good candidates:**
-- Results can be processed later
-- No user interaction required
-- Task is well-defined with clear completion criteria
-- Output is a report or artifact, not a conversation
-
-**Poor candidates:**
-- Needs clarification mid-task
-- Time-sensitive (user waiting for result)
-- Requires real-time coordination with other agents
+Good candidates have clear completion criteria, can run without clarification,
+and produce a report or durable artifact.
 
 ## Spawning Background Agents
 
@@ -51,8 +43,7 @@ Task(
     - src/services/
 
     Write report to: .agents/reports/YYYYMMDD-HHMMSS-security-audit.md
-
-    Session: .agents/sessions/20260123-143000-auth-feature.md
+    Active session: SESSION-ALIAS if available from loaf session list/show
     """,
     run_in_background=True
 )
@@ -60,187 +51,57 @@ Task(
 
 ### Cursor
 
-Background agents are configured via the `is_background: true` YAML property. When spawning:
+Background agents are configured via the `is_background: true` YAML property.
+When spawning, specify the report destination and any task/spec/session IDs:
 
 ```
 @background-runner Run security audit on backend codebase.
-Write report to .agents/reports/
+Write report to .agents/reports/.
+Reference TASK-123 and the active session alias if available.
 ```
 
-## Background Agent Tracking
+## Tracking
 
-Track background agents in session frontmatter:
+Track background work with durable references:
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security-scan"
-    agent: background-runner
-    task: "Full security audit of backend"
-    status: running  # running | completed | failed
-    result_location: null
-  - id: "bg-20260123-144500-coverage"
-    agent: background-runner
-    task: "Test coverage analysis"
-    status: completed
-    result_location: ".agents/reports/20260123-144500-coverage-report.md"
-```
+1. Log the spawn with `loaf session log "todo(background): started <id> for <task>"`.
+2. Ask the background agent to write a report under `.agents/reports/`.
+3. When complete, log `discover(background): <id> wrote <report>`.
+4. Process findings into tasks, specs, ADRs, or report verdicts as appropriate.
 
-### Status Values
-
-| Status | Meaning |
-|--------|---------|
-| `running` | Agent still executing |
-| `completed` | Work finished, results available |
-| `failed` | Agent encountered error |
-
-### ID Convention
-
-Background agent IDs follow: `bg-YYYYMMDD-HHMMSS-<description>`
-
-Generate with:
-```bash
-echo "bg-$(date -u +"%Y%m%d-%H%M%S")-<description>"
-```
+Use a stable ID such as `bg-YYYYMMDD-HHMMSS-description` in the prompt and
+journal entries.
 
 ## Result Retrieval
 
-Background agents write results to `.agents/reports/` with standard frontmatter:
-
-```yaml
----
-report:
-  title: "Security Audit Report"
-  type: background-agent-output
-  status: unprocessed  # unprocessed | processed | archived
-  created: "2026-01-23T14:30:00Z"
-  background_agent_id: "bg-20260123-143000-security-scan"
-  session_reference: "20260123-140000-auth-feature.md"
----
-```
-
-### Processing Results
-
-1. SessionStart hook alerts user to completed background work
-2. User or orchestrator reviews report in `.agents/reports/`
-3. Orchestrator updates session frontmatter:
-   - Change `status` from `running` to `completed`
-   - Set `result_location` to report path
-4. Process findings as needed (spawn agents, create issues)
-5. Set report `status` to `processed`
+Background agents write results to `.agents/reports/` with enough metadata to
+identify the source task and report status. In SQLite-backed projects, use
+`loaf report list`, `loaf report show`, and `loaf report archive` when report
+state is available.
 
 ## Workflow Example
 
-### 1. Orchestrator Identifies Low-Priority Work
-
-During auth feature implementation, orchestrator identifies need for security audit but it is not blocking current work.
-
-### 2. Orchestrator Spawns Background Agent
-
-```python
-Task(
-    agent_type="background-runner",
-    prompt="""
-    Run comprehensive security audit on auth implementation.
-
-    Files to audit:
-    - src/auth/endpoints.py
-    - src/auth/token.py
-    - src/auth/middleware.py
-
-    Check for:
-    - OWASP Top 10 vulnerabilities
-    - Secrets in code
-    - SQL injection risks
-    - Authentication bypasses
-
-    Write report to: .agents/reports/20260123-143000-auth-security.md
-
-    Session: .agents/sessions/20260123-140000-auth-feature.md
-    """,
-    run_in_background=True
-)
-```
-
-### 3. Orchestrator Updates Session Frontmatter
-
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-auth-security"
-    agent: background-runner
-    task: "Auth security audit"
-    status: running
-    result_location: null
-```
-
-### 4. Work Continues
-
-Orchestrator and other agents continue with main implementation while background agent works.
-
-### 5. Session Resumes Later
-
-SessionStart hook detects completed background work:
-
-```
-# Background Work Completed
-
-The following background agents have completed:
-
-- **bg-20260123-143000-auth-security** (background-runner)
-  - Task: Auth security audit
-  - Result: .agents/reports/20260123-143000-auth-security.md
-
-Review reports and update session frontmatter after processing.
-```
-
-### 6. Results Processed
-
-Orchestrator reads report, creates issues for findings, updates session.
+1. Orchestrator identifies non-blocking security audit work.
+2. Orchestrator logs the background spawn in the active session.
+3. Background agent writes `.agents/reports/YYYYMMDD-HHMMSS-auth-security.md`.
+4. Orchestrator reviews the report, creates follow-up tasks, and logs the
+   outcome.
+5. Report state is finalized or archived through the report lifecycle.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
 | Use for blocking work | Keep blocking work in foreground |
-| Spawn without tracking | Always update session frontmatter |
-| Ignore completed results | Process results when alerted |
+| Spawn without tracking | Log the spawn and require a report path |
+| Ignore completed results | Process reports into tasks, findings, or decisions |
 | Use for interactive tasks | Reserve for autonomous work |
-| Spawn many concurrent background agents | Limit to 2-3 to avoid resource contention |
-| Skip result location in prompt | Always specify where to write output |
+| Spawn many concurrent background agents | Limit concurrency to avoid resource contention |
+| Skip result location in prompt | Always specify where output belongs |
 
 ## Integration Points
 
-### SessionStart Hook
-
-Checks session frontmatter for `background_agents` with `status: completed`. Alerts user to review results.
-
-### PreCompact Hook
-
-Includes background agent state in preservation. PreCompact hook captures:
-- Active background agent list
-- Current status of each
-- Result locations for completed agents
-
-### Session Frontmatter
-
-Full template with background agents:
-
-```yaml
----
-session:
-  title: "Feature implementation"
-  status: in_progress
-  # ... other session fields ...
-
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: completed
-    result_location: ".agents/reports/20260123-143000-security.md"
-  - id: "bg-20260123-150000-coverage"
-    agent: background-runner
-    task: "Coverage analysis"
-    status: running
-    result_location: null
----
-```
+- `loaf session log` records spawn and completion facts.
+- `loaf session show` exposes recent background-work journal entries.
+- `loaf report` commands own durable report lifecycle when available.
+- `/wrap` should mention unprocessed background reports before ending a session.

--- a/dist/opencode/skills/orchestration/references/context-management.md
+++ b/dist/opencode/skills/orchestration/references/context-management.md
@@ -1,54 +1,34 @@
 # Context Management
 
-Patterns for managing context efficiently across sessions and agent spawns.
+Patterns for keeping long work resumable while using SQLite-backed session
+journals as the external memory.
 
 ## Contents
 
 - Design for Compaction
-- Overview
 - Context Commands
 - When to Clear Context
-- The 2-Correction Rule
-- Context Compaction
-- Session Files as Context Anchors
+- Compaction Lifecycle
 - subtask agent for Context Isolation
 - Context Budget Guidelines
-- Preventing Context Bloat
-- Session Context Patterns
 - Warning Signs
 - Best Practices
 
 ## Design for Compaction
 
-Compaction is a normal part of long workflows, not an emergency measure. Any workflow expected to exceed 15-20 exchanges should be designed with compaction in mind from the start.
+Compaction is a normal part of long workflows. Design any workflow expected to
+span many exchanges so important state is already outside chat context.
 
 ### Compaction-First Principles
 
-1. **The journal IS external memory** — Session journal entries (decisions, discoveries, progress) survive compaction. Compaction can be lossy because all important state is already on disk.
-2. **`## Current State` is the resumption context** — Keep this section handoff-ready at all times. The PreCompact hook requires writing a state summary here before compaction.
-3. **Decisions go to disk, not context** — Record key decisions in the session journal immediately via `loaf session log`. Context may be compressed; journal entries persist.
-4. **subtask agent absorb exploration** — Investigation and exploration should happen in subtask agent. Only the summary returns to the main context.
-
-### Compaction Lifecycle
-
-```
-PreCompact:
-  1. Flush all unrecorded journal entries (decisions, discoveries, progress)
-  2. Write condensed state summary to session file's ## Current State
-  3. compact.sh writes compact(session) marker to journal
-
-PostCompact:
-  1. PostCompact nudge fires — tells model to read session file
-  2. Model reads ## Current State for resumption context
-  3. Model reads ## Journal for decision trail
-  4. Work resumes without "where were we?"
-```
-
-This makes compaction invisible to workflow continuity. The session file's `## Current State` section is the resumption prompt — written by the model before compaction, read by the model after.
-
-## Overview
-
-Context is finite. Long conversations accumulate irrelevant information that degrades performance. Active context management keeps conversations focused and effective.
+1. **The journal is external memory.** Record decisions, discoveries, blockers,
+   and next actions with `loaf session log`.
+2. **Artifacts carry detail.** Specs, tasks, reports, ADRs, and commits hold rich
+   detail; journal entries point to them.
+3. **subtask agent absorb exploration.** Use subtask agent for broad investigation and
+   return concise findings to the main context.
+4. **`wrap` closes the loop.** End meaningful work with `loaf session end --wrap`
+   so the session lifecycle matches the journal.
 
 ## Context Commands
 
@@ -60,191 +40,78 @@ Context is finite. Long conversations accumulate irrelevant information that deg
 
 ## When to Clear Context
 
-### Clear Between Tasks
-
 Use `/clear` when:
 
 - Starting a completely new task
-- Previous task is fully complete
-- Context has become cluttered with failed attempts
+- Previous task is complete
+- Debugging noise is crowding out the current objective
 - Switching between unrelated codebases
 
-### Don't Clear When
+Avoid clearing mid-task until you have logged enough state for recovery.
 
-- Mid-task and need previous context
-- Debugging requires understanding of prior attempts
-- Session file provides necessary handoff information
-
-## The 2-Correction Rule
-
-**If Claude makes the same mistake twice after correction, the context may be polluted.**
-
-Signs of context pollution:
-- Repeating errors you've already corrected
-- Ignoring instructions you've given
-- Reverting to patterns you've explicitly rejected
-- Confusion about current task state
-
-**Action:** Consider `/clear` and restart with fresh context, referencing session file for state.
-
-## Context Compaction
-
-Use `/compact` when:
-- Conversation is long but task continues
-- Need to preserve key decisions while reducing noise
-- Approaching context limits
-
-**Journal entries are compaction insurance.** Every `loaf session log` call writes state to disk that survives compaction. Don't defer journaling — entries not flushed before compaction are lost.
-
-### What Compaction Preserves (via session file)
-
-- Journal entries: decisions, discoveries, progress, commits
-- `## Current State` summary (written by PreCompact)
-- All externalized artifacts: specs, tasks, ideas, code
-
-### What Compaction Discards
-
-- Intermediate exploration steps
-- Failed attempts and debugging noise
-- Verbose tool output
-- Redundant explanations
-
-## Session Files as Context Anchors
-
-Session files provide persistent context that survives `/clear`:
-
-```markdown
-## Current State
-[Always handoff-ready summary]
-
-## Key Decisions
-- Chose X over Y because Z
-
-## Next Steps
-- Immediate action items
-```
-
-### Pattern: Clear + Resume
+## Compaction Lifecycle
 
 ```
-1. Update session file with current state
-2. /clear to reset context
-3. /resume to reload from session file
-4. Continue with clean context
+PreCompact:
+  1. Flush unrecorded decisions, discoveries, blockers, and next actions
+  2. Reference specs, tasks, reports, commits, and files by stable ID/path
+  3. Let the hook persist the compact marker
+
+PostCompact:
+  1. Run or inspect `loaf session start` output for the active branch
+  2. Use `loaf session show <session-ref> --json` when more context is needed
+  3. Continue from the journal and linked artifacts
 ```
+
+This makes compaction survivable without relying on hand-maintained markdown
+state. Any state not logged or captured in a durable artifact can be lost.
 
 ## subtask agent for Context Isolation
 
-Use subtask agent (subtask agent) to investigate without polluting main context:
-
-```
-# Instead of exploring in main conversation:
-Let me look at how auth works...
-[reads 10 files, fills context]
-
-# Use subtask agent for investigation:
-Task(Explore, "How does authentication work in this codebase?")
-[returns focused summary, main context stays clean]
-```
-
-### When to Use subtask agent
+Use subtask agent to investigate without filling the main context:
 
 | Situation | Approach |
 |-----------|----------|
-| Quick file lookup | Direct Read tool |
-| Multi-file exploration | Task(Explore) |
-| Implementation work | Task(implementer) |
-| Complex investigation | Task(Plan) then implement |
+| Quick file lookup | Direct read/search tool |
+| Multi-file exploration | Explorer/research subtask agent |
+| Implementation work | Implementer or task-focused agent |
+| Long audit | Background agent with report output |
+
+Pass stable references to subtask agent: task IDs, spec IDs, branch names, report
+paths, and the active session alias when available.
 
 ## Context Budget Guidelines
 
-### Short Conversations (< 10 exchanges)
+### Short Conversations
 
-- No management needed
-- Context stays fresh naturally
+No special management is usually needed.
 
-### Medium Conversations (10-30 exchanges)
+### Medium Conversations
 
-- Consider `/compact` at midpoint
-- Delegate investigations to subtask agent
-- Keep session file updated
+- Log decisions as they happen.
+- Delegate broad searches.
+- Keep tool output scoped.
 
-### Long Conversations (30+ exchanges)
+### Long Conversations
 
-- `/compact` every 15-20 exchanges
-- Heavy use of subtask agent for exploration
-- Session file as primary state holder
-- Consider `/clear` + restart if degraded
-
-## Preventing Context Bloat
-
-### Minimize Tool Output
-
-```
-# Instead of reading entire large files:
-Read(file, limit=50)  # Read first 50 lines
-
-# Instead of globbing everything:
-Glob("src/**/*.py", path="src/auth/")  # Scoped search
-```
-
-### Focused Queries
-
-```
-# Instead of "show me all the code":
-"Find where user authentication is validated"
-
-# Instead of exploring blindly:
-"What files handle the /api/users endpoint?"
-```
-
-### Progressive Disclosure
-
-1. Get overview first (symbols, structure)
-2. Drill into specific areas
-3. Read full content only when needed
-
-## Session Context Patterns
-
-### Starting a Session
-
-```
-1. Create session file (minimal context recorded)
-2. Break down task (decisions recorded)
-3. Spawn first agent (isolated context)
-4. Update session (state persisted)
-```
-
-### Mid-Session Context Check
-
-Every 10-15 exchanges, assess:
-- [ ] Is context still focused on current task?
-- [ ] Are previous decisions still relevant?
-- [ ] Has debugging noise accumulated?
-- [ ] Would `/compact` help?
-
-### Session Handoff
-
-When pausing or handing off:
-1. Update session file with complete state
-2. Include "resumption notes" for context
-3. Reference key files and decisions
-4. Clear main context if long
+- Expect compaction.
+- Keep the journal current.
+- Use reports or handoffs for rich summaries rather than stuffing prose into the
+  session journal.
 
 ## Warning Signs
 
 | Symptom | Likely Cause | Action |
 |---------|--------------|--------|
-| Repeating same mistakes | Context pollution | `/clear` + restart |
-| Forgetting recent decisions | Overcrowded context | `/compact` |
-| Slow responses | Large context | Use subtask agent |
-| Confusion about task | Too many pivots | Update session, `/clear` |
+| Repeating same mistakes | Context pollution | Log current facts, then clear or compact |
+| Forgetting recent decisions | Overcrowded context | Inspect `loaf session show` and continue from journal |
+| Slow responses | Large context | Delegate exploration |
+| Confusion about task | Too many pivots | Re-anchor on task/spec/session IDs |
 
 ## Best Practices
 
-1. **Update session files continuously** - they survive context resets
-2. **Use subtask agent for exploration** - keep main context clean
-3. **Clear between unrelated tasks** - fresh start beats polluted context
-4. **Compact mid-task if needed** - preserve decisions, discard noise
-5. **Monitor for pollution** - 2-correction rule catches degradation early
-6. **Scope tool calls** - don't read entire codebases into context
+1. Log durable facts early with `loaf session log`.
+2. Use subtask agent for exploration-heavy work.
+3. Clear between unrelated tasks.
+4. Compact mid-task when the journal and artifacts are current.
+5. Scope tool calls so context stays focused.

--- a/dist/opencode/skills/orchestration/references/cross-session.md
+++ b/dist/opencode/skills/orchestration/references/cross-session.md
@@ -135,7 +135,7 @@ When sessions are archived, decisions are extracted to Serena memory:
 
 1. `loaf session end --wrap` persists decisions to spec changelog
 2. Session stays in `sessions/` with `status: done` — no immediate archive
-3. `loaf session housekeeping` archives complete sessions after 7-day age threshold
+3. `loaf housekeeping` reports stale compatibility artifacts, and `loaf session archive` archives closed SQLite sessions when work is complete
 
 ### At Reference Time (spec changelog)
 

--- a/dist/opencode/skills/orchestration/references/product-development.md
+++ b/dist/opencode/skills/orchestration/references/product-development.md
@@ -11,7 +11,6 @@ A Research → Vision → Architecture → Requirements → Specs → Tasks → 
 - Configuration
 - Workflow Examples
 - Feedback Loops
-- Transcript Archival
 - Flexibility Preserved
 - Critical Files
 
@@ -33,10 +32,9 @@ docs/                               # Permanent project knowledge
 
 .agents/                            # Ephemeral orchestration
 ├── loaf.yaml                       # Project config (task backend, etc.)
-├── sessions/                       # Active work contexts
+├── sessions/                       # Compatibility/rendered session views
 ├── plans/                          # Implementation plans
 ├── councils/                       # Deliberation records
-├── transcripts/                    # Archived conversation transcripts
 ├── tasks/                          # Local tasks (when not using Linear)
 │   ├── active/
 │   │   └── TASK-001-oauth-provider.md
@@ -71,7 +69,7 @@ RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS → SE
 | `/architecture` | Decision question | ARCHITECTURE.md + ADR | Technical decisions |
 | `/shape` | Feature area or requirement | Spec in .agents/specs/ | Implementation-ready specification with boundaries |
 | `/breakdown` | Spec | Tasks in .agents/tasks/ | Atomic work items for agents |
-| `/implement` | TASK-ID | Session file | Execute a task |
+| `/implement` | TASK-ID | SQLite session + implementation commits | Execute a task |
 
 ## Document Formats
 
@@ -187,7 +185,7 @@ docs:
 
 # 6. Work on tasks
 /implement TASK-001
-# → Session → Implementation → Done
+# → SQLite session → Implementation → Done
 ```
 
 ### Quick Fix (Ad-hoc)
@@ -197,7 +195,7 @@ docs:
 /implement TASK-099
 # Orchestrator: "No parent spec. Proceed?"
 # User: "Yes, small fix"
-# → Session → Fix → Done
+# → SQLite session → Fix → Done
 ```
 
 ## Feedback Loops
@@ -210,23 +208,6 @@ The workflow is not rigid. Each level can feed back to higher levels:
 | Edge case invalidates requirement | Update REQUIREMENTS.md |
 | Spec too complex for its size | Re-scope or split |
 | Task reveals missing requirement | Add to REQUIREMENTS.md |
-
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference:
-
-1. **Copy transcript** to `.agents/transcripts/`
-2. **Link from session file** in frontmatter:
-
-```yaml
-session:
-  title: "Feature Implementation"
-  transcripts:
-    - 20260123-143500-pre-compact.jsonl
-    - 20260123-160000-final.jsonl
-```
-
-This preserves full context for debugging, knowledge extraction, and audit trails.
 
 ## Flexibility Preserved
 

--- a/dist/opencode/skills/orchestration/references/session-resume.md
+++ b/dist/opencode/skills/orchestration/references/session-resume.md
@@ -1,15 +1,15 @@
 # Session Resume Patterns
 
-Patterns for resuming work across OpenCode sessions using CLI flags and session files.
+Patterns for resuming work with CLI conversation history plus SQLite-backed
+Loaf session state.
 
 ## Contents
 
 - CLI Resume Flags
 - Resume Methods
 - When to Use Each Method
-- Session File as Resume Checkpoint
+- SQLite Session as Resume Checkpoint
 - Checkpoint Pattern
-- Naming Sessions Descriptively
 - Context Recovery Strategies
 - Handling Stale Sessions
 - Multi-Session Coordination
@@ -17,7 +17,7 @@ Patterns for resuming work across OpenCode sessions using CLI flags and session 
 
 ## CLI Resume Flags
 
-OpenCode provides built-in session continuation:
+Some harnesses provide built-in conversation continuation:
 
 | Flag | Purpose |
 |------|---------|
@@ -25,217 +25,113 @@ OpenCode provides built-in session continuation:
 | `--resume <id>` | Resume a specific conversation by ID |
 | `/resume` | In-session command to list and resume |
 
+Use harness resume for chat history. Use `loaf session` for operational state.
+
 ## Resume Methods
 
-### Method 1: CLI Continue
+### Method 1: Conversation Continue
+
+Resume the exact conversation when you need full chat history.
+
+### Method 2: SQLite Session Resume
+
+Start fresh and recover operational state:
 
 ```bash
-# Continue most recent conversation
-claude --continue
-
-# Resume specific conversation
-claude --resume abc123
+loaf session start
+loaf session list --all --json
+loaf session show <session-ref> --json
 ```
 
-**Best for:** Picking up exactly where you left off with full context.
-
-### Method 2: Session File Resume
-
-```bash
-# Start new conversation, resume from session file
-claude
-> /resume 20250123-143000-feature-auth
-```
-
-**Best for:** Fresh context but task continuity from session file.
+Best for clean context with task continuity.
 
 ### Method 3: Hybrid Resume
 
-```bash
-# Continue conversation AND sync with session file
-claude --continue
-> Check session file for any updates: .agents/sessions/20250123-143000-feature-auth.md
-```
-
-**Best for:** Recovering from context pollution while preserving conversation history.
+Continue the conversation, then compare it against `loaf session show` output.
+Best when chat history matters but the journal may contain newer facts.
 
 ## When to Use Each Method
 
 | Situation | Recommended Method |
 |-----------|-------------------|
-| Short break, same task | `--continue` |
-| Long break, clean state needed | Session file resume |
+| Short break, same task | Conversation continue |
+| Long break, clean state needed | SQLite session resume |
 | Context polluted but need history | Hybrid resume |
-| Different machine | Session file resume |
-| Handoff to another person | Session file resume |
+| Different machine | SQLite session resume |
+| Handoff to another person | SQLite session + handoff/report |
 
-## Session File as Resume Checkpoint
+## SQLite Session as Resume Checkpoint
 
-### Writing Resume-Ready State
+Before ending or compacting:
 
-Before ending a session, ensure session file contains:
-
-```markdown
-## Current State
-**Last Action:** Completed API endpoint implementation
-**Pending:** Tests need to be written
-
-## Resumption Notes
-- Branch: feature/auth-endpoints
-- Key files modified: src/auth/routes.py, src/auth/models.py
-- Tests to write: test_login, test_logout, test_refresh
-- Blocker: None
-
-## Next Steps
-1. Spawn QA agent for test implementation
-2. Run full test suite
-3. Update API documentation
-```
-
-### Reading Resume State
+1. Log last action, blockers, and next steps with `loaf session log`.
+2. Reference tasks, specs, reports, commits, and branch names by stable ID/path.
+3. Run `loaf session end --wrap` when work is complete.
 
 When resuming:
 
-1. Read session file for context
-2. Check `## Current State` for where you left off
-3. Check `## Resumption Notes` for key details
-4. Check `## Next Steps` for immediate actions
-5. Verify branch and file state match expectations
+1. Run `loaf session start` on the branch/worktree.
+2. Inspect `loaf session show <session-ref> --json`.
+3. Verify branch and file state match expectations.
+4. Continue from the next logged action.
 
 ## Checkpoint Pattern
 
-For long-running tasks, create explicit checkpoints:
-
-```markdown
-## Checkpoints
-
-### Checkpoint 1: Schema Complete
-**Timestamp:** 2025-01-23T14:30:00Z
-**State:** Database schema implemented and migrated
-**Can resume from:** This checkpoint if later work fails
-
-### Checkpoint 2: API Complete
-**Timestamp:** 2025-01-23T15:45:00Z
-**State:** All endpoints implemented, passing basic tests
-**Can resume from:** This checkpoint for test expansion
-```
-
-### Rewind to Checkpoint
-
-If work goes wrong:
-
-1. Identify safe checkpoint
-2. `git checkout <commit>` to restore code state
-3. Update session file to checkpoint state
-4. `/clear` to reset context
-5. Resume from checkpoint
-
-## Naming Sessions Descriptively
-
-Good session names aid resume:
-
-```
-# Good - descriptive, searchable
-20250123-143000-auth-jwt-implementation.md
-20250123-160000-api-rate-limiting.md
-
-# Bad - generic, hard to find
-20250123-143000-feature.md
-20250123-160000-fix.md
-```
-
-### Rename Pattern
+For long-running tasks, create explicit journal checkpoints:
 
 ```bash
-# If session name becomes unclear, rename for clarity
-mv .agents/sessions/20250123-143000-feature.md \
-   .agents/sessions/20250123-143000-user-auth-oauth.md
+loaf session log "decision(checkpoint): schema complete at <commit>"
+loaf session log "decision(checkpoint): API complete; next write tests"
 ```
 
-Update any references in Linear or other sessions.
+If work goes wrong, use Git to restore code state and log the reconciliation:
+
+```bash
+loaf session log "decision(recovery): rewound to <commit>; replaying tests"
+```
 
 ## Context Recovery Strategies
 
-### Strategy 1: Full Replay
+### Full Replay
 
-For complex state, replay key decisions:
+Use `loaf session show` plus ADR/spec/report links for complex state.
 
-```markdown
-## Decision Replay
+### Minimal Context
 
-When resuming, recall these decisions:
-1. Chose JWT over sessions (see ADR-007)
-2. Using Redis for token storage
-3. 15-minute access token expiry
-```
+Use the last few journal entries when the next action is obvious.
 
-### Strategy 2: Minimal Context
+### Reference Chain
 
-For simple continuation:
+For multi-session work, log relationships:
 
-```markdown
-## Minimal Resume Context
-
-Branch: feature/auth
-Last commit: "feat: add login endpoint"
-Next: Write tests for login endpoint
-```
-
-### Strategy 3: Reference Chain
-
-For multi-session work:
-
-```markdown
-## Session Chain
-
-Previous sessions:
-- 20250122-100000-auth-design.md (planning)
-- 20250122-143000-auth-schema.md (database)
-- This session: API implementation
+```bash
+loaf session log "discover(context): previous design captured in SPEC-123 and ADR-007"
 ```
 
 ## Handling Stale Sessions
 
-### Signs of Stale Session
+Signs of stale session state:
 
-- Code has changed since session was active
-- Other sessions modified same files
+- Code changed after the last journal entry
 - Branch was rebased or merged
+- Another task/spec superseded the work
 
-### Stale Session Recovery
+Recovery:
 
-```
-1. Read session file for intended state
-2. Compare with actual code state (git diff)
-3. Identify conflicts or drift
-4. Update session file to reflect reality
-5. Plan reconciliation if needed
-```
+1. Inspect `loaf session show`.
+2. Compare with `git status`, `git log`, and relevant specs/tasks.
+3. Log the drift and reconciliation plan.
 
 ## Multi-Session Coordination
 
-When multiple sessions touch same codebase:
-
-```markdown
-## Related Sessions
-
-| Session | Status | Overlaps |
-|---------|--------|----------|
-| auth-backend | completed | src/auth/ |
-| auth-frontend | in_progress | src/components/auth/ |
-| This session | in_progress | src/auth/models.py (shared) |
-
-## Coordination Notes
-- Wait for auth-backend completion before modifying models
-- Sync with auth-frontend on API contract changes
-```
+When multiple sessions touch related areas, use specs/tasks/reports as the shared
+coordination layer. Session journals should point to those durable artifacts
+rather than becoming the only place a dependency is described.
 
 ## Best Practices
 
-1. **Update session before stopping** - capture state while fresh
-2. **Use descriptive names** - aid future resume
-3. **Create checkpoints** - safe rollback points
-4. **Note dependencies** - what must complete first
-5. **Clear stale context** - don't resume into pollution
-6. **Verify state on resume** - code may have changed
-7. **Document decision context** - not just decisions
+1. Log before stopping.
+2. Prefer stable IDs over pasted summaries.
+3. Use `loaf session show` as the operational resume surface.
+4. Keep chat-history resume separate from Loaf session state.
+5. Verify code state on resume.

--- a/dist/opencode/skills/orchestration/references/sessions.md
+++ b/dist/opencode/skills/orchestration/references/sessions.md
@@ -1,523 +1,116 @@
 # Session Management
 
-Sessions are coordination artifacts for active work. They are archived (set status, `archived_at`, `archived_by`, move to `.agents/sessions/archive/`) when work completes to preserve an audit trail.
+Sessions are SQLite-backed coordination records for active work. Markdown is a
+rendered view for reading or compatibility export; agents persist new facts with
+`loaf session` commands.
 
 ## Contents
 
-- Compact vs New Session
+- Core Model
 - When to Use Sessions
-- Session Types
-- Session File Format
-- Lifecycle States
-- Updating During Work
-- Session Continuity Protocol
-- Completing a Session
-- Start Protocol
+- Lifecycle
+- Journal Protocol
+- Continuity
+- Completion
 - Hook Integration
 - Anti-Patterns
 
-## Compact vs New Session
+## Core Model
 
-| Scenario | Action |
-|----------|--------|
-| Picking up previous work, same scope | Compact or resume existing conversation |
-| Switching to entirely different scope | New conversation (new session) |
-| Finished and archived a spec | New conversation |
-| Context full mid-task | Auto-compact (journal survives) |
-| Quick unrelated question | New conversation (don't pollute working session) |
+Use the `wrap` skill as the canonical session model:
 
-**Rule of thumb:** if you'd need the same session file, compact. If you'd need a different one, start fresh.
+1. `loaf session start` finds or creates the active session for the current branch
+   and prints resumption context.
+2. `loaf session log "type(scope): description"` writes durable journal rows.
+3. `loaf session show <session-ref> --json` reads the SQLite-backed session view.
+4. `loaf session end --wrap` persists the wrapped end state.
+5. `loaf session archive` archives closed sessions when the branch/work is done.
+
+The render format is documented in `templates/session.md`; it is not an
+instruction to author markdown directly.
 
 ## When to Use Sessions
 
-- Multi-step work requiring agent coordination
+- Multi-step work requiring coordination
 - Handoffs between agents
-- Tracking progress during implementation
-- Context preservation across agent spawns
+- Implementation or release work that must survive compaction
+- Long research, architecture, council, or review efforts
 
-## Session Types
+For quick unrelated questions, start a fresh conversation so the active session
+stays focused.
 
-### Implementation Sessions (Invisible)
+## Lifecycle
 
-When implementing tasks via `/implement TASK-XXX`:
+The interim runtime lifecycle before SPEC-049 is:
 
-- Session created automatically with filename `YYYYMMDD-HHMMSS-session.md`
-- Task file updated with `session:` field linking to session
-- No user interaction needed for session naming
-- Resume via `loaf session start` then `/implement TASK-XXX`
+| State | Source | Meaning |
+|-------|--------|---------|
+| `active` | `loaf session start` | Current work may receive journal entries |
+| `stopped` | `loaf session end` | Work paused or closed without wrap |
+| `done` | `loaf session end --wrap` | Wrapped work is complete |
+| `archived` | `loaf session archive` | Closed session preserved outside active list |
 
-Users work with tasks; sessions are an implementation detail.
+Do not introduce additional session vocabulary in guidance. SPEC-049 owns the
+durable status vocabulary.
 
-### Explicit Sessions
+## Journal Protocol
 
-For non-task work, sessions are still created explicitly:
-
-- Research sessions (`/research`)
-- Architecture decisions (`/architecture`)
-- Council deliberations (`/council`)
-
-These sessions may not have a linked task but still follow standard session format.
-
-## Session File Format
-
-**Link policy**: Documents outside `.agents/` must not reference `.agents/` files. Keep `.agents/` links contained within `.agents/` artifacts, and update them when files move to `.agents/<type>/archive/`.
-
-### Location & Naming
-
-```
-.agents/sessions/YYYYMMDD-HHMMSS-session.md
-```
-
-**Archive location:** `.agents/sessions/archive/`
-
-**Transcripts location:** `.agents/transcripts/`
-
-Transcripts are OpenCode conversation exports (`.jsonl` files) archived after context compaction. They preserve the full audit trail of agent interactions.
-
-```
-.agents/
-├── sessions/
-│   ├── YYYYMMDD-HHMMSS-session.md
-│   └── archive/
-└── transcripts/              # OpenCode transcripts
-    ├── 2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl
-    └── archive/
-```
-
-**Why keep original filenames:** The UUID-like hash is unique and matches OpenCode's internal reference, making correlation easier if needed.
-
-**Generate timestamps:**
+Log compact, factual entries:
 
 ```bash
-# Filename timestamp
-date -u +"%Y%m%d-%H%M%S"
-
-# ISO timestamp (for YAML)
-date -u +"%Y-%m-%dT%H:%M:%SZ"
+loaf session log "decision(scope): chose X because Y"
+loaf session log "discover(scope): learned Z from file/path"
+loaf session log "block(scope): waiting on external approval"
+loaf session log "unblock(scope): approval received"
+loaf session log "spark(scope): possible follow-up idea"
+loaf session log "todo(scope): concrete follow-up action"
 ```
 
-### Naming Convention
+Log durable facts, not thoughts. The journal should let another agent resume
+without reading the whole conversation.
 
-All session files use the fixed format: `YYYYMMDD-HHMMSS-session.md`
+## Continuity
 
-The timestamp is the unique identifier. Descriptions, spec links, and branch names belong in frontmatter and the `# Session:` heading, not the filename. This keeps references stable — spec and task files can point to session filenames without them ever breaking.
+Before compaction, branch switches, or agent handoff:
 
-### Required Frontmatter
+1. Flush unrecorded decisions, discoveries, blockers, and next actions with
+   `loaf session log`.
+2. Use `loaf session show <session-ref> --json` to confirm the journal has the
+   required resumption context.
+3. Pass task IDs, spec IDs, report IDs, and commit refs rather than duplicating
+   large prose into the journal.
 
-```yaml
----
-session:
-  title: "Clear description of work"           # REQUIRED
-  status: in_progress                          # REQUIRED: in_progress|paused|completed|archived
-  created: "2025-12-04T14:30:00Z"              # REQUIRED: ISO 8601
-  last_updated: "2025-12-04T14:30:00Z"         # REQUIRED: ISO 8601
-  last_archived: "2025-12-04T16:00:00Z"        # Set by PreCompact hook before compaction
-  archive_reason: "pre-compact"                # Why archived (pre-compact, manual, etc.)
-  archived_at: "2025-12-04T18:10:00Z"          # Required when archived
-  task: TASK-001                               # If implementation work (links to .agents/tasks/)
-  linear_issue: "BACK-123"                     # Optional
-  linear_url: "https://linear.app/..."         # Optional
-  branch: "username/back-123-feature"          # Optional: working branch
-  transcripts: []                              # Archived OpenCode transcripts (filenames only)
-                                               # Example: ["2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl"]
-  referenced_sessions: []                      # Cross-session references (see below)
+Background and delegated agents should receive the relevant task/spec/report
+references plus the active session alias when the caller has one.
 
-orchestration:
-  current_task: "What's actively being worked" # REQUIRED
-  spawned_agents:
-    - agent: implementer
-      task: "Brief task description"
-      status: completed                        # pending|in_progress|completed
-      summary: "Outcome summary"
+## Completion
 
-background_agents:                             # Background work running independently
-  - id: "bg-20260123-143000-security-scan"     # ID: bg-YYYYMMDD-HHMMSS-description
-    agent: background-runner                              # Agent type
-    task: "Full security audit"                # Brief description
-    status: running                            # running|completed|failed
-    result_location: null                      # Path to report when complete
----
-```
+When work is complete:
 
-### Cross-Session References
+1. Ensure decisions and discoveries are captured in durable homes such as ADRs,
+   specs, reports, or docs.
+2. Run `loaf session end --wrap` so the CLI persists the wrapped state.
+3. After merge or closure, use `loaf session archive` if the session should leave
+   the active list.
 
-Track decisions imported from past sessions via Serena memory:
-
-```yaml
-session:
-  # ... other fields ...
-  referenced_sessions:
-    - session: "20250115-140000-auth-jwt.md"     # Source session filename
-      imported_at: "2025-01-23T14:30:00Z"        # When imported
-      content_type: decisions                     # decisions|context|all
-      decisions_imported:                         # List of decision titles
-        - "JWT token rotation strategy"
-        - "Refresh token storage approach"
-    - session: "20250110-090000-auth-oauth.md"
-      imported_at: "2025-01-23T14:35:00Z"
-      content_type: context
-      summary: "OAuth provider integration patterns"
-```
-
-**Why track references:**
-
-- Audit trail of where context came from
-- Avoids re-importing same decisions
-- Enables tracing decision lineage across sessions
-
-See `references/cross-session.md` for full patterns.
-
-### Required Sections
-
-Every session file MUST have:
-
-1. **`## Context`** - Background for anyone picking up this work
-2. **`## Current State`** - Where we are now (MUST be handoff-ready)
-3. **`## Next Steps`** - Immediate actions for continuation
-
-### Session Template
-
-```markdown
-# Session: [Title]
-
-## Context
-Background for anyone picking up this work.
-What problem are we solving? Why now?
-
-## Current State
-Where we are right now. What just happened.
-**This section should ALWAYS be handoff-ready.**
-
-## Resumption Prompt
-
-<!-- Generated by PreCompact hook before compaction -->
-<!-- Provides self-contained context for post-compaction continuation -->
-
-> **Context**: [Brief description of work being done]
->
-> **Last Action**: [What just happened]
->
-> **Immediate Next**: [Concrete next step]
->
-> **Key Files**: [Relevant file paths]
->
-> **Blockers**: [Any blockers, or "None"]
->
-> **Transcript Archive**: If OpenCode provided a transcript path after compaction,
-> copy it to `.agents/transcripts/` and add the filename to this session's
-> `transcripts:` array in frontmatter.
-
-## Execution Progress
-
-### Wave 1: [Name] (ACTIVE)
-- [ ] BACK-123 - Brief description
-- [x] BACK-124 - Brief description (completed)
-
-### Wave 2: [Name] (blocked by Wave 1)
-- [ ] BACK-125 - Brief description
-
-## Technical Context
-
-### Files to Update
-- `path/to/file.py` - What needs to change
-
-### Key Commands
-```bash
-pytest path/to/tests/ -v
-mypy path/to/code/
-```
-
-## Acceptance Criteria
-
-- [ ] Criterion 1
-- [ ] Criterion 2
-
-## Decisions
-
-### Decision 1: [Title]
-
-**Decision**: What was decided
-**Rationale**: Why
-
-## Architecture Diagrams
-
-### [Diagram Name]
-
-```mermaid
-[diagram content]
-```
-
-**Purpose**: Why this diagram helps understand the work
-**Files involved**: List of related file paths
-**Created**: When diagram was created (update if modified)
-
-<!--
-When to add diagrams:
-- Multi-service changes: Show interaction points
-- Data flow changes: Trace data through system
-- Schema modifications: Visualize relationships
-- API design: Document request/response flows
-
-For reusable diagrams, store in .agents/diagrams/ instead.
-See foundations skill reference/diagrams.md for Mermaid syntax.
--->
-
-## Council Outcomes
-
-### Council: [Topic]
-
-**Outcome**: Decision summary
-**Council File**: `.agents/councils/YYYYMMDD-HHMMSS-topic.md`
-**Next Steps**: Action items captured
-**Archive**: After this summary is captured, set council status to `archived`, set `archived_at`, set `archived_by`, and move to `.agents/councils/archive/` (archive indefinitely).
-
-## Reports Processed
-
-### Report: [Title]
-
-**Key Conclusions**: Summary of findings
-**Action Items**: What changed or will change
-**Report Output**: generated with `loaf report generate ...` or stored as an authored report when durable prose is needed.
-**Archive**: After report is processed and the linked session is archived, use `loaf report archive <report>` for SQLite-backed report state. Markdown report movement is compatibility/export handling.
-**Metadata**: Require enough state or frontmatter to identify status, linked session, and processing time. In SQLite-backed projects, CLI state is authoritative.
-**Note**: Reports without state/frontmatter metadata are treated as unprocessed compatibility artifacts.
-
-## Handoffs
-
-Explicit transfer packets belong to `/handoff`, which writes
-`.agents/handoffs/YYYYMMDD-HHMMSS-title.md`. Orchestration keeps live session
-state resumable; `/handoff` packages context for another agent, branch, task,
-or future session. `/housekeeping` deletes deprecated handoffs after
-confirmation.
-
-## Blockers
-
-- Current blocker (if any)
-
----
-
-## Session Log (Compact Inline Journal)
-
-Sessions use an **append-only structured journal** format — a running log of what happened, what was decided, and what's next. Think "conventional commits meets bullet journal."
-
-### Format
-
-```markdown
-## Journal
-
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-[YYYY-MM-DD HH:MM] decision(scope): description of decision
-[YYYY-MM-DD HH:MM] discover(scope): something learned
-
-[YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
-[YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
-[YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
-```
-
-### Entry Types
-
-| Type | Use For | Written By | Scope Convention |
-|------|---------|------------|------------------|
-| `resume(scope)` | Session started/resumed | Hook (auto) | Branch name |
-| `pause` | Session ended | Hook (auto) | — |
-| `commit(SHA)` | Code committed | Hook (auto) | Short SHA |
-| `pr(#N)` | PR created/updated | Hook (auto) | PR number |
-| `merge(#N)` | PR merged | Hook (auto) | PR number |
-| `decision(scope)` | Key decisions | Agent | Topic |
-| `discover(scope)` | Something learned | Agent | Topic |
-| `block(scope)` | Blocker encountered | Agent | Topic |
-| `unblock(scope)` | Blocker resolved | Agent | Topic |
-| `spark(scope)` | Ideas to promote | Agent | Topic |
-| `resolve(spark)` | Spark triaged via `/idea` | Agent/User | Spark slug → disposition [timestamp] |
-| `todo(scope)` | Action items | Agent | Topic |
-| `finding(scope)` | Findings from analysis | Agent | Topic |
-| `hypothesis` | Theory being tested | Agent | — |
-| `try` | Approach attempted | Agent | — |
-| `reject` | Approach abandoned | Agent | — |
-| `skill(name)` | Skill invoked with context | Skill (self-log) | Skill name |
-| `idea(slug)` | Idea captured or promoted | Agent/Skill | Idea slug or `.agents/ideas/` ref |
-| `spec(id)` | Spec created, updated, or approved | Agent/Skill | Spec ID (e.g. `SPEC-024`) |
-| `handoff(slug)` | Handoff created or deprecated | Agent/Skill | Handoff slug or `.agents/handoffs/` ref |
-| `report(slug)` | Report generated | Agent/Skill | Report slug or `.agents/reports/` ref |
-| `council(slug)` | Council convened or concluded | Agent/Skill | Council slug or `.agents/councils/` ref |
-| `brainstorm(slug)` | Brainstorm session held | Agent/Skill | Draft slug or topic |
-| `plan(slug)` | Plan created or updated | Agent/Skill | Plan slug or topic |
-| `draft(slug)` | Draft document created | Agent/Skill | Draft slug or `.agents/drafts/` ref |
-
-### Format Rules
-
-1. **Timestamp:** `YYYY-MM-DD HH:MM` (no seconds)
-2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank line separator:** Insert when:
-   - Gap ≥ 5 minutes since last entry, OR
-   - State transition (block/unblock/pause/resume)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated by `loaf session end`)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-### Example Session
-
-```markdown
----
-spec: SPEC-020
-branch: feat/target-convergence
-status: active
-created: 2026-03-31T14:30:00Z
-last_entry: 2026-04-02T09:15:00Z
----
-
-# Session: Target Convergence
-
-## Journal
-
-[2026-03-31 14:30] resume(feat/target-convergence): from commit abc1234, 3 tasks pending
-[2026-03-31 14:30] decision(hooks): remove bash wrappers, go direct
-[2026-03-31 14:32] discover(cursor): prompt hooks filtered at line 269
-
-[2026-03-31 15:10] block(parity): Codex output differs by trailing newline
-[2026-03-31 15:11] hypothesis: gray-matter serialization adds trailing \n
-
-[2026-03-31 16:45] unblock(parity): confirmed gray-matter quirk, fixed with trim
-[2026-03-31 16:46] commit(def5678): fix: trim frontmatter for Codex byte parity
-
---- PAUSE 2026-03-31 17:00 ---
-
-[2026-04-02 09:15] resume(feat/target-convergence): 16 hours paused, last: verification
-```
-
-### CLI Commands
-
-```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decide(scope): desc"
-loaf session archive  # Move to archive when branch merges
-```
-
-### Consistency
-
-- **`loaf session log`** validates and appends entries in correct format
-- **Read-only agents** (reviewer, researcher) CAN write journal entries via `loaf session log` (Bash command, not file edit)
-- **Concurrent writes** are safe: atomic append, timestamps provide ordering
-
-## Lifecycle States
-
-| State | Description |
-|-------|-------------|
-| `in_progress` | Work actively happening |
-| `paused` | Temporarily stopped |
-| `completed` | Work finished; ready to archive (set status, `archived_at`, `archived_by`, move) after extraction |
-| `archived` | Closed and preserved for audit (set `archived_at`/`archived_by`, status set + moved to `.agents/sessions/archive/`) |
-
-## Updating During Work
-
-After each significant action, append entries to the session journal:
-
-1. **Use `loaf session log`** to append entries in the correct format
-2. **Add `decision`, `discover`, `block`, `spark`, `wrap` entries** during normal work
-3. **Hooks auto-append:** `resume`, `commit(SHA)`, `pr(#N)`, `merge(#N)`, `pause`
-4. **Blank line rules:** Inserted automatically by `loaf session log` based on time gaps and state transitions
-
-**Cross-agent protocol:** When any agent starts work on a branch, `loaf session start` outputs the last 15-20 journal entries. The agent reads context, continues work, appends entries.
-
-## Session Continuity Protocol
-
-### Before Pausing or Switching Agents
-
-1. Update session file with completed work
-2. Update `Current State` with where you stopped
-3. Update `Next Steps` with immediate actions
-4. Include `Files Modified` for context
-
-### Session as Continuity Medium
-
-Each agent:
-1. Reads current state from session
-2. Performs assigned work
-3. Updates session with outcomes
-4. Sets up context for next agent
-
-## Completing a Session
-
-Sessions are **archived, not deleted** when complete to preserve audit trail (set status to `archived`, set `archived_at` and `archived_by`, and move into `.agents/sessions/archive/`). Archive indefinitely (no deletion policy).
-
-**Archive timing:** only after extraction and council/report summaries are captured.
-
-### Knowledge Extraction Checklist
-
-| Information Type | Where It Belongs |
-|------------------|------------------|
-| Work tracking | External issue (Linear, GitHub) |
-| Implementation details | Git commits/PRs |
-| Architectural decisions | ADRs (`docs/decisions/`) |
-| API contracts | API documentation |
-| Remaining work | External issue backlog |
-| Council outcomes | Session summary + council file link |
-| Report conclusions | Session summary + report file link |
-| Archived artifacts | SQLite lifecycle state plus compatibility archive metadata when Markdown files exist |
-
-### Archival Checklist
-
-- [ ] External issue updated with final status
-- [ ] Decisions captured as ADRs (if architectural)
-- [ ] Lessons learned added to relevant docs
-- [ ] Remaining work created as issues
-- [ ] Council outcomes summarized in this session (link council file)
-- [ ] Reports processed and summarized in this session (link report file)
-- [ ] Reports archived only after session is archived (`loaf report archive` for SQLite-backed state)
-- [ ] Handoffs reviewed; deprecated handoffs marked for `/housekeeping` deletion
-- [ ] No orphaned references to session file
-- [ ] Set session status to `archived`
-- [ ] Set `archived_at` and `archived_by`
-- [ ] Move compatibility session file to `.agents/sessions/archive/` when one exists
-- [ ] Linked councils moved to `.agents/councils/archive/` after session summary
-- [ ] Linked report state archived after session archived + conclusions captured
-- [ ] Deprecated handoffs deleted by `/housekeeping` after confirmation
-- [ ] Update `.agents/` references to archived paths (no `.agents` links outside `.agents/`)
-- [ ] Archive indefinitely (no deletion policy)
-- [ ] Use `/housekeeping` for auto-move + link updates after confirmation
-
-## Start Protocol
-
-When starting a new orchestration context:
-
-1. Check for existing active sessions
-2. If found, ask user which to resume or start fresh
-3. If resuming, read session for context
-4. If starting fresh, create new session file
+Reports, councils, and handoffs have their own archive or finalization commands.
+Do not use session archival as a substitute for those lifecycles.
 
 ## Hook Integration
 
-### SessionStart Hook
-- Lists active sessions
-- Provides agent-specific context
-- Suggests session review/resume
-
-### SessionEnd Hook
-- Displays completion checklist
-- Reminds about session file updates
-- Shows count of active sessions
-
-### PreCompact Hook
-- `loaf session context for-compact` logs compact marker and injects flush instructions
-- Model flushes unrecorded decisions/discoveries to journal
-- Model writes structured `## Current State` summary
-- After compaction: `loaf session context for-resumption` prints rich resumption context (session, spec, journal, git)
+- Session start hooks should surface recent journal entries from SQLite.
+- Session-end hooks should nudge for missing durable journal entries before wrap.
+- Pre-compaction hooks should ask the agent to flush facts through
+  `loaf session log`.
+- Post-compaction recovery should use `loaf session start` and
+  `loaf session show`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Archive without extraction | Extract outcomes before archiving |
-| Use sessions as permanent records | Use proper documentation locations |
-| Reference stale sessions | Keep sessions current or archive (status + move) when done |
-| Store decisions only in sessions | Create ADRs for important decisions |
-| Archive without council/report summaries | Summarize outcomes in session before archive |
-| Archive but leave in active folder | Move file to `.agents/sessions/archive/` after setting status |
-| Batch session updates | Update after each significant event |
-| Keep status as `in_progress` when paused | Update status when state changes |
+| Hand-author session markdown as source | Use `loaf session start/log/show/end` |
+| Store decisions only in chat context | Log them and promote durable decisions to ADR/spec/report/docs |
+| Invent status values | Cite the runtime lifecycle until SPEC-049 lands |
+| Archive before extracting outcomes | Promote outcomes first, then wrap/archive |
+| Batch all journal entries at the end | Log significant facts as they happen |

--- a/dist/opencode/skills/orchestration/templates/session.md
+++ b/dist/opencode/skills/orchestration/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/opencode/skills/reflect/SKILL.md
+++ b/dist/opencode/skills/reflect/SKILL.md
@@ -34,12 +34,13 @@ Update VISION, STRATEGY, and ARCHITECTURE based on proven implementation.
 - **Post-implementation only** -- reflect after shipping, not before or during planning
 - **Get explicit approval** -- never update strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) without user confirmation
 - **Consolidate** -- batch related learnings into coherent updates, avoid micro-updates
-- **Link back** -- always reference the specs/sessions that informed each update
+- **Log first** -- log invocation before gathering evidence: `loaf session log "skill(reflect): <scope>"`
+- **Link back** -- always reference the specs, SQLite sessions, reports, and commits that informed each update
 - **Log updates** -- log each strategic document update to session journal: `loaf session log "decision(scope): updated STRATEGY.md with learning"`
 
 ## Verification
 
-- Proposals cite specific specs, sessions, or commits as evidence
+- Proposals cite specific specs, SQLite sessions, reports, or commits as evidence
 - No strategic document was modified without explicit user approval
 - Completed specs referenced in updates are archived after reflection
 
@@ -87,7 +88,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 
 Sources:
 1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
-2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
+2. **SQLite sessions** (`loaf session list --all --json`, then `loaf session show <ref> --json`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?
 

--- a/dist/opencode/skills/research/SKILL.md
+++ b/dist/opencode/skills/research/SKILL.md
@@ -34,6 +34,7 @@ Patterns for zooming out, investigating topics, and evolving project direction.
 - Cite sources with confidence levels
 - Present options, let user decide
 - Get approval before editing VISION
+- Log invocation first: `loaf session log "skill(research): <topic or mode>"`
 - Log findings to session journal: `loaf session log "discover(scope): summary of finding"`
 
 ### Never
@@ -80,7 +81,7 @@ Parse `$ARGUMENTS` to determine mode:
 
 Prioritize sources in this order:
 
-1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, session files, codebase patterns
+1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, SQLite sessions, codebase patterns
 2. **Authoritative docs** -- Context7, official docs, RFCs
 3. **Community knowledge** -- Stack Overflow (verified), GitHub issues, expert blogs
 4. **General web** (lowest) -- Search results, unverified sources
@@ -95,7 +96,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 
 1. Read project documents: VISION.md, STRATEGY.md, ARCHITECTURE.md
 2. Check ideas (`.agents/ideas/`) and specs (`docs/specs/`)
-3. Review recent sessions (`.agents/sessions/`)
+3. Review recent sessions with `loaf session list --all --json` and `loaf session show <ref> --json`
 4. Check recent commits: `git log --oneline -20`
 5. Synthesize following [state-assessment template](templates/state-assessment.md)
 
@@ -104,7 +105,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 **Trigger:** Specific topic or question
 
 1. **Interview** with prompt the user in chat: what are you trying to understand? What context do you have? What decision will this inform?
-2. Check project context first (ADRs, ARCHITECTURE, sessions)
+2. Check project context first (ADRs, ARCHITECTURE, SQLite sessions)
 3. Apply confidence hierarchy for external sources
 4. For a transient review artifact, use `loaf report generate` when an existing
    SQLite-backed export kind fits; for authored long-form research, create a

--- a/dist/opencode/skills/research/templates/state-assessment.md
+++ b/dist/opencode/skills/research/templates/state-assessment.md
@@ -12,7 +12,7 @@ title: "State Assessment: [YYYY-MM-DD]"
 type: state-assessment
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active | archived
-session: ".agents/sessions/YYYYMMDD-HHMMSS-description.md"  # Session that produced this assessment
+session: "session alias or loaf session show reference"  # Session that produced this assessment
 tags: []
 ---
 

--- a/dist/skills/bootstrap/SKILL.md
+++ b/dist/skills/bootstrap/SKILL.md
@@ -40,6 +40,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - **BRIEF is input, not output** -- the BRIEF is raw intake. Extract every useful fact into VISION/STRATEGY/ARCHITECTURE/AGENTS during bootstrap.
 - **BRIEF is archeological after bootstrap** -- once extraction completes, the BRIEF is a frozen historical snapshot. No skill, agent, command, or template should reference `docs/BRIEF.md` post-bootstrap. Operating documents must stand on their own.
 - **Suggest, don't execute** -- recommend next skills at the end, never auto-run them
+- **Log first** -- log invocation before interviewing: `loaf session log "skill(bootstrap): <project or intake>"`
 - **Log outcome** -- log bootstrap completion to session journal: `loaf session log "decision(bootstrap): project bootstrapped, mode detected"`
 
 ---
@@ -49,7 +50,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - All expected operating documents (`docs/VISION.md`, `.agents/AGENTS.md` at minimum) exist and contain populated content
 - Useful BRIEF content has been extracted into operating documents (no future reader should need to open the BRIEF)
 - Symlinks are correct: `.claude/CLAUDE.md -> .agents/AGENTS.md` and `./AGENTS.md -> .agents/AGENTS.md`
-- A session file was saved in `.agents/sessions/` capturing key decisions and interview exchanges
+- Key decisions and interview outcomes were logged with `loaf session log` and are readable with `loaf session show`
 
 ---
 
@@ -368,13 +369,13 @@ If symlinks already exist and point to the right targets, skip silently. If they
 
 ### 3. Session Recording
 
-Save the bootstrap interview as a session file:
+Record the bootstrap interview in the active SQLite-backed session:
 
-```
-.agents/sessions/{YYYYMMDD}-{HHMMSS}-bootstrap.md
-```
+1. Run `loaf session start` if there is no active session.
+2. Log mode detection and key interview decisions with `loaf session log`.
+3. Use `loaf session show <session-ref>` to inspect the rendered session view.
 
-The session should capture:
+The session journal should capture:
 - Mode detected and why
 - Key decisions made during the interview
 - Key interview exchanges that informed those decisions
@@ -382,7 +383,8 @@ The session should capture:
 - The original problem framing and user intent
 - Any open questions or deferred decisions
 
-Follow [templates/session.md](templates/session.md) for structure and frontmatter schema.
+Use [templates/session.md](templates/session.md) only as the rendered journal
+format reference; do not hand-author session markdown as the source of truth.
 
 ### 4. Next Steps
 

--- a/dist/skills/bootstrap/templates/session.md
+++ b/dist/skills/bootstrap/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/skills/brainstorm/SKILL.md
+++ b/dist/skills/brainstorm/SKILL.md
@@ -17,7 +17,8 @@ Generative thinking — expanding possibilities before narrowing through structu
 - Diverge before converging — generate options before judging
 - Connect exploration to VISION.md and STRATEGY.md context
 - Document discarded options — they hold valuable reasoning
-- Capture sparks (speculative byproducts) in a dedicated section — brainstorm documents are the canonical home for sparks
+- Log invocation first: `loaf session log "skill(brainstorm): <topic>"`
+- Capture sparks (speculative byproducts) with `loaf spark capture --scope <scope> --text <text>`; brainstorm documents may render or summarize them
 - Set boundaries on exploration time
 - Log outcome to session journal: `loaf session log "decision(scope): direction chosen and rationale"`
 
@@ -31,7 +32,7 @@ Generative thinking — expanding possibilities before narrowing through structu
 
 After work completes, verify:
 - Brainstorm document created at `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
-- `## Sparks` section present with speculative byproducts
+- Sparks captured with `loaf spark capture` and optionally summarized in `## Sparks`
 - Spark lifecycle documented: unprocessed → promoted/discarded
 - Brainstorm references strategic context from VISION/STRATEGY
 
@@ -56,7 +57,7 @@ After work completes, verify:
 
 Sparks are: lightweight, byproducts, worth remembering. Mark as `*(promoted)*` or `*(abandoned)*` after processing.
 
-Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value.
+Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value. SQLite spark state is the lifecycle source; draft markdown is a projection or narrative summary.
 
 ## Suggests Next
 

--- a/dist/skills/brainstorm/templates/brainstorm.md
+++ b/dist/skills/brainstorm/templates/brainstorm.md
@@ -11,7 +11,7 @@ type: brainstorm
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active (has unprocessed sparks) | archived
 tags: []
-related: []            # Optional: idea files, spec IDs, session files
+related: []            # Optional: idea aliases, spec IDs, session aliases, report refs
 ---
 
 # Brainstorm: [Topic]

--- a/dist/skills/handoff/templates/handoff.md
+++ b/dist/skills/handoff/templates/handoff.md
@@ -8,7 +8,7 @@ title: "[Handoff Title]"
 created: YYYY-MM-DDTHH:MM:SSZ
 status: draft | final | deprecated
 source: session | branch | task | ad-hoc
-session: .agents/sessions/YYYYMMDD-HHMMSS-session.md
+session: session alias or loaf session show reference
 branch: branch-name
 deprecated_at: YYYY-MM-DDTHH:MM:SSZ  # Set only when confirmed obsolete
 deprecated_by: orchestrator

--- a/dist/skills/housekeeping/SKILL.md
+++ b/dist/skills/housekeeping/SKILL.md
@@ -16,10 +16,11 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Critical Rules
 
 **Always**
+- Log invocation as the first action: `loaf session log "skill(housekeeping): <scope or trigger>"`
 - Review EVERY file individually — never sample or average
 - Check Linear issue status before archiving sessions
 - Extract lessons learned and decisions before archiving
-- Use CLI (`loaf session housekeeping`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
+- Use CLI (`loaf housekeeping`, `loaf session archive`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
 - Treat `.agents/handoffs/` as first-class but disposable: keep active/final handoffs, delete only after confirmed deprecated status
 - Check report `status` is `processed` and linked session is archived before archiving reports (see [templates/report.md](templates/report.md))
 - Check state assessment `session:` field before flagging for cleanup — only flag when linked session is archived
@@ -34,7 +35,7 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Verification
 
 After work completes, verify:
-- Session files archived with proper metadata (status, archived_at, archived_by)
+- Session lifecycle state is visible through `loaf session list --json`
 - Tasks archived via `loaf task archive`
 - Specs archived via `loaf spec archive`
 - SQLite-backed task/spec/report state reflects lifecycle changes when initialized
@@ -47,10 +48,11 @@ After work completes, verify:
 ### CLI Commands
 
 ```bash
-loaf session housekeeping --dry-run  # Preview all actions
-loaf session housekeeping            # Run all checks and fixes
+loaf housekeeping --dry-run          # Preview recommendations
+loaf housekeeping                    # Run artifact scanner
+loaf housekeeping --sessions         # Review sessions only
 loaf session archive                 # Archive single session
-loaf session enrich <file>           # Enrich a session's journal from JSONL
+loaf session enrich --json           # Compatibility diagnostic for legacy enrichment
 loaf task archive TASK-XXX           # Archive single task
 loaf spec archive SPEC-XXX           # Archive single spec
 loaf task sync                       # Compatibility: repair Markdown task index drift
@@ -60,7 +62,7 @@ loaf task sync                       # Compatibility: repair Markdown task index
 
 | Artifact | Active Location | Archive | Action |
 |----------|-----------------|---------|--------|
-| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf session archive` / `loaf session housekeeping` |
+| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf housekeeping --sessions` / `loaf session archive` |
 | Tasks (local mode only) | SQLite state + `.agents/tasks/` source prose | `archive/` | `loaf task archive` |
 | Specs | SQLite state + `.agents/specs/` authored prose | `archive/` | `loaf spec archive` |
 | Drafts (state assessments) | `.agents/drafts/` | delete | Flag for cleanup when linked session is archived |
@@ -77,7 +79,10 @@ every mode.
 
 ## Session Enrichment
 
-For each session with status `stopped` or `done` that has a `claude_session_id` in frontmatter, run `loaf session enrich <file>` to catch up on journal entries that weren't logged during the session.
+In SQLite-backed projects, `loaf session log` is the canonical journal writer and
+`wrap` owns end-of-session checks. `loaf session enrich --json` is a compatibility
+diagnostic for legacy markdown enrichment; it is not part of the normal
+housekeeping flow.
 
 Do NOT enrich `active` sessions — those are handled by the wrap skill when the session ends.
 

--- a/dist/skills/housekeeping/templates/session.md
+++ b/dist/skills/housekeeping/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/skills/implement/SKILL.md
+++ b/dist/skills/implement/SKILL.md
@@ -3,9 +3,9 @@ name: implement
 description: >-
   Orchestrates implementation sessions through agent delegation and batch
   execution. Use for all implementation work — features, bug fixes, refactors,
-  and code changes. Produces session files, agent spawn plans, and progress
-  tracking. Not for shaping (use shape), breakdown (use breakdown), research, or
-  review.
+  and code changes. Produces SQLite-backed session journals, agent spawn plans,
+  and progress tracking. Not for shaping (use shape), breakdown (use breakdown),
+  research, or review.
 ---
 
 # Implement
@@ -37,7 +37,7 @@ You are the coordinator. Start by understanding the task:
 **You are the ORCHESTRATOR, not the implementer.**
 
 ### Orchestrator Can Do Directly
-- Create/edit session files, council files
+- Start/log/show sessions, create council files
 - Use TodoWrite/TodoRead; **if `integrations.linear.enabled` is `true` in `.agents/loaf.json`**, use Linear MCP tools when helpful
 - Read any file for context
 - Ask clarifying questions
@@ -47,11 +47,11 @@ You are the coordinator. Start by understanding the task:
 
 ## Verification
 
-- Session file exists before any implementation work begins
+- `loaf session start` has created or resumed an active SQLite-backed session before implementation work begins
 - All code changes delegated via Task tool -- no direct edits by orchestrator
-- Session file is continuously updated with spawns, progress, and current state
+- Session journal is continuously updated with spawns, progress, and current state
 - Spec artifacts closed out on branch before PR creation
-- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session file is created; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
+- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session is started; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
 
 ## Quick Reference
 
@@ -79,7 +79,7 @@ Before starting, evaluate context suitability.
 | Just completed a different task/spec | Suggest clear |
 | About to start multi-file implementation | Check depth |
 
-If restart needed: capture state in session file, generate resumption prompt, ask user to restart.
+If restart needed: log current state with `loaf session log`, generate resumption prompt, ask user to restart.
 
 ## Input Detection
 
@@ -87,7 +87,7 @@ Parse `$ARGUMENTS` to determine session type:
 
 | Input Pattern | Type | Action |
 |---------------|------|--------|
-| `TASK-XXX` | Local task | Load via `loaf task show`, auto-create session |
+| `TASK-XXX` | Local task | Load via `loaf task show`, start/resume session |
 | `SPEC-XXX` | Spec orchestration | If spec frontmatter has `linear_parent`, resolve to that Linear parent and follow Linear-Native Routing. Otherwise resolve local tasks and build dependency waves |
 | `TASK-XXX..YYY` | Task range | Expand range, build dependency waves |
 | `TASK-XXX,YYY,ZZZ` | Task list | Parse list, build dependency waves |
@@ -99,8 +99,8 @@ Parse `$ARGUMENTS` to determine session type:
 When starting from `TASK-XXX`:
 
 1. Load task metadata via `loaf task show TASK-XXX --json`; read `.agents/TASKS.json` only as a Markdown-compatibility fallback
-2. Auto-generate session: `YYYYMMDD-HHMMSS-task-XXX.md`
-3. Create session file, update task with session reference: `loaf task update TASK-XXX --session <session-file>`
+2. Run `loaf session start` to find or create the active session for the branch
+3. Log the task coupling: `loaf session log "decision(implement): implementing TASK-XXX"`
 4. Load parent spec if task has `spec:` field
 
 **No user interaction required for session naming.**
@@ -186,7 +186,7 @@ The issue is an actual task. Implement it directly — with a pre-flight gate.
    - Resolve branch name from the sub-issue's `branchName` field (Linear
      auto-generates one) — see
      [session-management.md](references/session-management.md).
-   - Create session file, continue with the standard Startup Checklist.
+   - Run `loaf session start`, then continue with the standard Startup Checklist.
 
 ### Completion (after implementer + reviewer finish cleanly)
 
@@ -223,8 +223,8 @@ When the sub-issue's implementation passes review and tests:
   implementation reveals a missing task, surface it to the user; they
   decide whether to run `/breakdown` again or add an ad-hoc sub-issue.
 - Does not sync in-progress state bidirectionally. Source of truth at any
-  moment: Linear for issue state, local files for spec content, session
-  file for current handoff.
+  moment: Linear for issue state, local files for spec content, SQLite session
+  journal for current handoff.
 
 ---
 
@@ -247,19 +247,19 @@ Use the **Task tool** with appropriate `subagent_type`:
 
 ---
 
-## Session Creation
+## Session Start
 
-**MANDATORY: Create session file BEFORE any other work.**
+**MANDATORY: Run `loaf session start` BEFORE any implementation work.**
 
-1. Generate timestamps: `date -u +"%Y%m%d-%H%M%S"` and `date -u +"%Y-%m-%dT%H:%M:%SZ"`
-2. Create session file following [session template](templates/session.md)
-3. Verify session file exists with valid frontmatter
+1. Run `loaf session start` from the target branch/worktree.
+2. Log invocation context: `loaf session log "skill(implement): <task/spec/context>"`
+3. Verify the active session is readable with `loaf session list --json` or `loaf session show <session-ref> --json`.
 4. Suggest renaming Claude Code session with a meaningful name derived from context:
    - From spec: `Suggestion: /rename SPEC-027-session-stability`
    - From task: `Suggestion: /rename TASK-042-login-fix`
    - From ad-hoc: `Suggestion: /rename {short-slug-from-description}`
 
-**DO NOT PROCEED WITHOUT A SESSION FILE.**
+**Do not proceed until the active session is visible through `loaf session` commands.**
 
 ---
 
@@ -270,8 +270,8 @@ Use the **Task tool** with appropriate `subagent_type`:
 3. **When uncertain** -- convene council, present results, **wait for user approval**
 4. **Ensure quality** -- spawn implementer for tests, route reviews to reviewer subagents
 5. **When debugging** -- if a test failure or error isn't immediately obvious, load the **debugging** skill for structured hypothesis tracking before retrying
-6. **Update session file continuously** -- log spawns, update current_task, keep handoff-ready
-6. **Clean up** -- no ephemeral files, archive completed sessions (status + `archived_at` + `archived_by` + move to archive/)
+6. **Update session continuously** -- log spawns, progress, blockers, and next actions with `loaf session log`
+6. **Clean up** -- no ephemeral files; wrap with `loaf session end --wrap` and archive closed sessions with `loaf session archive`
 7. **When in doubt, ask the user**
 
 ## Decision Tree
@@ -280,7 +280,7 @@ Use the **Task tool** with appropriate `subagent_type`:
 Is this a code/config/doc change?
 +-- YES -> Spawn appropriate agent
 +-- NO -> Is this a planning/coordination decision?
-    +-- YES with clear path -> Proceed, update session
+    +-- YES with clear path -> Proceed, log session decision
     +-- YES but ambiguous -> Ask user
     +-- NO -> Ask user
 ```
@@ -291,18 +291,18 @@ When multiple valid approaches exist: spawn council (5-7 agents, odd), present r
 
 ## Startup Checklist
 
-After creating session file:
+After `loaf session start`:
 
 1. [ ] Parse input (task, Linear ID, or description)
-2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, update with `loaf task update TASK-XXX --session <session-file>`, load parent spec
+2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, log task coupling, load parent spec
 3. [ ] If Linear ID (or `SPEC-XXX` with `linear_parent`): follow [Linear-Native Routing](#linear-native-routing). Parent → walk sub-issues and select next. Sub-issue → verify `blockedBy` is clear, then start it as one logical Linear operation so the parent is promoted when needed
 4. [ ] If description: auto-create task (see Ad-hoc Task Auto-Creation above)
 5. [ ] Create dedicated branch (see [session-management.md](references/session-management.md))
 6. [ ] Suggest team based on task context
-7. [ ] Populate session Context section
+7. [ ] Log initial context and references with `loaf session log`
 8. [ ] Break down work using TodoWrite
 9. [ ] Identify needed specialized agents
-10. [ ] Update session Next Steps
+10. [ ] Log next steps before spawning
 11. [ ] **Get user approval** before spawning
 
 ---
@@ -310,7 +310,7 @@ After creating session file:
 ## Then Execute
 
 ### BEFORE (Planning)
-1. Create session file
+1. Run `loaf session start`
 2. Set task status: `loaf task update TASK-XXX --status in_progress`
 3. Break down work into agent-sized tasks
 4. Identify spawn order (respect dependencies)
@@ -318,10 +318,10 @@ After creating session file:
 
 ### DURING (Execution)
 1. Spawn specialized agents via Task tool
-2. Log each spawn in session `orchestration.spawned_agents`
+2. Log each spawn with `loaf session log "todo(agent): spawned <agent> for <task>"`
 3. Update Linear with progress (no emoji, no file paths)
-4. Keep session `## Current State` handoff-ready
-5. After each agent completes: update session, spawn next
+4. Keep journal entries handoff-ready
+5. After each agent completes: log outcome, spawn next
 
 ### AFTER (Completion)
 1. Code review pass (spawn `reviewer` agent)
@@ -330,13 +330,13 @@ After creating session file:
    - **Local-tasks mode:** `loaf task update TASK-XXX --status done` (per task), then `loaf task archive --spec SPEC-XXX`
    - **Linear-native mode:** `update_issue` the sub-issue to `completed`-type state. Then query the parent's sub-issues; if all are `completed`, also close the parent. If some remain, list them for the user (see [Linear-Native Routing → Completion](#completion-after-implementer--reviewer-finish-cleanly))
    - Mark spec complete and archive: `loaf spec archive SPEC-XXX` (both modes)
-   - Update session file (status: done, `archived_at`, `archived_by`)
-   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
+   - Run `loaf session end --wrap`; archive later with `loaf session archive` when appropriate
+   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session state`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
 5. After PR is created and approved, use `/ship` to review, verify, and land the PR. Use `/release` later when a coherent batch of landed work is ready to publish.
-6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
-   - `## Key Decisions` has content (not `*(none yet)*` or empty)
-   - `traceability.decisions` has entries (ADRs were recorded)
+6. **Suggest reflection:** Check the session journal for extractable learnings before closing out:
+   - `decision(...)` entries are present
+   - ADRs, report verdicts, or spec changelog entries were recorded
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
@@ -359,4 +359,4 @@ After all tasks are complete, suggest `/ship` to land the PR. Suggest `/release`
 - **orchestration/product-development** - Full workflow hierarchy
 - **orchestration/specs** - Spec format and lifecycle
 - **orchestration/local-tasks** - Task file format including `session:` field
-- **orchestration/sessions** - Session lifecycle details
+- **orchestration/sessions** - SQLite-backed session lifecycle details

--- a/dist/skills/implement/references/session-management.md
+++ b/dist/skills/implement/references/session-management.md
@@ -8,7 +8,6 @@
 - Linear Status Management
 - Handoff State Requirements
 - Timestamps for User Context
-- Transcript Archival
 - Task Completion
 
 Detailed reference for session lifecycle management during implementation.
@@ -87,7 +86,7 @@ Use Linear MCP's `list_teams` (if configured) to get all workspace teams for val
 
 ## Diagram Consideration
 
-For multi-file or multi-service changes, consider adding architecture diagrams to the session file.
+For multi-file or multi-service changes, consider adding architecture diagrams to the linked spec, report, ADR, or implementation notes.
 
 ### When to Create Diagrams
 
@@ -106,7 +105,7 @@ Ask yourself:
 2. Is there a data flow that needs to be understood?
 3. Would a visual help communicate the approach?
 
-If yes to any, add an `## Architecture Diagrams` section to the session file.
+If yes to any, capture the diagram in a durable artifact such as a spec, report, ADR, or implementation note, and log the reference with `loaf session log`.
 
 ### Diagram Template
 
@@ -144,7 +143,7 @@ For complex tasks, explore before implementing:
 1. Use Task(Explore) or Task(Plan) to investigate codebase
 2. Map existing patterns and conventions
 3. Identify integration points
-4. Document findings in session file
+4. Log findings with `loaf session log` and reference durable artifacts
 5. Present approach to user for approval before spawning
 ```
 
@@ -193,12 +192,12 @@ never implement through open `blockedBy`.
 
 ## Handoff State Requirements
 
-**The session file must ALWAYS be handoff-ready.** After every significant action:
+**The session journal must ALWAYS be handoff-ready.** After every significant action:
 
-1. Update `## Current State` to reflect what just happened
-2. Update `orchestration.current_task` in frontmatter
+1. Log what just happened with `loaf session log`
+2. Reference task/spec/report/commit IDs rather than duplicating long prose
 3. Log completed agent work with outcomes
-4. Ensure anyone could pick up the work immediately
+4. Ensure anyone could pick up the work immediately from `loaf session show`
 
 ---
 
@@ -217,44 +216,6 @@ Generate with: `date -u +"%Y-%m-%d %H:%M UTC"`
 
 ---
 
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference.
-
-### Process
-
-1. **Get transcript path** from Claude Code output after compaction
-2. **Create transcripts directory** if needed:
-   ```bash
-   mkdir -p .agents/transcripts
-   ```
-3. **Copy transcript** with descriptive name:
-   ```bash
-   cp /path/to/transcript.jsonl .agents/transcripts/YYYYMMDD-HHMMSS-description.jsonl
-   ```
-4. **Update session frontmatter**:
-   ```yaml
-   transcripts:
-     - 20260123-143500-pre-compact.jsonl
-   ```
-
-### When to Archive
-
-| Event | Action |
-|-------|--------|
-| Before `/compact` | Archive current transcript |
-| Before `/clear` | Archive current transcript |
-| Session end | Archive final transcript |
-
-### Benefits
-
-- **Audit trail** - Full history of decisions and work
-- **Knowledge extraction** - Mining past sessions for patterns
-- **Debugging** - Understanding how errors occurred
-- **Training** - Learning from past sessions
-
----
-
 ## Task Completion
 
 When a task-coupled session completes:
@@ -267,7 +228,7 @@ When a task-coupled session completes:
      `list_issues` with `parent: <parent-id>`; if all are `completed`-type,
      close the parent and mark the local spec `complete`, else both stay
      in flight
-3. **Archive session** (standard process)
+3. **Wrap session** with `loaf session end --wrap`; archive with `loaf session archive` when the work is closed
 
 ### Spec Completion Check
 

--- a/dist/skills/implement/templates/session.md
+++ b/dist/skills/implement/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/skills/orchestration/SKILL.md
+++ b/dist/skills/orchestration/SKILL.md
@@ -25,12 +25,12 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 ## Critical Rules
 
 ### Sessions
-- Create following [session template](templates/session.md) — compact inline journal format
-- Use `loaf session log` for journal entries: `decide(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
+- Start or resume with `loaf session start`; SQLite is the operational source.
+- Use `loaf session log` for journal entries: `decision(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
 - **SESSION JOURNAL NUDGE**: When you see this hook trigger, log unrecorded decisions or findings before responding. Use `loaf session log "entry(scope): description"`. Only log actions (decisions made, things discovered, conclusions reached) — not thoughts or read-only work.
-- Archive when complete (status + `archived_at` + `archived_by` + move to `.agents/sessions/archive/`)
-- PreCompact hook: appends `compact` entry with context summary
-- Post-compaction: `loaf session start` outputs recent journal entries for recovery
+- Wrap with `loaf session end --wrap`; archive with `loaf session archive` when complete.
+- PreCompact hook: flushes journal-worthy state before compaction.
+- Post-compaction: `loaf session start` and `loaf session show` expose recent journal context for recovery.
 
 ### Councils
 - Always odd number: 5 or 7 agents
@@ -55,7 +55,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 ## Verification
 
-- Validate session files with `validate-session.py` before archiving
+- Verify `loaf session list --json` / `loaf session show <ref> --json` reflect the active work before archiving
 - Validate council files with `validate-council.py` before concluding
 - Confirm Linear issue updates are self-contained (no local paths, no emoji)
 
@@ -63,7 +63,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 | Task | Action |
 |------|--------|
-| Multi-step work | Create session file, spawn agents |
+| Multi-step work | Start/resume session, spawn agents |
 | Complex decision | Convene council (5-7 agents, odd) |
 | Linear update | Checkboxes, no emoji, no local paths |
 | Feature planning | Size by complexity, shape before building |
@@ -85,7 +85,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 | Subagent Development | [references/subagent-development.md](references/subagent-development.md) | Delegating to specialized agents |
 | Background Agents | [references/background-agents.md](references/background-agents.md) | Running non-interactive work in background |
 | Council Workflow | [references/councils.md](references/councils.md) | Convening councils for complex decisions |
-| Session Management | [references/sessions.md](references/sessions.md) | Creating sessions and keeping live work resumable |
+| Session Management | [references/sessions.md](references/sessions.md) | Starting sessions and keeping live work resumable |
 | Session Resume | [references/session-resume.md](references/session-resume.md) | Resuming sessions, checkpoints, context recovery |
 | Context Management | [references/context-management.md](references/context-management.md) | Using /clear, /compact, managing context limits |
 | Linear Integration | [references/linear.md](references/linear.md) | Updating Linear issues, magic words, status conventions |
@@ -97,7 +97,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 **You are the orchestrator, not the implementer.**
 
 The orchestrator:
-1. Creates issues and session files for tracking
+1. Creates issues and starts sessions for tracking
 2. Breaks down work into delegable tasks
 3. Spawns specialized agents for implementation
 4. Coordinates outcomes and updates external systems
@@ -112,7 +112,6 @@ This skill uses paths from `.agents/loaf.json`:
 ```json
 {
   "sessions": {
-    "directory": ".agents/sessions",
     "councils_directory": ".agents/councils"
   },
   "linear": {
@@ -127,9 +126,8 @@ This skill uses paths from `.agents/loaf.json`:
 
 | Artifact | Location | Archive | Naming |
 |----------|----------|---------|--------|
-| Sessions | `.agents/sessions/` | `.agents/sessions/archive/` | `YYYYMMDD-HHMMSS-description.md` |
+| Sessions | SQLite (`loaf session show`) | `loaf session archive` | CLI alias / session ID |
 | Councils | `.agents/councils/` | `.agents/councils/archive/` | `YYYYMMDD-HHMMSS-topic.md` |
-| Transcripts | `.agents/transcripts/` | N/A | Copied from tool output |
 | Handoffs | `.agents/handoffs/` | delete after deprecated | Created by `/handoff` |
 | Reports | `.agents/reports/` | N/A | `YYYYMMDD-HHMMSS-subject.md` |
 | Tasks | `.agents/tasks/` | N/A | Per task manager conventions |
@@ -140,16 +138,16 @@ This skill uses paths from `.agents/loaf.json`:
 
 ### BEFORE (Planning)
 - Create/check external issue (Linear, GitHub)
-- Create session file following [session template](templates/session.md)
+- Run `loaf session start` and log the orchestration intent
 - Break down into tasks, identify agents, get user approval
 
 ### DURING (Execution)
 - Spawn specialized agents (never implement directly)
-- Track progress in session file and external issue
+- Track progress with `loaf session log` and external issue updates
 - Convene councils for uncertain decisions
 
 ### AFTER (Completion)
 - Code review + QA testing
 - Update external issue to Done
 - Ensure knowledge captured in permanent locations
-- Archive session (status + `archived_at` + `archived_by` + move + update links)
+- Run `loaf session end --wrap`; archive with `loaf session archive` after merge/closure

--- a/dist/skills/orchestration/references/background-agents.md
+++ b/dist/skills/orchestration/references/background-agents.md
@@ -1,12 +1,13 @@
 # Background Agents
 
-Background agents handle low-priority, long-running, or non-interactive work that can run independently while the user continues with other tasks.
+Background agents handle low-priority, long-running, or non-interactive work
+while the user continues with other tasks.
 
 ## Contents
 
 - When to Use Background Agents
 - Spawning Background Agents
-- Background Agent Tracking
+- Tracking
 - Result Retrieval
 - Workflow Example
 - Anti-Patterns
@@ -19,20 +20,11 @@ Background agents handle low-priority, long-running, or non-interactive work tha
 | Security audits | Interactive debugging |
 | Code coverage analysis | User-facing questions |
 | Large-scale refactoring reports | Time-sensitive fixes |
-| Codebase-wide linting reports | Tasks requiring immediate feedback |
 | Documentation audits | Work needing user decisions mid-task |
 | Dependency vulnerability scans | Blocking tasks for current work |
 
-**Good candidates:**
-- Results can be processed later
-- No user interaction required
-- Task is well-defined with clear completion criteria
-- Output is a report or artifact, not a conversation
-
-**Poor candidates:**
-- Needs clarification mid-task
-- Time-sensitive (user waiting for result)
-- Requires real-time coordination with other agents
+Good candidates have clear completion criteria, can run without clarification,
+and produce a report or durable artifact.
 
 ## Spawning Background Agents
 
@@ -51,8 +43,7 @@ Task(
     - src/services/
 
     Write report to: .agents/reports/YYYYMMDD-HHMMSS-security-audit.md
-
-    Session: .agents/sessions/20260123-143000-auth-feature.md
+    Active session: SESSION-ALIAS if available from loaf session list/show
     """,
     run_in_background=True
 )
@@ -60,187 +51,57 @@ Task(
 
 ### Cursor
 
-Background agents are configured via the `is_background: true` YAML property. When spawning:
+Background agents are configured via the `is_background: true` YAML property.
+When spawning, specify the report destination and any task/spec/session IDs:
 
 ```
 @background-runner Run security audit on backend codebase.
-Write report to .agents/reports/
+Write report to .agents/reports/.
+Reference TASK-123 and the active session alias if available.
 ```
 
-## Background Agent Tracking
+## Tracking
 
-Track background agents in session frontmatter:
+Track background work with durable references:
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security-scan"
-    agent: background-runner
-    task: "Full security audit of backend"
-    status: running  # running | completed | failed
-    result_location: null
-  - id: "bg-20260123-144500-coverage"
-    agent: background-runner
-    task: "Test coverage analysis"
-    status: completed
-    result_location: ".agents/reports/20260123-144500-coverage-report.md"
-```
+1. Log the spawn with `loaf session log "todo(background): started <id> for <task>"`.
+2. Ask the background agent to write a report under `.agents/reports/`.
+3. When complete, log `discover(background): <id> wrote <report>`.
+4. Process findings into tasks, specs, ADRs, or report verdicts as appropriate.
 
-### Status Values
-
-| Status | Meaning |
-|--------|---------|
-| `running` | Agent still executing |
-| `completed` | Work finished, results available |
-| `failed` | Agent encountered error |
-
-### ID Convention
-
-Background agent IDs follow: `bg-YYYYMMDD-HHMMSS-<description>`
-
-Generate with:
-```bash
-echo "bg-$(date -u +"%Y%m%d-%H%M%S")-<description>"
-```
+Use a stable ID such as `bg-YYYYMMDD-HHMMSS-description` in the prompt and
+journal entries.
 
 ## Result Retrieval
 
-Background agents write results to `.agents/reports/` with standard frontmatter:
-
-```yaml
----
-report:
-  title: "Security Audit Report"
-  type: background-agent-output
-  status: unprocessed  # unprocessed | processed | archived
-  created: "2026-01-23T14:30:00Z"
-  background_agent_id: "bg-20260123-143000-security-scan"
-  session_reference: "20260123-140000-auth-feature.md"
----
-```
-
-### Processing Results
-
-1. SessionStart hook alerts user to completed background work
-2. User or orchestrator reviews report in `.agents/reports/`
-3. Orchestrator updates session frontmatter:
-   - Change `status` from `running` to `completed`
-   - Set `result_location` to report path
-4. Process findings as needed (spawn agents, create issues)
-5. Set report `status` to `processed`
+Background agents write results to `.agents/reports/` with enough metadata to
+identify the source task and report status. In SQLite-backed projects, use
+`loaf report list`, `loaf report show`, and `loaf report archive` when report
+state is available.
 
 ## Workflow Example
 
-### 1. Orchestrator Identifies Low-Priority Work
-
-During auth feature implementation, orchestrator identifies need for security audit but it is not blocking current work.
-
-### 2. Orchestrator Spawns Background Agent
-
-```python
-Task(
-    subagent_type="background-runner",
-    prompt="""
-    Run comprehensive security audit on auth implementation.
-
-    Files to audit:
-    - src/auth/endpoints.py
-    - src/auth/token.py
-    - src/auth/middleware.py
-
-    Check for:
-    - OWASP Top 10 vulnerabilities
-    - Secrets in code
-    - SQL injection risks
-    - Authentication bypasses
-
-    Write report to: .agents/reports/20260123-143000-auth-security.md
-
-    Session: .agents/sessions/20260123-140000-auth-feature.md
-    """,
-    run_in_background=True
-)
-```
-
-### 3. Orchestrator Updates Session Frontmatter
-
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-auth-security"
-    agent: background-runner
-    task: "Auth security audit"
-    status: running
-    result_location: null
-```
-
-### 4. Work Continues
-
-Orchestrator and other agents continue with main implementation while background agent works.
-
-### 5. Session Resumes Later
-
-SessionStart hook detects completed background work:
-
-```
-# Background Work Completed
-
-The following background agents have completed:
-
-- **bg-20260123-143000-auth-security** (background-runner)
-  - Task: Auth security audit
-  - Result: .agents/reports/20260123-143000-auth-security.md
-
-Review reports and update session frontmatter after processing.
-```
-
-### 6. Results Processed
-
-Orchestrator reads report, creates issues for findings, updates session.
+1. Orchestrator identifies non-blocking security audit work.
+2. Orchestrator logs the background spawn in the active session.
+3. Background agent writes `.agents/reports/YYYYMMDD-HHMMSS-auth-security.md`.
+4. Orchestrator reviews the report, creates follow-up tasks, and logs the
+   outcome.
+5. Report state is finalized or archived through the report lifecycle.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
 | Use for blocking work | Keep blocking work in foreground |
-| Spawn without tracking | Always update session frontmatter |
-| Ignore completed results | Process results when alerted |
+| Spawn without tracking | Log the spawn and require a report path |
+| Ignore completed results | Process reports into tasks, findings, or decisions |
 | Use for interactive tasks | Reserve for autonomous work |
-| Spawn many concurrent background agents | Limit to 2-3 to avoid resource contention |
-| Skip result location in prompt | Always specify where to write output |
+| Spawn many concurrent background agents | Limit concurrency to avoid resource contention |
+| Skip result location in prompt | Always specify where output belongs |
 
 ## Integration Points
 
-### SessionStart Hook
-
-Checks session frontmatter for `background_agents` with `status: completed`. Alerts user to review results.
-
-### PreCompact Hook
-
-Includes background agent state in preservation. PreCompact hook captures:
-- Active background agent list
-- Current status of each
-- Result locations for completed agents
-
-### Session Frontmatter
-
-Full template with background agents:
-
-```yaml
----
-session:
-  title: "Feature implementation"
-  status: in_progress
-  # ... other session fields ...
-
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: completed
-    result_location: ".agents/reports/20260123-143000-security.md"
-  - id: "bg-20260123-150000-coverage"
-    agent: background-runner
-    task: "Coverage analysis"
-    status: running
-    result_location: null
----
-```
+- `loaf session log` records spawn and completion facts.
+- `loaf session show` exposes recent background-work journal entries.
+- `loaf report` commands own durable report lifecycle when available.
+- `/wrap` should mention unprocessed background reports before ending a session.

--- a/dist/skills/orchestration/references/context-management.md
+++ b/dist/skills/orchestration/references/context-management.md
@@ -1,54 +1,34 @@
 # Context Management
 
-Patterns for managing context efficiently across sessions and agent spawns.
+Patterns for keeping long work resumable while using SQLite-backed session
+journals as the external memory.
 
 ## Contents
 
 - Design for Compaction
-- Overview
 - Context Commands
 - When to Clear Context
-- The 2-Correction Rule
-- Context Compaction
-- Session Files as Context Anchors
+- Compaction Lifecycle
 - Subagents for Context Isolation
 - Context Budget Guidelines
-- Preventing Context Bloat
-- Session Context Patterns
 - Warning Signs
 - Best Practices
 
 ## Design for Compaction
 
-Compaction is a normal part of long workflows, not an emergency measure. Any workflow expected to exceed 15-20 exchanges should be designed with compaction in mind from the start.
+Compaction is a normal part of long workflows. Design any workflow expected to
+span many exchanges so important state is already outside chat context.
 
 ### Compaction-First Principles
 
-1. **The journal IS external memory** — Session journal entries (decisions, discoveries, progress) survive compaction. Compaction can be lossy because all important state is already on disk.
-2. **`## Current State` is the resumption context** — Keep this section handoff-ready at all times. The PreCompact hook requires writing a state summary here before compaction.
-3. **Decisions go to disk, not context** — Record key decisions in the session journal immediately via `loaf session log`. Context may be compressed; journal entries persist.
-4. **Subagents absorb exploration** — Investigation and exploration should happen in subagents. Only the summary returns to the main context.
-
-### Compaction Lifecycle
-
-```
-PreCompact:
-  1. Flush all unrecorded journal entries (decisions, discoveries, progress)
-  2. Write condensed state summary to session file's ## Current State
-  3. compact.sh writes compact(session) marker to journal
-
-PostCompact:
-  1. PostCompact nudge fires — tells model to read session file
-  2. Model reads ## Current State for resumption context
-  3. Model reads ## Journal for decision trail
-  4. Work resumes without "where were we?"
-```
-
-This makes compaction invisible to workflow continuity. The session file's `## Current State` section is the resumption prompt — written by the model before compaction, read by the model after.
-
-## Overview
-
-Context is finite. Long conversations accumulate irrelevant information that degrades performance. Active context management keeps conversations focused and effective.
+1. **The journal is external memory.** Record decisions, discoveries, blockers,
+   and next actions with `loaf session log`.
+2. **Artifacts carry detail.** Specs, tasks, reports, ADRs, and commits hold rich
+   detail; journal entries point to them.
+3. **Subagents absorb exploration.** Use subagents for broad investigation and
+   return concise findings to the main context.
+4. **`wrap` closes the loop.** End meaningful work with `loaf session end --wrap`
+   so the session lifecycle matches the journal.
 
 ## Context Commands
 
@@ -60,191 +40,78 @@ Context is finite. Long conversations accumulate irrelevant information that deg
 
 ## When to Clear Context
 
-### Clear Between Tasks
-
 Use `/clear` when:
 
 - Starting a completely new task
-- Previous task is fully complete
-- Context has become cluttered with failed attempts
+- Previous task is complete
+- Debugging noise is crowding out the current objective
 - Switching between unrelated codebases
 
-### Don't Clear When
+Avoid clearing mid-task until you have logged enough state for recovery.
 
-- Mid-task and need previous context
-- Debugging requires understanding of prior attempts
-- Session file provides necessary handoff information
-
-## The 2-Correction Rule
-
-**If Claude makes the same mistake twice after correction, the context may be polluted.**
-
-Signs of context pollution:
-- Repeating errors you've already corrected
-- Ignoring instructions you've given
-- Reverting to patterns you've explicitly rejected
-- Confusion about current task state
-
-**Action:** Consider `/clear` and restart with fresh context, referencing session file for state.
-
-## Context Compaction
-
-Use `/compact` when:
-- Conversation is long but task continues
-- Need to preserve key decisions while reducing noise
-- Approaching context limits
-
-**Journal entries are compaction insurance.** Every `loaf session log` call writes state to disk that survives compaction. Don't defer journaling — entries not flushed before compaction are lost.
-
-### What Compaction Preserves (via session file)
-
-- Journal entries: decisions, discoveries, progress, commits
-- `## Current State` summary (written by PreCompact)
-- All externalized artifacts: specs, tasks, ideas, code
-
-### What Compaction Discards
-
-- Intermediate exploration steps
-- Failed attempts and debugging noise
-- Verbose tool output
-- Redundant explanations
-
-## Session Files as Context Anchors
-
-Session files provide persistent context that survives `/clear`:
-
-```markdown
-## Current State
-[Always handoff-ready summary]
-
-## Key Decisions
-- Chose X over Y because Z
-
-## Next Steps
-- Immediate action items
-```
-
-### Pattern: Clear + Resume
+## Compaction Lifecycle
 
 ```
-1. Update session file with current state
-2. /clear to reset context
-3. /resume to reload from session file
-4. Continue with clean context
+PreCompact:
+  1. Flush unrecorded decisions, discoveries, blockers, and next actions
+  2. Reference specs, tasks, reports, commits, and files by stable ID/path
+  3. Let the hook persist the compact marker
+
+PostCompact:
+  1. Run or inspect `loaf session start` output for the active branch
+  2. Use `loaf session show <session-ref> --json` when more context is needed
+  3. Continue from the journal and linked artifacts
 ```
+
+This makes compaction survivable without relying on hand-maintained markdown
+state. Any state not logged or captured in a durable artifact can be lost.
 
 ## Subagents for Context Isolation
 
-Use subagents (Task tool) to investigate without polluting main context:
-
-```
-# Instead of exploring in main conversation:
-Let me look at how auth works...
-[reads 10 files, fills context]
-
-# Use subagent for investigation:
-Task(Explore, "How does authentication work in this codebase?")
-[returns focused summary, main context stays clean]
-```
-
-### When to Use Subagents
+Use subagents to investigate without filling the main context:
 
 | Situation | Approach |
 |-----------|----------|
-| Quick file lookup | Direct Read tool |
-| Multi-file exploration | Task(Explore) |
-| Implementation work | Task(implementer) |
-| Complex investigation | Task(Plan) then implement |
+| Quick file lookup | Direct read/search tool |
+| Multi-file exploration | Explorer/research subagent |
+| Implementation work | Implementer or task-focused agent |
+| Long audit | Background agent with report output |
+
+Pass stable references to subagents: task IDs, spec IDs, branch names, report
+paths, and the active session alias when available.
 
 ## Context Budget Guidelines
 
-### Short Conversations (< 10 exchanges)
+### Short Conversations
 
-- No management needed
-- Context stays fresh naturally
+No special management is usually needed.
 
-### Medium Conversations (10-30 exchanges)
+### Medium Conversations
 
-- Consider `/compact` at midpoint
-- Delegate investigations to subagents
-- Keep session file updated
+- Log decisions as they happen.
+- Delegate broad searches.
+- Keep tool output scoped.
 
-### Long Conversations (30+ exchanges)
+### Long Conversations
 
-- `/compact` every 15-20 exchanges
-- Heavy use of subagents for exploration
-- Session file as primary state holder
-- Consider `/clear` + restart if degraded
-
-## Preventing Context Bloat
-
-### Minimize Tool Output
-
-```
-# Instead of reading entire large files:
-Read(file, limit=50)  # Read first 50 lines
-
-# Instead of globbing everything:
-Glob("src/**/*.py", path="src/auth/")  # Scoped search
-```
-
-### Focused Queries
-
-```
-# Instead of "show me all the code":
-"Find where user authentication is validated"
-
-# Instead of exploring blindly:
-"What files handle the /api/users endpoint?"
-```
-
-### Progressive Disclosure
-
-1. Get overview first (symbols, structure)
-2. Drill into specific areas
-3. Read full content only when needed
-
-## Session Context Patterns
-
-### Starting a Session
-
-```
-1. Create session file (minimal context recorded)
-2. Break down task (decisions recorded)
-3. Spawn first agent (isolated context)
-4. Update session (state persisted)
-```
-
-### Mid-Session Context Check
-
-Every 10-15 exchanges, assess:
-- [ ] Is context still focused on current task?
-- [ ] Are previous decisions still relevant?
-- [ ] Has debugging noise accumulated?
-- [ ] Would `/compact` help?
-
-### Session Handoff
-
-When pausing or handing off:
-1. Update session file with complete state
-2. Include "resumption notes" for context
-3. Reference key files and decisions
-4. Clear main context if long
+- Expect compaction.
+- Keep the journal current.
+- Use reports or handoffs for rich summaries rather than stuffing prose into the
+  session journal.
 
 ## Warning Signs
 
 | Symptom | Likely Cause | Action |
 |---------|--------------|--------|
-| Repeating same mistakes | Context pollution | `/clear` + restart |
-| Forgetting recent decisions | Overcrowded context | `/compact` |
-| Slow responses | Large context | Use subagents |
-| Confusion about task | Too many pivots | Update session, `/clear` |
+| Repeating same mistakes | Context pollution | Log current facts, then clear or compact |
+| Forgetting recent decisions | Overcrowded context | Inspect `loaf session show` and continue from journal |
+| Slow responses | Large context | Delegate exploration |
+| Confusion about task | Too many pivots | Re-anchor on task/spec/session IDs |
 
 ## Best Practices
 
-1. **Update session files continuously** - they survive context resets
-2. **Use subagents for exploration** - keep main context clean
-3. **Clear between unrelated tasks** - fresh start beats polluted context
-4. **Compact mid-task if needed** - preserve decisions, discard noise
-5. **Monitor for pollution** - 2-correction rule catches degradation early
-6. **Scope tool calls** - don't read entire codebases into context
+1. Log durable facts early with `loaf session log`.
+2. Use subagents for exploration-heavy work.
+3. Clear between unrelated tasks.
+4. Compact mid-task when the journal and artifacts are current.
+5. Scope tool calls so context stays focused.

--- a/dist/skills/orchestration/references/cross-session.md
+++ b/dist/skills/orchestration/references/cross-session.md
@@ -135,7 +135,7 @@ When sessions are archived, decisions are extracted to Serena memory:
 
 1. `loaf session end --wrap` persists decisions to spec changelog
 2. Session stays in `sessions/` with `status: done` — no immediate archive
-3. `loaf session housekeeping` archives complete sessions after 7-day age threshold
+3. `loaf housekeeping` reports stale compatibility artifacts, and `loaf session archive` archives closed SQLite sessions when work is complete
 
 ### At Reference Time (spec changelog)
 

--- a/dist/skills/orchestration/references/product-development.md
+++ b/dist/skills/orchestration/references/product-development.md
@@ -11,7 +11,6 @@ A Research → Vision → Architecture → Requirements → Specs → Tasks → 
 - Configuration
 - Workflow Examples
 - Feedback Loops
-- Transcript Archival
 - Flexibility Preserved
 - Critical Files
 
@@ -33,10 +32,9 @@ docs/                               # Permanent project knowledge
 
 .agents/                            # Ephemeral orchestration
 ├── loaf.yaml                       # Project config (task backend, etc.)
-├── sessions/                       # Active work contexts
+├── sessions/                       # Compatibility/rendered session views
 ├── plans/                          # Implementation plans
 ├── councils/                       # Deliberation records
-├── transcripts/                    # Archived conversation transcripts
 ├── tasks/                          # Local tasks (when not using Linear)
 │   ├── active/
 │   │   └── TASK-001-oauth-provider.md
@@ -71,7 +69,7 @@ RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS → SE
 | `/architecture` | Decision question | ARCHITECTURE.md + ADR | Technical decisions |
 | `/shape` | Feature area or requirement | Spec in .agents/specs/ | Implementation-ready specification with boundaries |
 | `/breakdown` | Spec | Tasks in .agents/tasks/ | Atomic work items for agents |
-| `/implement` | TASK-ID | Session file | Execute a task |
+| `/implement` | TASK-ID | SQLite session + implementation commits | Execute a task |
 
 ## Document Formats
 
@@ -187,7 +185,7 @@ docs:
 
 # 6. Work on tasks
 /implement TASK-001
-# → Session → Implementation → Done
+# → SQLite session → Implementation → Done
 ```
 
 ### Quick Fix (Ad-hoc)
@@ -197,7 +195,7 @@ docs:
 /implement TASK-099
 # Orchestrator: "No parent spec. Proceed?"
 # User: "Yes, small fix"
-# → Session → Fix → Done
+# → SQLite session → Fix → Done
 ```
 
 ## Feedback Loops
@@ -210,23 +208,6 @@ The workflow is not rigid. Each level can feed back to higher levels:
 | Edge case invalidates requirement | Update REQUIREMENTS.md |
 | Spec too complex for its size | Re-scope or split |
 | Task reveals missing requirement | Add to REQUIREMENTS.md |
-
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference:
-
-1. **Copy transcript** to `.agents/transcripts/`
-2. **Link from session file** in frontmatter:
-
-```yaml
-session:
-  title: "Feature Implementation"
-  transcripts:
-    - 20260123-143500-pre-compact.jsonl
-    - 20260123-160000-final.jsonl
-```
-
-This preserves full context for debugging, knowledge extraction, and audit trails.
 
 ## Flexibility Preserved
 

--- a/dist/skills/orchestration/references/session-resume.md
+++ b/dist/skills/orchestration/references/session-resume.md
@@ -1,15 +1,15 @@
 # Session Resume Patterns
 
-Patterns for resuming work across Claude Code sessions using CLI flags and session files.
+Patterns for resuming work with CLI conversation history plus SQLite-backed
+Loaf session state.
 
 ## Contents
 
 - CLI Resume Flags
 - Resume Methods
 - When to Use Each Method
-- Session File as Resume Checkpoint
+- SQLite Session as Resume Checkpoint
 - Checkpoint Pattern
-- Naming Sessions Descriptively
 - Context Recovery Strategies
 - Handling Stale Sessions
 - Multi-Session Coordination
@@ -17,7 +17,7 @@ Patterns for resuming work across Claude Code sessions using CLI flags and sessi
 
 ## CLI Resume Flags
 
-Claude Code provides built-in session continuation:
+Some harnesses provide built-in conversation continuation:
 
 | Flag | Purpose |
 |------|---------|
@@ -25,217 +25,113 @@ Claude Code provides built-in session continuation:
 | `--resume <id>` | Resume a specific conversation by ID |
 | `/resume` | In-session command to list and resume |
 
+Use harness resume for chat history. Use `loaf session` for operational state.
+
 ## Resume Methods
 
-### Method 1: CLI Continue
+### Method 1: Conversation Continue
+
+Resume the exact conversation when you need full chat history.
+
+### Method 2: SQLite Session Resume
+
+Start fresh and recover operational state:
 
 ```bash
-# Continue most recent conversation
-claude --continue
-
-# Resume specific conversation
-claude --resume abc123
+loaf session start
+loaf session list --all --json
+loaf session show <session-ref> --json
 ```
 
-**Best for:** Picking up exactly where you left off with full context.
-
-### Method 2: Session File Resume
-
-```bash
-# Start new conversation, resume from session file
-claude
-> /resume 20250123-143000-feature-auth
-```
-
-**Best for:** Fresh context but task continuity from session file.
+Best for clean context with task continuity.
 
 ### Method 3: Hybrid Resume
 
-```bash
-# Continue conversation AND sync with session file
-claude --continue
-> Check session file for any updates: .agents/sessions/20250123-143000-feature-auth.md
-```
-
-**Best for:** Recovering from context pollution while preserving conversation history.
+Continue the conversation, then compare it against `loaf session show` output.
+Best when chat history matters but the journal may contain newer facts.
 
 ## When to Use Each Method
 
 | Situation | Recommended Method |
 |-----------|-------------------|
-| Short break, same task | `--continue` |
-| Long break, clean state needed | Session file resume |
+| Short break, same task | Conversation continue |
+| Long break, clean state needed | SQLite session resume |
 | Context polluted but need history | Hybrid resume |
-| Different machine | Session file resume |
-| Handoff to another person | Session file resume |
+| Different machine | SQLite session resume |
+| Handoff to another person | SQLite session + handoff/report |
 
-## Session File as Resume Checkpoint
+## SQLite Session as Resume Checkpoint
 
-### Writing Resume-Ready State
+Before ending or compacting:
 
-Before ending a session, ensure session file contains:
-
-```markdown
-## Current State
-**Last Action:** Completed API endpoint implementation
-**Pending:** Tests need to be written
-
-## Resumption Notes
-- Branch: feature/auth-endpoints
-- Key files modified: src/auth/routes.py, src/auth/models.py
-- Tests to write: test_login, test_logout, test_refresh
-- Blocker: None
-
-## Next Steps
-1. Spawn QA agent for test implementation
-2. Run full test suite
-3. Update API documentation
-```
-
-### Reading Resume State
+1. Log last action, blockers, and next steps with `loaf session log`.
+2. Reference tasks, specs, reports, commits, and branch names by stable ID/path.
+3. Run `loaf session end --wrap` when work is complete.
 
 When resuming:
 
-1. Read session file for context
-2. Check `## Current State` for where you left off
-3. Check `## Resumption Notes` for key details
-4. Check `## Next Steps` for immediate actions
-5. Verify branch and file state match expectations
+1. Run `loaf session start` on the branch/worktree.
+2. Inspect `loaf session show <session-ref> --json`.
+3. Verify branch and file state match expectations.
+4. Continue from the next logged action.
 
 ## Checkpoint Pattern
 
-For long-running tasks, create explicit checkpoints:
-
-```markdown
-## Checkpoints
-
-### Checkpoint 1: Schema Complete
-**Timestamp:** 2025-01-23T14:30:00Z
-**State:** Database schema implemented and migrated
-**Can resume from:** This checkpoint if later work fails
-
-### Checkpoint 2: API Complete
-**Timestamp:** 2025-01-23T15:45:00Z
-**State:** All endpoints implemented, passing basic tests
-**Can resume from:** This checkpoint for test expansion
-```
-
-### Rewind to Checkpoint
-
-If work goes wrong:
-
-1. Identify safe checkpoint
-2. `git checkout <commit>` to restore code state
-3. Update session file to checkpoint state
-4. `/clear` to reset context
-5. Resume from checkpoint
-
-## Naming Sessions Descriptively
-
-Good session names aid resume:
-
-```
-# Good - descriptive, searchable
-20250123-143000-auth-jwt-implementation.md
-20250123-160000-api-rate-limiting.md
-
-# Bad - generic, hard to find
-20250123-143000-feature.md
-20250123-160000-fix.md
-```
-
-### Rename Pattern
+For long-running tasks, create explicit journal checkpoints:
 
 ```bash
-# If session name becomes unclear, rename for clarity
-mv .agents/sessions/20250123-143000-feature.md \
-   .agents/sessions/20250123-143000-user-auth-oauth.md
+loaf session log "decision(checkpoint): schema complete at <commit>"
+loaf session log "decision(checkpoint): API complete; next write tests"
 ```
 
-Update any references in Linear or other sessions.
+If work goes wrong, use Git to restore code state and log the reconciliation:
+
+```bash
+loaf session log "decision(recovery): rewound to <commit>; replaying tests"
+```
 
 ## Context Recovery Strategies
 
-### Strategy 1: Full Replay
+### Full Replay
 
-For complex state, replay key decisions:
+Use `loaf session show` plus ADR/spec/report links for complex state.
 
-```markdown
-## Decision Replay
+### Minimal Context
 
-When resuming, recall these decisions:
-1. Chose JWT over sessions (see ADR-007)
-2. Using Redis for token storage
-3. 15-minute access token expiry
-```
+Use the last few journal entries when the next action is obvious.
 
-### Strategy 2: Minimal Context
+### Reference Chain
 
-For simple continuation:
+For multi-session work, log relationships:
 
-```markdown
-## Minimal Resume Context
-
-Branch: feature/auth
-Last commit: "feat: add login endpoint"
-Next: Write tests for login endpoint
-```
-
-### Strategy 3: Reference Chain
-
-For multi-session work:
-
-```markdown
-## Session Chain
-
-Previous sessions:
-- 20250122-100000-auth-design.md (planning)
-- 20250122-143000-auth-schema.md (database)
-- This session: API implementation
+```bash
+loaf session log "discover(context): previous design captured in SPEC-123 and ADR-007"
 ```
 
 ## Handling Stale Sessions
 
-### Signs of Stale Session
+Signs of stale session state:
 
-- Code has changed since session was active
-- Other sessions modified same files
+- Code changed after the last journal entry
 - Branch was rebased or merged
+- Another task/spec superseded the work
 
-### Stale Session Recovery
+Recovery:
 
-```
-1. Read session file for intended state
-2. Compare with actual code state (git diff)
-3. Identify conflicts or drift
-4. Update session file to reflect reality
-5. Plan reconciliation if needed
-```
+1. Inspect `loaf session show`.
+2. Compare with `git status`, `git log`, and relevant specs/tasks.
+3. Log the drift and reconciliation plan.
 
 ## Multi-Session Coordination
 
-When multiple sessions touch same codebase:
-
-```markdown
-## Related Sessions
-
-| Session | Status | Overlaps |
-|---------|--------|----------|
-| auth-backend | completed | src/auth/ |
-| auth-frontend | in_progress | src/components/auth/ |
-| This session | in_progress | src/auth/models.py (shared) |
-
-## Coordination Notes
-- Wait for auth-backend completion before modifying models
-- Sync with auth-frontend on API contract changes
-```
+When multiple sessions touch related areas, use specs/tasks/reports as the shared
+coordination layer. Session journals should point to those durable artifacts
+rather than becoming the only place a dependency is described.
 
 ## Best Practices
 
-1. **Update session before stopping** - capture state while fresh
-2. **Use descriptive names** - aid future resume
-3. **Create checkpoints** - safe rollback points
-4. **Note dependencies** - what must complete first
-5. **Clear stale context** - don't resume into pollution
-6. **Verify state on resume** - code may have changed
-7. **Document decision context** - not just decisions
+1. Log before stopping.
+2. Prefer stable IDs over pasted summaries.
+3. Use `loaf session show` as the operational resume surface.
+4. Keep chat-history resume separate from Loaf session state.
+5. Verify code state on resume.

--- a/dist/skills/orchestration/references/sessions.md
+++ b/dist/skills/orchestration/references/sessions.md
@@ -1,523 +1,116 @@
 # Session Management
 
-Sessions are coordination artifacts for active work. They are archived (set status, `archived_at`, `archived_by`, move to `.agents/sessions/archive/`) when work completes to preserve an audit trail.
+Sessions are SQLite-backed coordination records for active work. Markdown is a
+rendered view for reading or compatibility export; agents persist new facts with
+`loaf session` commands.
 
 ## Contents
 
-- Compact vs New Session
+- Core Model
 - When to Use Sessions
-- Session Types
-- Session File Format
-- Lifecycle States
-- Updating During Work
-- Session Continuity Protocol
-- Completing a Session
-- Start Protocol
+- Lifecycle
+- Journal Protocol
+- Continuity
+- Completion
 - Hook Integration
 - Anti-Patterns
 
-## Compact vs New Session
+## Core Model
 
-| Scenario | Action |
-|----------|--------|
-| Picking up previous work, same scope | Compact or resume existing conversation |
-| Switching to entirely different scope | New conversation (new session) |
-| Finished and archived a spec | New conversation |
-| Context full mid-task | Auto-compact (journal survives) |
-| Quick unrelated question | New conversation (don't pollute working session) |
+Use the `wrap` skill as the canonical session model:
 
-**Rule of thumb:** if you'd need the same session file, compact. If you'd need a different one, start fresh.
+1. `loaf session start` finds or creates the active session for the current branch
+   and prints resumption context.
+2. `loaf session log "type(scope): description"` writes durable journal rows.
+3. `loaf session show <session-ref> --json` reads the SQLite-backed session view.
+4. `loaf session end --wrap` persists the wrapped end state.
+5. `loaf session archive` archives closed sessions when the branch/work is done.
+
+The render format is documented in `templates/session.md`; it is not an
+instruction to author markdown directly.
 
 ## When to Use Sessions
 
-- Multi-step work requiring agent coordination
+- Multi-step work requiring coordination
 - Handoffs between agents
-- Tracking progress during implementation
-- Context preservation across agent spawns
+- Implementation or release work that must survive compaction
+- Long research, architecture, council, or review efforts
 
-## Session Types
+For quick unrelated questions, start a fresh conversation so the active session
+stays focused.
 
-### Implementation Sessions (Invisible)
+## Lifecycle
 
-When implementing tasks via `/implement TASK-XXX`:
+The interim runtime lifecycle before SPEC-049 is:
 
-- Session created automatically with filename `YYYYMMDD-HHMMSS-session.md`
-- Task file updated with `session:` field linking to session
-- No user interaction needed for session naming
-- Resume via `loaf session start` then `/implement TASK-XXX`
+| State | Source | Meaning |
+|-------|--------|---------|
+| `active` | `loaf session start` | Current work may receive journal entries |
+| `stopped` | `loaf session end` | Work paused or closed without wrap |
+| `done` | `loaf session end --wrap` | Wrapped work is complete |
+| `archived` | `loaf session archive` | Closed session preserved outside active list |
 
-Users work with tasks; sessions are an implementation detail.
+Do not introduce additional session vocabulary in guidance. SPEC-049 owns the
+durable status vocabulary.
 
-### Explicit Sessions
+## Journal Protocol
 
-For non-task work, sessions are still created explicitly:
-
-- Research sessions (`/research`)
-- Architecture decisions (`/architecture`)
-- Council deliberations (`/council`)
-
-These sessions may not have a linked task but still follow standard session format.
-
-## Session File Format
-
-**Link policy**: Documents outside `.agents/` must not reference `.agents/` files. Keep `.agents/` links contained within `.agents/` artifacts, and update them when files move to `.agents/<type>/archive/`.
-
-### Location & Naming
-
-```
-.agents/sessions/YYYYMMDD-HHMMSS-session.md
-```
-
-**Archive location:** `.agents/sessions/archive/`
-
-**Transcripts location:** `.agents/transcripts/`
-
-Transcripts are Claude Code conversation exports (`.jsonl` files) archived after context compaction. They preserve the full audit trail of agent interactions.
-
-```
-.agents/
-├── sessions/
-│   ├── YYYYMMDD-HHMMSS-session.md
-│   └── archive/
-└── transcripts/              # Claude Code transcripts
-    ├── 2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl
-    └── archive/
-```
-
-**Why keep original filenames:** The UUID-like hash is unique and matches Claude Code's internal reference, making correlation easier if needed.
-
-**Generate timestamps:**
+Log compact, factual entries:
 
 ```bash
-# Filename timestamp
-date -u +"%Y%m%d-%H%M%S"
-
-# ISO timestamp (for YAML)
-date -u +"%Y-%m-%dT%H:%M:%SZ"
+loaf session log "decision(scope): chose X because Y"
+loaf session log "discover(scope): learned Z from file/path"
+loaf session log "block(scope): waiting on external approval"
+loaf session log "unblock(scope): approval received"
+loaf session log "spark(scope): possible follow-up idea"
+loaf session log "todo(scope): concrete follow-up action"
 ```
 
-### Naming Convention
+Log durable facts, not thoughts. The journal should let another agent resume
+without reading the whole conversation.
 
-All session files use the fixed format: `YYYYMMDD-HHMMSS-session.md`
+## Continuity
 
-The timestamp is the unique identifier. Descriptions, spec links, and branch names belong in frontmatter and the `# Session:` heading, not the filename. This keeps references stable — spec and task files can point to session filenames without them ever breaking.
+Before compaction, branch switches, or agent handoff:
 
-### Required Frontmatter
+1. Flush unrecorded decisions, discoveries, blockers, and next actions with
+   `loaf session log`.
+2. Use `loaf session show <session-ref> --json` to confirm the journal has the
+   required resumption context.
+3. Pass task IDs, spec IDs, report IDs, and commit refs rather than duplicating
+   large prose into the journal.
 
-```yaml
----
-session:
-  title: "Clear description of work"           # REQUIRED
-  status: in_progress                          # REQUIRED: in_progress|paused|completed|archived
-  created: "2025-12-04T14:30:00Z"              # REQUIRED: ISO 8601
-  last_updated: "2025-12-04T14:30:00Z"         # REQUIRED: ISO 8601
-  last_archived: "2025-12-04T16:00:00Z"        # Set by PreCompact hook before compaction
-  archive_reason: "pre-compact"                # Why archived (pre-compact, manual, etc.)
-  archived_at: "2025-12-04T18:10:00Z"          # Required when archived
-  task: TASK-001                               # If implementation work (links to .agents/tasks/)
-  linear_issue: "BACK-123"                     # Optional
-  linear_url: "https://linear.app/..."         # Optional
-  branch: "username/back-123-feature"          # Optional: working branch
-  transcripts: []                              # Archived Claude Code transcripts (filenames only)
-                                               # Example: ["2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl"]
-  referenced_sessions: []                      # Cross-session references (see below)
+Background and delegated agents should receive the relevant task/spec/report
+references plus the active session alias when the caller has one.
 
-orchestration:
-  current_task: "What's actively being worked" # REQUIRED
-  spawned_agents:
-    - agent: implementer
-      task: "Brief task description"
-      status: completed                        # pending|in_progress|completed
-      summary: "Outcome summary"
+## Completion
 
-background_agents:                             # Background work running independently
-  - id: "bg-20260123-143000-security-scan"     # ID: bg-YYYYMMDD-HHMMSS-description
-    agent: background-runner                              # Agent type
-    task: "Full security audit"                # Brief description
-    status: running                            # running|completed|failed
-    result_location: null                      # Path to report when complete
----
-```
+When work is complete:
 
-### Cross-Session References
+1. Ensure decisions and discoveries are captured in durable homes such as ADRs,
+   specs, reports, or docs.
+2. Run `loaf session end --wrap` so the CLI persists the wrapped state.
+3. After merge or closure, use `loaf session archive` if the session should leave
+   the active list.
 
-Track decisions imported from past sessions via Serena memory:
-
-```yaml
-session:
-  # ... other fields ...
-  referenced_sessions:
-    - session: "20250115-140000-auth-jwt.md"     # Source session filename
-      imported_at: "2025-01-23T14:30:00Z"        # When imported
-      content_type: decisions                     # decisions|context|all
-      decisions_imported:                         # List of decision titles
-        - "JWT token rotation strategy"
-        - "Refresh token storage approach"
-    - session: "20250110-090000-auth-oauth.md"
-      imported_at: "2025-01-23T14:35:00Z"
-      content_type: context
-      summary: "OAuth provider integration patterns"
-```
-
-**Why track references:**
-
-- Audit trail of where context came from
-- Avoids re-importing same decisions
-- Enables tracing decision lineage across sessions
-
-See `references/cross-session.md` for full patterns.
-
-### Required Sections
-
-Every session file MUST have:
-
-1. **`## Context`** - Background for anyone picking up this work
-2. **`## Current State`** - Where we are now (MUST be handoff-ready)
-3. **`## Next Steps`** - Immediate actions for continuation
-
-### Session Template
-
-```markdown
-# Session: [Title]
-
-## Context
-Background for anyone picking up this work.
-What problem are we solving? Why now?
-
-## Current State
-Where we are right now. What just happened.
-**This section should ALWAYS be handoff-ready.**
-
-## Resumption Prompt
-
-<!-- Generated by PreCompact hook before compaction -->
-<!-- Provides self-contained context for post-compaction continuation -->
-
-> **Context**: [Brief description of work being done]
->
-> **Last Action**: [What just happened]
->
-> **Immediate Next**: [Concrete next step]
->
-> **Key Files**: [Relevant file paths]
->
-> **Blockers**: [Any blockers, or "None"]
->
-> **Transcript Archive**: If Claude Code provided a transcript path after compaction,
-> copy it to `.agents/transcripts/` and add the filename to this session's
-> `transcripts:` array in frontmatter.
-
-## Execution Progress
-
-### Wave 1: [Name] (ACTIVE)
-- [ ] BACK-123 - Brief description
-- [x] BACK-124 - Brief description (completed)
-
-### Wave 2: [Name] (blocked by Wave 1)
-- [ ] BACK-125 - Brief description
-
-## Technical Context
-
-### Files to Update
-- `path/to/file.py` - What needs to change
-
-### Key Commands
-```bash
-pytest path/to/tests/ -v
-mypy path/to/code/
-```
-
-## Acceptance Criteria
-
-- [ ] Criterion 1
-- [ ] Criterion 2
-
-## Decisions
-
-### Decision 1: [Title]
-
-**Decision**: What was decided
-**Rationale**: Why
-
-## Architecture Diagrams
-
-### [Diagram Name]
-
-```mermaid
-[diagram content]
-```
-
-**Purpose**: Why this diagram helps understand the work
-**Files involved**: List of related file paths
-**Created**: When diagram was created (update if modified)
-
-<!--
-When to add diagrams:
-- Multi-service changes: Show interaction points
-- Data flow changes: Trace data through system
-- Schema modifications: Visualize relationships
-- API design: Document request/response flows
-
-For reusable diagrams, store in .agents/diagrams/ instead.
-See foundations skill reference/diagrams.md for Mermaid syntax.
--->
-
-## Council Outcomes
-
-### Council: [Topic]
-
-**Outcome**: Decision summary
-**Council File**: `.agents/councils/YYYYMMDD-HHMMSS-topic.md`
-**Next Steps**: Action items captured
-**Archive**: After this summary is captured, set council status to `archived`, set `archived_at`, set `archived_by`, and move to `.agents/councils/archive/` (archive indefinitely).
-
-## Reports Processed
-
-### Report: [Title]
-
-**Key Conclusions**: Summary of findings
-**Action Items**: What changed or will change
-**Report Output**: generated with `loaf report generate ...` or stored as an authored report when durable prose is needed.
-**Archive**: After report is processed and the linked session is archived, use `loaf report archive <report>` for SQLite-backed report state. Markdown report movement is compatibility/export handling.
-**Metadata**: Require enough state or frontmatter to identify status, linked session, and processing time. In SQLite-backed projects, CLI state is authoritative.
-**Note**: Reports without state/frontmatter metadata are treated as unprocessed compatibility artifacts.
-
-## Handoffs
-
-Explicit transfer packets belong to `/handoff`, which writes
-`.agents/handoffs/YYYYMMDD-HHMMSS-title.md`. Orchestration keeps live session
-state resumable; `/handoff` packages context for another agent, branch, task,
-or future session. `/housekeeping` deletes deprecated handoffs after
-confirmation.
-
-## Blockers
-
-- Current blocker (if any)
-
----
-
-## Session Log (Compact Inline Journal)
-
-Sessions use an **append-only structured journal** format — a running log of what happened, what was decided, and what's next. Think "conventional commits meets bullet journal."
-
-### Format
-
-```markdown
-## Journal
-
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-[YYYY-MM-DD HH:MM] decision(scope): description of decision
-[YYYY-MM-DD HH:MM] discover(scope): something learned
-
-[YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
-[YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
-[YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
-```
-
-### Entry Types
-
-| Type | Use For | Written By | Scope Convention |
-|------|---------|------------|------------------|
-| `resume(scope)` | Session started/resumed | Hook (auto) | Branch name |
-| `pause` | Session ended | Hook (auto) | — |
-| `commit(SHA)` | Code committed | Hook (auto) | Short SHA |
-| `pr(#N)` | PR created/updated | Hook (auto) | PR number |
-| `merge(#N)` | PR merged | Hook (auto) | PR number |
-| `decision(scope)` | Key decisions | Agent | Topic |
-| `discover(scope)` | Something learned | Agent | Topic |
-| `block(scope)` | Blocker encountered | Agent | Topic |
-| `unblock(scope)` | Blocker resolved | Agent | Topic |
-| `spark(scope)` | Ideas to promote | Agent | Topic |
-| `resolve(spark)` | Spark triaged via `/idea` | Agent/User | Spark slug → disposition [timestamp] |
-| `todo(scope)` | Action items | Agent | Topic |
-| `finding(scope)` | Findings from analysis | Agent | Topic |
-| `hypothesis` | Theory being tested | Agent | — |
-| `try` | Approach attempted | Agent | — |
-| `reject` | Approach abandoned | Agent | — |
-| `skill(name)` | Skill invoked with context | Skill (self-log) | Skill name |
-| `idea(slug)` | Idea captured or promoted | Agent/Skill | Idea slug or `.agents/ideas/` ref |
-| `spec(id)` | Spec created, updated, or approved | Agent/Skill | Spec ID (e.g. `SPEC-024`) |
-| `handoff(slug)` | Handoff created or deprecated | Agent/Skill | Handoff slug or `.agents/handoffs/` ref |
-| `report(slug)` | Report generated | Agent/Skill | Report slug or `.agents/reports/` ref |
-| `council(slug)` | Council convened or concluded | Agent/Skill | Council slug or `.agents/councils/` ref |
-| `brainstorm(slug)` | Brainstorm session held | Agent/Skill | Draft slug or topic |
-| `plan(slug)` | Plan created or updated | Agent/Skill | Plan slug or topic |
-| `draft(slug)` | Draft document created | Agent/Skill | Draft slug or `.agents/drafts/` ref |
-
-### Format Rules
-
-1. **Timestamp:** `YYYY-MM-DD HH:MM` (no seconds)
-2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank line separator:** Insert when:
-   - Gap ≥ 5 minutes since last entry, OR
-   - State transition (block/unblock/pause/resume)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated by `loaf session end`)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-### Example Session
-
-```markdown
----
-spec: SPEC-020
-branch: feat/target-convergence
-status: active
-created: 2026-03-31T14:30:00Z
-last_entry: 2026-04-02T09:15:00Z
----
-
-# Session: Target Convergence
-
-## Journal
-
-[2026-03-31 14:30] resume(feat/target-convergence): from commit abc1234, 3 tasks pending
-[2026-03-31 14:30] decision(hooks): remove bash wrappers, go direct
-[2026-03-31 14:32] discover(cursor): prompt hooks filtered at line 269
-
-[2026-03-31 15:10] block(parity): Codex output differs by trailing newline
-[2026-03-31 15:11] hypothesis: gray-matter serialization adds trailing \n
-
-[2026-03-31 16:45] unblock(parity): confirmed gray-matter quirk, fixed with trim
-[2026-03-31 16:46] commit(def5678): fix: trim frontmatter for Codex byte parity
-
---- PAUSE 2026-03-31 17:00 ---
-
-[2026-04-02 09:15] resume(feat/target-convergence): 16 hours paused, last: verification
-```
-
-### CLI Commands
-
-```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decide(scope): desc"
-loaf session archive  # Move to archive when branch merges
-```
-
-### Consistency
-
-- **`loaf session log`** validates and appends entries in correct format
-- **Read-only agents** (reviewer, researcher) CAN write journal entries via `loaf session log` (Bash command, not file edit)
-- **Concurrent writes** are safe: atomic append, timestamps provide ordering
-
-## Lifecycle States
-
-| State | Description |
-|-------|-------------|
-| `in_progress` | Work actively happening |
-| `paused` | Temporarily stopped |
-| `completed` | Work finished; ready to archive (set status, `archived_at`, `archived_by`, move) after extraction |
-| `archived` | Closed and preserved for audit (set `archived_at`/`archived_by`, status set + moved to `.agents/sessions/archive/`) |
-
-## Updating During Work
-
-After each significant action, append entries to the session journal:
-
-1. **Use `loaf session log`** to append entries in the correct format
-2. **Add `decision`, `discover`, `block`, `spark`, `wrap` entries** during normal work
-3. **Hooks auto-append:** `resume`, `commit(SHA)`, `pr(#N)`, `merge(#N)`, `pause`
-4. **Blank line rules:** Inserted automatically by `loaf session log` based on time gaps and state transitions
-
-**Cross-agent protocol:** When any agent starts work on a branch, `loaf session start` outputs the last 15-20 journal entries. The agent reads context, continues work, appends entries.
-
-## Session Continuity Protocol
-
-### Before Pausing or Switching Agents
-
-1. Update session file with completed work
-2. Update `Current State` with where you stopped
-3. Update `Next Steps` with immediate actions
-4. Include `Files Modified` for context
-
-### Session as Continuity Medium
-
-Each agent:
-1. Reads current state from session
-2. Performs assigned work
-3. Updates session with outcomes
-4. Sets up context for next agent
-
-## Completing a Session
-
-Sessions are **archived, not deleted** when complete to preserve audit trail (set status to `archived`, set `archived_at` and `archived_by`, and move into `.agents/sessions/archive/`). Archive indefinitely (no deletion policy).
-
-**Archive timing:** only after extraction and council/report summaries are captured.
-
-### Knowledge Extraction Checklist
-
-| Information Type | Where It Belongs |
-|------------------|------------------|
-| Work tracking | External issue (Linear, GitHub) |
-| Implementation details | Git commits/PRs |
-| Architectural decisions | ADRs (`docs/decisions/`) |
-| API contracts | API documentation |
-| Remaining work | External issue backlog |
-| Council outcomes | Session summary + council file link |
-| Report conclusions | Session summary + report file link |
-| Archived artifacts | SQLite lifecycle state plus compatibility archive metadata when Markdown files exist |
-
-### Archival Checklist
-
-- [ ] External issue updated with final status
-- [ ] Decisions captured as ADRs (if architectural)
-- [ ] Lessons learned added to relevant docs
-- [ ] Remaining work created as issues
-- [ ] Council outcomes summarized in this session (link council file)
-- [ ] Reports processed and summarized in this session (link report file)
-- [ ] Reports archived only after session is archived (`loaf report archive` for SQLite-backed state)
-- [ ] Handoffs reviewed; deprecated handoffs marked for `/housekeeping` deletion
-- [ ] No orphaned references to session file
-- [ ] Set session status to `archived`
-- [ ] Set `archived_at` and `archived_by`
-- [ ] Move compatibility session file to `.agents/sessions/archive/` when one exists
-- [ ] Linked councils moved to `.agents/councils/archive/` after session summary
-- [ ] Linked report state archived after session archived + conclusions captured
-- [ ] Deprecated handoffs deleted by `/housekeeping` after confirmation
-- [ ] Update `.agents/` references to archived paths (no `.agents` links outside `.agents/`)
-- [ ] Archive indefinitely (no deletion policy)
-- [ ] Use `/housekeeping` for auto-move + link updates after confirmation
-
-## Start Protocol
-
-When starting a new orchestration context:
-
-1. Check for existing active sessions
-2. If found, ask user which to resume or start fresh
-3. If resuming, read session for context
-4. If starting fresh, create new session file
+Reports, councils, and handoffs have their own archive or finalization commands.
+Do not use session archival as a substitute for those lifecycles.
 
 ## Hook Integration
 
-### SessionStart Hook
-- Lists active sessions
-- Provides agent-specific context
-- Suggests session review/resume
-
-### SessionEnd Hook
-- Displays completion checklist
-- Reminds about session file updates
-- Shows count of active sessions
-
-### PreCompact Hook
-- `loaf session context for-compact` logs compact marker and injects flush instructions
-- Model flushes unrecorded decisions/discoveries to journal
-- Model writes structured `## Current State` summary
-- After compaction: `loaf session context for-resumption` prints rich resumption context (session, spec, journal, git)
+- Session start hooks should surface recent journal entries from SQLite.
+- Session-end hooks should nudge for missing durable journal entries before wrap.
+- Pre-compaction hooks should ask the agent to flush facts through
+  `loaf session log`.
+- Post-compaction recovery should use `loaf session start` and
+  `loaf session show`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Archive without extraction | Extract outcomes before archiving |
-| Use sessions as permanent records | Use proper documentation locations |
-| Reference stale sessions | Keep sessions current or archive (status + move) when done |
-| Store decisions only in sessions | Create ADRs for important decisions |
-| Archive without council/report summaries | Summarize outcomes in session before archive |
-| Archive but leave in active folder | Move file to `.agents/sessions/archive/` after setting status |
-| Batch session updates | Update after each significant event |
-| Keep status as `in_progress` when paused | Update status when state changes |
+| Hand-author session markdown as source | Use `loaf session start/log/show/end` |
+| Store decisions only in chat context | Log them and promote durable decisions to ADR/spec/report/docs |
+| Invent status values | Cite the runtime lifecycle until SPEC-049 lands |
+| Archive before extracting outcomes | Promote outcomes first, then wrap/archive |
+| Batch all journal entries at the end | Log significant facts as they happen |

--- a/dist/skills/orchestration/templates/session.md
+++ b/dist/skills/orchestration/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/dist/skills/reflect/SKILL.md
+++ b/dist/skills/reflect/SKILL.md
@@ -32,12 +32,13 @@ Update VISION, STRATEGY, and ARCHITECTURE based on proven implementation.
 - **Post-implementation only** -- reflect after shipping, not before or during planning
 - **Get explicit approval** -- never update strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) without user confirmation
 - **Consolidate** -- batch related learnings into coherent updates, avoid micro-updates
-- **Link back** -- always reference the specs/sessions that informed each update
+- **Log first** -- log invocation before gathering evidence: `loaf session log "skill(reflect): <scope>"`
+- **Link back** -- always reference the specs, SQLite sessions, reports, and commits that informed each update
 - **Log updates** -- log each strategic document update to session journal: `loaf session log "decision(scope): updated STRATEGY.md with learning"`
 
 ## Verification
 
-- Proposals cite specific specs, sessions, or commits as evidence
+- Proposals cite specific specs, SQLite sessions, reports, or commits as evidence
 - No strategic document was modified without explicit user approval
 - Completed specs referenced in updates are archived after reflection
 
@@ -85,7 +86,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 
 Sources:
 1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
-2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
+2. **SQLite sessions** (`loaf session list --all --json`, then `loaf session show <ref> --json`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?
 

--- a/dist/skills/research/SKILL.md
+++ b/dist/skills/research/SKILL.md
@@ -32,6 +32,7 @@ Patterns for zooming out, investigating topics, and evolving project direction.
 - Cite sources with confidence levels
 - Present options, let user decide
 - Get approval before editing VISION
+- Log invocation first: `loaf session log "skill(research): <topic or mode>"`
 - Log findings to session journal: `loaf session log "discover(scope): summary of finding"`
 
 ### Never
@@ -78,7 +79,7 @@ Parse `$ARGUMENTS` to determine mode:
 
 Prioritize sources in this order:
 
-1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, session files, codebase patterns
+1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, SQLite sessions, codebase patterns
 2. **Authoritative docs** -- Context7, official docs, RFCs
 3. **Community knowledge** -- Stack Overflow (verified), GitHub issues, expert blogs
 4. **General web** (lowest) -- Search results, unverified sources
@@ -93,7 +94,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 
 1. Read project documents: VISION.md, STRATEGY.md, ARCHITECTURE.md
 2. Check ideas (`.agents/ideas/`) and specs (`docs/specs/`)
-3. Review recent sessions (`.agents/sessions/`)
+3. Review recent sessions with `loaf session list --all --json` and `loaf session show <ref> --json`
 4. Check recent commits: `git log --oneline -20`
 5. Synthesize following [state-assessment template](templates/state-assessment.md)
 
@@ -102,7 +103,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 **Trigger:** Specific topic or question
 
 1. **Interview** with AskUserQuestion: what are you trying to understand? What context do you have? What decision will this inform?
-2. Check project context first (ADRs, ARCHITECTURE, sessions)
+2. Check project context first (ADRs, ARCHITECTURE, SQLite sessions)
 3. Apply confidence hierarchy for external sources
 4. For a transient review artifact, use `loaf report generate` when an existing
    SQLite-backed export kind fits; for authored long-form research, create a

--- a/dist/skills/research/templates/state-assessment.md
+++ b/dist/skills/research/templates/state-assessment.md
@@ -12,7 +12,7 @@ title: "State Assessment: [YYYY-MM-DD]"
 type: state-assessment
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active | archived
-session: ".agents/sessions/YYYYMMDD-HHMMSS-description.md"  # Session that produced this assessment
+session: "session alias or loaf session show reference"  # Session that produced this assessment
 tags: []
 ---
 

--- a/plugins/loaf/agents/background-runner.md
+++ b/plugins/loaf/agents/background-runner.md
@@ -27,7 +27,7 @@ You execute specific tasks in the background, writing results to a specified loc
 
 1. **Execute assigned task** - Security audits, coverage analysis, code reviews, etc.
 2. **Write results** - Output to specified `.agents/reports/` location
-3. **Update session** - Mark your background agent entry as complete
+3. **Report completion** - Write completion status in the report and log a concise session entry when session context is available
 
 ## Input You Receive
 
@@ -35,7 +35,7 @@ The spawning agent provides:
 - Specific task to execute
 - Files or scope to analyze
 - Output location (`.agents/reports/YYYYMMDD-HHMMSS-<name>.md`)
-- Session reference
+- Session alias or task/spec reference when available
 
 ## Execution Process
 
@@ -45,7 +45,7 @@ Extract from prompt:
 - What to do (audit, analyze, review)
 - Scope (files, directories)
 - Output location
-- Session file path
+- Session alias, task ID, or spec ID when provided
 
 ### 2. Execute Work
 
@@ -67,7 +67,7 @@ report:
   status: unprocessed
   created: "2026-01-23T14:30:00Z"
   background_agent_id: "bg-YYYYMMDD-HHMMSS-description"
-  session_reference: "YYYYMMDD-HHMMSS-session-name.md"
+  session_reference: "session alias or task/spec reference"
 ---
 
 # Report Title
@@ -94,17 +94,13 @@ Prioritized list of actions.
 - `path/to/file2.py`
 ```
 
-### 4. Update Session Frontmatter
+### 4. Report Completion
 
-Read session file and update your background agent entry:
+If the prompt supplied an active session alias and the `loaf` CLI is available,
+log the result:
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: completed  # Changed from running
-    result_location: ".agents/reports/20260123-143000-security.md"  # Set path
+```bash
+loaf session log "discover(background): bg-YYYYMMDD-HHMMSS-description completed; report .agents/reports/..."
 ```
 
 ## Constraints
@@ -121,8 +117,7 @@ Before completing:
 - [ ] Task executed per prompt instructions
 - [ ] Report written to specified location
 - [ ] Report has valid frontmatter with `background_agent_id`
-- [ ] Session frontmatter updated with `status: completed`
-- [ ] Session frontmatter updated with `result_location`
+- [ ] Completion logged to session journal when session context was provided
 - [ ] No user interaction attempted
 
 ## Error Handling
@@ -131,16 +126,11 @@ If task cannot be completed:
 
 1. Write partial report with what was accomplished
 2. Document blockers in report
-3. Update session frontmatter with `status: failed`
+3. Log failure to session journal when session context was provided
 4. Include error details in report
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: failed
-    result_location: ".agents/reports/20260123-143000-security-partial.md"
+```bash
+loaf session log "block(background): bg-YYYYMMDD-HHMMSS-description failed; partial report .agents/reports/..."
 ```
 
 ## Example Task
@@ -157,7 +147,7 @@ Check for OWASP Top 10 vulnerabilities.
 
 Write report to: .agents/reports/20260123-143000-auth-security.md
 
-Session: .agents/sessions/20260123-140000-auth-feature.md
+Session: active session alias if available
 Background Agent ID: bg-20260123-143000-auth-security
 ```
 
@@ -165,7 +155,7 @@ Background Agent ID: bg-20260123-143000-auth-security
 1. Read `src/auth/endpoints.py` and `src/auth/token.py`
 2. Analyze for OWASP vulnerabilities
 3. Write findings to `.agents/reports/20260123-143000-auth-security.md`
-4. Update `.agents/sessions/20260123-140000-auth-feature.md` frontmatter
+4. Log completion to the session journal if session context was provided
 
 ---
 version: 2.0.0-pre.20260614235428

--- a/plugins/loaf/agents/implementer.md
+++ b/plugins/loaf/agents/implementer.md
@@ -19,7 +19,7 @@ You are an implementer. You have full write access to the codebase: code, tests,
 ## Behavioral Contract
 
 - Your domain speciality comes from the skills loaded at spawn time, not from this profile. An implementer with Python skills implements Python; an implementer with infrastructure skills writes Terraform. The role is the same; the material differs.
-- Work within an active session. If no session file was provided in your spawn prompt, say so immediately.
+- Work within an active session. If no session alias, task ID, or branch context was provided in your spawn prompt, say so immediately.
 - Follow the conventions defined in your loaded skills. They are your blueprints.
 - Write tests alongside implementation, never after.
 - Run verification commands (linters, type checkers, test suites) before reporting completion.

--- a/plugins/loaf/agents/librarian.md
+++ b/plugins/loaf/agents/librarian.md
@@ -15,21 +15,21 @@ tools:
 ---
 # Librarian
 
-You are a librarian. You shepherd session files through their lifecycle and tend the operational artifacts under `.agents/`. You have read access to the repository and edit access scoped to `.agents/` only.
+You are a librarian. You shepherd SQLite-backed session journals through their lifecycle and tend operational artifacts under `.agents/`. You have read access to the repository and edit access scoped to `.agents/` only.
 
 ## Behavioral Contract
 
-- Tend session files: Current State summaries, journal quality, wrap summaries, lifecycle transitions.
+- Tend session journals: journal quality, wrap summaries, and lifecycle transitions.
 - Never modify code, tests, or configuration — only `.agents/` artifacts.
 - Never research, review, or orchestrate — those are other profiles' work.
 - Work quickly and silently. The user should not notice you unless something is wrong.
-- Read before writing — always check the current state of a session file before modifying it.
+- Read before writing — always check the current state with `loaf session show` before modifying related artifacts.
 
 ## What You Tend
 
-- **Session files** in `.agents/sessions/` — frontmatter, Current State, journal entries
+- **SQLite sessions** — inspect with `loaf session list --json` and `loaf session show <ref> --json`
 - **Session lifecycle** — status transitions (active → stopped → done → archived)
-- **Pre-compaction preservation** — flush journal entries, write Current State before context compaction
+- **Pre-compaction preservation** — flush journal entries before context compaction
 - **Knowledge artifacts** in `.agents/knowledge/` — staleness markers, coverage notes
 - **Wrap summaries** — end-of-session distillation when invoked by `/wrap`
 - **Decision persistence** — extract decisions to spec changelog via `loaf session end --wrap`

--- a/plugins/loaf/skills/bootstrap/SKILL.md
+++ b/plugins/loaf/skills/bootstrap/SKILL.md
@@ -43,6 +43,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - **BRIEF is input, not output** -- the BRIEF is raw intake. Extract every useful fact into VISION/STRATEGY/ARCHITECTURE/AGENTS during bootstrap.
 - **BRIEF is archeological after bootstrap** -- once extraction completes, the BRIEF is a frozen historical snapshot. No skill, agent, command, or template should reference `docs/BRIEF.md` post-bootstrap. Operating documents must stand on their own.
 - **Suggest, don't execute** -- recommend next skills at the end, never auto-run them
+- **Log first** -- log invocation before interviewing: `loaf session log "skill(bootstrap): <project or intake>"`
 - **Log outcome** -- log bootstrap completion to session journal: `loaf session log "decision(bootstrap): project bootstrapped, mode detected"`
 
 ---
@@ -52,7 +53,7 @@ First-contact project setup: detect state, interview the builder, populate proje
 - All expected operating documents (`docs/VISION.md`, `.agents/AGENTS.md` at minimum) exist and contain populated content
 - Useful BRIEF content has been extracted into operating documents (no future reader should need to open the BRIEF)
 - Symlinks are correct: `.claude/CLAUDE.md -> .agents/AGENTS.md` and `./AGENTS.md -> .agents/AGENTS.md`
-- A session file was saved in `.agents/sessions/` capturing key decisions and interview exchanges
+- Key decisions and interview outcomes were logged with `loaf session log` and are readable with `loaf session show`
 
 ---
 
@@ -371,13 +372,13 @@ If symlinks already exist and point to the right targets, skip silently. If they
 
 ### 3. Session Recording
 
-Save the bootstrap interview as a session file:
+Record the bootstrap interview in the active SQLite-backed session:
 
-```
-.agents/sessions/{YYYYMMDD}-{HHMMSS}-bootstrap.md
-```
+1. Run `loaf session start` if there is no active session.
+2. Log mode detection and key interview decisions with `loaf session log`.
+3. Use `loaf session show <session-ref>` to inspect the rendered session view.
 
-The session should capture:
+The session journal should capture:
 - Mode detected and why
 - Key decisions made during the interview
 - Key interview exchanges that informed those decisions
@@ -385,7 +386,8 @@ The session should capture:
 - The original problem framing and user intent
 - Any open questions or deferred decisions
 
-Follow [templates/session.md](templates/session.md) for structure and frontmatter schema.
+Use [templates/session.md](templates/session.md) only as the rendered journal
+format reference; do not hand-author session markdown as the source of truth.
 
 ### 4. Next Steps
 

--- a/plugins/loaf/skills/bootstrap/templates/session.md
+++ b/plugins/loaf/skills/bootstrap/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/plugins/loaf/skills/brainstorm/SKILL.md
+++ b/plugins/loaf/skills/brainstorm/SKILL.md
@@ -20,7 +20,8 @@ Generative thinking — expanding possibilities before narrowing through structu
 - Diverge before converging — generate options before judging
 - Connect exploration to VISION.md and STRATEGY.md context
 - Document discarded options — they hold valuable reasoning
-- Capture sparks (speculative byproducts) in a dedicated section — brainstorm documents are the canonical home for sparks
+- Log invocation first: `loaf session log "skill(brainstorm): <topic>"`
+- Capture sparks (speculative byproducts) with `loaf spark capture --scope <scope> --text <text>`; brainstorm documents may render or summarize them
 - Set boundaries on exploration time
 - Log outcome to session journal: `loaf session log "decision(scope): direction chosen and rationale"`
 
@@ -34,7 +35,7 @@ Generative thinking — expanding possibilities before narrowing through structu
 
 After work completes, verify:
 - Brainstorm document created at `.agents/drafts/{YYYYMMDD}-{HHMMSS}-brainstorm-{slug}.md`
-- `## Sparks` section present with speculative byproducts
+- Sparks captured with `loaf spark capture` and optionally summarized in `## Sparks`
 - Spark lifecycle documented: unprocessed → promoted/discarded
 - Brainstorm references strategic context from VISION/STRATEGY
 
@@ -59,7 +60,7 @@ After work completes, verify:
 
 Sparks are: lightweight, byproducts, worth remembering. Mark as `*(promoted)*` or `*(abandoned)*` after processing.
 
-Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value.
+Brainstorm documents are archived after sparks are processed — never deleted, since the exploration context has lasting value. SQLite spark state is the lifecycle source; draft markdown is a projection or narrative summary.
 
 ## Suggests Next
 

--- a/plugins/loaf/skills/brainstorm/templates/brainstorm.md
+++ b/plugins/loaf/skills/brainstorm/templates/brainstorm.md
@@ -11,7 +11,7 @@ type: brainstorm
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active (has unprocessed sparks) | archived
 tags: []
-related: []            # Optional: idea files, spec IDs, session files
+related: []            # Optional: idea aliases, spec IDs, session aliases, report refs
 ---
 
 # Brainstorm: [Topic]

--- a/plugins/loaf/skills/handoff/templates/handoff.md
+++ b/plugins/loaf/skills/handoff/templates/handoff.md
@@ -8,7 +8,7 @@ title: "[Handoff Title]"
 created: YYYY-MM-DDTHH:MM:SSZ
 status: draft | final | deprecated
 source: session | branch | task | ad-hoc
-session: .agents/sessions/YYYYMMDD-HHMMSS-session.md
+session: session alias or loaf session show reference
 branch: branch-name
 deprecated_at: YYYY-MM-DDTHH:MM:SSZ  # Set only when confirmed obsolete
 deprecated_by: orchestrator

--- a/plugins/loaf/skills/housekeeping/SKILL.md
+++ b/plugins/loaf/skills/housekeeping/SKILL.md
@@ -17,10 +17,11 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Critical Rules
 
 **Always**
+- Log invocation as the first action: `loaf session log "skill(housekeeping): <scope or trigger>"`
 - Review EVERY file individually — never sample or average
 - Check Linear issue status before archiving sessions
 - Extract lessons learned and decisions before archiving
-- Use CLI (`loaf session housekeeping`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
+- Use CLI (`loaf housekeeping`, `loaf session archive`, `loaf task archive`, `loaf spec archive`) — never raw `mv`
 - Treat `.agents/handoffs/` as first-class but disposable: keep active/final handoffs, delete only after confirmed deprecated status
 - Check report `status` is `processed` and linked session is archived before archiving reports (see [templates/report.md](templates/report.md))
 - Check state assessment `session:` field before flagging for cleanup — only flag when linked session is archived
@@ -35,7 +36,7 @@ Systematic review and archival of all `.agents/` artifacts with Linear-aware che
 ## Verification
 
 After work completes, verify:
-- Session files archived with proper metadata (status, archived_at, archived_by)
+- Session lifecycle state is visible through `loaf session list --json`
 - Tasks archived via `loaf task archive`
 - Specs archived via `loaf spec archive`
 - SQLite-backed task/spec/report state reflects lifecycle changes when initialized
@@ -48,10 +49,11 @@ After work completes, verify:
 ### CLI Commands
 
 ```bash
-loaf session housekeeping --dry-run  # Preview all actions
-loaf session housekeeping            # Run all checks and fixes
+loaf housekeeping --dry-run          # Preview recommendations
+loaf housekeeping                    # Run artifact scanner
+loaf housekeeping --sessions         # Review sessions only
 loaf session archive                 # Archive single session
-loaf session enrich <file>           # Enrich a session's journal from JSONL
+loaf session enrich --json           # Compatibility diagnostic for legacy enrichment
 loaf task archive TASK-XXX           # Archive single task
 loaf spec archive SPEC-XXX           # Archive single spec
 loaf task sync                       # Compatibility: repair Markdown task index drift
@@ -61,7 +63,7 @@ loaf task sync                       # Compatibility: repair Markdown task index
 
 | Artifact | Active Location | Archive | Action |
 |----------|-----------------|---------|--------|
-| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf session archive` / `loaf session housekeeping` |
+| Sessions | SQLite state + `.agents/sessions/` compatibility views | `archive/` | `loaf housekeeping --sessions` / `loaf session archive` |
 | Tasks (local mode only) | SQLite state + `.agents/tasks/` source prose | `archive/` | `loaf task archive` |
 | Specs | SQLite state + `.agents/specs/` authored prose | `archive/` | `loaf spec archive` |
 | Drafts (state assessments) | `.agents/drafts/` | delete | Flag for cleanup when linked session is archived |
@@ -78,7 +80,10 @@ every mode.
 
 ## Session Enrichment
 
-For each session with status `stopped` or `done` that has a `claude_session_id` in frontmatter, run `loaf session enrich <file>` to catch up on journal entries that weren't logged during the session.
+In SQLite-backed projects, `loaf session log` is the canonical journal writer and
+`wrap` owns end-of-session checks. `loaf session enrich --json` is a compatibility
+diagnostic for legacy markdown enrichment; it is not part of the normal
+housekeeping flow.
 
 Do NOT enrich `active` sessions — those are handled by the wrap skill when the session ends.
 

--- a/plugins/loaf/skills/housekeeping/templates/session.md
+++ b/plugins/loaf/skills/housekeeping/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/plugins/loaf/skills/implement/SKILL.md
+++ b/plugins/loaf/skills/implement/SKILL.md
@@ -3,8 +3,8 @@ name: implement
 description: >-
   Orchestrates implementation sessions through agent delegation and batch
   execution. Use for all implementation work — features, bug fixes, refactors,
-  and code changes. Produces session files, agent spawn plans, and progress
-  tracking. Not for shapin...
+  and code changes. Produces SQLite-backed session journals, agent spawn plans,
+  and progress trackin...
 user-invocable: true
 argument-hint: '[TASK-XXX | SPEC-XXX | TASK-XXX..YYY | TASK-XXX,YYY | description]'
 version: 2.0.0-pre.20260614235428
@@ -39,7 +39,7 @@ You are the coordinator. Start by understanding the task:
 **You are the ORCHESTRATOR, not the implementer.**
 
 ### Orchestrator Can Do Directly
-- Create/edit session files, council files
+- Start/log/show sessions, create council files
 - Use TodoWrite/TodoRead; **if `integrations.linear.enabled` is `true` in `.agents/loaf.json`**, use Linear MCP tools when helpful
 - Read any file for context
 - Ask clarifying questions
@@ -49,11 +49,11 @@ You are the coordinator. Start by understanding the task:
 
 ## Verification
 
-- Session file exists before any implementation work begins
+- `loaf session start` has created or resumed an active SQLite-backed session before implementation work begins
 - All code changes delegated via Task tool -- no direct edits by orchestrator
-- Session file is continuously updated with spawns, progress, and current state
+- Session journal is continuously updated with spawns, progress, and current state
 - Spec artifacts closed out on branch before PR creation
-- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session file is created; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
+- **Linear-native mode:** `blockedBy` of the target sub-issue is fully `completed` before any session is started; starting a sub-issue also promotes an unstarted parent rollup to active; parent rollup is auto-closed only when all sub-issues are `completed`
 
 ## Quick Reference
 
@@ -81,7 +81,7 @@ Before starting, evaluate context suitability.
 | Just completed a different task/spec | Suggest clear |
 | About to start multi-file implementation | Check depth |
 
-If restart needed: capture state in session file, generate resumption prompt, ask user to restart.
+If restart needed: log current state with `loaf session log`, generate resumption prompt, ask user to restart.
 
 ## Input Detection
 
@@ -89,7 +89,7 @@ Parse `$ARGUMENTS` to determine session type:
 
 | Input Pattern | Type | Action |
 |---------------|------|--------|
-| `TASK-XXX` | Local task | Load via `loaf task show`, auto-create session |
+| `TASK-XXX` | Local task | Load via `loaf task show`, start/resume session |
 | `SPEC-XXX` | Spec orchestration | If spec frontmatter has `linear_parent`, resolve to that Linear parent and follow Linear-Native Routing. Otherwise resolve local tasks and build dependency waves |
 | `TASK-XXX..YYY` | Task range | Expand range, build dependency waves |
 | `TASK-XXX,YYY,ZZZ` | Task list | Parse list, build dependency waves |
@@ -101,8 +101,8 @@ Parse `$ARGUMENTS` to determine session type:
 When starting from `TASK-XXX`:
 
 1. Load task metadata via `loaf task show TASK-XXX --json`; read `.agents/TASKS.json` only as a Markdown-compatibility fallback
-2. Auto-generate session: `YYYYMMDD-HHMMSS-task-XXX.md`
-3. Create session file, update task with session reference: `loaf task update TASK-XXX --session <session-file>`
+2. Run `loaf session start` to find or create the active session for the branch
+3. Log the task coupling: `loaf session log "decision(implement): implementing TASK-XXX"`
 4. Load parent spec if task has `spec:` field
 
 **No user interaction required for session naming.**
@@ -188,7 +188,7 @@ The issue is an actual task. Implement it directly — with a pre-flight gate.
    - Resolve branch name from the sub-issue's `branchName` field (Linear
      auto-generates one) — see
      [session-management.md](references/session-management.md).
-   - Create session file, continue with the standard Startup Checklist.
+   - Run `loaf session start`, then continue with the standard Startup Checklist.
 
 ### Completion (after implementer + reviewer finish cleanly)
 
@@ -225,8 +225,8 @@ When the sub-issue's implementation passes review and tests:
   implementation reveals a missing task, surface it to the user; they
   decide whether to run `/loaf:breakdown` again or add an ad-hoc sub-issue.
 - Does not sync in-progress state bidirectionally. Source of truth at any
-  moment: Linear for issue state, local files for spec content, session
-  file for current handoff.
+  moment: Linear for issue state, local files for spec content, SQLite session
+  journal for current handoff.
 
 ---
 
@@ -249,19 +249,19 @@ Use the **Task tool** with appropriate `subagent_type`:
 
 ---
 
-## Session Creation
+## Session Start
 
-**MANDATORY: Create session file BEFORE any other work.**
+**MANDATORY: Run `loaf session start` BEFORE any implementation work.**
 
-1. Generate timestamps: `date -u +"%Y%m%d-%H%M%S"` and `date -u +"%Y-%m-%dT%H:%M:%SZ"`
-2. Create session file following [session template](templates/session.md)
-3. Verify session file exists with valid frontmatter
+1. Run `loaf session start` from the target branch/worktree.
+2. Log invocation context: `loaf session log "skill(implement): <task/spec/context>"`
+3. Verify the active session is readable with `loaf session list --json` or `loaf session show <session-ref> --json`.
 4. Suggest renaming Claude Code session with a meaningful name derived from context:
    - From spec: `Suggestion: /rename SPEC-027-session-stability`
    - From task: `Suggestion: /rename TASK-042-login-fix`
    - From ad-hoc: `Suggestion: /rename {short-slug-from-description}`
 
-**DO NOT PROCEED WITHOUT A SESSION FILE.**
+**Do not proceed until the active session is visible through `loaf session` commands.**
 
 ---
 
@@ -272,8 +272,8 @@ Use the **Task tool** with appropriate `subagent_type`:
 3. **When uncertain** -- convene council, present results, **wait for user approval**
 4. **Ensure quality** -- spawn implementer for tests, route reviews to reviewer subagents
 5. **When debugging** -- if a test failure or error isn't immediately obvious, load the **debugging** skill for structured hypothesis tracking before retrying
-6. **Update session file continuously** -- log spawns, update current_task, keep handoff-ready
-6. **Clean up** -- no ephemeral files, archive completed sessions (status + `archived_at` + `archived_by` + move to archive/)
+6. **Update session continuously** -- log spawns, progress, blockers, and next actions with `loaf session log`
+6. **Clean up** -- no ephemeral files; wrap with `loaf session end --wrap` and archive closed sessions with `loaf session archive`
 7. **When in doubt, ask the user**
 
 ## Decision Tree
@@ -282,7 +282,7 @@ Use the **Task tool** with appropriate `subagent_type`:
 Is this a code/config/doc change?
 +-- YES -> Spawn appropriate agent
 +-- NO -> Is this a planning/coordination decision?
-    +-- YES with clear path -> Proceed, update session
+    +-- YES with clear path -> Proceed, log session decision
     +-- YES but ambiguous -> Ask user
     +-- NO -> Ask user
 ```
@@ -293,18 +293,18 @@ When multiple valid approaches exist: spawn council (5-7 agents, odd), present r
 
 ## Startup Checklist
 
-After creating session file:
+After `loaf session start`:
 
 1. [ ] Parse input (task, Linear ID, or description)
-2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, update with `loaf task update TASK-XXX --session <session-file>`, load parent spec
+2. [ ] If TASK-XXX: load task via `loaf task show TASK-XXX`, log task coupling, load parent spec
 3. [ ] If Linear ID (or `SPEC-XXX` with `linear_parent`): follow [Linear-Native Routing](#linear-native-routing). Parent → walk sub-issues and select next. Sub-issue → verify `blockedBy` is clear, then start it as one logical Linear operation so the parent is promoted when needed
 4. [ ] If description: auto-create task (see Ad-hoc Task Auto-Creation above)
 5. [ ] Create dedicated branch (see [session-management.md](references/session-management.md))
 6. [ ] Suggest team based on task context
-7. [ ] Populate session Context section
+7. [ ] Log initial context and references with `loaf session log`
 8. [ ] Break down work using TodoWrite
 9. [ ] Identify needed specialized agents
-10. [ ] Update session Next Steps
+10. [ ] Log next steps before spawning
 11. [ ] **Get user approval** before spawning
 
 ---
@@ -312,7 +312,7 @@ After creating session file:
 ## Then Execute
 
 ### BEFORE (Planning)
-1. Create session file
+1. Run `loaf session start`
 2. Set task status: `loaf task update TASK-XXX --status in_progress`
 3. Break down work into agent-sized tasks
 4. Identify spawn order (respect dependencies)
@@ -320,10 +320,10 @@ After creating session file:
 
 ### DURING (Execution)
 1. Spawn specialized agents via Task tool
-2. Log each spawn in session `orchestration.spawned_agents`
+2. Log each spawn with `loaf session log "todo(agent): spawned <agent> for <task>"`
 3. Update Linear with progress (no emoji, no file paths)
-4. Keep session `## Current State` handoff-ready
-5. After each agent completes: update session, spawn next
+4. Keep journal entries handoff-ready
+5. After each agent completes: log outcome, spawn next
 
 ### AFTER (Completion)
 1. Code review pass (spawn `reviewer` agent)
@@ -332,13 +332,13 @@ After creating session file:
    - **Local-tasks mode:** `loaf task update TASK-XXX --status done` (per task), then `loaf task archive --spec SPEC-XXX`
    - **Linear-native mode:** `update_issue` the sub-issue to `completed`-type state. Then query the parent's sub-issues; if all are `completed`, also close the parent. If some remain, list them for the user (see [Linear-Native Routing → Completion](#completion-after-implementer--reviewer-finish-cleanly))
    - Mark spec complete and archive: `loaf spec archive SPEC-XXX` (both modes)
-   - Update session file (status: done, `archived_at`, `archived_by`)
-   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session`
+   - Run `loaf session end --wrap`; archive later with `loaf session archive` when appropriate
+   - Commit: `chore: close SPEC-XXX — archive tasks, spec, and session state`
 4. If on a feature branch: push and create PR (`gh pr create`). Follow PR format and squash merge conventions in [commits reference](../git-workflow/references/commits.md).
 5. After PR is created and approved, use `/loaf:ship` to review, verify, and land the PR. Use `/loaf:release` later when a coherent batch of landed work is ready to publish.
-6. **Suggest reflection:** Check the session file for extractable learnings before closing out:
-   - `## Key Decisions` has content (not `*(none yet)*` or empty)
-   - `traceability.decisions` has entries (ADRs were recorded)
+6. **Suggest reflection:** Check the session journal for extractable learnings before closing out:
+   - `decision(...)` entries are present
+   - ADRs, report verdicts, or spec changelog entries were recorded
    If any signal is present, suggest: *"This session produced key decisions. Consider running `/loaf:reflect` to update strategic docs."* If none are present, stay silent.
 
 ---
@@ -361,4 +361,4 @@ After all tasks are complete, suggest `/loaf:ship` to land the PR. Suggest `/loa
 - **orchestration/product-development** - Full workflow hierarchy
 - **orchestration/specs** - Spec format and lifecycle
 - **orchestration/local-tasks** - Task file format including `session:` field
-- **orchestration/sessions** - Session lifecycle details
+- **orchestration/sessions** - SQLite-backed session lifecycle details

--- a/plugins/loaf/skills/implement/references/session-management.md
+++ b/plugins/loaf/skills/implement/references/session-management.md
@@ -8,7 +8,6 @@
 - Linear Status Management
 - Handoff State Requirements
 - Timestamps for User Context
-- Transcript Archival
 - Task Completion
 
 Detailed reference for session lifecycle management during implementation.
@@ -87,7 +86,7 @@ Use Linear MCP's `list_teams` (if configured) to get all workspace teams for val
 
 ## Diagram Consideration
 
-For multi-file or multi-service changes, consider adding architecture diagrams to the session file.
+For multi-file or multi-service changes, consider adding architecture diagrams to the linked spec, report, ADR, or implementation notes.
 
 ### When to Create Diagrams
 
@@ -106,7 +105,7 @@ Ask yourself:
 2. Is there a data flow that needs to be understood?
 3. Would a visual help communicate the approach?
 
-If yes to any, add an `## Architecture Diagrams` section to the session file.
+If yes to any, capture the diagram in a durable artifact such as a spec, report, ADR, or implementation note, and log the reference with `loaf session log`.
 
 ### Diagram Template
 
@@ -144,7 +143,7 @@ For complex tasks, explore before implementing:
 1. Use Task(Explore) or Task(Plan) to investigate codebase
 2. Map existing patterns and conventions
 3. Identify integration points
-4. Document findings in session file
+4. Log findings with `loaf session log` and reference durable artifacts
 5. Present approach to user for approval before spawning
 ```
 
@@ -193,12 +192,12 @@ never implement through open `blockedBy`.
 
 ## Handoff State Requirements
 
-**The session file must ALWAYS be handoff-ready.** After every significant action:
+**The session journal must ALWAYS be handoff-ready.** After every significant action:
 
-1. Update `## Current State` to reflect what just happened
-2. Update `orchestration.current_task` in frontmatter
+1. Log what just happened with `loaf session log`
+2. Reference task/spec/report/commit IDs rather than duplicating long prose
 3. Log completed agent work with outcomes
-4. Ensure anyone could pick up the work immediately
+4. Ensure anyone could pick up the work immediately from `loaf session show`
 
 ---
 
@@ -217,44 +216,6 @@ Generate with: `date -u +"%Y-%m-%d %H:%M UTC"`
 
 ---
 
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference.
-
-### Process
-
-1. **Get transcript path** from Claude Code output after compaction
-2. **Create transcripts directory** if needed:
-   ```bash
-   mkdir -p .agents/transcripts
-   ```
-3. **Copy transcript** with descriptive name:
-   ```bash
-   cp /path/to/transcript.jsonl .agents/transcripts/YYYYMMDD-HHMMSS-description.jsonl
-   ```
-4. **Update session frontmatter**:
-   ```yaml
-   transcripts:
-     - 20260123-143500-pre-compact.jsonl
-   ```
-
-### When to Archive
-
-| Event | Action |
-|-------|--------|
-| Before `/compact` | Archive current transcript |
-| Before `/clear` | Archive current transcript |
-| Session end | Archive final transcript |
-
-### Benefits
-
-- **Audit trail** - Full history of decisions and work
-- **Knowledge extraction** - Mining past sessions for patterns
-- **Debugging** - Understanding how errors occurred
-- **Training** - Learning from past sessions
-
----
-
 ## Task Completion
 
 When a task-coupled session completes:
@@ -267,7 +228,7 @@ When a task-coupled session completes:
      `list_issues` with `parent: <parent-id>`; if all are `completed`-type,
      close the parent and mark the local spec `complete`, else both stay
      in flight
-3. **Archive session** (standard process)
+3. **Wrap session** with `loaf session end --wrap`; archive with `loaf session archive` when the work is closed
 
 ### Spec Completion Check
 

--- a/plugins/loaf/skills/implement/templates/session.md
+++ b/plugins/loaf/skills/implement/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/plugins/loaf/skills/orchestration/SKILL.md
+++ b/plugins/loaf/skills/orchestration/SKILL.md
@@ -27,12 +27,12 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 ## Critical Rules
 
 ### Sessions
-- Create following [session template](templates/session.md) — compact inline journal format
-- Use `loaf session log` for journal entries: `decide(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
+- Start or resume with `loaf session start`; SQLite is the operational source.
+- Use `loaf session log` for journal entries: `decision(scope)`, `discover(scope)`, `block(scope)`, `spark(scope)`, `todo(scope)`
 - **SESSION JOURNAL NUDGE**: When you see this hook trigger, log unrecorded decisions or findings before responding. Use `loaf session log "entry(scope): description"`. Only log actions (decisions made, things discovered, conclusions reached) — not thoughts or read-only work.
-- Archive when complete (status + `archived_at` + `archived_by` + move to `.agents/sessions/archive/`)
-- PreCompact hook: appends `compact` entry with context summary
-- Post-compaction: `loaf session start` outputs recent journal entries for recovery
+- Wrap with `loaf session end --wrap`; archive with `loaf session archive` when complete.
+- PreCompact hook: flushes journal-worthy state before compaction.
+- Post-compaction: `loaf session start` and `loaf session show` expose recent journal context for recovery.
 
 ### Councils
 - Always odd number: 5 or 7 agents
@@ -57,7 +57,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 ## Verification
 
-- Validate session files with `validate-session.py` before archiving
+- Verify `loaf session list --json` / `loaf session show <ref> --json` reflect the active work before archiving
 - Validate council files with `validate-council.py` before concluding
 - Confirm Linear issue updates are self-contained (no local paths, no emoji)
 
@@ -65,7 +65,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 
 | Task | Action |
 |------|--------|
-| Multi-step work | Create session file, spawn agents |
+| Multi-step work | Start/resume session, spawn agents |
 | Complex decision | Convene council (5-7 agents, odd) |
 | Linear update | Checkboxes, no emoji, no local paths |
 | Feature planning | Size by complexity, shape before building |
@@ -87,7 +87,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 | Subagent Development | [references/subagent-development.md](references/subagent-development.md) | Delegating to specialized agents |
 | Background Agents | [references/background-agents.md](references/background-agents.md) | Running non-interactive work in background |
 | Council Workflow | [references/councils.md](references/councils.md) | Convening councils for complex decisions |
-| Session Management | [references/sessions.md](references/sessions.md) | Creating sessions and keeping live work resumable |
+| Session Management | [references/sessions.md](references/sessions.md) | Starting sessions and keeping live work resumable |
 | Session Resume | [references/session-resume.md](references/session-resume.md) | Resuming sessions, checkpoints, context recovery |
 | Context Management | [references/context-management.md](references/context-management.md) | Using /clear, /compact, managing context limits |
 | Linear Integration | [references/linear.md](references/linear.md) | Updating Linear issues, magic words, status conventions |
@@ -99,7 +99,7 @@ Comprehensive patterns for orchestration: coordinating multi-agent work, managin
 **You are the orchestrator, not the implementer.**
 
 The orchestrator:
-1. Creates issues and session files for tracking
+1. Creates issues and starts sessions for tracking
 2. Breaks down work into delegable tasks
 3. Spawns specialized agents for implementation
 4. Coordinates outcomes and updates external systems
@@ -114,7 +114,6 @@ This skill uses paths from `.agents/loaf.json`:
 ```json
 {
   "sessions": {
-    "directory": ".agents/sessions",
     "councils_directory": ".agents/councils"
   },
   "linear": {
@@ -129,9 +128,8 @@ This skill uses paths from `.agents/loaf.json`:
 
 | Artifact | Location | Archive | Naming |
 |----------|----------|---------|--------|
-| Sessions | `.agents/sessions/` | `.agents/sessions/archive/` | `YYYYMMDD-HHMMSS-description.md` |
+| Sessions | SQLite (`loaf session show`) | `loaf session archive` | CLI alias / session ID |
 | Councils | `.agents/councils/` | `.agents/councils/archive/` | `YYYYMMDD-HHMMSS-topic.md` |
-| Transcripts | `.agents/transcripts/` | N/A | Copied from tool output |
 | Handoffs | `.agents/handoffs/` | delete after deprecated | Created by `/loaf:handoff` |
 | Reports | `.agents/reports/` | N/A | `YYYYMMDD-HHMMSS-subject.md` |
 | Tasks | `.agents/tasks/` | N/A | Per task manager conventions |
@@ -142,16 +140,16 @@ This skill uses paths from `.agents/loaf.json`:
 
 ### BEFORE (Planning)
 - Create/check external issue (Linear, GitHub)
-- Create session file following [session template](templates/session.md)
+- Run `loaf session start` and log the orchestration intent
 - Break down into tasks, identify agents, get user approval
 
 ### DURING (Execution)
 - Spawn specialized agents (never implement directly)
-- Track progress in session file and external issue
+- Track progress with `loaf session log` and external issue updates
 - Convene councils for uncertain decisions
 
 ### AFTER (Completion)
 - Code review + QA testing
 - Update external issue to Done
 - Ensure knowledge captured in permanent locations
-- Archive session (status + `archived_at` + `archived_by` + move + update links)
+- Run `loaf session end --wrap`; archive with `loaf session archive` after merge/closure

--- a/plugins/loaf/skills/orchestration/references/background-agents.md
+++ b/plugins/loaf/skills/orchestration/references/background-agents.md
@@ -1,12 +1,13 @@
 # Background Agents
 
-Background agents handle low-priority, long-running, or non-interactive work that can run independently while the user continues with other tasks.
+Background agents handle low-priority, long-running, or non-interactive work
+while the user continues with other tasks.
 
 ## Contents
 
 - When to Use Background Agents
 - Spawning Background Agents
-- Background Agent Tracking
+- Tracking
 - Result Retrieval
 - Workflow Example
 - Anti-Patterns
@@ -19,20 +20,11 @@ Background agents handle low-priority, long-running, or non-interactive work tha
 | Security audits | Interactive debugging |
 | Code coverage analysis | User-facing questions |
 | Large-scale refactoring reports | Time-sensitive fixes |
-| Codebase-wide linting reports | Tasks requiring immediate feedback |
 | Documentation audits | Work needing user decisions mid-task |
 | Dependency vulnerability scans | Blocking tasks for current work |
 
-**Good candidates:**
-- Results can be processed later
-- No user interaction required
-- Task is well-defined with clear completion criteria
-- Output is a report or artifact, not a conversation
-
-**Poor candidates:**
-- Needs clarification mid-task
-- Time-sensitive (user waiting for result)
-- Requires real-time coordination with other agents
+Good candidates have clear completion criteria, can run without clarification,
+and produce a report or durable artifact.
 
 ## Spawning Background Agents
 
@@ -51,8 +43,7 @@ Task(
     - src/services/
 
     Write report to: .agents/reports/YYYYMMDD-HHMMSS-security-audit.md
-
-    Session: .agents/sessions/20260123-143000-auth-feature.md
+    Active session: SESSION-ALIAS if available from loaf session list/show
     """,
     run_in_background=True
 )
@@ -60,187 +51,57 @@ Task(
 
 ### Cursor
 
-Background agents are configured via the `is_background: true` YAML property. When spawning:
+Background agents are configured via the `is_background: true` YAML property.
+When spawning, specify the report destination and any task/spec/session IDs:
 
 ```
 @background-runner Run security audit on backend codebase.
-Write report to .agents/reports/
+Write report to .agents/reports/.
+Reference TASK-123 and the active session alias if available.
 ```
 
-## Background Agent Tracking
+## Tracking
 
-Track background agents in session frontmatter:
+Track background work with durable references:
 
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-security-scan"
-    agent: background-runner
-    task: "Full security audit of backend"
-    status: running  # running | completed | failed
-    result_location: null
-  - id: "bg-20260123-144500-coverage"
-    agent: background-runner
-    task: "Test coverage analysis"
-    status: completed
-    result_location: ".agents/reports/20260123-144500-coverage-report.md"
-```
+1. Log the spawn with `loaf session log "todo(background): started <id> for <task>"`.
+2. Ask the background agent to write a report under `.agents/reports/`.
+3. When complete, log `discover(background): <id> wrote <report>`.
+4. Process findings into tasks, specs, ADRs, or report verdicts as appropriate.
 
-### Status Values
-
-| Status | Meaning |
-|--------|---------|
-| `running` | Agent still executing |
-| `completed` | Work finished, results available |
-| `failed` | Agent encountered error |
-
-### ID Convention
-
-Background agent IDs follow: `bg-YYYYMMDD-HHMMSS-<description>`
-
-Generate with:
-```bash
-echo "bg-$(date -u +"%Y%m%d-%H%M%S")-<description>"
-```
+Use a stable ID such as `bg-YYYYMMDD-HHMMSS-description` in the prompt and
+journal entries.
 
 ## Result Retrieval
 
-Background agents write results to `.agents/reports/` with standard frontmatter:
-
-```yaml
----
-report:
-  title: "Security Audit Report"
-  type: background-agent-output
-  status: unprocessed  # unprocessed | processed | archived
-  created: "2026-01-23T14:30:00Z"
-  background_agent_id: "bg-20260123-143000-security-scan"
-  session_reference: "20260123-140000-auth-feature.md"
----
-```
-
-### Processing Results
-
-1. SessionStart hook alerts user to completed background work
-2. User or orchestrator reviews report in `.agents/reports/`
-3. Orchestrator updates session frontmatter:
-   - Change `status` from `running` to `completed`
-   - Set `result_location` to report path
-4. Process findings as needed (spawn agents, create issues)
-5. Set report `status` to `processed`
+Background agents write results to `.agents/reports/` with enough metadata to
+identify the source task and report status. In SQLite-backed projects, use
+`loaf report list`, `loaf report show`, and `loaf report archive` when report
+state is available.
 
 ## Workflow Example
 
-### 1. Orchestrator Identifies Low-Priority Work
-
-During auth feature implementation, orchestrator identifies need for security audit but it is not blocking current work.
-
-### 2. Orchestrator Spawns Background Agent
-
-```python
-Task(
-    subagent_type="background-runner",
-    prompt="""
-    Run comprehensive security audit on auth implementation.
-
-    Files to audit:
-    - src/auth/endpoints.py
-    - src/auth/token.py
-    - src/auth/middleware.py
-
-    Check for:
-    - OWASP Top 10 vulnerabilities
-    - Secrets in code
-    - SQL injection risks
-    - Authentication bypasses
-
-    Write report to: .agents/reports/20260123-143000-auth-security.md
-
-    Session: .agents/sessions/20260123-140000-auth-feature.md
-    """,
-    run_in_background=True
-)
-```
-
-### 3. Orchestrator Updates Session Frontmatter
-
-```yaml
-background_agents:
-  - id: "bg-20260123-143000-auth-security"
-    agent: background-runner
-    task: "Auth security audit"
-    status: running
-    result_location: null
-```
-
-### 4. Work Continues
-
-Orchestrator and other agents continue with main implementation while background agent works.
-
-### 5. Session Resumes Later
-
-SessionStart hook detects completed background work:
-
-```
-# Background Work Completed
-
-The following background agents have completed:
-
-- **bg-20260123-143000-auth-security** (background-runner)
-  - Task: Auth security audit
-  - Result: .agents/reports/20260123-143000-auth-security.md
-
-Review reports and update session frontmatter after processing.
-```
-
-### 6. Results Processed
-
-Orchestrator reads report, creates issues for findings, updates session.
+1. Orchestrator identifies non-blocking security audit work.
+2. Orchestrator logs the background spawn in the active session.
+3. Background agent writes `.agents/reports/YYYYMMDD-HHMMSS-auth-security.md`.
+4. Orchestrator reviews the report, creates follow-up tasks, and logs the
+   outcome.
+5. Report state is finalized or archived through the report lifecycle.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
 | Use for blocking work | Keep blocking work in foreground |
-| Spawn without tracking | Always update session frontmatter |
-| Ignore completed results | Process results when alerted |
+| Spawn without tracking | Log the spawn and require a report path |
+| Ignore completed results | Process reports into tasks, findings, or decisions |
 | Use for interactive tasks | Reserve for autonomous work |
-| Spawn many concurrent background agents | Limit to 2-3 to avoid resource contention |
-| Skip result location in prompt | Always specify where to write output |
+| Spawn many concurrent background agents | Limit concurrency to avoid resource contention |
+| Skip result location in prompt | Always specify where output belongs |
 
 ## Integration Points
 
-### SessionStart Hook
-
-Checks session frontmatter for `background_agents` with `status: completed`. Alerts user to review results.
-
-### PreCompact Hook
-
-Includes background agent state in preservation. PreCompact hook captures:
-- Active background agent list
-- Current status of each
-- Result locations for completed agents
-
-### Session Frontmatter
-
-Full template with background agents:
-
-```yaml
----
-session:
-  title: "Feature implementation"
-  status: in_progress
-  # ... other session fields ...
-
-background_agents:
-  - id: "bg-20260123-143000-security"
-    agent: background-runner
-    task: "Security audit"
-    status: completed
-    result_location: ".agents/reports/20260123-143000-security.md"
-  - id: "bg-20260123-150000-coverage"
-    agent: background-runner
-    task: "Coverage analysis"
-    status: running
-    result_location: null
----
-```
+- `loaf session log` records spawn and completion facts.
+- `loaf session show` exposes recent background-work journal entries.
+- `loaf report` commands own durable report lifecycle when available.
+- `/loaf:wrap` should mention unprocessed background reports before ending a session.

--- a/plugins/loaf/skills/orchestration/references/context-management.md
+++ b/plugins/loaf/skills/orchestration/references/context-management.md
@@ -1,54 +1,34 @@
 # Context Management
 
-Patterns for managing context efficiently across sessions and agent spawns.
+Patterns for keeping long work resumable while using SQLite-backed session
+journals as the external memory.
 
 ## Contents
 
 - Design for Compaction
-- Overview
 - Context Commands
 - When to Clear Context
-- The 2-Correction Rule
-- Context Compaction
-- Session Files as Context Anchors
+- Compaction Lifecycle
 - Subagents for Context Isolation
 - Context Budget Guidelines
-- Preventing Context Bloat
-- Session Context Patterns
 - Warning Signs
 - Best Practices
 
 ## Design for Compaction
 
-Compaction is a normal part of long workflows, not an emergency measure. Any workflow expected to exceed 15-20 exchanges should be designed with compaction in mind from the start.
+Compaction is a normal part of long workflows. Design any workflow expected to
+span many exchanges so important state is already outside chat context.
 
 ### Compaction-First Principles
 
-1. **The journal IS external memory** — Session journal entries (decisions, discoveries, progress) survive compaction. Compaction can be lossy because all important state is already on disk.
-2. **`## Current State` is the resumption context** — Keep this section handoff-ready at all times. The PreCompact hook requires writing a state summary here before compaction.
-3. **Decisions go to disk, not context** — Record key decisions in the session journal immediately via `loaf session log`. Context may be compressed; journal entries persist.
-4. **Subagents absorb exploration** — Investigation and exploration should happen in subagents. Only the summary returns to the main context.
-
-### Compaction Lifecycle
-
-```
-PreCompact:
-  1. Flush all unrecorded journal entries (decisions, discoveries, progress)
-  2. Write condensed state summary to session file's ## Current State
-  3. compact.sh writes compact(session) marker to journal
-
-PostCompact:
-  1. PostCompact nudge fires — tells model to read session file
-  2. Model reads ## Current State for resumption context
-  3. Model reads ## Journal for decision trail
-  4. Work resumes without "where were we?"
-```
-
-This makes compaction invisible to workflow continuity. The session file's `## Current State` section is the resumption prompt — written by the model before compaction, read by the model after.
-
-## Overview
-
-Context is finite. Long conversations accumulate irrelevant information that degrades performance. Active context management keeps conversations focused and effective.
+1. **The journal is external memory.** Record decisions, discoveries, blockers,
+   and next actions with `loaf session log`.
+2. **Artifacts carry detail.** Specs, tasks, reports, ADRs, and commits hold rich
+   detail; journal entries point to them.
+3. **Subagents absorb exploration.** Use subagents for broad investigation and
+   return concise findings to the main context.
+4. **`wrap` closes the loop.** End meaningful work with `loaf session end --wrap`
+   so the session lifecycle matches the journal.
 
 ## Context Commands
 
@@ -60,191 +40,78 @@ Context is finite. Long conversations accumulate irrelevant information that deg
 
 ## When to Clear Context
 
-### Clear Between Tasks
-
 Use `/clear` when:
 
 - Starting a completely new task
-- Previous task is fully complete
-- Context has become cluttered with failed attempts
+- Previous task is complete
+- Debugging noise is crowding out the current objective
 - Switching between unrelated codebases
 
-### Don't Clear When
+Avoid clearing mid-task until you have logged enough state for recovery.
 
-- Mid-task and need previous context
-- Debugging requires understanding of prior attempts
-- Session file provides necessary handoff information
-
-## The 2-Correction Rule
-
-**If Claude makes the same mistake twice after correction, the context may be polluted.**
-
-Signs of context pollution:
-- Repeating errors you've already corrected
-- Ignoring instructions you've given
-- Reverting to patterns you've explicitly rejected
-- Confusion about current task state
-
-**Action:** Consider `/clear` and restart with fresh context, referencing session file for state.
-
-## Context Compaction
-
-Use `/compact` when:
-- Conversation is long but task continues
-- Need to preserve key decisions while reducing noise
-- Approaching context limits
-
-**Journal entries are compaction insurance.** Every `loaf session log` call writes state to disk that survives compaction. Don't defer journaling — entries not flushed before compaction are lost.
-
-### What Compaction Preserves (via session file)
-
-- Journal entries: decisions, discoveries, progress, commits
-- `## Current State` summary (written by PreCompact)
-- All externalized artifacts: specs, tasks, ideas, code
-
-### What Compaction Discards
-
-- Intermediate exploration steps
-- Failed attempts and debugging noise
-- Verbose tool output
-- Redundant explanations
-
-## Session Files as Context Anchors
-
-Session files provide persistent context that survives `/clear`:
-
-```markdown
-## Current State
-[Always handoff-ready summary]
-
-## Key Decisions
-- Chose X over Y because Z
-
-## Next Steps
-- Immediate action items
-```
-
-### Pattern: Clear + Resume
+## Compaction Lifecycle
 
 ```
-1. Update session file with current state
-2. /clear to reset context
-3. /resume to reload from session file
-4. Continue with clean context
+PreCompact:
+  1. Flush unrecorded decisions, discoveries, blockers, and next actions
+  2. Reference specs, tasks, reports, commits, and files by stable ID/path
+  3. Let the hook persist the compact marker
+
+PostCompact:
+  1. Run or inspect `loaf session start` output for the active branch
+  2. Use `loaf session show <session-ref> --json` when more context is needed
+  3. Continue from the journal and linked artifacts
 ```
+
+This makes compaction survivable without relying on hand-maintained markdown
+state. Any state not logged or captured in a durable artifact can be lost.
 
 ## Subagents for Context Isolation
 
-Use subagents (Task tool) to investigate without polluting main context:
-
-```
-# Instead of exploring in main conversation:
-Let me look at how auth works...
-[reads 10 files, fills context]
-
-# Use subagent for investigation:
-Task(Explore, "How does authentication work in this codebase?")
-[returns focused summary, main context stays clean]
-```
-
-### When to Use Subagents
+Use subagents to investigate without filling the main context:
 
 | Situation | Approach |
 |-----------|----------|
-| Quick file lookup | Direct Read tool |
-| Multi-file exploration | Task(Explore) |
-| Implementation work | Task(implementer) |
-| Complex investigation | Task(Plan) then implement |
+| Quick file lookup | Direct read/search tool |
+| Multi-file exploration | Explorer/loaf:research subagent |
+| Implementation work | Implementer or task-focused agent |
+| Long audit | Background agent with report output |
+
+Pass stable references to subagents: task IDs, spec IDs, branch names, report
+paths, and the active session alias when available.
 
 ## Context Budget Guidelines
 
-### Short Conversations (< 10 exchanges)
+### Short Conversations
 
-- No management needed
-- Context stays fresh naturally
+No special management is usually needed.
 
-### Medium Conversations (10-30 exchanges)
+### Medium Conversations
 
-- Consider `/compact` at midpoint
-- Delegate investigations to subagents
-- Keep session file updated
+- Log decisions as they happen.
+- Delegate broad searches.
+- Keep tool output scoped.
 
-### Long Conversations (30+ exchanges)
+### Long Conversations
 
-- `/compact` every 15-20 exchanges
-- Heavy use of subagents for exploration
-- Session file as primary state holder
-- Consider `/clear` + restart if degraded
-
-## Preventing Context Bloat
-
-### Minimize Tool Output
-
-```
-# Instead of reading entire large files:
-Read(file, limit=50)  # Read first 50 lines
-
-# Instead of globbing everything:
-Glob("src/**/*.py", path="src/auth/")  # Scoped search
-```
-
-### Focused Queries
-
-```
-# Instead of "show me all the code":
-"Find where user authentication is validated"
-
-# Instead of exploring blindly:
-"What files handle the /api/users endpoint?"
-```
-
-### Progressive Disclosure
-
-1. Get overview first (symbols, structure)
-2. Drill into specific areas
-3. Read full content only when needed
-
-## Session Context Patterns
-
-### Starting a Session
-
-```
-1. Create session file (minimal context recorded)
-2. Break down task (decisions recorded)
-3. Spawn first agent (isolated context)
-4. Update session (state persisted)
-```
-
-### Mid-Session Context Check
-
-Every 10-15 exchanges, assess:
-- [ ] Is context still focused on current task?
-- [ ] Are previous decisions still relevant?
-- [ ] Has debugging noise accumulated?
-- [ ] Would `/compact` help?
-
-### Session Handoff
-
-When pausing or handing off:
-1. Update session file with complete state
-2. Include "resumption notes" for context
-3. Reference key files and decisions
-4. Clear main context if long
+- Expect compaction.
+- Keep the journal current.
+- Use reports or handoffs for rich summaries rather than stuffing prose into the
+  session journal.
 
 ## Warning Signs
 
 | Symptom | Likely Cause | Action |
 |---------|--------------|--------|
-| Repeating same mistakes | Context pollution | `/clear` + restart |
-| Forgetting recent decisions | Overcrowded context | `/compact` |
-| Slow responses | Large context | Use subagents |
-| Confusion about task | Too many pivots | Update session, `/clear` |
+| Repeating same mistakes | Context pollution | Log current facts, then clear or compact |
+| Forgetting recent decisions | Overcrowded context | Inspect `loaf session show` and continue from journal |
+| Slow responses | Large context | Delegate exploration |
+| Confusion about task | Too many pivots | Re-anchor on task/spec/session IDs |
 
 ## Best Practices
 
-1. **Update session files continuously** - they survive context resets
-2. **Use subagents for exploration** - keep main context clean
-3. **Clear between unrelated tasks** - fresh start beats polluted context
-4. **Compact mid-task if needed** - preserve decisions, discard noise
-5. **Monitor for pollution** - 2-correction rule catches degradation early
-6. **Scope tool calls** - don't read entire codebases into context
+1. Log durable facts early with `loaf session log`.
+2. Use subagents for exploration-heavy work.
+3. Clear between unrelated tasks.
+4. Compact mid-task when the journal and artifacts are current.
+5. Scope tool calls so context stays focused.

--- a/plugins/loaf/skills/orchestration/references/cross-session.md
+++ b/plugins/loaf/skills/orchestration/references/cross-session.md
@@ -135,7 +135,7 @@ When sessions are archived, decisions are extracted to Serena memory:
 
 1. `loaf session end --wrap` persists decisions to spec changelog
 2. Session stays in `sessions/` with `status: done` — no immediate archive
-3. `loaf session housekeeping` archives complete sessions after 7-day age threshold
+3. `loaf housekeeping` reports stale compatibility artifacts, and `loaf session archive` archives closed SQLite sessions when work is complete
 
 ### At Reference Time (spec changelog)
 

--- a/plugins/loaf/skills/orchestration/references/product-development.md
+++ b/plugins/loaf/skills/orchestration/references/product-development.md
@@ -11,7 +11,6 @@ A Research → Vision → Architecture → Requirements → Specs → Tasks → 
 - Configuration
 - Workflow Examples
 - Feedback Loops
-- Transcript Archival
 - Flexibility Preserved
 - Critical Files
 
@@ -33,10 +32,9 @@ docs/                               # Permanent project knowledge
 
 .agents/                            # Ephemeral orchestration
 ├── loaf.yaml                       # Project config (task backend, etc.)
-├── sessions/                       # Active work contexts
+├── sessions/                       # Compatibility/rendered session views
 ├── plans/                          # Implementation plans
 ├── councils/                       # Deliberation records
-├── transcripts/                    # Archived conversation transcripts
 ├── tasks/                          # Local tasks (when not using Linear)
 │   ├── active/
 │   │   └── TASK-001-oauth-provider.md
@@ -71,7 +69,7 @@ RESEARCH → VISION → ARCHITECTURE → REQUIREMENTS → SPECS → TASKS → SE
 | `/loaf:architecture` | Decision question | ARCHITECTURE.md + ADR | Technical decisions |
 | `/loaf:shape` | Feature area or requirement | Spec in .agents/specs/ | Implementation-ready specification with boundaries |
 | `/loaf:breakdown` | Spec | Tasks in .agents/tasks/ | Atomic work items for agents |
-| `/loaf:implement` | TASK-ID | Session file | Execute a task |
+| `/loaf:implement` | TASK-ID | SQLite session + implementation commits | Execute a task |
 
 ## Document Formats
 
@@ -187,7 +185,7 @@ docs:
 
 # 6. Work on tasks
 /loaf:implement TASK-001
-# → Session → Implementation → Done
+# → SQLite session → Implementation → Done
 ```
 
 ### Quick Fix (Ad-hoc)
@@ -197,7 +195,7 @@ docs:
 /loaf:implement TASK-099
 # Orchestrator: "No parent spec. Proceed?"
 # User: "Yes, small fix"
-# → Session → Fix → Done
+# → SQLite session → Fix → Done
 ```
 
 ## Feedback Loops
@@ -210,23 +208,6 @@ The workflow is not rigid. Each level can feed back to higher levels:
 | Edge case invalidates requirement | Update REQUIREMENTS.md |
 | Spec too complex for its size | Re-scope or split |
 | Task reveals missing requirement | Add to REQUIREMENTS.md |
-
-## Transcript Archival
-
-After `/compact` or `/clear`, archive conversation transcripts for future reference:
-
-1. **Copy transcript** to `.agents/transcripts/`
-2. **Link from session file** in frontmatter:
-
-```yaml
-session:
-  title: "Feature Implementation"
-  transcripts:
-    - 20260123-143500-pre-compact.jsonl
-    - 20260123-160000-final.jsonl
-```
-
-This preserves full context for debugging, knowledge extraction, and audit trails.
 
 ## Flexibility Preserved
 

--- a/plugins/loaf/skills/orchestration/references/session-resume.md
+++ b/plugins/loaf/skills/orchestration/references/session-resume.md
@@ -1,15 +1,15 @@
 # Session Resume Patterns
 
-Patterns for resuming work across Claude Code sessions using CLI flags and session files.
+Patterns for resuming work with CLI conversation history plus SQLite-backed
+Loaf session state.
 
 ## Contents
 
 - CLI Resume Flags
 - Resume Methods
 - When to Use Each Method
-- Session File as Resume Checkpoint
+- SQLite Session as Resume Checkpoint
 - Checkpoint Pattern
-- Naming Sessions Descriptively
 - Context Recovery Strategies
 - Handling Stale Sessions
 - Multi-Session Coordination
@@ -17,7 +17,7 @@ Patterns for resuming work across Claude Code sessions using CLI flags and sessi
 
 ## CLI Resume Flags
 
-Claude Code provides built-in session continuation:
+Some harnesses provide built-in conversation continuation:
 
 | Flag | Purpose |
 |------|---------|
@@ -25,217 +25,113 @@ Claude Code provides built-in session continuation:
 | `--resume <id>` | Resume a specific conversation by ID |
 | `/resume` | In-session command to list and resume |
 
+Use harness resume for chat history. Use `loaf session` for operational state.
+
 ## Resume Methods
 
-### Method 1: CLI Continue
+### Method 1: Conversation Continue
+
+Resume the exact conversation when you need full chat history.
+
+### Method 2: SQLite Session Resume
+
+Start fresh and recover operational state:
 
 ```bash
-# Continue most recent conversation
-claude --continue
-
-# Resume specific conversation
-claude --resume abc123
+loaf session start
+loaf session list --all --json
+loaf session show <session-ref> --json
 ```
 
-**Best for:** Picking up exactly where you left off with full context.
-
-### Method 2: Session File Resume
-
-```bash
-# Start new conversation, resume from session file
-claude
-> /resume 20250123-143000-feature-auth
-```
-
-**Best for:** Fresh context but task continuity from session file.
+Best for clean context with task continuity.
 
 ### Method 3: Hybrid Resume
 
-```bash
-# Continue conversation AND sync with session file
-claude --continue
-> Check session file for any updates: .agents/sessions/20250123-143000-feature-auth.md
-```
-
-**Best for:** Recovering from context pollution while preserving conversation history.
+Continue the conversation, then compare it against `loaf session show` output.
+Best when chat history matters but the journal may contain newer facts.
 
 ## When to Use Each Method
 
 | Situation | Recommended Method |
 |-----------|-------------------|
-| Short break, same task | `--continue` |
-| Long break, clean state needed | Session file resume |
+| Short break, same task | Conversation continue |
+| Long break, clean state needed | SQLite session resume |
 | Context polluted but need history | Hybrid resume |
-| Different machine | Session file resume |
-| Handoff to another person | Session file resume |
+| Different machine | SQLite session resume |
+| Handoff to another person | SQLite session + handoff/report |
 
-## Session File as Resume Checkpoint
+## SQLite Session as Resume Checkpoint
 
-### Writing Resume-Ready State
+Before ending or compacting:
 
-Before ending a session, ensure session file contains:
-
-```markdown
-## Current State
-**Last Action:** Completed API endpoint implementation
-**Pending:** Tests need to be written
-
-## Resumption Notes
-- Branch: feature/auth-endpoints
-- Key files modified: src/auth/routes.py, src/auth/models.py
-- Tests to write: test_login, test_logout, test_refresh
-- Blocker: None
-
-## Next Steps
-1. Spawn QA agent for test implementation
-2. Run full test suite
-3. Update API documentation
-```
-
-### Reading Resume State
+1. Log last action, blockers, and next steps with `loaf session log`.
+2. Reference tasks, specs, reports, commits, and branch names by stable ID/path.
+3. Run `loaf session end --wrap` when work is complete.
 
 When resuming:
 
-1. Read session file for context
-2. Check `## Current State` for where you left off
-3. Check `## Resumption Notes` for key details
-4. Check `## Next Steps` for immediate actions
-5. Verify branch and file state match expectations
+1. Run `loaf session start` on the branch/worktree.
+2. Inspect `loaf session show <session-ref> --json`.
+3. Verify branch and file state match expectations.
+4. Continue from the next logged action.
 
 ## Checkpoint Pattern
 
-For long-running tasks, create explicit checkpoints:
-
-```markdown
-## Checkpoints
-
-### Checkpoint 1: Schema Complete
-**Timestamp:** 2025-01-23T14:30:00Z
-**State:** Database schema implemented and migrated
-**Can resume from:** This checkpoint if later work fails
-
-### Checkpoint 2: API Complete
-**Timestamp:** 2025-01-23T15:45:00Z
-**State:** All endpoints implemented, passing basic tests
-**Can resume from:** This checkpoint for test expansion
-```
-
-### Rewind to Checkpoint
-
-If work goes wrong:
-
-1. Identify safe checkpoint
-2. `git checkout <commit>` to restore code state
-3. Update session file to checkpoint state
-4. `/clear` to reset context
-5. Resume from checkpoint
-
-## Naming Sessions Descriptively
-
-Good session names aid resume:
-
-```
-# Good - descriptive, searchable
-20250123-143000-auth-jwt-implementation.md
-20250123-160000-api-rate-limiting.md
-
-# Bad - generic, hard to find
-20250123-143000-feature.md
-20250123-160000-fix.md
-```
-
-### Rename Pattern
+For long-running tasks, create explicit journal checkpoints:
 
 ```bash
-# If session name becomes unclear, rename for clarity
-mv .agents/sessions/20250123-143000-feature.md \
-   .agents/sessions/20250123-143000-user-auth-oauth.md
+loaf session log "decision(checkpoint): schema complete at <commit>"
+loaf session log "decision(checkpoint): API complete; next write tests"
 ```
 
-Update any references in Linear or other sessions.
+If work goes wrong, use Git to restore code state and log the reconciliation:
+
+```bash
+loaf session log "decision(recovery): rewound to <commit>; replaying tests"
+```
 
 ## Context Recovery Strategies
 
-### Strategy 1: Full Replay
+### Full Replay
 
-For complex state, replay key decisions:
+Use `loaf session show` plus ADR/spec/report links for complex state.
 
-```markdown
-## Decision Replay
+### Minimal Context
 
-When resuming, recall these decisions:
-1. Chose JWT over sessions (see ADR-007)
-2. Using Redis for token storage
-3. 15-minute access token expiry
-```
+Use the last few journal entries when the next action is obvious.
 
-### Strategy 2: Minimal Context
+### Reference Chain
 
-For simple continuation:
+For multi-session work, log relationships:
 
-```markdown
-## Minimal Resume Context
-
-Branch: feature/auth
-Last commit: "feat: add login endpoint"
-Next: Write tests for login endpoint
-```
-
-### Strategy 3: Reference Chain
-
-For multi-session work:
-
-```markdown
-## Session Chain
-
-Previous sessions:
-- 20250122-100000-auth-design.md (planning)
-- 20250122-143000-auth-schema.md (database)
-- This session: API implementation
+```bash
+loaf session log "discover(context): previous design captured in SPEC-123 and ADR-007"
 ```
 
 ## Handling Stale Sessions
 
-### Signs of Stale Session
+Signs of stale session state:
 
-- Code has changed since session was active
-- Other sessions modified same files
+- Code changed after the last journal entry
 - Branch was rebased or merged
+- Another task/spec superseded the work
 
-### Stale Session Recovery
+Recovery:
 
-```
-1. Read session file for intended state
-2. Compare with actual code state (git diff)
-3. Identify conflicts or drift
-4. Update session file to reflect reality
-5. Plan reconciliation if needed
-```
+1. Inspect `loaf session show`.
+2. Compare with `git status`, `git log`, and relevant specs/tasks.
+3. Log the drift and reconciliation plan.
 
 ## Multi-Session Coordination
 
-When multiple sessions touch same codebase:
-
-```markdown
-## Related Sessions
-
-| Session | Status | Overlaps |
-|---------|--------|----------|
-| auth-backend | completed | src/auth/ |
-| auth-frontend | in_progress | src/components/auth/ |
-| This session | in_progress | src/auth/models.py (shared) |
-
-## Coordination Notes
-- Wait for auth-backend completion before modifying models
-- Sync with auth-frontend on API contract changes
-```
+When multiple sessions touch related areas, use specs/tasks/reports as the shared
+coordination layer. Session journals should point to those durable artifacts
+rather than becoming the only place a dependency is described.
 
 ## Best Practices
 
-1. **Update session before stopping** - capture state while fresh
-2. **Use descriptive names** - aid future resume
-3. **Create checkpoints** - safe rollback points
-4. **Note dependencies** - what must complete first
-5. **Clear stale context** - don't resume into pollution
-6. **Verify state on resume** - code may have changed
-7. **Document decision context** - not just decisions
+1. Log before stopping.
+2. Prefer stable IDs over pasted summaries.
+3. Use `loaf session show` as the operational resume surface.
+4. Keep chat-history resume separate from Loaf session state.
+5. Verify code state on resume.

--- a/plugins/loaf/skills/orchestration/references/sessions.md
+++ b/plugins/loaf/skills/orchestration/references/sessions.md
@@ -1,523 +1,116 @@
 # Session Management
 
-Sessions are coordination artifacts for active work. They are archived (set status, `archived_at`, `archived_by`, move to `.agents/sessions/archive/`) when work completes to preserve an audit trail.
+Sessions are SQLite-backed coordination records for active work. Markdown is a
+rendered view for reading or compatibility export; agents persist new facts with
+`loaf session` commands.
 
 ## Contents
 
-- Compact vs New Session
+- Core Model
 - When to Use Sessions
-- Session Types
-- Session File Format
-- Lifecycle States
-- Updating During Work
-- Session Continuity Protocol
-- Completing a Session
-- Start Protocol
+- Lifecycle
+- Journal Protocol
+- Continuity
+- Completion
 - Hook Integration
 - Anti-Patterns
 
-## Compact vs New Session
+## Core Model
 
-| Scenario | Action |
-|----------|--------|
-| Picking up previous work, same scope | Compact or resume existing conversation |
-| Switching to entirely different scope | New conversation (new session) |
-| Finished and archived a spec | New conversation |
-| Context full mid-task | Auto-compact (journal survives) |
-| Quick unrelated question | New conversation (don't pollute working session) |
+Use the `wrap` skill as the canonical session model:
 
-**Rule of thumb:** if you'd need the same session file, compact. If you'd need a different one, start fresh.
+1. `loaf session start` finds or creates the active session for the current branch
+   and prints resumption context.
+2. `loaf session log "type(scope): description"` writes durable journal rows.
+3. `loaf session show <session-ref> --json` reads the SQLite-backed session view.
+4. `loaf session end --wrap` persists the wrapped end state.
+5. `loaf session archive` archives closed sessions when the branch/work is done.
+
+The render format is documented in `templates/session.md`; it is not an
+instruction to author markdown directly.
 
 ## When to Use Sessions
 
-- Multi-step work requiring agent coordination
+- Multi-step work requiring coordination
 - Handoffs between agents
-- Tracking progress during implementation
-- Context preservation across agent spawns
+- Implementation or release work that must survive compaction
+- Long research, architecture, council, or review efforts
 
-## Session Types
+For quick unrelated questions, start a fresh conversation so the active session
+stays focused.
 
-### Implementation Sessions (Invisible)
+## Lifecycle
 
-When implementing tasks via `/loaf:implement TASK-XXX`:
+The interim runtime lifecycle before SPEC-049 is:
 
-- Session created automatically with filename `YYYYMMDD-HHMMSS-session.md`
-- Task file updated with `session:` field linking to session
-- No user interaction needed for session naming
-- Resume via `loaf session start` then `/loaf:implement TASK-XXX`
+| State | Source | Meaning |
+|-------|--------|---------|
+| `active` | `loaf session start` | Current work may receive journal entries |
+| `stopped` | `loaf session end` | Work paused or closed without wrap |
+| `done` | `loaf session end --wrap` | Wrapped work is complete |
+| `archived` | `loaf session archive` | Closed session preserved outside active list |
 
-Users work with tasks; sessions are an implementation detail.
+Do not introduce additional session vocabulary in guidance. SPEC-049 owns the
+durable status vocabulary.
 
-### Explicit Sessions
+## Journal Protocol
 
-For non-task work, sessions are still created explicitly:
-
-- Research sessions (`/loaf:research`)
-- Architecture decisions (`/loaf:architecture`)
-- Council deliberations (`/loaf:council`)
-
-These sessions may not have a linked task but still follow standard session format.
-
-## Session File Format
-
-**Link policy**: Documents outside `.agents/` must not reference `.agents/` files. Keep `.agents/` links contained within `.agents/` artifacts, and update them when files move to `.agents/<type>/archive/`.
-
-### Location & Naming
-
-```
-.agents/sessions/YYYYMMDD-HHMMSS-session.md
-```
-
-**Archive location:** `.agents/sessions/archive/`
-
-**Transcripts location:** `.agents/transcripts/`
-
-Transcripts are Claude Code conversation exports (`.jsonl` files) archived after context compaction. They preserve the full audit trail of agent interactions.
-
-```
-.agents/
-├── sessions/
-│   ├── YYYYMMDD-HHMMSS-session.md
-│   └── archive/
-└── transcripts/              # Claude Code transcripts
-    ├── 2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl
-    └── archive/
-```
-
-**Why keep original filenames:** The UUID-like hash is unique and matches Claude Code's internal reference, making correlation easier if needed.
-
-**Generate timestamps:**
+Log compact, factual entries:
 
 ```bash
-# Filename timestamp
-date -u +"%Y%m%d-%H%M%S"
-
-# ISO timestamp (for YAML)
-date -u +"%Y-%m-%dT%H:%M:%SZ"
+loaf session log "decision(scope): chose X because Y"
+loaf session log "discover(scope): learned Z from file/path"
+loaf session log "block(scope): waiting on external approval"
+loaf session log "unblock(scope): approval received"
+loaf session log "spark(scope): possible follow-up idea"
+loaf session log "todo(scope): concrete follow-up action"
 ```
 
-### Naming Convention
+Log durable facts, not thoughts. The journal should let another agent resume
+without reading the whole conversation.
 
-All session files use the fixed format: `YYYYMMDD-HHMMSS-session.md`
+## Continuity
 
-The timestamp is the unique identifier. Descriptions, spec links, and branch names belong in frontmatter and the `# Session:` heading, not the filename. This keeps references stable — spec and task files can point to session filenames without them ever breaking.
+Before compaction, branch switches, or agent handoff:
 
-### Required Frontmatter
+1. Flush unrecorded decisions, discoveries, blockers, and next actions with
+   `loaf session log`.
+2. Use `loaf session show <session-ref> --json` to confirm the journal has the
+   required resumption context.
+3. Pass task IDs, spec IDs, report IDs, and commit refs rather than duplicating
+   large prose into the journal.
 
-```yaml
----
-session:
-  title: "Clear description of work"           # REQUIRED
-  status: in_progress                          # REQUIRED: in_progress|paused|completed|archived
-  created: "2025-12-04T14:30:00Z"              # REQUIRED: ISO 8601
-  last_updated: "2025-12-04T14:30:00Z"         # REQUIRED: ISO 8601
-  last_archived: "2025-12-04T16:00:00Z"        # Set by PreCompact hook before compaction
-  archive_reason: "pre-compact"                # Why archived (pre-compact, manual, etc.)
-  archived_at: "2025-12-04T18:10:00Z"          # Required when archived
-  task: TASK-001                               # If implementation work (links to .agents/tasks/)
-  linear_issue: "BACK-123"                     # Optional
-  linear_url: "https://linear.app/..."         # Optional
-  branch: "username/back-123-feature"          # Optional: working branch
-  transcripts: []                              # Archived Claude Code transcripts (filenames only)
-                                               # Example: ["2a244262-8599-4bef-8bb8-3feea33d14e2.jsonl"]
-  referenced_sessions: []                      # Cross-session references (see below)
+Background and delegated agents should receive the relevant task/spec/report
+references plus the active session alias when the caller has one.
 
-orchestration:
-  current_task: "What's actively being worked" # REQUIRED
-  spawned_agents:
-    - agent: implementer
-      task: "Brief task description"
-      status: completed                        # pending|in_progress|completed
-      summary: "Outcome summary"
+## Completion
 
-background_agents:                             # Background work running independently
-  - id: "bg-20260123-143000-security-scan"     # ID: bg-YYYYMMDD-HHMMSS-description
-    agent: background-runner                              # Agent type
-    task: "Full security audit"                # Brief description
-    status: running                            # running|completed|failed
-    result_location: null                      # Path to report when complete
----
-```
+When work is complete:
 
-### Cross-Session References
+1. Ensure decisions and discoveries are captured in durable homes such as ADRs,
+   specs, reports, or docs.
+2. Run `loaf session end --wrap` so the CLI persists the wrapped state.
+3. After merge or closure, use `loaf session archive` if the session should leave
+   the active list.
 
-Track decisions imported from past sessions via Serena memory:
-
-```yaml
-session:
-  # ... other fields ...
-  referenced_sessions:
-    - session: "20250115-140000-auth-jwt.md"     # Source session filename
-      imported_at: "2025-01-23T14:30:00Z"        # When imported
-      content_type: decisions                     # decisions|context|all
-      decisions_imported:                         # List of decision titles
-        - "JWT token rotation strategy"
-        - "Refresh token storage approach"
-    - session: "20250110-090000-auth-oauth.md"
-      imported_at: "2025-01-23T14:35:00Z"
-      content_type: context
-      summary: "OAuth provider integration patterns"
-```
-
-**Why track references:**
-
-- Audit trail of where context came from
-- Avoids re-importing same decisions
-- Enables tracing decision lineage across sessions
-
-See `references/cross-session.md` for full patterns.
-
-### Required Sections
-
-Every session file MUST have:
-
-1. **`## Context`** - Background for anyone picking up this work
-2. **`## Current State`** - Where we are now (MUST be handoff-ready)
-3. **`## Next Steps`** - Immediate actions for continuation
-
-### Session Template
-
-```markdown
-# Session: [Title]
-
-## Context
-Background for anyone picking up this work.
-What problem are we solving? Why now?
-
-## Current State
-Where we are right now. What just happened.
-**This section should ALWAYS be handoff-ready.**
-
-## Resumption Prompt
-
-<!-- Generated by PreCompact hook before compaction -->
-<!-- Provides self-contained context for post-compaction continuation -->
-
-> **Context**: [Brief description of work being done]
->
-> **Last Action**: [What just happened]
->
-> **Immediate Next**: [Concrete next step]
->
-> **Key Files**: [Relevant file paths]
->
-> **Blockers**: [Any blockers, or "None"]
->
-> **Transcript Archive**: If Claude Code provided a transcript path after compaction,
-> copy it to `.agents/transcripts/` and add the filename to this session's
-> `transcripts:` array in frontmatter.
-
-## Execution Progress
-
-### Wave 1: [Name] (ACTIVE)
-- [ ] BACK-123 - Brief description
-- [x] BACK-124 - Brief description (completed)
-
-### Wave 2: [Name] (blocked by Wave 1)
-- [ ] BACK-125 - Brief description
-
-## Technical Context
-
-### Files to Update
-- `path/to/file.py` - What needs to change
-
-### Key Commands
-```bash
-pytest path/to/tests/ -v
-mypy path/to/code/
-```
-
-## Acceptance Criteria
-
-- [ ] Criterion 1
-- [ ] Criterion 2
-
-## Decisions
-
-### Decision 1: [Title]
-
-**Decision**: What was decided
-**Rationale**: Why
-
-## Architecture Diagrams
-
-### [Diagram Name]
-
-```mermaid
-[diagram content]
-```
-
-**Purpose**: Why this diagram helps understand the work
-**Files involved**: List of related file paths
-**Created**: When diagram was created (update if modified)
-
-<!--
-When to add diagrams:
-- Multi-service changes: Show interaction points
-- Data flow changes: Trace data through system
-- Schema modifications: Visualize relationships
-- API design: Document request/response flows
-
-For reusable diagrams, store in .agents/diagrams/ instead.
-See foundations skill reference/diagrams.md for Mermaid syntax.
--->
-
-## Council Outcomes
-
-### Council: [Topic]
-
-**Outcome**: Decision summary
-**Council File**: `.agents/councils/YYYYMMDD-HHMMSS-topic.md`
-**Next Steps**: Action items captured
-**Archive**: After this summary is captured, set council status to `archived`, set `archived_at`, set `archived_by`, and move to `.agents/councils/archive/` (archive indefinitely).
-
-## Reports Processed
-
-### Report: [Title]
-
-**Key Conclusions**: Summary of findings
-**Action Items**: What changed or will change
-**Report Output**: generated with `loaf report generate ...` or stored as an authored report when durable prose is needed.
-**Archive**: After report is processed and the linked session is archived, use `loaf report archive <report>` for SQLite-backed report state. Markdown report movement is compatibility/export handling.
-**Metadata**: Require enough state or frontmatter to identify status, linked session, and processing time. In SQLite-backed projects, CLI state is authoritative.
-**Note**: Reports without state/frontmatter metadata are treated as unprocessed compatibility artifacts.
-
-## Handoffs
-
-Explicit transfer packets belong to `/loaf:handoff`, which writes
-`.agents/handoffs/YYYYMMDD-HHMMSS-title.md`. Orchestration keeps live session
-state resumable; `/loaf:handoff` packages context for another agent, branch, task,
-or future session. `/loaf:housekeeping` deletes deprecated handoffs after
-confirmation.
-
-## Blockers
-
-- Current blocker (if any)
-
----
-
-## Session Log (Compact Inline Journal)
-
-Sessions use an **append-only structured journal** format — a running log of what happened, what was decided, and what's next. Think "conventional commits meets bullet journal."
-
-### Format
-
-```markdown
-## Journal
-
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-[YYYY-MM-DD HH:MM] decision(scope): description of decision
-[YYYY-MM-DD HH:MM] discover(scope): something learned
-
-[YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
-[YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
-[YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
-```
-
-### Entry Types
-
-| Type | Use For | Written By | Scope Convention |
-|------|---------|------------|------------------|
-| `resume(scope)` | Session started/resumed | Hook (auto) | Branch name |
-| `pause` | Session ended | Hook (auto) | — |
-| `commit(SHA)` | Code committed | Hook (auto) | Short SHA |
-| `pr(#N)` | PR created/updated | Hook (auto) | PR number |
-| `merge(#N)` | PR merged | Hook (auto) | PR number |
-| `decision(scope)` | Key decisions | Agent | Topic |
-| `discover(scope)` | Something learned | Agent | Topic |
-| `block(scope)` | Blocker encountered | Agent | Topic |
-| `unblock(scope)` | Blocker resolved | Agent | Topic |
-| `spark(scope)` | Ideas to promote | Agent | Topic |
-| `resolve(spark)` | Spark triaged via `/loaf:idea` | Agent/User | Spark slug → disposition [timestamp] |
-| `todo(scope)` | Action items | Agent | Topic |
-| `finding(scope)` | Findings from analysis | Agent | Topic |
-| `hypothesis` | Theory being tested | Agent | — |
-| `try` | Approach attempted | Agent | — |
-| `reject` | Approach abandoned | Agent | — |
-| `skill(name)` | Skill invoked with context | Skill (self-log) | Skill name |
-| `idea(slug)` | Idea captured or promoted | Agent/Skill | Idea slug or `.agents/ideas/` ref |
-| `spec(id)` | Spec created, updated, or approved | Agent/Skill | Spec ID (e.g. `SPEC-024`) |
-| `handoff(slug)` | Handoff created or deprecated | Agent/Skill | Handoff slug or `.agents/handoffs/` ref |
-| `report(slug)` | Report generated | Agent/Skill | Report slug or `.agents/reports/` ref |
-| `council(slug)` | Council convened or concluded | Agent/Skill | Council slug or `.agents/councils/` ref |
-| `brainstorm(slug)` | Brainstorm session held | Agent/Skill | Draft slug or topic |
-| `plan(slug)` | Plan created or updated | Agent/Skill | Plan slug or topic |
-| `draft(slug)` | Draft document created | Agent/Skill | Draft slug or `.agents/drafts/` ref |
-
-### Format Rules
-
-1. **Timestamp:** `YYYY-MM-DD HH:MM` (no seconds)
-2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank line separator:** Insert when:
-   - Gap ≥ 5 minutes since last entry, OR
-   - State transition (block/unblock/pause/resume)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated by `loaf session end`)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-### Example Session
-
-```markdown
----
-spec: SPEC-020
-branch: feat/target-convergence
-status: active
-created: 2026-03-31T14:30:00Z
-last_entry: 2026-04-02T09:15:00Z
----
-
-# Session: Target Convergence
-
-## Journal
-
-[2026-03-31 14:30] resume(feat/target-convergence): from commit abc1234, 3 tasks pending
-[2026-03-31 14:30] decision(hooks): remove bash wrappers, go direct
-[2026-03-31 14:32] discover(cursor): prompt hooks filtered at line 269
-
-[2026-03-31 15:10] block(parity): Codex output differs by trailing newline
-[2026-03-31 15:11] hypothesis: gray-matter serialization adds trailing \n
-
-[2026-03-31 16:45] unblock(parity): confirmed gray-matter quirk, fixed with trim
-[2026-03-31 16:46] commit(def5678): fix: trim frontmatter for Codex byte parity
-
---- PAUSE 2026-03-31 17:00 ---
-
-[2026-04-02 09:15] resume(feat/target-convergence): 16 hours paused, last: verification
-```
-
-### CLI Commands
-
-```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decide(scope): desc"
-loaf session archive  # Move to archive when branch merges
-```
-
-### Consistency
-
-- **`loaf session log`** validates and appends entries in correct format
-- **Read-only agents** (reviewer, researcher) CAN write journal entries via `loaf session log` (Bash command, not file edit)
-- **Concurrent writes** are safe: atomic append, timestamps provide ordering
-
-## Lifecycle States
-
-| State | Description |
-|-------|-------------|
-| `in_progress` | Work actively happening |
-| `paused` | Temporarily stopped |
-| `completed` | Work finished; ready to archive (set status, `archived_at`, `archived_by`, move) after extraction |
-| `archived` | Closed and preserved for audit (set `archived_at`/`archived_by`, status set + moved to `.agents/sessions/archive/`) |
-
-## Updating During Work
-
-After each significant action, append entries to the session journal:
-
-1. **Use `loaf session log`** to append entries in the correct format
-2. **Add `decision`, `discover`, `block`, `spark`, `wrap` entries** during normal work
-3. **Hooks auto-append:** `resume`, `commit(SHA)`, `pr(#N)`, `merge(#N)`, `pause`
-4. **Blank line rules:** Inserted automatically by `loaf session log` based on time gaps and state transitions
-
-**Cross-agent protocol:** When any agent starts work on a branch, `loaf session start` outputs the last 15-20 journal entries. The agent reads context, continues work, appends entries.
-
-## Session Continuity Protocol
-
-### Before Pausing or Switching Agents
-
-1. Update session file with completed work
-2. Update `Current State` with where you stopped
-3. Update `Next Steps` with immediate actions
-4. Include `Files Modified` for context
-
-### Session as Continuity Medium
-
-Each agent:
-1. Reads current state from session
-2. Performs assigned work
-3. Updates session with outcomes
-4. Sets up context for next agent
-
-## Completing a Session
-
-Sessions are **archived, not deleted** when complete to preserve audit trail (set status to `archived`, set `archived_at` and `archived_by`, and move into `.agents/sessions/archive/`). Archive indefinitely (no deletion policy).
-
-**Archive timing:** only after extraction and council/report summaries are captured.
-
-### Knowledge Extraction Checklist
-
-| Information Type | Where It Belongs |
-|------------------|------------------|
-| Work tracking | External issue (Linear, GitHub) |
-| Implementation details | Git commits/PRs |
-| Architectural decisions | ADRs (`docs/decisions/`) |
-| API contracts | API documentation |
-| Remaining work | External issue backlog |
-| Council outcomes | Session summary + council file link |
-| Report conclusions | Session summary + report file link |
-| Archived artifacts | SQLite lifecycle state plus compatibility archive metadata when Markdown files exist |
-
-### Archival Checklist
-
-- [ ] External issue updated with final status
-- [ ] Decisions captured as ADRs (if architectural)
-- [ ] Lessons learned added to relevant docs
-- [ ] Remaining work created as issues
-- [ ] Council outcomes summarized in this session (link council file)
-- [ ] Reports processed and summarized in this session (link report file)
-- [ ] Reports archived only after session is archived (`loaf report archive` for SQLite-backed state)
-- [ ] Handoffs reviewed; deprecated handoffs marked for `/loaf:housekeeping` deletion
-- [ ] No orphaned references to session file
-- [ ] Set session status to `archived`
-- [ ] Set `archived_at` and `archived_by`
-- [ ] Move compatibility session file to `.agents/sessions/archive/` when one exists
-- [ ] Linked councils moved to `.agents/councils/archive/` after session summary
-- [ ] Linked report state archived after session archived + conclusions captured
-- [ ] Deprecated handoffs deleted by `/loaf:housekeeping` after confirmation
-- [ ] Update `.agents/` references to archived paths (no `.agents` links outside `.agents/`)
-- [ ] Archive indefinitely (no deletion policy)
-- [ ] Use `/loaf:housekeeping` for auto-move + link updates after confirmation
-
-## Start Protocol
-
-When starting a new orchestration context:
-
-1. Check for existing active sessions
-2. If found, ask user which to resume or start fresh
-3. If resuming, read session for context
-4. If starting fresh, create new session file
+Reports, councils, and handoffs have their own archive or finalization commands.
+Do not use session archival as a substitute for those lifecycles.
 
 ## Hook Integration
 
-### SessionStart Hook
-- Lists active sessions
-- Provides agent-specific context
-- Suggests session review/resume
-
-### SessionEnd Hook
-- Displays completion checklist
-- Reminds about session file updates
-- Shows count of active sessions
-
-### PreCompact Hook
-- `loaf session context for-compact` logs compact marker and injects flush instructions
-- Model flushes unrecorded decisions/discoveries to journal
-- Model writes structured `## Current State` summary
-- After compaction: `loaf session context for-resumption` prints rich resumption context (session, spec, journal, git)
+- Session start hooks should surface recent journal entries from SQLite.
+- Session-end hooks should nudge for missing durable journal entries before wrap.
+- Pre-compaction hooks should ask the agent to flush facts through
+  `loaf session log`.
+- Post-compaction recovery should use `loaf session start` and
+  `loaf session show`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Archive without extraction | Extract outcomes before archiving |
-| Use sessions as permanent records | Use proper documentation locations |
-| Reference stale sessions | Keep sessions current or archive (status + move) when done |
-| Store decisions only in sessions | Create ADRs for important decisions |
-| Archive without council/report summaries | Summarize outcomes in session before archive |
-| Archive but leave in active folder | Move file to `.agents/sessions/archive/` after setting status |
-| Batch session updates | Update after each significant event |
-| Keep status as `in_progress` when paused | Update status when state changes |
+| Hand-author session markdown as source | Use `loaf session start/log/show/end` |
+| Store decisions only in chat context | Log them and promote durable decisions to ADR/spec/report/docs |
+| Invent status values | Cite the runtime lifecycle until SPEC-049 lands |
+| Archive before extracting outcomes | Promote outcomes first, then wrap/archive |
+| Batch all journal entries at the end | Log significant facts as they happen |

--- a/plugins/loaf/skills/orchestration/templates/session.md
+++ b/plugins/loaf/skills/orchestration/templates/session.md
@@ -1,43 +1,42 @@
-# Session File Template
+# Session Render Template
 
-**Location:** `.agents/sessions/YYYYMMDD-HHMMSS-session.md`
+This is the render template and journal-format reference for sessions stored in
+SQLite. Agents do not create or edit session markdown as the source of truth.
+Use `loaf session start`, `loaf session log "type(scope): desc"`, and
+`loaf session end --wrap`; use `loaf session show <session-ref>` to inspect the
+rendered view.
 
-```yaml
----
-spec: SPEC-XXX
-branch: feat/feature-name
-status: active
-created: "YYYY-MM-DDTHH:MM:SSZ"
-last_entry: "YYYY-MM-DDTHH:MM:SSZ"
----
-
+```markdown
 # Session: Brief Description
+
+- Branch: feat/feature-name
+- Status: active
+- Created: YYYY-MM-DDTHH:MM:SSZ
+- Updated: YYYY-MM-DDTHH:MM:SSZ
 
 ## Journal
 
-[YYYY-MM-DD HH:MM] resume(branch-name): from commit abc1234, context summary
-
+[YYYY-MM-DD HH:MM] session(start): === SESSION STARTED ===
 [YYYY-MM-DD HH:MM] decision(scope): description of decision
 [YYYY-MM-DD HH:MM] discover(scope): something learned
-
 [YYYY-MM-DD HH:MM] block(scope): what is blocked
-[YYYY-MM-DD HH:MM] hypothesis: theory being tested
-
+[YYYY-MM-DD HH:MM] hypothesis(scope): theory being tested
 [YYYY-MM-DD HH:MM] unblock(scope): how it was resolved
 [YYYY-MM-DD HH:MM] commit(abc1234): commit message
-
---- PAUSE YYYY-MM-DD HH:MM ---
-
-[YYYY-MM-DD HH:MM] resume(branch-name): duration paused, last action summary
+[YYYY-MM-DD HH:MM] session(end): concise wrap summary
+[YYYY-MM-DD HH:MM] session(stop): === SESSION STOPPED ===
 ```
 
 ## Entry Types
 
 | Type | Use For | Written By |
 |------|---------|------------|
-| `resume(scope)` | Session started/resumed | Auto (hook) |
-| `pause` | Session ended | Auto (hook) |
-| `commit(SHA)` | Code committed | Auto (hook) |
+| `session(start)` | Session started | CLI |
+| `session(resume)` | Session resumed | CLI |
+| `session(end)` | Session ended or wrapped | CLI |
+| `session(stop)` | Session stopped | CLI |
+| `commit(SHA)` | Code committed | Auto hook |
+| `skill(name)` | User-invocable workflow skill ran | Agent |
 | `decision(scope)` | Key decisions with rationale | Agent |
 | `discover(scope)` | Something learned | Agent |
 | `block(scope)` | Blocker encountered | Agent |
@@ -50,19 +49,19 @@ last_entry: "YYYY-MM-DDTHH:MM:SSZ"
 
 1. **Timestamp format:** `YYYY-MM-DD HH:MM` (no seconds)
 2. **Entry format:** `[<timestamp>] <type>(<scope>): <description>`
-3. **Blank lines:** Insert when gap ≥ 5 minutes OR state transition (block/unblock)
-4. **PAUSE header:** `--- PAUSE YYYY-MM-DD HH:MM ---` (auto-generated, never manual)
-5. **Resume after pause:** Always starts new section after `--- PAUSE ---`
-
-## Filename Convention
-
-All session files: `YYYYMMDD-HHMMSS-session.md` — descriptions belong in frontmatter, not filenames.
+3. **Lifecycle entries:** Use `session(start)`, `session(resume)`,
+   `session(end)`, and `session(stop)` for session lifecycle state.
+4. **Blank lines:** Render burst boundaries only; SQLite journal rows are the
+   durable ordering source.
+5. **No manual markdown edits:** Rendered markdown is a projection. Persist new
+   facts with `loaf session log`.
 
 ## CLI Commands
 
 ```bash
-loaf session start    # Find/create session, append resume entry, output context
-loaf session end      # Append pause entry with summary
-loaf session log      # Append typed entry: loaf session log "decision(scope): desc"
-loaf session archive  # Move to archive when branch merges
+loaf session start      # Find/create session, append resume entry, output context
+loaf session log        # Append typed entry: loaf session log "decision(scope): desc"
+loaf session show       # Read the SQLite-backed rendered view
+loaf session end --wrap # Persist wrapped end state for the active session
+loaf session archive    # Archive when branch merges
 ```

--- a/plugins/loaf/skills/reflect/SKILL.md
+++ b/plugins/loaf/skills/reflect/SKILL.md
@@ -34,12 +34,13 @@ Update VISION, STRATEGY, and ARCHITECTURE based on proven implementation.
 - **Post-implementation only** -- reflect after shipping, not before or during planning
 - **Get explicit approval** -- never update strategic docs (VISION.md, STRATEGY.md, ARCHITECTURE.md) without user confirmation
 - **Consolidate** -- batch related learnings into coherent updates, avoid micro-updates
-- **Link back** -- always reference the specs/sessions that informed each update
+- **Log first** -- log invocation before gathering evidence: `loaf session log "skill(reflect): <scope>"`
+- **Link back** -- always reference the specs, SQLite sessions, reports, and commits that informed each update
 - **Log updates** -- log each strategic document update to session journal: `loaf session log "decision(scope): updated STRATEGY.md with learning"`
 
 ## Verification
 
-- Proposals cite specific specs, sessions, or commits as evidence
+- Proposals cite specific specs, SQLite sessions, reports, or commits as evidence
 - No strategic document was modified without explicit user approval
 - Completed specs referenced in updates are archived after reflection
 
@@ -87,7 +88,7 @@ After completing work, `/loaf:reflect` extracts learnings and proposes updates t
 
 Sources:
 1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
-2. **Session files** (`.agents/sessions/`) -- insights, surprises, pivots
+2. **SQLite sessions** (`loaf session list --all --json`, then `loaf session show <ref> --json`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?
 

--- a/plugins/loaf/skills/research/SKILL.md
+++ b/plugins/loaf/skills/research/SKILL.md
@@ -34,6 +34,7 @@ Patterns for zooming out, investigating topics, and evolving project direction.
 - Cite sources with confidence levels
 - Present options, let user decide
 - Get approval before editing VISION
+- Log invocation first: `loaf session log "skill(research): <topic or mode>"`
 - Log findings to session journal: `loaf session log "discover(scope): summary of finding"`
 
 ### Never
@@ -80,7 +81,7 @@ Parse `$ARGUMENTS` to determine mode:
 
 Prioritize sources in this order:
 
-1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, session files, codebase patterns
+1. **Project context** (highest) -- VISION.md, ARCHITECTURE.md, SQLite sessions, codebase patterns
 2. **Authoritative docs** -- Context7, official docs, RFCs
 3. **Community knowledge** -- Stack Overflow (verified), GitHub issues, expert blogs
 4. **General web** (lowest) -- Search results, unverified sources
@@ -95,7 +96,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 
 1. Read project documents: VISION.md, STRATEGY.md, ARCHITECTURE.md
 2. Check ideas (`.agents/ideas/`) and specs (`docs/specs/`)
-3. Review recent sessions (`.agents/sessions/`)
+3. Review recent sessions with `loaf session list --all --json` and `loaf session show <ref> --json`
 4. Check recent commits: `git log --oneline -20`
 5. Synthesize following [state-assessment template](templates/state-assessment.md)
 
@@ -104,7 +105,7 @@ Always check project context first. Rate findings: **High** (official/verified),
 **Trigger:** Specific topic or question
 
 1. **Interview** with AskUserQuestion: what are you trying to understand? What context do you have? What decision will this inform?
-2. Check project context first (ADRs, ARCHITECTURE, sessions)
+2. Check project context first (ADRs, ARCHITECTURE, SQLite sessions)
 3. Apply confidence hierarchy for external sources
 4. For a transient review artifact, use `loaf report generate` when an existing
    SQLite-backed export kind fits; for authored long-form research, create a

--- a/plugins/loaf/skills/research/templates/state-assessment.md
+++ b/plugins/loaf/skills/research/templates/state-assessment.md
@@ -12,7 +12,7 @@ title: "State Assessment: [YYYY-MM-DD]"
 type: state-assessment
 created: YYYY-MM-DDTHH:MM:SSZ
 status: active         # active | archived
-session: ".agents/sessions/YYYYMMDD-HHMMSS-description.md"  # Session that produced this assessment
+session: "session alias or loaf session show reference"  # Session that produced this assessment
 tags: []
 ---
 


### PR DESCRIPTION
## Summary
- implements SPEC-048 on top of SPEC-046
- converges session workflow guidance around SQLite-backed session state, `wrap`, native journal commands, and render-on-demand Markdown artifacts
- updates skills, templates, agents, and generated target outputs to remove competing markdown-first session guidance
- rebased onto refreshed feat/docs-tier2-indexing and dropped duplicate SPEC-047 validator commits from the stack

## Verification
- npm run build
- npm run typecheck
- npm run test
- bin/loaf check --hook render-drift --json
- npm run verify:go-artifacts

## Notes
- Session journal logging succeeded on this branch: `journal:761acc9be98b02904dc3bbaf`.