### PR TITLE
docs: resolve minor conformance-review findings

### DIFF
--- a/.agents/specs/SPEC-049-status-vocabulary-unification.md
+++ b/.agents/specs/SPEC-049-status-vocabulary-unification.md
@@ -6,7 +6,7 @@ source_sessions:
   - id: 20260621-001541-session
     role: shaped
 created: 2026-06-22T09:13:21Z
-status: done
+status: complete
 branch: feat/status-vocabulary-unification
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ is a Loaf workflow staging section for curated entries before release.
 
 ## [Unreleased]
 
-- _No unreleased changes yet._
+### Fixed
+
+- Corrected the stale `config/targets.yaml` amp target comment to reflect that Amp is a first-class target emitting skills plus an auto-generated TypeScript runtime plugin, not an experimental skills-only target.
+- Aligned SPEC-049 frontmatter status to `complete`, matching sibling specs and the canonical spec lifecycle vocabulary.
+- Renumbered the duplicate `ADR-017` install-convention decision to `ADR-018` and listed it in the decisions README.
+- Corrected ADR-017 to record that ADRs and knowledge live under `docs/`, not `.agents/`, fixing an ADR-013 factual error.
 
 ## [2.0.0-pre.20260625192947] - 2026-06-25
 

--- a/config/targets.yaml
+++ b/config/targets.yaml
@@ -38,6 +38,6 @@ targets:
 
   amp:
     output: dist/amp/
-    # Experimental Amp target
-    # Skills only - no sidecar merge, standard SKILL.md
-    # Runtime plugin at .amp/plugins/loaf.ts (auto-generated)
+    # First-class Amp target
+    # Skills (standard SKILL.md, no sidecar merge) + auto-generated runtime
+    # plugin at .amp/plugins/loaf.ts

--- a/docs/decisions/ADR-017-ephemeral-agent-markdown-cutover.md
+++ b/docs/decisions/ADR-017-ephemeral-agent-markdown-cutover.md
@@ -44,6 +44,13 @@ the operational routing surface. Project-scoped state still stands; the state is
 now the SQLite noun model, with Markdown only as compatibility import, export,
 or deterministic render.
 
+This also corrects a factual error in ADR-013's Decision, which lists "ADRs,
+knowledge" among the artifact kinds that "all live in one place" under
+`.agents/`. They do not: ADRs live in `docs/decisions/` and knowledge lives in
+`docs/` (Tier-2, git-native). ADR-013's project-scoped-resolution rule governs
+only the artifact kinds that actually live under `.agents/`; the `docs/` tree is
+git-native and outside that resolver.
+
 ## Consequences
 
 ### Positive

--- a/docs/decisions/ADR-018-global-agents-install-convention.md
+++ b/docs/decisions/ADR-018-global-agents-install-convention.md
@@ -1,4 +1,4 @@
-# ADR-017: Global Agents Install Convention
+# ADR-018: Global Agents Install Convention
 
 ## Status
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -21,5 +21,6 @@ Immutable records of significant architectural decisions.
 | [ADR-015](ADR-015-portable-launcher-during-go-port.md) | Portable Launcher During Go Port | Accepted | 2026-05-29 |
 | [ADR-016](ADR-016-artifact-storage-trichotomy.md) | Artifact Storage Trichotomy — Nouns in SQLite, Verbs in Git, Markdown is a Render | Accepted | 2026-06-24 |
 | [ADR-017](ADR-017-ephemeral-agent-markdown-cutover.md) | Ephemeral Agent Markdown Cutover | Accepted | 2026-06-25 |
+| [ADR-018](ADR-018-global-agents-install-convention.md) | Global Agents Install Convention | Accepted | 2026-06-25 |
 
 See [../knowledge/](../knowledge/) for domain knowledge files.


### PR DESCRIPTION
Cleanup pass from a deep claim-by-claim conformance review of the merged
SPEC-043..054 restructuring program. The program is **conformant** — ADR-016's
trichotomy is honored on all three homes with zero violations — and these are
the minor doc/config findings the review surfaced.

## Changes
- **config/targets.yaml** — correct the stale amp comment. Amp is a first-class
  target and emits skills **plus** an auto-generated TS runtime plugin at
  `.amp/plugins/loaf.ts` — not "experimental / skills only."
- **SPEC-049** — frontmatter `status: done → complete`, matching all 11 sibling
  specs and SPEC-049's own canonical spec vocabulary (`complete`, not the task
  word `done`).
- **ADR-017 duplicate** — two files shared the `ADR-017` number. Renumber the
  install-convention ADR to **ADR-018** and add the missing row to
  `docs/decisions/README.md`. (The cutover ADR keeps 017 — it's the one
  referenced by README/CHANGELOG/SPEC-045.)
- **ADR-017 (cutover)** — add the correction it was supposed to carry: ADR-013's
  Decision wrongly lists "ADRs, knowledge" among kinds that "all live in one
  place" under `.agents/`. They live in `docs/decisions/` and `docs/` (Tier-2).

## Verification
`loaf build`, `npm run typecheck`, full `go test ./...`, and the `render-drift`
+ `ephemeral-provenance` check hooks all pass. `dist/`/`plugins/` regenerate
clean (`git diff --exit-code` — the comment change is inert).

## Deferred (filed as follow-ups, not in this PR)
Two doc fixes were blocked by the live failClosed `artifact-body-write` hook +
the missing spec/report body-edit verb, and fold into TASK-407:
- **TASK-406** (P1) — FTS indexes secrets verbatim on ingest; only the query
  snippet is redacted, so secrets are cross-project `MATCH`-able. SPEC-043's own
  "exclusion on ingest" mitigation and SPEC-040:169 No-Go are unmet. → `/shape`.
- **TASK-407** (P1) — no sanctioned spec/report body-edit path: the
  `artifact-body-write` hook is failClosed but no `edit` verb exists and legacy
  bodies are `has_body:False`. Absorbs the SPEC-040 amendment notes + SPEC-053
  signoff correction; also fixes SPEC-044's phantom-command drift-gate redirect.
- **TASK-408** (P2) — SPEC-049's unified vocabulary isn't enforced on SQLite
  spec rows (they use task vocab, unmaintained, no set-status verb).

https://claude.ai/code/session_0161HjEHFKV8Ssen4kn3ATpX