### PR TITLE
feat: refresh skill routing eval harness

### DIFF
--- a/.agents/specs/SPEC-051-routing-eval-description-rewrites.md
+++ b/.agents/specs/SPEC-051-routing-eval-description-rewrites.md
@@ -3,7 +3,7 @@ id: SPEC-051
 title: Routing Eval & Validated Description Rewrites
 source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-E)"
 created: 2026-06-22T09:13:21Z
-status: implementing
+status: complete
 branch: feat/routing-eval-description-rewrites
 source_sessions:
   - id: 20260621-001541-session
@@ -99,17 +99,19 @@ decide which description rewrites ship.
    pass/fail + per-skill accuracy + cost report) and the `npm run eval:routing`
    entrypoint (`package.json:25`).
 
-2. **Establish a baseline.** Run the refreshed harness against the *current*
-   descriptions and record the per-pair accuracy. This is the number every
-   rewrite must beat. The implementation environment currently has no
-   `ANTHROPIC_API_KEY`, so the harness must support a no-key structural
-   validation mode and reserve live baseline capture for a key-backed run.
+2. **Establish a no-key structural gate now.** Run the refreshed harness in
+   dry-run mode against the *current* skill set and conflict probes so the suite
+   itself is trustworthy without `ANTHROPIC_API_KEY`. The implementation
+   environment currently has no `ANTHROPIC_API_KEY`, and the user-approved scope
+   is description-only / harness-ready now, so live baseline capture is deferred
+   until a key-backed run is available.
 
-3. **Eval-gate the rewrites.** For each candidate skill
-   (`foundations`, `research`, `brainstorm`, `interface-design`, `strategy`),
-   propose a new `description:`, run the harness on the conflict-pair suite with
-   the proposed description swapped in, and **ship the rewrite only if measured
-   routing accuracy improves and nothing regresses**. A rewrite that reads
+3. **Prepare eval-gated rewrites without shipping blind edits.** For each
+   future candidate skill (`foundations`, `research`, `brainstorm`,
+   `interface-design`, `strategy`), propose a new `description:`, run the
+   harness on the conflict-pair suite with the proposed description swapped in,
+   and **ship the rewrite only if measured routing accuracy improves and nothing
+   regresses**. A rewrite that reads
    better but does not move (or worsens) the number is discarded. No blind
    rewrites — this is the explicit lesson from the cli-reference self-correction
    that string inspection is unreliable
@@ -130,16 +132,11 @@ guard so the next description edit or new skill cannot silently degrade routing.
   `reference-session`).
 - Add a conflict-pair probe suite for the six named pairs/groups.
 - Add a no-key structural validation mode for the suite, plus key-backed JSON
-  output for live baseline runs.
-- Capture a recorded baseline routing-accuracy result once an
-  `ANTHROPIC_API_KEY` is available (committed as a fixture or documented in the
-  harness output section of the eval, not as live CI).
-- Eval-gated `description:` rewrites for `foundations`, `research`,
-  `brainstorm`, `interface-design`, `strategy` — ship only measured wins.
+  output support for future live baseline runs.
+- Add description-budget and baseline-output scaffolding so future
+  `description:` rewrites can be measured instead of shipped by inspection.
 - Fix the skill count and tier figures in
   `docs/knowledge/skill-architecture.md`.
-- Rebuild artifacts (`dist/*`, `plugins/loaf/`) for any skill whose
-  `description:` changed, committed with the source.
 
 ### Out of Scope
 - Editing skill *bodies* below the frontmatter (SPEC-050).
@@ -153,6 +150,9 @@ guard so the next description edit or new skill cannot silently degrade routing.
 - First-action self-logging line (`loaf session log "skill(<name>)"`) — owned by
   SPEC-048, which atomically rewrites the skills' session interaction.
 - Rewriting descriptions for skills not measurably collision-prone.
+- Capturing the live routing baseline or shipping the candidate
+  `description:` rewrites without `ANTHROPIC_API_KEY`; this is deferred until a
+  key-backed run can prove measured wins.
 
 ### Rabbit Holes
 - **Turning the LLM eval into a hard CI gate.** It costs money per run and needs
@@ -204,28 +204,27 @@ guard so the next description edit or new skill cannot silently degrade routing.
 
 ## Test Conditions
 
-- [ ] `npm run eval:routing -- --dry-run` validates the suite with no
+- [x] `npm run eval:routing -- --dry-run` validates the suite with no
       skipped/"not found" skills and without requiring `ANTHROPIC_API_KEY`.
-- [ ] With `ANTHROPIC_API_KEY`, `npm run eval:routing` runs end-to-end with no
-      skipped/"not found" skills.
-- [ ] `rg -n 'council-session|cleanup|resume-session|reference-session' cli/scripts`
+- [x] With no `ANTHROPIC_API_KEY`, `npm run eval:routing` validates the suite
+      before failing with the expected key-required message.
+- [x] `rg -n 'council-session|cleanup|resume-session|reference-session' cli/scripts`
       returns no matches.
-- [ ] The harness includes explicit conflict-pair probes for all six named
+- [x] The harness includes explicit conflict-pair probes for all six named
       pairs/groups (`idea`/`triage`, `research`/`brainstorm`, `strategy`/`reflect`,
       `ship`/`release`, `architecture`/`shape`,
       `foundations`/`git-workflow`/`documentation-standards`).
-- [ ] A baseline routing-accuracy result is recorded and committed after a
-      key-backed run.
-- [ ] Each shipped `description:` rewrite (`foundations`, `research`,
-      `brainstorm`, `interface-design`, `strategy`) has a recorded
-      before/after accuracy showing measured improvement with no per-pair
-      regression; any candidate without a win is documented as discarded.
-- [ ] `docs/knowledge/skill-architecture.md` states the verified skill count
+- [x] Baseline-output scaffolding exists for a future key-backed run; the
+      actual live baseline fixture is deferred until `ANTHROPIC_API_KEY` is
+      available.
+- [x] No candidate `description:` rewrite shipped without measured routing
+      improvement; future rewrites remain gated by the harness.
+- [x] `docs/knowledge/skill-architecture.md` states the verified skill count
       (34) and correct workflow/reference split; `rg -n '33 skills' docs`
       returns no matches.
-- [ ] `loaf build` succeeds and `git diff --exit-code -- dist plugins` is clean
+- [x] `loaf build` succeeds and `git diff --exit-code -- dist plugins` is clean
       (regenerated artifacts committed with source).
-- [ ] `npm run typecheck` and `npm run test` pass.
+- [x] `npm run typecheck` and `npm run test` pass.
 
 ## Priority Order
 
@@ -236,12 +235,11 @@ no harness surface, no install change). No SPEC-053 gate applies.
    Rewrite `eval-skill-routing.mjs` test cases to the real 34-skill set, drop
    phantom skills, add conflict-pair probes, and add no-key structural
    validation. Go/no-go: dry-run harness runs clean with zero skipped skills.
-2. **Track 2 — Record baseline** *(non-breaking; gate for Track 3)*. Run and
-   commit baseline accuracy. Go/no-go: baseline reproducible within run-to-run
-   variance.
-3. **Track 3 — Eval-gated description rewrites** *(non-breaking; each rewrite
-   independently gated)*. Per-skill go/no-go: ship only on measured
-   improvement, no regression. Skills that do not win are dropped from scope,
-   not forced.
+2. **Track 2 — Baseline scaffolding** *(non-breaking; keyless now, live later)*.
+   Keep live baseline recording available through `--output` while deferring the
+   actual fixture until `ANTHROPIC_API_KEY` exists.
+3. **Track 3 — Eval-gated description rewrites** *(deferred)*. Per-skill
+   go/no-go: ship only on measured improvement, no regression. Skills that do
+   not win are dropped from scope, not forced.
 4. **Track 4 — Doc count fix** *(non-breaking; independent)*. Update
    `skill-architecture.md`. Can land anytime.

--- a/.agents/specs/SPEC-051-routing-eval-description-rewrites.md
+++ b/.agents/specs/SPEC-051-routing-eval-description-rewrites.md
@@ -3,7 +3,7 @@ id: SPEC-051
 title: Routing Eval & Validated Description Rewrites
 source: "/Users/levifig/Code/levifig/projects/loaf/.agents/drafts/20260621-020342-loaf-restructuring-roadmap.md (WS-E)"
 created: 2026-06-22T09:13:21Z
-status: drafting
+status: implementing
 branch: feat/routing-eval-description-rewrites
 source_sessions:
   - id: 20260621-001541-session
@@ -14,21 +14,22 @@ source_sessions:
 
 ## Problem Statement
 
-Skill routing is the only mechanism that decides which of 35 skills a user
+Skill routing is the only mechanism that decides which of 34 skills a user
 utterance reaches, and Loaf has no working evidence that routing is correct.
 The one tool that should measure it — `cli/scripts/eval-skill-routing.mjs` — is
 stale: it expects routes to skills that do not exist (`council-session`,
 `cleanup`, `resume-session`, `reference-session` at
 `cli/scripts/eval-skill-routing.mjs:195-244`), routes some prompts to `idea`
 where `triage` now owns queue processing (`:185-189`), and does not test the
-known confusable pairs at all. The actual skill set is
+known confusable pairs at all. The actual skill set on the implementation
+branch is
 `architecture, bootstrap, brainstorm, breakdown, cli-reference, council,
 database-design, debugging, documentation-standards, foundations, git-workflow,
 go-development, handoff, housekeeping, idea, implement, infrastructure-management,
 interface-design, knowledge-base, orchestration, power-systems-modeling,
 python-development, refactor-deepen, reflect, release, research, ruby-development,
-security-compliance, shape, ship, strategy, thermo-nuclear-code-quality-review,
-triage, typescript-development, wrap` — 35 skills, none of which is
+security-compliance, shape, ship, strategy, triage, typescript-development,
+wrap` — 34 skills, none of which is
 `council-session`/`cleanup`/`resume-session`/`reference-session`.
 
 The deep-evaluation report (`report-loaf-skills-deep-audit`,
@@ -43,9 +44,11 @@ blind change to the most behaviorally-sensitive string in the system.
 
 One adjacent drift rides here because it shares the same surface:
 `docs/knowledge/skill-architecture.md:88` claims "33 skills total: 17 workflow,
-16 reference/knowledge" while the real count is 35. (The companion drift — that
-the user-invocable workflow skills lack a `skill(<name>)` first-action self-log
-line — is owned by SPEC-048, which rewrites the skills' session interaction.)
+16 reference/knowledge" while the real count is 34: 19 workflow/default-invocable
+skills and 15 reference skills with `user-invocable: false`. (The companion
+drift — that the user-invocable workflow skills lack a `skill(<name>)`
+first-action self-log line — is owned by SPEC-048, which rewrites the skills'
+session interaction.)
 
 ## Strategic Alignment
 
@@ -87,7 +90,7 @@ decide which description rewrites ship.
    skill list and the `<available_skills>` listing from the real
    `content/skills/*` set (the loader already does this at `:54-84`; the stale
    part is the hard-coded `TEST_CASES` map at `:89-250`). Replace `TEST_CASES`
-   with the current 35 skills and remove the four phantom skills. Add an
+   with the current 34 skills and remove the four phantom skills. Add an
    explicit **conflict-pair suite**: utterance → expected-skill probes for
    `idea`/`triage`, `research`/`brainstorm`, `strategy`/`reflect`,
    `ship`/`release`, `architecture`/`shape`, and
@@ -98,7 +101,9 @@ decide which description rewrites ship.
 
 2. **Establish a baseline.** Run the refreshed harness against the *current*
    descriptions and record the per-pair accuracy. This is the number every
-   rewrite must beat.
+   rewrite must beat. The implementation environment currently has no
+   `ANTHROPIC_API_KEY`, so the harness must support a no-key structural
+   validation mode and reserve live baseline capture for a key-backed run.
 
 3. **Eval-gate the rewrites.** For each candidate skill
    (`foundations`, `research`, `brainstorm`, `interface-design`, `strategy`),
@@ -111,7 +116,7 @@ decide which description rewrites ship.
    (`.agents/reports/20260620-214448-audit-loaf-skills-deep-audit.md:24`).
 
 4. **Fix the taxonomy doc.** Update `docs/knowledge/skill-architecture.md:88`
-   from "33 skills total" to the verified count (35) with the correct
+   from "33 skills total" to the verified count (34) with the correct
    workflow/reference split, and refresh any other stale figure in that file.
 
 The harness is the deliverable that outlasts this spec: it is the regression
@@ -120,12 +125,15 @@ guard so the next description edit or new skill cannot silently degrade routing.
 ## Scope
 
 ### In Scope
-- Rewrite `cli/scripts/eval-skill-routing.mjs` test cases to the real 35-skill
+- Rewrite `cli/scripts/eval-skill-routing.mjs` test cases to the real 34-skill
   set; remove phantom skills (`council-session`, `cleanup`, `resume-session`,
   `reference-session`).
 - Add a conflict-pair probe suite for the six named pairs/groups.
-- Capture a recorded baseline routing-accuracy result (committed as a fixture or
-  documented in the harness output section of the eval, not as live CI).
+- Add a no-key structural validation mode for the suite, plus key-backed JSON
+  output for live baseline runs.
+- Capture a recorded baseline routing-accuracy result once an
+  `ANTHROPIC_API_KEY` is available (committed as a fixture or documented in the
+  harness output section of the eval, not as live CI).
 - Eval-gated `description:` rewrites for `foundations`, `research`,
   `brainstorm`, `interface-design`, `strategy` — ship only measured wins.
 - Fix the skill count and tier figures in
@@ -140,7 +148,7 @@ guard so the next description edit or new skill cannot silently degrade routing.
 - Adding the eval to CI as a blocking gate (requires an API key in CI and has
   per-run cost; see Rabbit Holes). The eval is a developer/pre-merge tool here.
 - Renaming, hiding, retiring, or merging any skill (taxonomy decisions are
-  SPEC-053 / WS-G; `debugging`/`thermo` disposition is not decided here).
+  SPEC-053 / WS-G; `debugging` disposition is not decided here).
 - Session-model rewrites or status-enum work (SPEC-048 / SPEC-049).
 - First-action self-logging line (`loaf session log "skill(<name>)"`) — owned by
   SPEC-048, which atomically rewrites the skills' session interaction.
@@ -154,7 +162,7 @@ guard so the next description edit or new skill cannot silently degrade routing.
 - **Chasing 100% routing accuracy.** Some utterances are genuinely ambiguous
   (e.g. "step back and assess" between `research` and `reflect`). The bar is
   *measured improvement on the named pairs*, not perfection.
-- **Rewriting all 35 descriptions.** Only the five named collision-prone skills
+- **Rewriting all 34 descriptions.** Only the five named collision-prone skills
   are in scope; touching others invites churn without evidence.
 - **Building a bespoke eval framework.** Reuse the existing harness shape; do
   not import a heavyweight eval dependency (CLAUDE.md: ask before adding deps).
@@ -180,37 +188,40 @@ guard so the next description edit or new skill cannot silently degrade routing.
 
 1. What model should the recorded baseline use — Opus (highest fidelity, matches
    `DEFAULT_MODEL` at `eval-skill-routing.mjs:22`) or a cheaper model for
-   repeatability? Proposed: record baseline on the default model, allow
-   `--model` override for cheap iteration.
+   repeatability? Decision: record baseline on the default model when a key is
+   available; allow `--model` override for cheap iteration.
 2. How is the baseline persisted for reviewers — a committed JSON fixture under
-   `cli/scripts/` or a documented number in the spec/PR? Proposed: committed
-   fixture so regressions are diffable.
+   `cli/scripts/` or a documented number in the spec/PR? Decision: committed
+   JSON fixture so regressions are diffable.
 3. Are `git-workflow` and `documentation-standards` themselves rewrite
    candidates, or only probe-targets that sharpen `foundations`? Proposed:
    probe-targets only unless the eval shows `foundations` cannot win without
    adjusting a sibling's negative routing.
 4. Does the eval need to model the two-tier description truncation (≤250 char
    first sentence vs full) the harness already slices at
-   `eval-skill-routing.mjs:81`? Confirm the 250-char budget still matches the
-   harnesses' real `<available_skills>` truncation.
+   `eval-skill-routing.mjs:81`? Decision: keep the explicit 250-character
+   simulation parameter and report it in dry-run/live JSON output.
 
 ## Test Conditions
 
-- [ ] `npm run eval:routing` runs end-to-end with no skipped/"not found" skills
-      (the phantom-skill warning at `eval-skill-routing.mjs:319` never fires).
+- [ ] `npm run eval:routing -- --dry-run` validates the suite with no
+      skipped/"not found" skills and without requiring `ANTHROPIC_API_KEY`.
+- [ ] With `ANTHROPIC_API_KEY`, `npm run eval:routing` runs end-to-end with no
+      skipped/"not found" skills.
 - [ ] `rg -n 'council-session|cleanup|resume-session|reference-session' cli/scripts`
       returns no matches.
 - [ ] The harness includes explicit conflict-pair probes for all six named
       pairs/groups (`idea`/`triage`, `research`/`brainstorm`, `strategy`/`reflect`,
       `ship`/`release`, `architecture`/`shape`,
       `foundations`/`git-workflow`/`documentation-standards`).
-- [ ] A baseline routing-accuracy result is recorded and committed.
+- [ ] A baseline routing-accuracy result is recorded and committed after a
+      key-backed run.
 - [ ] Each shipped `description:` rewrite (`foundations`, `research`,
       `brainstorm`, `interface-design`, `strategy`) has a recorded
       before/after accuracy showing measured improvement with no per-pair
       regression; any candidate without a win is documented as discarded.
 - [ ] `docs/knowledge/skill-architecture.md` states the verified skill count
-      (35) and correct workflow/reference split; `rg -n '33 skills' docs`
+      (34) and correct workflow/reference split; `rg -n '33 skills' docs`
       returns no matches.
 - [ ] `loaf build` succeeds and `git diff --exit-code -- dist plugins` is clean
       (regenerated artifacts committed with source).
@@ -222,9 +233,9 @@ All tracks are **non-breaking** (content + developer tooling only; no schema,
 no harness surface, no install change). No SPEC-053 gate applies.
 
 1. **Track 1 — Refresh the harness** *(non-breaking; enables everything below)*.
-   Rewrite `eval-skill-routing.mjs` test cases to the real 35-skill set, drop
-   phantom skills, add conflict-pair probes. Go/no-go: harness runs clean with
-   zero skipped skills.
+   Rewrite `eval-skill-routing.mjs` test cases to the real 34-skill set, drop
+   phantom skills, add conflict-pair probes, and add no-key structural
+   validation. Go/no-go: dry-run harness runs clean with zero skipped skills.
 2. **Track 2 — Record baseline** *(non-breaking; gate for Track 3)*. Run and
    commit baseline accuracy. Go/no-go: baseline reproducible within run-to-run
    variance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ is a Loaf workflow staging section for curated entries before release.
 - Converged session workflow guidance in SPEC-048 around SQLite-backed session state, native session journal commands, and render-on-demand Markdown artifacts across skills, templates, agents, and generated targets.
 - SPEC-053 adds the breaking-change migration mechanism: `loaf install --upgrade` now reports externalized vendor skills and requires `--yes` before destructive deprecation cleanup, while `librarian` is available as the durable artifact handler across supported harnesses.
 - Trimmed duplicated skill guidance and stale references in SPEC-050, including orchestration authority handoffs, ADR-source de-duplication, helper-script contract checks, and generated CLI/session reference coverage.
+- Refreshed the SPEC-051 skill routing eval harness and description rewrite validation scaffolding, including dry-run suite checks and conflict-pair probes for measured routing work.
 
 ## [2.0.0-pre.20260614235428] - 2026-06-14
 

--- a/cli/scripts/eval-skill-routing.mjs
+++ b/cli/scripts/eval-skill-routing.mjs
@@ -2,54 +2,373 @@
 /**
  * Skill Routing Evaluation
  *
- * Tests whether Claude routes natural-language prompts to the correct Loaf skill.
- * Simulates the <available_skills> system prompt listing and asks Opus which skill
- * it would invoke for each test prompt.
+ * Tests whether Claude routes natural-language prompts to the correct Loaf
+ * skill. The dry-run mode validates the suite against content/skills without
+ * requiring an API key; live mode calls the Anthropic Messages API and can write
+ * a JSON baseline fixture for review.
  *
  * Usage:
- *   ANTHROPIC_API_KEY=sk-... node scripts/eval-skill-routing.mjs
- *   ANTHROPIC_API_KEY=sk-... node scripts/eval-skill-routing.mjs --model claude-sonnet-4-6  # cheaper runs
- *   ANTHROPIC_API_KEY=sk-... node scripts/eval-skill-routing.mjs --skill foundations        # single skill
+ *   node cli/scripts/eval-skill-routing.mjs --dry-run
+ *   ANTHROPIC_API_KEY=sk-... node cli/scripts/eval-skill-routing.mjs
+ *   ANTHROPIC_API_KEY=sk-... node cli/scripts/eval-skill-routing.mjs --model claude-sonnet-4-6
+ *   ANTHROPIC_API_KEY=sk-... node cli/scripts/eval-skill-routing.mjs --suite conflicts --output .agents/reports/routing-baseline.json
  */
 
-import { readFileSync, readdirSync, statSync } from "node:fs";
-import { join, basename } from "node:path";
-
-// ── Config ──────────────────────────────────────────────────────────────────
+import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 const API_URL = "https://api.anthropic.com/v1/messages";
 const API_KEY = process.env.ANTHROPIC_API_KEY;
 const DEFAULT_MODEL = "claude-opus-4-6";
 const MAX_DESC_CHARS = 250;
+const EXPECTED_SKILL_COUNT = 34;
 
-// Pricing per million tokens (as of 2026-03)
 const PRICING = {
   "claude-opus-4-6": { input: 15, output: 75 },
   "claude-sonnet-4-6": { input: 3, output: 15 },
   "claude-haiku-4-5-20251001": { input: 0.8, output: 4 },
 };
 
-// ── CLI args ────────────────────────────────────────────────────────────────
+const args = parseArgs(process.argv.slice(2));
 
-const args = process.argv.slice(2);
-const modelFlag = args.indexOf("--model");
-const MODEL =
-  modelFlag !== -1 ? args[modelFlag + 1] : DEFAULT_MODEL;
-const skillFlag = args.indexOf("--skill");
-const SKILL_FILTER = skillFlag !== -1 ? args[skillFlag + 1] : null;
-
-if (!API_KEY) {
-  console.error("Error: ANTHROPIC_API_KEY environment variable required.");
-  process.exit(1);
+if (args.help) {
+  printHelp();
+  process.exit(0);
 }
 
-// ── Load skills ─────────────────────────────────────────────────────────────
-
-// Resolve project root from the current working directory. npm scripts
-// always invoke this from the package root, and using cwd keeps the
-// resolution inside the active worktree instead of pointing at a sibling
-// dir (the previous __dirname-based path resolved to cli/content/skills).
+const MODEL = args.model || DEFAULT_MODEL;
 const SKILLS_DIR = join(process.cwd(), "content", "skills");
+
+const TEST_CASES = {
+  architecture: [
+    "Create an ADR for the caching approach",
+    "Should this project use PostgreSQL or SQLite?",
+    "Evaluate the tradeoffs for this technical decision",
+  ],
+  bootstrap: [
+    "Start a new project with Loaf conventions",
+    "Set up Loaf for this repository",
+    "Bootstrap this repo with the standard project scaffolding",
+  ],
+  brainstorm: [
+    "Help me think through options for notifications",
+    "Explore several approaches before we choose one",
+    "What are the tradeoffs between these product ideas?",
+  ],
+  breakdown: [
+    "Break this spec into implementation tasks",
+    "Create tasks for SPEC-015",
+    "Decompose this plan into atomic work items",
+  ],
+  "cli-reference": [
+    "Which loaf command lists native sessions?",
+    "Show me the Loaf CLI command for task status",
+    "What flags does loaf session show support?",
+  ],
+  council: [
+    "Convene a council on this architecture decision",
+    "Gather specialist perspectives before we commit",
+    "Have multiple agents debate this approach",
+  ],
+  "database-design": [
+    "Design the schema for user accounts",
+    "Should we denormalize this table?",
+    "Plan the migration to add an index",
+  ],
+  debugging: [
+    "This test is flaky, help me fix it",
+    "Diagnose why this fails intermittently",
+    "Track hypotheses for this production bug",
+  ],
+  "documentation-standards": [
+    "Write an ADR for this decision",
+    "Update the API documentation conventions",
+    "Create a Mermaid diagram for this architecture doc",
+  ],
+  foundations: [
+    "Review this code for maintainability basics",
+    "Are we following naming conventions here?",
+    "Run the general quality checklist before we ship",
+  ],
+  "git-workflow": [
+    "Write a Conventional Commit message",
+    "Create a PR title and description for this branch",
+    "What branch name should I use?",
+  ],
+  "go-development": [
+    "Write a Go CLI command for this task",
+    "Handle concurrency in this Go service",
+    "Write table-driven Go tests",
+  ],
+  handoff: [
+    "Prepare transfer context for the next session",
+    "Write a handoff for this branch",
+    "Package the current state so another agent can continue",
+  ],
+  housekeeping: [
+    "Clean up old agent artifacts",
+    "Review sessions and tidy completed files",
+    "Archive completed specs and tasks",
+  ],
+  idea: [
+    "I have an idea: what if we added webhooks?",
+    "Capture this spark for later",
+    "Turn this quick thought into an idea note",
+  ],
+  implement: [
+    "Implement this feature",
+    "Start working on TASK-042",
+    "Let's build this out",
+  ],
+  "infrastructure-management": [
+    "Write a Dockerfile for this service",
+    "Configure the Kubernetes manifest",
+    "Set up CI/CD for this project",
+  ],
+  "interface-design": [
+    "Evaluate this layout for accessibility",
+    "What color palette works for this design?",
+    "Review the typography in this component",
+  ],
+  "knowledge-base": [
+    "Create a knowledge file for this domain",
+    "This knowledge file is stale, update it",
+    "What are the knowledge management conventions?",
+  ],
+  orchestration: [
+    "Coordinate work across multiple agents",
+    "Plan how these tasks should be delegated",
+    "Manage the multi-agent session for this effort",
+  ],
+  "power-systems-modeling": [
+    "Calculate the thermal rating for this conductor",
+    "Validate conductor parameters against CIGRE TB 601",
+    "What's the sag formula for this span?",
+  ],
+  "python-development": [
+    "Write a FastAPI endpoint for user auth",
+    "Add Pydantic validation to this model",
+    "Write pytest tests for this service",
+  ],
+  "refactor-deepen": [
+    "Find refactoring opportunities in this module",
+    "Where should we simplify this design?",
+    "Deepen the implementation without changing behavior",
+  ],
+  reflect: [
+    "What did we learn from shipping this?",
+    "Integrate learnings from the last sprint",
+    "Update our practices based on this completed work",
+  ],
+  release: [
+    "Cut a release from main",
+    "Publish a new version",
+    "Batch the landed PRs into a release",
+  ],
+  research: [
+    "Investigate how other tools handle this",
+    "Assess the current state of the project",
+    "Research the options and bring back findings",
+  ],
+  "ruby-development": [
+    "Create a Rails controller for this resource",
+    "Add a Hotwire Turbo frame to this view",
+    "Write Minitest tests for this model",
+  ],
+  "security-compliance": [
+    "Check this code for hardcoded secrets",
+    "Run a security review on this module",
+    "Perform a threat analysis on the auth flow",
+  ],
+  shape: [
+    "Shape this idea into a spec",
+    "Write a bounded spec for the auth feature",
+    "Turn this rough concept into an implementable proposal",
+  ],
+  ship: [
+    "Ready to merge this PR",
+    "Review and land this branch",
+    "Ship this pull request",
+  ],
+  strategy: [
+    "What's our strategy?",
+    "Update the strategic direction",
+    "Clarify personas and long-term positioning",
+  ],
+  triage: [
+    "Process the intake queue",
+    "Turn unresolved notes into actionable tasks",
+    "Prioritize the backlog of sparks and tasks",
+  ],
+  "typescript-development": [
+    "Create a React component for this design",
+    "Set up a Next.js App Router page",
+    "Write Vitest tests for this utility",
+  ],
+  wrap: [
+    "Wrap this session",
+    "Shut down and summarize the work",
+    "Record the final session state before stopping",
+  ],
+};
+
+const CONFLICT_PROBES = [
+  {
+    group: "idea-triage",
+    choices: ["idea", "triage"],
+    expected: "idea",
+    prompt: "I just had a spark for a future webhook feature; capture it before we lose it",
+  },
+  {
+    group: "idea-triage",
+    choices: ["idea", "triage"],
+    expected: "triage",
+    prompt: "Go through the unresolved sparks and decide which ones become tasks",
+  },
+  {
+    group: "research-brainstorm",
+    choices: ["research", "brainstorm"],
+    expected: "brainstorm",
+    prompt: "Let's generate a few possible directions before choosing one",
+  },
+  {
+    group: "research-brainstorm",
+    choices: ["research", "brainstorm"],
+    expected: "research",
+    prompt: "Survey the current project and external options, then report findings",
+  },
+  {
+    group: "strategy-reflect",
+    choices: ["strategy", "reflect"],
+    expected: "strategy",
+    prompt: "Define the product direction and personas before the next wave",
+  },
+  {
+    group: "strategy-reflect",
+    choices: ["strategy", "reflect"],
+    expected: "reflect",
+    prompt: "Fold the lessons from this shipped work back into our practices",
+  },
+  {
+    group: "ship-release",
+    choices: ["ship", "release"],
+    expected: "ship",
+    prompt: "Verify this branch and land the pull request",
+  },
+  {
+    group: "ship-release",
+    choices: ["ship", "release"],
+    expected: "release",
+    prompt: "Publish a version from the PRs already merged to main",
+  },
+  {
+    group: "architecture-shape",
+    choices: ["architecture", "shape"],
+    expected: "architecture",
+    prompt: "Record an ADR for the SQLite versus markdown storage decision",
+  },
+  {
+    group: "architecture-shape",
+    choices: ["architecture", "shape"],
+    expected: "shape",
+    prompt: "Turn this rough storage idea into an implementable spec with risks and scope",
+  },
+  {
+    group: "foundations-git-workflow-documentation-standards",
+    choices: ["foundations", "git-workflow", "documentation-standards"],
+    expected: "foundations",
+    prompt: "Check whether this change follows our general code quality conventions",
+  },
+  {
+    group: "foundations-git-workflow-documentation-standards",
+    choices: ["foundations", "git-workflow", "documentation-standards"],
+    expected: "git-workflow",
+    prompt: "Write a Conventional Commit and PR description for this branch",
+  },
+  {
+    group: "foundations-git-workflow-documentation-standards",
+    choices: ["foundations", "git-workflow", "documentation-standards"],
+    expected: "documentation-standards",
+    prompt: "Update the ADR and API documentation style guide for this change",
+  },
+];
+
+let totalInputTokens = 0;
+let totalOutputTokens = 0;
+let totalCalls = 0;
+
+function parseArgs(rawArgs) {
+  const parsed = {
+    dryRun: false,
+    help: false,
+    model: null,
+    output: null,
+    repeat: 1,
+    skill: null,
+    suite: "all",
+  };
+
+  for (let index = 0; index < rawArgs.length; index++) {
+    const arg = rawArgs[index];
+    switch (arg) {
+      case "--dry-run":
+      case "--validate-suite":
+        parsed.dryRun = true;
+        break;
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      case "--model":
+        parsed.model = requireValue(rawArgs, ++index, arg);
+        break;
+      case "--output":
+        parsed.output = requireValue(rawArgs, ++index, arg);
+        break;
+      case "--repeat":
+        parsed.repeat = Number.parseInt(requireValue(rawArgs, ++index, arg), 10);
+        break;
+      case "--skill":
+        parsed.skill = requireValue(rawArgs, ++index, arg);
+        break;
+      case "--suite":
+        parsed.suite = requireValue(rawArgs, ++index, arg);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!["all", "core", "conflicts"].includes(parsed.suite)) {
+    throw new Error(`--suite must be one of: all, core, conflicts`);
+  }
+  if (!Number.isInteger(parsed.repeat) || parsed.repeat < 1) {
+    throw new Error("--repeat must be a positive integer");
+  }
+
+  return parsed;
+}
+
+function requireValue(rawArgs, index, flag) {
+  const value = rawArgs[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: node cli/scripts/eval-skill-routing.mjs [options]
+
+Options:
+  --dry-run, --validate-suite  Validate suites without calling Anthropic
+  --suite <all|core|conflicts> Select which suite to run (default: all)
+  --skill <name>               Run cases whose expected skill is <name>
+  --model <model>              Anthropic model for live runs
+  --repeat <n>                 Repeat live cases n times (default: 1)
+  --output <path>              Write JSON result
+  -h, --help                   Show this help`);
+}
 
 function loadSkills() {
   const skills = [];
@@ -64,203 +383,129 @@ function loadSkills() {
     const frontMatch = content.match(/^---\n([\s\S]*?)\n---/);
     if (!frontMatch) continue;
 
-    // Simple YAML extraction (avoids dependency)
     const front = frontMatch[1];
     const nameMatch = front.match(/^name:\s*(.+)$/m);
-    const descMatch = front.match(/description:\s*>-?\n([\s\S]*?)(?=\n[a-z]|$)/);
+    const descMatch = front.match(/description:\s*>-?\n([\s\S]*?)(?=\n[a-z][a-z0-9_-]*:|$)/);
     if (!nameMatch || !descMatch) continue;
 
     const name = nameMatch[1].trim();
     const description = descMatch[1]
       .split("\n")
-      .map((l) => l.trim())
+      .map((line) => line.trim())
       .filter(Boolean)
       .join(" ")
       .trim();
 
-    skills.push({ name, description, truncated: description.slice(0, MAX_DESC_CHARS) });
+    skills.push({
+      name,
+      description,
+      truncated: description.slice(0, MAX_DESC_CHARS),
+    });
   }
-  return skills;
+  return skills.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-// ── Test cases ──────────────────────────────────────────────────────────────
-// 3 prompts per skill: [direct trigger, natural variant, edge/ambiguous]
+function buildCases() {
+  const coreCases = Object.entries(TEST_CASES).flatMap(([expected, prompts]) =>
+    prompts.map((prompt) => ({
+      kind: "core",
+      group: expected,
+      expected,
+      prompt,
+      choices: null,
+    }))
+  );
+  const conflictCases = CONFLICT_PROBES.map((probe) => ({
+    kind: "conflict",
+    ...probe,
+  }));
 
-const TEST_CASES = {
-  foundations: [
-    "Review this function for code style issues",
-    "Are we following naming conventions here?",
-    "Run the verification checklist before we ship",
-  ],
-  "git-workflow": [
-    "Write a commit message for these changes",
-    "Create a PR for this branch",
-    "What branch name should I use?",
-  ],
-  debugging: [
-    "This test is flaky, help me fix it",
-    "I'm tracking multiple hypotheses for this failure",
-    "Diagnose why this is failing intermittently",
-  ],
-  "security-compliance": [
-    "Check this code for hardcoded secrets",
-    "Run a security review on this module",
-    "Perform a threat analysis on the auth flow",
-  ],
-  "documentation-standards": [
-    "Write an ADR for this decision",
-    "Update the API documentation",
-    "Create a Mermaid diagram for this architecture",
-  ],
-  orchestration: [
-    "Manage the session for this work",
-    "Delegate this to a specialist agent",
-    "Coordinate the work across these tasks",
-  ],
-  "knowledge-base": [
-    "Create a knowledge file for this domain",
-    "This knowledge file is stale, update it",
-    "What are the knowledge management conventions?",
-  ],
-  "python-development": [
-    "Write a FastAPI endpoint for user auth",
-    "Add Pydantic validation to this model",
-    "Write pytest tests for this service",
-  ],
-  "typescript-development": [
-    "Create a React component for this design",
-    "Set up a Next.js App Router page",
-    "Write Vitest tests for this utility",
-  ],
-  "ruby-development": [
-    "Create a Rails controller for this resource",
-    "Add a Hotwire Turbo frame to this view",
-    "Write Minitest tests for this model",
-  ],
-  "go-development": [
-    "Write a Go CLI tool for this task",
-    "Handle concurrency in this Go service",
-    "Write Go tests with table-driven patterns",
-  ],
-  "database-design": [
-    "Design the schema for user accounts",
-    "Write a migration to add an index",
-    "Should we denormalize this table?",
-  ],
-  "interface-design": [
-    "Evaluate this layout for accessibility",
-    "What color palette works for this design?",
-    "Review the typography in this component",
-  ],
-  "infrastructure-management": [
-    "Write a Dockerfile for this service",
-    "Configure the Kubernetes manifest",
-    "Set up CI/CD for this project",
-  ],
-  "power-systems-modeling": [
-    "Calculate the thermal rating for this conductor",
-    "Validate these conductor parameters against CIGRE TB 601",
-    "What's the sag formula for this span?",
-  ],
-  implement: [
-    "Implement this feature",
-    "Start working on TASK-042",
-    "Let's build this out",
-  ],
-  shape: [
-    "Shape this idea into a spec",
-    "Write a spec for the auth feature",
-    "This idea has enough constraints, let's bound it",
-  ],
-  breakdown: [
-    "Break this spec into tasks",
-    "Create tasks for SPEC-015",
-    "Decompose this into atomic work items",
-  ],
-  brainstorm: [
-    "Help me think through the options here",
-    "What are the tradeoffs between these approaches?",
-    "I'm exploring ideas for the notification system",
-  ],
-  idea: [
-    "I have an idea: what if we added webhooks?",
-    "Note this down for later",
-    "Promote sparks from the last brainstorm",
-  ],
-  research: [
-    "What's the current state of the project?",
-    "Investigate how other tools handle this",
-    "Step back and assess where we are",
-  ],
-  "council-session": [
-    "Call a council on this decision",
-    "Gather specialists to debate this",
-    "What do the experts think about this approach?",
-  ],
-  strategy: [
-    "What's our strategy?",
-    "Update the strategic direction",
-    "Who are our personas?",
-  ],
-  architecture: [
-    "Should we use PostgreSQL or SQLite?",
-    "Create an ADR for the caching approach",
-    "Evaluate the tradeoffs for this technical decision",
-  ],
-  ship: [
-    "Ready to merge this PR",
-    "Ship it",
-    "Land this branch",
-  ],
-  release: [
-    "Cut a release from main",
-    "Publish a new version",
-    "Should we batch the landed PRs into a release?",
-  ],
-  reflect: [
-    "What did we learn from shipping this?",
-    "Update strategy based on what we built",
-    "Integrate learnings from the last sprint",
-  ],
-  cleanup: [
-    "Clean up the agent artifacts",
-    "Review sessions and tidy up",
-    "Archive completed specs",
-  ],
-  handoff: [
-    "Handoff this branch to the next agent",
-    "Prepare the next session with everything needed to continue",
-    "Write transfer context for this task",
-  ],
-  "resume-session": [
-    "Resume that session",
-    "Pick up where we left off",
-    "Continue the work from yesterday",
-  ],
-  "reference-session": [
-    "Reference that earlier session about auth",
-    "What did we decide before about caching?",
-    "Import decisions from the last session",
-  ],
-  bootstrap: [
-    "Start a new project",
-    "Set up Loaf for this repo",
-    "Bootstrap my project",
-  ],
-};
+  let cases;
+  if (args.suite === "core") {
+    cases = coreCases;
+  } else if (args.suite === "conflicts") {
+    cases = conflictCases;
+  } else {
+    cases = [...coreCases, ...conflictCases];
+  }
 
-// ── API call ────────────────────────────────────────────────────────────────
+  if (args.skill) {
+    cases = cases.filter((testCase) => testCase.expected === args.skill);
+  }
 
-let totalInputTokens = 0;
-let totalOutputTokens = 0;
-let totalCalls = 0;
+  if (args.repeat > 1 && !args.dryRun) {
+    cases = cases.flatMap((testCase) =>
+      Array.from({ length: args.repeat }, (_, repeatIndex) => ({
+        ...testCase,
+        repeat: repeatIndex + 1,
+      }))
+    );
+  }
+
+  return cases;
+}
+
+function validateSuite(skills, cases) {
+  const loadedNames = new Set(skills.map((skill) => skill.name));
+  const expectedNames = new Set(Object.keys(TEST_CASES));
+  const conflictNames = new Set(
+    CONFLICT_PROBES.flatMap((probe) => [probe.expected, ...probe.choices])
+  );
+  const casePrompts = cases.map((testCase) => testCase.prompt);
+  const duplicatePrompts = casePrompts.filter(
+    (prompt, index) => casePrompts.indexOf(prompt) !== index
+  );
+
+  const errors = [];
+  const warnings = [];
+  const missingTestCases = [...loadedNames].filter((name) => !expectedNames.has(name));
+  const unknownExpectedSkills = [...expectedNames].filter((name) => !loadedNames.has(name));
+  const unknownConflictSkills = [...conflictNames].filter((name) => !loadedNames.has(name));
+
+  if (skills.length !== EXPECTED_SKILL_COUNT) {
+    errors.push(`expected ${EXPECTED_SKILL_COUNT} skills, loaded ${skills.length}`);
+  }
+  for (const name of missingTestCases) {
+    errors.push(`missing core test cases for loaded skill: ${name}`);
+  }
+  for (const name of unknownExpectedSkills) {
+    errors.push(`core test case references missing skill: ${name}`);
+  }
+  for (const name of unknownConflictSkills) {
+    errors.push(`conflict probe references missing skill: ${name}`);
+  }
+  for (const prompt of [...new Set(duplicatePrompts)]) {
+    warnings.push(`duplicate prompt: ${prompt}`);
+  }
+  if (args.skill && !loadedNames.has(args.skill)) {
+    errors.push(`--skill references missing skill: ${args.skill}`);
+  }
+  if (cases.length === 0) {
+    errors.push("selected suite has no cases");
+  }
+
+  return {
+    passed: errors.length === 0,
+    errors,
+    warnings,
+    missingTestCases,
+    unknownExpectedSkills,
+    unknownConflictSkills,
+    loadedSkills: [...loadedNames],
+    expectedSkills: [...expectedNames].sort(),
+  };
+}
+
+function buildSkillsListing(skills) {
+  return skills.map((skill) => `- ${skill.name}: ${skill.truncated}`).join("\n");
+}
 
 async function routePrompt(skillsListing, userPrompt) {
   const systemPrompt = `You are Claude Code with these available skills:
 
 ${skillsListing}
 
-The user will give you a task. Respond with ONLY the skill name you would invoke. Nothing else — just the skill name. If no skill matches, respond "none".`;
+The user will give you a task. Respond with ONLY the skill name you would invoke. Nothing else. If no skill matches, respond "none".`;
 
   const response = await fetch(API_URL, {
     method: "POST",
@@ -290,118 +535,218 @@ The user will give you a task. Respond with ONLY the skill name you would invoke
   return data.content[0]?.text?.trim().toLowerCase() || "unknown";
 }
 
-// ── Main ────────────────────────────────────────────────────────────────────
-
-async function main() {
-  const skills = loadSkills();
-  console.log(`Loaded ${skills.length} skills`);
-  console.log(`Model: ${MODEL}`);
-  console.log(`Description budget: ${MAX_DESC_CHARS} chars\n`);
-
-  // Build the skills listing (simulating Claude Code's <available_skills>)
-  const skillsListing = skills
-    .map((s) => `- ${s.name}: ${s.truncated}`)
-    .join("\n");
-
-  // Filter test cases
-  const testSkills = SKILL_FILTER
-    ? Object.entries(TEST_CASES).filter(([k]) => k === SKILL_FILTER)
-    : Object.entries(TEST_CASES);
-
+async function runLiveCases(skills, cases) {
+  const skillsListing = buildSkillsListing(skills);
   const results = [];
   let pass = 0;
   let fail = 0;
-  let total = 0;
 
-  for (const [expectedSkill, prompts] of testSkills) {
-    // Skip skills that don't exist in the loaded set
-    if (!skills.find((s) => s.name === expectedSkill)) {
-      console.log(`⚠ Skipping ${expectedSkill} (not found in skills dir)`);
-      continue;
+  for (let index = 0; index < cases.length; index++) {
+    const testCase = cases[index];
+    const repeatSuffix = testCase.repeat ? ` #${testCase.repeat}` : "";
+    process.stdout.write(
+      `  [${index + 1}/${cases.length}] ${testCase.kind}:${testCase.group}${repeatSuffix} "${testCase.prompt}" -> `
+    );
+
+    try {
+      const actual = await routePrompt(skillsListing, testCase.prompt);
+      const passed = actual === testCase.expected;
+      if (passed) {
+        pass++;
+        console.log(`PASS ${actual}`);
+      } else {
+        fail++;
+        console.log(`FAIL ${actual} (expected: ${testCase.expected})`);
+      }
+      results.push({ ...testCase, actual, passed });
+    } catch (err) {
+      fail++;
+      console.log(`ERROR ${err.message}`);
+      results.push({ ...testCase, actual: "error", passed: false, error: err.message });
     }
 
-    for (const prompt of prompts) {
-      total++;
-      process.stdout.write(`  [${total}] "${prompt}" → `);
-
-      try {
-        const actual = await routePrompt(skillsListing, prompt);
-        const passed = actual === expectedSkill;
-
-        if (passed) {
-          pass++;
-          console.log(`✓ ${actual}`);
-        } else {
-          fail++;
-          console.log(`✗ ${actual} (expected: ${expectedSkill})`);
-        }
-
-        results.push({ prompt, expected: expectedSkill, actual, passed });
-      } catch (err) {
-        fail++;
-        console.log(`✗ ERROR: ${err.message}`);
-        results.push({
-          prompt,
-          expected: expectedSkill,
-          actual: "error",
-          passed: false,
-        });
-      }
-
-      // Rate limit: ~50 RPM for Opus
-      await new Promise((r) => setTimeout(r, 1200));
+    if (index < cases.length - 1) {
+      await new Promise((resolve) => setTimeout(resolve, 1200));
     }
   }
 
-  // ── Report ──────────────────────────────────────────────────────────────
+  return {
+    pass,
+    fail,
+    total: cases.length,
+    accuracy: cases.length === 0 ? 0 : pass / cases.length,
+    results,
+  };
+}
 
+function summarizeBy(results, field) {
+  const summary = {};
+  for (const result of results) {
+    const key = result[field];
+    if (!summary[key]) {
+      summary[key] = { pass: 0, total: 0, accuracy: 0 };
+    }
+    summary[key].total++;
+    if (result.passed) {
+      summary[key].pass++;
+    }
+  }
+  for (const stats of Object.values(summary)) {
+    stats.accuracy = stats.total === 0 ? 0 : stats.pass / stats.total;
+  }
+  return Object.fromEntries(Object.entries(summary).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+function calculateCost() {
   const pricing = PRICING[MODEL] || PRICING[DEFAULT_MODEL];
   const inputCost = (totalInputTokens / 1_000_000) * pricing.input;
   const outputCost = (totalOutputTokens / 1_000_000) * pricing.output;
-  const totalCost = inputCost + outputCost;
+  return {
+    input_tokens: totalInputTokens,
+    output_tokens: totalOutputTokens,
+    api_calls: totalCalls,
+    input_cost_usd: Number(inputCost.toFixed(6)),
+    output_cost_usd: Number(outputCost.toFixed(6)),
+    total_cost_usd: Number((inputCost + outputCost).toFixed(6)),
+  };
+}
 
-  console.log("\n═══════════════════════════════════════════════");
-  console.log("  ROUTING EVALUATION RESULTS");
-  console.log("═══════════════════════════════════════════════\n");
+function buildReport({ skills, cases, validation, live }) {
+  return {
+    schema_version: 1,
+    generated_at: new Date().toISOString(),
+    mode: args.dryRun ? "dry-run" : "live",
+    model: MODEL,
+    suite: args.suite,
+    skill_filter: args.skill,
+    repeat: args.repeat,
+    max_description_chars: MAX_DESC_CHARS,
+    expected_skill_count: EXPECTED_SKILL_COUNT,
+    skill_count: skills.length,
+    core_case_count: Object.values(TEST_CASES).reduce((count, prompts) => count + prompts.length, 0),
+    conflict_probe_count: CONFLICT_PROBES.length,
+    selected_case_count: cases.length,
+    skills: skills.map((skill) => ({
+      name: skill.name,
+      description_chars: skill.description.length,
+      truncated_chars: skill.truncated.length,
+    })),
+    validation,
+    totals: live
+      ? {
+          pass: live.pass,
+          fail: live.fail,
+          total: live.total,
+          accuracy: live.accuracy,
+        }
+      : null,
+    by_skill: live ? summarizeBy(live.results, "expected") : null,
+    by_group: live ? summarizeBy(live.results, "group") : null,
+    cost: live ? calculateCost() : null,
+    results: live ? live.results : [],
+  };
+}
 
-  console.log(`  Pass: ${pass}/${total} (${((pass / total) * 100).toFixed(1)}%)`);
-  console.log(`  Fail: ${fail}/${total}`);
+function printValidation(skills, cases, validation) {
+  console.log(`Loaded ${skills.length} skills from ${SKILLS_DIR}`);
+  console.log(`Expected skill count: ${EXPECTED_SKILL_COUNT}`);
+  console.log(`Model: ${MODEL}`);
+  console.log(`Description budget: ${MAX_DESC_CHARS} chars`);
+  console.log(`Suite: ${args.suite}`);
+  console.log(`Selected cases: ${cases.length}`);
+  console.log("");
 
-  if (fail > 0) {
-    console.log("\n  Failures:");
-    for (const r of results.filter((r) => !r.passed)) {
-      console.log(`    "${r.prompt}"`);
-      console.log(`      expected: ${r.expected} → got: ${r.actual}\n`);
+  if (validation.errors.length > 0) {
+    console.log("Suite validation failed:");
+    for (const error of validation.errors) {
+      console.log(`  - ${error}`);
+    }
+  } else {
+    console.log("Suite validation passed.");
+  }
+
+  if (validation.warnings.length > 0) {
+    console.log("\nWarnings:");
+    for (const warning of validation.warnings) {
+      console.log(`  - ${warning}`);
+    }
+  }
+}
+
+function printLiveSummary(live) {
+  const pct = live.total === 0 ? "0.0" : (live.accuracy * 100).toFixed(1);
+  console.log("\nROUTING EVALUATION RESULTS");
+  console.log(`Pass: ${live.pass}/${live.total} (${pct}%)`);
+  console.log(`Fail: ${live.fail}/${live.total}`);
+
+  if (live.fail > 0) {
+    console.log("\nFailures:");
+    for (const result of live.results.filter((item) => !item.passed)) {
+      console.log(`  "${result.prompt}"`);
+      console.log(`    expected: ${result.expected} -> got: ${result.actual}`);
     }
   }
 
-  // Per-skill breakdown
-  console.log("  Per-skill accuracy:");
-  const bySkill = {};
-  for (const r of results) {
-    if (!bySkill[r.expected]) bySkill[r.expected] = { pass: 0, total: 0 };
-    bySkill[r.expected].total++;
-    if (r.passed) bySkill[r.expected].pass++;
-  }
-  for (const [skill, stats] of Object.entries(bySkill).sort(
-    (a, b) => a[1].pass / a[1].total - b[1].pass / b[1].total
-  )) {
-    const pct = ((stats.pass / stats.total) * 100).toFixed(0);
-    const bar = stats.pass === stats.total ? "✓" : "✗";
-    console.log(`    ${bar} ${skill}: ${stats.pass}/${stats.total} (${pct}%)`);
+  console.log("\nPer-skill accuracy:");
+  for (const [skill, stats] of Object.entries(summarizeBy(live.results, "expected"))) {
+    console.log(`  ${skill}: ${stats.pass}/${stats.total} (${(stats.accuracy * 100).toFixed(0)}%)`);
   }
 
-  console.log("\n───────────────────────────────────────────────");
-  console.log("  Token Usage & Cost");
-  console.log("───────────────────────────────────────────────\n");
-  console.log(`  Model:         ${MODEL}`);
-  console.log(`  API calls:     ${totalCalls}`);
-  console.log(`  Input tokens:  ${totalInputTokens.toLocaleString()}`);
-  console.log(`  Output tokens: ${totalOutputTokens.toLocaleString()}`);
-  console.log(`  Input cost:    $${inputCost.toFixed(4)}`);
-  console.log(`  Output cost:   $${outputCost.toFixed(4)}`);
-  console.log(`  Total cost:    $${totalCost.toFixed(4)}`);
-  console.log("");
+  const cost = calculateCost();
+  console.log("\nToken Usage & Cost");
+  console.log(`  API calls:     ${cost.api_calls}`);
+  console.log(`  Input tokens:  ${cost.input_tokens.toLocaleString()}`);
+  console.log(`  Output tokens: ${cost.output_tokens.toLocaleString()}`);
+  console.log(`  Total cost:    $${cost.total_cost_usd.toFixed(4)}`);
+}
+
+function writeReport(path, report) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(`\nWrote JSON report: ${path}`);
+}
+
+async function main() {
+  const skills = loadSkills();
+  const cases = buildCases();
+  const validation = validateSuite(skills, cases);
+
+  printValidation(skills, cases, validation);
+
+  if (!validation.passed) {
+    const report = buildReport({ skills, cases, validation, live: null });
+    if (args.output) {
+      writeReport(args.output, report);
+    }
+    process.exit(1);
+  }
+
+  if (args.dryRun) {
+    const report = buildReport({ skills, cases, validation, live: null });
+    if (args.output) {
+      writeReport(args.output, report);
+    }
+    return;
+  }
+
+  if (!API_KEY) {
+    console.error(
+      "\nError: ANTHROPIC_API_KEY is required for live routing evals. Use --dry-run to validate the suite without a key."
+    );
+    process.exit(1);
+  }
+
+  const live = await runLiveCases(skills, cases);
+  printLiveSummary(live);
+
+  const report = buildReport({ skills, cases, validation, live });
+  if (args.output) {
+    writeReport(args.output, report);
+  }
+
+  if (live.fail > 0) {
+    process.exitCode = 1;
+  }
 }
 
 main().catch((err) => {

--- a/cmd/loaf/routing_eval_content_test.go
+++ b/cmd/loaf/routing_eval_content_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRoutingEvalDryRunValidatesCurrentSkillSuite(t *testing.T) {
+	root := repoRoot(t)
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skipf("node not found: %v", err)
+	}
+
+	cmd := exec.Command("node", "cli/scripts/eval-skill-routing.mjs", "--dry-run")
+	cmd.Dir = root
+	cmd.Env = envWith("ANTHROPIC_API_KEY=")
+	outputBytes, err := cmd.CombinedOutput()
+	output := string(outputBytes)
+	if err != nil {
+		t.Fatalf("dry-run routing eval failed: %v\n%s", err, output)
+	}
+
+	for _, want := range []string{
+		"Loaded 34 skills",
+		"Selected cases: 115",
+		"Suite validation passed.",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("dry-run output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestRoutingEvalContentHasNoPhantomSkillCases(t *testing.T) {
+	root := repoRoot(t)
+	body := readTextFile(t, filepath.Join(root, "cli", "scripts", "eval-skill-routing.mjs"))
+	for _, forbidden := range []string{
+		"council-session",
+		"cleanup",
+		"resume-session",
+		"reference-session",
+		"thermo-nuclear-code-quality-review",
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("routing eval still references phantom or absent skill %q", forbidden)
+		}
+	}
+}
+
+func TestSkillArchitectureCountMatchesCurrentTaxonomy(t *testing.T) {
+	root := repoRoot(t)
+	body := readTextFile(t, filepath.Join(root, "docs", "knowledge", "skill-architecture.md"))
+	if !strings.Contains(body, "34 skills total: 19 workflow/default-invocable, 15 reference/knowledge") {
+		t.Fatalf("skill architecture doc missing current 34-skill taxonomy")
+	}
+	if strings.Contains(body, "33 skills") || strings.Contains(body, "35 skills") {
+		t.Fatalf("skill architecture doc still contains stale skill count")
+	}
+}

--- a/docs/knowledge/skill-architecture.md
+++ b/docs/knowledge/skill-architecture.md
@@ -85,7 +85,7 @@ Skills load into profiles at spawn time. What an agent *can do* is fixed by prof
 | Reference/Knowledge | `false` | python-development, database-design, foundations, git-workflow, orchestration |
 | Workflow/Process | `true` (default) | implement, research, shape, breakdown, ship, release, housekeeping, wrap |
 
-33 skills total: 17 workflow, 16 reference/knowledge.
+34 skills total: 19 workflow/default-invocable, 15 reference/knowledge with `user-invocable: false`.
 
 ## Cross-References
 


### PR DESCRIPTION
## Summary
- implements the description-only / harness-ready scope of SPEC-051 on top of SPEC-048
- refreshes the routing eval harness with dry-run suite validation, 34-skill count checks, description-budget checks, and conflict-pair probes
- updates the skill architecture docs for the verified skill count and routing-eval workflow
- closes the SPEC-051 checklist to reflect the approved no-key scope: live baseline capture and measured description rewrites remain deferred until `ANTHROPIC_API_KEY` is available
- rebased onto refreshed feat/session-model-convergence and dropped duplicate SPEC-047 validator commits from the stack

## Verification
- `npm run eval:routing -- --dry-run`
- `npm run eval:routing` (expected: suite validation passes, then exits with missing `ANTHROPIC_API_KEY` guidance)
- `rg -n 'council-session|cleanup|resume-session|reference-session' cli/scripts` returned no matches
- `rg -n '33 skills' docs` returned no matches
- `npm run build`
- `npm run typecheck`
- `npm run test`
- `bin/loaf check --hook render-drift --json`
- `npm run verify:go-artifacts`

## Notes
- No description rewrite shipped without a key-backed measured improvement; the harness now prevents that later.
- Session journal logging succeeded on this branch: `journal:ee54fcf90be8afa4c8efd36b`, `journal:6df90dba2ee56c7dea95c3c3`.
