### PR TITLE
fix: align council validator and scaffold with council template contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ is a Loaf workflow staging section for curated entries before release.
 
 ### Fixed
 
+- Aligned `validate-council.py` and the `new-council.sh` scaffold with the council skill's template contract (frontmatter `topic`/`created`/`status`/`composition`, canonical `draft`/`done`/`archived` lifecycle from SPEC-049), and added a Go contract test that locks the validator, template, and scaffold together so they cannot drift apart again.
 - Treat command-authored relationship provenance as valid in `loaf state doctor`, avoiding a misleading `relationship-origin-unknown` repair prompt for rows created by current Loaf commands.
 - Stop `loaf release --dry-run` after reporting that no unreleased changes exist, instead of generating a bogus next-version release plan.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ is a Loaf workflow staging section for curated entries before release.
 
 ## [Unreleased]
 
-- _No unreleased changes yet._
+### Fixed
+
+- Treat command-authored relationship provenance as valid in `loaf state doctor`, avoiding a misleading `relationship-origin-unknown` repair prompt for rows created by current Loaf commands.
+- Stop `loaf release --dry-run` after reporting that no unreleased changes exist, instead of generating a bogus next-version release plan.
 
 ## [2.0.0-alpha.1] - 2026-06-27
 

--- a/content/skills/council/templates/council.md
+++ b/content/skills/council/templates/council.md
@@ -7,7 +7,7 @@
 council:
   topic: "[Clear decision description]"
   created: "[ISO timestamp]"
-  status: in_progress
+  status: draft  # draft | done | archived
   composition:
     - [agent1]
     - [agent2]

--- a/content/skills/orchestration/scripts/new-council.sh
+++ b/content/skills/orchestration/scripts/new-council.sh
@@ -47,39 +47,42 @@ if [[ -f "$FILEPATH" ]]; then
     exit 1
 fi
 
-# Build participants YAML
-PARTICIPANTS_YAML=""
+# Build composition YAML
+COMPOSITION_YAML=""
 for p in "${PARTICIPANTS[@]}"; do
-    PARTICIPANTS_YAML="${PARTICIPANTS_YAML}    - ${p}
+    COMPOSITION_YAML="${COMPOSITION_YAML}    - ${p}
 "
 done
 
-# Generate council file
+# Generate council file (shape must match council/templates/council.md)
 cat > "$FILEPATH" << EOF
 ---
 council:
   topic: "${TOPIC//-/ }"
-  timestamp: "${ISO_TIMESTAMP}"
-  status: pending
-  session: "${SESSION}"
-  participants:
-${PARTICIPANTS_YAML}  decision: ""
+  created: "${ISO_TIMESTAMP}"
+  status: draft
+  composition:
+${COMPOSITION_YAML}  session_reference: "${SESSION}"
 ---
 
 # Council: ${TOPIC//-/ }
+
+## Decision Question
+
+[Clear, specific question being decided]
+
+## Options
+
+### Option 1: [Name]
+Brief description and trade-offs.
+
+### Option 2: [Name]
+Brief description and trade-offs.
 
 ## Context
 
 Why this council was convened.
 What problem or decision needed multiple perspectives.
-
-## Options Considered
-
-### Option A: [Name]
-Brief description and trade-offs.
-
-### Option B: [Name]
-Brief description and trade-offs.
 
 ## Agent Perspectives
 
@@ -112,15 +115,15 @@ done)
 
 ## Decision
 
-**Chosen**: [Pending user approval]
+[To be filled after user approval]
 
-## Rationale
+---
 
-[To be filled after deliberation]
+## Deliberation Log
 
-## Implementation Notes
-
-[To be filled after decision]
+### ${ISO_TIMESTAMP} - Council Convened
+Agents: ${PARTICIPANTS[*]}
+Composition selected by orchestrator.
 EOF
 
 echo "Created: $FILEPATH"

--- a/content/skills/orchestration/scripts/validate-council.py
+++ b/content/skills/orchestration/scripts/validate-council.py
@@ -57,26 +57,32 @@ def validate_frontmatter(fm: dict) -> list[str]:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Status follows the canonical council lifecycle (SPEC-049)
+    # Status follows the canonical council lifecycle (SPEC-049).
+    # Empty or null values are invalid, so validate whenever the key exists.
     valid_statuses = ['draft', 'done', 'archived']
-    if council.get('status') and council['status'] not in valid_statuses:
+    if 'status' in council and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 created timestamp
-    created = council.get('created', '')
-    if created:
-        try:
-            datetime.fromisoformat(created.replace('Z', '+00:00'))
-        except ValueError:
-            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
+    # Validate ISO 8601 created timestamp; YAML may parse an unquoted
+    # timestamp into a datetime already
+    if 'created' in council:
+        created = council['created']
+        if not isinstance(created, datetime):
+            try:
+                datetime.fromisoformat(str(created).replace('Z', '+00:00'))
+            except (TypeError, ValueError):
+                errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate composition
-    composition = council.get('composition', [])
-    if composition:
-        if len(composition) < 5:
-            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
-        if len(composition) % 2 == 0:
-            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
+    # Validate composition; an empty or non-list value fails
+    if 'composition' in council:
+        composition = council['composition']
+        if not isinstance(composition, list):
+            errors.append(f"council.composition must be a list of agents (got {type(composition).__name__})")
+        else:
+            if len(composition) < 5:
+                errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+            if len(composition) % 2 == 0:
+                errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
     # session_reference and linear_issue are optional free-form references
 

--- a/content/skills/orchestration/scripts/validate-council.py
+++ b/content/skills/orchestration/scripts/validate-council.py
@@ -51,39 +51,34 @@ def validate_frontmatter(fm: dict) -> list[str]:
         errors.append("Missing 'council' block in frontmatter")
         return errors
 
-    # Required council fields
-    required_fields = ['topic', 'timestamp', 'status', 'session', 'participants', 'decision']
+    # Required council fields — must match council/templates/council.md
+    required_fields = ['topic', 'created', 'status', 'composition']
     for field in required_fields:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Validate status values
-    valid_statuses = ['pending', 'approved', 'rejected', 'deferred']
+    # Status follows the canonical council lifecycle (SPEC-049)
+    valid_statuses = ['draft', 'done', 'archived']
     if council.get('status') and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 timestamp
-    timestamp = council.get('timestamp', '')
-    if timestamp:
+    # Validate ISO 8601 created timestamp
+    created = council.get('created', '')
+    if created:
         try:
-            datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+            datetime.fromisoformat(created.replace('Z', '+00:00'))
         except ValueError:
-            errors.append(f"Invalid ISO 8601 timestamp: {timestamp}")
+            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate participants
-    participants = council.get('participants', [])
-    if participants:
-        if len(participants) < 5:
-            errors.append(f"Council requires at least 5 participants (got {len(participants)})")
-        if len(participants) % 2 == 0:
-            errors.append(f"Council requires an ODD number of participants (got {len(participants)})")
+    # Validate composition
+    composition = council.get('composition', [])
+    if composition:
+        if len(composition) < 5:
+            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+        if len(composition) % 2 == 0:
+            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
-    # Validate session link (file should exist, but we just check format here)
-    session = council.get('session', '')
-    if session:
-        session_pattern = r'^\d{8}-\d{6}-[a-z0-9-]+$'
-        if not re.match(session_pattern, session):
-            errors.append(f"Invalid session reference format: {session}")
+    # session_reference and linear_issue are optional free-form references
 
     return errors
 
@@ -91,10 +86,12 @@ def validate_frontmatter(fm: dict) -> list[str]:
 def validate_sections(body: str) -> list[str]:
     """Validate required markdown sections."""
     errors = []
-    required_sections = ['## Context', '## Decision', '## Rationale']
+    required_sections = ['## Decision Question', '## Context', '## Agent Perspectives', '## Synthesis', '## Decision']
 
+    # Exact heading match so '## Decision Question' does not satisfy '## Decision'
+    headings = {line.strip() for line in body.splitlines() if line.strip().startswith('##')}
     for section in required_sections:
-        if section not in body:
+        if section not in headings:
             errors.append(f"Missing required section: {section}")
 
     return errors

--- a/dist/amp/skills/council/templates/council.md
+++ b/dist/amp/skills/council/templates/council.md
@@ -7,7 +7,7 @@
 council:
   topic: "[Clear decision description]"
   created: "[ISO timestamp]"
-  status: in_progress
+  status: draft  # draft | done | archived
   composition:
     - [agent1]
     - [agent2]

--- a/dist/amp/skills/orchestration/scripts/new-council.sh
+++ b/dist/amp/skills/orchestration/scripts/new-council.sh
@@ -47,39 +47,42 @@ if [[ -f "$FILEPATH" ]]; then
     exit 1
 fi
 
-# Build participants YAML
-PARTICIPANTS_YAML=""
+# Build composition YAML
+COMPOSITION_YAML=""
 for p in "${PARTICIPANTS[@]}"; do
-    PARTICIPANTS_YAML="${PARTICIPANTS_YAML}    - ${p}
+    COMPOSITION_YAML="${COMPOSITION_YAML}    - ${p}
 "
 done
 
-# Generate council file
+# Generate council file (shape must match council/templates/council.md)
 cat > "$FILEPATH" << EOF
 ---
 council:
   topic: "${TOPIC//-/ }"
-  timestamp: "${ISO_TIMESTAMP}"
-  status: pending
-  session: "${SESSION}"
-  participants:
-${PARTICIPANTS_YAML}  decision: ""
+  created: "${ISO_TIMESTAMP}"
+  status: draft
+  composition:
+${COMPOSITION_YAML}  session_reference: "${SESSION}"
 ---
 
 # Council: ${TOPIC//-/ }
+
+## Decision Question
+
+[Clear, specific question being decided]
+
+## Options
+
+### Option 1: [Name]
+Brief description and trade-offs.
+
+### Option 2: [Name]
+Brief description and trade-offs.
 
 ## Context
 
 Why this council was convened.
 What problem or decision needed multiple perspectives.
-
-## Options Considered
-
-### Option A: [Name]
-Brief description and trade-offs.
-
-### Option B: [Name]
-Brief description and trade-offs.
 
 ## Agent Perspectives
 
@@ -112,15 +115,15 @@ done)
 
 ## Decision
 
-**Chosen**: [Pending user approval]
+[To be filled after user approval]
 
-## Rationale
+---
 
-[To be filled after deliberation]
+## Deliberation Log
 
-## Implementation Notes
-
-[To be filled after decision]
+### ${ISO_TIMESTAMP} - Council Convened
+Agents: ${PARTICIPANTS[*]}
+Composition selected by orchestrator.
 EOF
 
 echo "Created: $FILEPATH"

--- a/dist/amp/skills/orchestration/scripts/validate-council.py
+++ b/dist/amp/skills/orchestration/scripts/validate-council.py
@@ -57,26 +57,32 @@ def validate_frontmatter(fm: dict) -> list[str]:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Status follows the canonical council lifecycle (SPEC-049)
+    # Status follows the canonical council lifecycle (SPEC-049).
+    # Empty or null values are invalid, so validate whenever the key exists.
     valid_statuses = ['draft', 'done', 'archived']
-    if council.get('status') and council['status'] not in valid_statuses:
+    if 'status' in council and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 created timestamp
-    created = council.get('created', '')
-    if created:
-        try:
-            datetime.fromisoformat(created.replace('Z', '+00:00'))
-        except ValueError:
-            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
+    # Validate ISO 8601 created timestamp; YAML may parse an unquoted
+    # timestamp into a datetime already
+    if 'created' in council:
+        created = council['created']
+        if not isinstance(created, datetime):
+            try:
+                datetime.fromisoformat(str(created).replace('Z', '+00:00'))
+            except (TypeError, ValueError):
+                errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate composition
-    composition = council.get('composition', [])
-    if composition:
-        if len(composition) < 5:
-            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
-        if len(composition) % 2 == 0:
-            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
+    # Validate composition; an empty or non-list value fails
+    if 'composition' in council:
+        composition = council['composition']
+        if not isinstance(composition, list):
+            errors.append(f"council.composition must be a list of agents (got {type(composition).__name__})")
+        else:
+            if len(composition) < 5:
+                errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+            if len(composition) % 2 == 0:
+                errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
     # session_reference and linear_issue are optional free-form references
 

--- a/dist/amp/skills/orchestration/scripts/validate-council.py
+++ b/dist/amp/skills/orchestration/scripts/validate-council.py
@@ -51,39 +51,34 @@ def validate_frontmatter(fm: dict) -> list[str]:
         errors.append("Missing 'council' block in frontmatter")
         return errors
 
-    # Required council fields
-    required_fields = ['topic', 'timestamp', 'status', 'session', 'participants', 'decision']
+    # Required council fields — must match council/templates/council.md
+    required_fields = ['topic', 'created', 'status', 'composition']
     for field in required_fields:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Validate status values
-    valid_statuses = ['pending', 'approved', 'rejected', 'deferred']
+    # Status follows the canonical council lifecycle (SPEC-049)
+    valid_statuses = ['draft', 'done', 'archived']
     if council.get('status') and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 timestamp
-    timestamp = council.get('timestamp', '')
-    if timestamp:
+    # Validate ISO 8601 created timestamp
+    created = council.get('created', '')
+    if created:
         try:
-            datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+            datetime.fromisoformat(created.replace('Z', '+00:00'))
         except ValueError:
-            errors.append(f"Invalid ISO 8601 timestamp: {timestamp}")
+            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate participants
-    participants = council.get('participants', [])
-    if participants:
-        if len(participants) < 5:
-            errors.append(f"Council requires at least 5 participants (got {len(participants)})")
-        if len(participants) % 2 == 0:
-            errors.append(f"Council requires an ODD number of participants (got {len(participants)})")
+    # Validate composition
+    composition = council.get('composition', [])
+    if composition:
+        if len(composition) < 5:
+            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+        if len(composition) % 2 == 0:
+            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
-    # Validate session link (file should exist, but we just check format here)
-    session = council.get('session', '')
-    if session:
-        session_pattern = r'^\d{8}-\d{6}-[a-z0-9-]+$'
-        if not re.match(session_pattern, session):
-            errors.append(f"Invalid session reference format: {session}")
+    # session_reference and linear_issue are optional free-form references
 
     return errors
 
@@ -91,10 +86,12 @@ def validate_frontmatter(fm: dict) -> list[str]:
 def validate_sections(body: str) -> list[str]:
     """Validate required markdown sections."""
     errors = []
-    required_sections = ['## Context', '## Decision', '## Rationale']
+    required_sections = ['## Decision Question', '## Context', '## Agent Perspectives', '## Synthesis', '## Decision']
 
+    # Exact heading match so '## Decision Question' does not satisfy '## Decision'
+    headings = {line.strip() for line in body.splitlines() if line.strip().startswith('##')}
     for section in required_sections:
-        if section not in body:
+        if section not in headings:
             errors.append(f"Missing required section: {section}")
 
     return errors

--- a/dist/codex/skills/council/templates/council.md
+++ b/dist/codex/skills/council/templates/council.md
@@ -7,7 +7,7 @@
 council:
   topic: "[Clear decision description]"
   created: "[ISO timestamp]"
-  status: in_progress
+  status: draft  # draft | done | archived
   composition:
     - [agent1]
     - [agent2]

--- a/dist/codex/skills/orchestration/scripts/new-council.sh
+++ b/dist/codex/skills/orchestration/scripts/new-council.sh
@@ -47,39 +47,42 @@ if [[ -f "$FILEPATH" ]]; then
     exit 1
 fi
 
-# Build participants YAML
-PARTICIPANTS_YAML=""
+# Build composition YAML
+COMPOSITION_YAML=""
 for p in "${PARTICIPANTS[@]}"; do
-    PARTICIPANTS_YAML="${PARTICIPANTS_YAML}    - ${p}
+    COMPOSITION_YAML="${COMPOSITION_YAML}    - ${p}
 "
 done
 
-# Generate council file
+# Generate council file (shape must match council/templates/council.md)
 cat > "$FILEPATH" << EOF
 ---
 council:
   topic: "${TOPIC//-/ }"
-  timestamp: "${ISO_TIMESTAMP}"
-  status: pending
-  session: "${SESSION}"
-  participants:
-${PARTICIPANTS_YAML}  decision: ""
+  created: "${ISO_TIMESTAMP}"
+  status: draft
+  composition:
+${COMPOSITION_YAML}  session_reference: "${SESSION}"
 ---
 
 # Council: ${TOPIC//-/ }
+
+## Decision Question
+
+[Clear, specific question being decided]
+
+## Options
+
+### Option 1: [Name]
+Brief description and trade-offs.
+
+### Option 2: [Name]
+Brief description and trade-offs.
 
 ## Context
 
 Why this council was convened.
 What problem or decision needed multiple perspectives.
-
-## Options Considered
-
-### Option A: [Name]
-Brief description and trade-offs.
-
-### Option B: [Name]
-Brief description and trade-offs.
 
 ## Agent Perspectives
 
@@ -112,15 +115,15 @@ done)
 
 ## Decision
 
-**Chosen**: [Pending user approval]
+[To be filled after user approval]
 
-## Rationale
+---
 
-[To be filled after deliberation]
+## Deliberation Log
 
-## Implementation Notes
-
-[To be filled after decision]
+### ${ISO_TIMESTAMP} - Council Convened
+Agents: ${PARTICIPANTS[*]}
+Composition selected by orchestrator.
 EOF
 
 echo "Created: $FILEPATH"

--- a/dist/codex/skills/orchestration/scripts/validate-council.py
+++ b/dist/codex/skills/orchestration/scripts/validate-council.py
@@ -57,26 +57,32 @@ def validate_frontmatter(fm: dict) -> list[str]:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Status follows the canonical council lifecycle (SPEC-049)
+    # Status follows the canonical council lifecycle (SPEC-049).
+    # Empty or null values are invalid, so validate whenever the key exists.
     valid_statuses = ['draft', 'done', 'archived']
-    if council.get('status') and council['status'] not in valid_statuses:
+    if 'status' in council and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 created timestamp
-    created = council.get('created', '')
-    if created:
-        try:
-            datetime.fromisoformat(created.replace('Z', '+00:00'))
-        except ValueError:
-            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
+    # Validate ISO 8601 created timestamp; YAML may parse an unquoted
+    # timestamp into a datetime already
+    if 'created' in council:
+        created = council['created']
+        if not isinstance(created, datetime):
+            try:
+                datetime.fromisoformat(str(created).replace('Z', '+00:00'))
+            except (TypeError, ValueError):
+                errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate composition
-    composition = council.get('composition', [])
-    if composition:
-        if len(composition) < 5:
-            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
-        if len(composition) % 2 == 0:
-            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
+    # Validate composition; an empty or non-list value fails
+    if 'composition' in council:
+        composition = council['composition']
+        if not isinstance(composition, list):
+            errors.append(f"council.composition must be a list of agents (got {type(composition).__name__})")
+        else:
+            if len(composition) < 5:
+                errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+            if len(composition) % 2 == 0:
+                errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
     # session_reference and linear_issue are optional free-form references
 

--- a/dist/codex/skills/orchestration/scripts/validate-council.py
+++ b/dist/codex/skills/orchestration/scripts/validate-council.py
@@ -51,39 +51,34 @@ def validate_frontmatter(fm: dict) -> list[str]:
         errors.append("Missing 'council' block in frontmatter")
         return errors
 
-    # Required council fields
-    required_fields = ['topic', 'timestamp', 'status', 'session', 'participants', 'decision']
+    # Required council fields — must match council/templates/council.md
+    required_fields = ['topic', 'created', 'status', 'composition']
     for field in required_fields:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Validate status values
-    valid_statuses = ['pending', 'approved', 'rejected', 'deferred']
+    # Status follows the canonical council lifecycle (SPEC-049)
+    valid_statuses = ['draft', 'done', 'archived']
     if council.get('status') and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 timestamp
-    timestamp = council.get('timestamp', '')
-    if timestamp:
+    # Validate ISO 8601 created timestamp
+    created = council.get('created', '')
+    if created:
         try:
-            datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+            datetime.fromisoformat(created.replace('Z', '+00:00'))
         except ValueError:
-            errors.append(f"Invalid ISO 8601 timestamp: {timestamp}")
+            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate participants
-    participants = council.get('participants', [])
-    if participants:
-        if len(participants) < 5:
-            errors.append(f"Council requires at least 5 participants (got {len(participants)})")
-        if len(participants) % 2 == 0:
-            errors.append(f"Council requires an ODD number of participants (got {len(participants)})")
+    # Validate composition
+    composition = council.get('composition', [])
+    if composition:
+        if len(composition) < 5:
+            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+        if len(composition) % 2 == 0:
+            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
-    # Validate session link (file should exist, but we just check format here)
-    session = council.get('session', '')
-    if session:
-        session_pattern = r'^\d{8}-\d{6}-[a-z0-9-]+$'
-        if not re.match(session_pattern, session):
-            errors.append(f"Invalid session reference format: {session}")
+    # session_reference and linear_issue are optional free-form references
 
     return errors
 
@@ -91,10 +86,12 @@ def validate_frontmatter(fm: dict) -> list[str]:
 def validate_sections(body: str) -> list[str]:
     """Validate required markdown sections."""
     errors = []
-    required_sections = ['## Context', '## Decision', '## Rationale']
+    required_sections = ['## Decision Question', '## Context', '## Agent Perspectives', '## Synthesis', '## Decision']
 
+    # Exact heading match so '## Decision Question' does not satisfy '## Decision'
+    headings = {line.strip() for line in body.splitlines() if line.strip().startswith('##')}
     for section in required_sections:
-        if section not in body:
+        if section not in headings:
             errors.append(f"Missing required section: {section}")
 
     return errors

--- a/dist/cursor/skills/council/templates/council.md
+++ b/dist/cursor/skills/council/templates/council.md
@@ -7,7 +7,7 @@
 council:
   topic: "[Clear decision description]"
   created: "[ISO timestamp]"
-  status: in_progress
+  status: draft  # draft | done | archived
   composition:
     - [agent1]
     - [agent2]

--- a/dist/cursor/skills/orchestration/scripts/new-council.sh
+++ b/dist/cursor/skills/orchestration/scripts/new-council.sh
@@ -47,39 +47,42 @@ if [[ -f "$FILEPATH" ]]; then
     exit 1
 fi
 
-# Build participants YAML
-PARTICIPANTS_YAML=""
+# Build composition YAML
+COMPOSITION_YAML=""
 for p in "${PARTICIPANTS[@]}"; do
-    PARTICIPANTS_YAML="${PARTICIPANTS_YAML}    - ${p}
+    COMPOSITION_YAML="${COMPOSITION_YAML}    - ${p}
 "
 done
 
-# Generate council file
+# Generate council file (shape must match council/templates/council.md)
 cat > "$FILEPATH" << EOF
 ---
 council:
   topic: "${TOPIC//-/ }"
-  timestamp: "${ISO_TIMESTAMP}"
-  status: pending
-  session: "${SESSION}"
-  participants:
-${PARTICIPANTS_YAML}  decision: ""
+  created: "${ISO_TIMESTAMP}"
+  status: draft
+  composition:
+${COMPOSITION_YAML}  session_reference: "${SESSION}"
 ---
 
 # Council: ${TOPIC//-/ }
+
+## Decision Question
+
+[Clear, specific question being decided]
+
+## Options
+
+### Option 1: [Name]
+Brief description and trade-offs.
+
+### Option 2: [Name]
+Brief description and trade-offs.
 
 ## Context
 
 Why this council was convened.
 What problem or decision needed multiple perspectives.
-
-## Options Considered
-
-### Option A: [Name]
-Brief description and trade-offs.
-
-### Option B: [Name]
-Brief description and trade-offs.
 
 ## Agent Perspectives
 
@@ -112,15 +115,15 @@ done)
 
 ## Decision
 
-**Chosen**: [Pending user approval]
+[To be filled after user approval]
 
-## Rationale
+---
 
-[To be filled after deliberation]
+## Deliberation Log
 
-## Implementation Notes
-
-[To be filled after decision]
+### ${ISO_TIMESTAMP} - Council Convened
+Agents: ${PARTICIPANTS[*]}
+Composition selected by orchestrator.
 EOF
 
 echo "Created: $FILEPATH"

--- a/dist/cursor/skills/orchestration/scripts/validate-council.py
+++ b/dist/cursor/skills/orchestration/scripts/validate-council.py
@@ -57,26 +57,32 @@ def validate_frontmatter(fm: dict) -> list[str]:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Status follows the canonical council lifecycle (SPEC-049)
+    # Status follows the canonical council lifecycle (SPEC-049).
+    # Empty or null values are invalid, so validate whenever the key exists.
     valid_statuses = ['draft', 'done', 'archived']
-    if council.get('status') and council['status'] not in valid_statuses:
+    if 'status' in council and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 created timestamp
-    created = council.get('created', '')
-    if created:
-        try:
-            datetime.fromisoformat(created.replace('Z', '+00:00'))
-        except ValueError:
-            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
+    # Validate ISO 8601 created timestamp; YAML may parse an unquoted
+    # timestamp into a datetime already
+    if 'created' in council:
+        created = council['created']
+        if not isinstance(created, datetime):
+            try:
+                datetime.fromisoformat(str(created).replace('Z', '+00:00'))
+            except (TypeError, ValueError):
+                errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate composition
-    composition = council.get('composition', [])
-    if composition:
-        if len(composition) < 5:
-            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
-        if len(composition) % 2 == 0:
-            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
+    # Validate composition; an empty or non-list value fails
+    if 'composition' in council:
+        composition = council['composition']
+        if not isinstance(composition, list):
+            errors.append(f"council.composition must be a list of agents (got {type(composition).__name__})")
+        else:
+            if len(composition) < 5:
+                errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+            if len(composition) % 2 == 0:
+                errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
     # session_reference and linear_issue are optional free-form references
 

--- a/dist/cursor/skills/orchestration/scripts/validate-council.py
+++ b/dist/cursor/skills/orchestration/scripts/validate-council.py
@@ -51,39 +51,34 @@ def validate_frontmatter(fm: dict) -> list[str]:
         errors.append("Missing 'council' block in frontmatter")
         return errors
 
-    # Required council fields
-    required_fields = ['topic', 'timestamp', 'status', 'session', 'participants', 'decision']
+    # Required council fields — must match council/templates/council.md
+    required_fields = ['topic', 'created', 'status', 'composition']
     for field in required_fields:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Validate status values
-    valid_statuses = ['pending', 'approved', 'rejected', 'deferred']
+    # Status follows the canonical council lifecycle (SPEC-049)
+    valid_statuses = ['draft', 'done', 'archived']
     if council.get('status') and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 timestamp
-    timestamp = council.get('timestamp', '')
-    if timestamp:
+    # Validate ISO 8601 created timestamp
+    created = council.get('created', '')
+    if created:
         try:
-            datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+            datetime.fromisoformat(created.replace('Z', '+00:00'))
         except ValueError:
-            errors.append(f"Invalid ISO 8601 timestamp: {timestamp}")
+            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate participants
-    participants = council.get('participants', [])
-    if participants:
-        if len(participants) < 5:
-            errors.append(f"Council requires at least 5 participants (got {len(participants)})")
-        if len(participants) % 2 == 0:
-            errors.append(f"Council requires an ODD number of participants (got {len(participants)})")
+    # Validate composition
+    composition = council.get('composition', [])
+    if composition:
+        if len(composition) < 5:
+            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+        if len(composition) % 2 == 0:
+            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
-    # Validate session link (file should exist, but we just check format here)
-    session = council.get('session', '')
-    if session:
-        session_pattern = r'^\d{8}-\d{6}-[a-z0-9-]+$'
-        if not re.match(session_pattern, session):
-            errors.append(f"Invalid session reference format: {session}")
+    # session_reference and linear_issue are optional free-form references
 
     return errors
 
@@ -91,10 +86,12 @@ def validate_frontmatter(fm: dict) -> list[str]:
 def validate_sections(body: str) -> list[str]:
     """Validate required markdown sections."""
     errors = []
-    required_sections = ['## Context', '## Decision', '## Rationale']
+    required_sections = ['## Decision Question', '## Context', '## Agent Perspectives', '## Synthesis', '## Decision']
 
+    # Exact heading match so '## Decision Question' does not satisfy '## Decision'
+    headings = {line.strip() for line in body.splitlines() if line.strip().startswith('##')}
     for section in required_sections:
-        if section not in body:
+        if section not in headings:
             errors.append(f"Missing required section: {section}")
 
     return errors

--- a/dist/opencode/skills/council/templates/council.md
+++ b/dist/opencode/skills/council/templates/council.md
@@ -7,7 +7,7 @@
 council:
   topic: "[Clear decision description]"
   created: "[ISO timestamp]"
-  status: in_progress
+  status: draft  # draft | done | archived
   composition:
     - [agent1]
     - [agent2]

--- a/dist/opencode/skills/orchestration/scripts/new-council.sh
+++ b/dist/opencode/skills/orchestration/scripts/new-council.sh
@@ -47,39 +47,42 @@ if [[ -f "$FILEPATH" ]]; then
     exit 1
 fi
 
-# Build participants YAML
-PARTICIPANTS_YAML=""
+# Build composition YAML
+COMPOSITION_YAML=""
 for p in "${PARTICIPANTS[@]}"; do
-    PARTICIPANTS_YAML="${PARTICIPANTS_YAML}    - ${p}
+    COMPOSITION_YAML="${COMPOSITION_YAML}    - ${p}
 "
 done
 
-# Generate council file
+# Generate council file (shape must match council/templates/council.md)
 cat > "$FILEPATH" << EOF
 ---
 council:
   topic: "${TOPIC//-/ }"
-  timestamp: "${ISO_TIMESTAMP}"
-  status: pending
-  session: "${SESSION}"
-  participants:
-${PARTICIPANTS_YAML}  decision: ""
+  created: "${ISO_TIMESTAMP}"
+  status: draft
+  composition:
+${COMPOSITION_YAML}  session_reference: "${SESSION}"
 ---
 
 # Council: ${TOPIC//-/ }
+
+## Decision Question
+
+[Clear, specific question being decided]
+
+## Options
+
+### Option 1: [Name]
+Brief description and trade-offs.
+
+### Option 2: [Name]
+Brief description and trade-offs.
 
 ## Context
 
 Why this council was convened.
 What problem or decision needed multiple perspectives.
-
-## Options Considered
-
-### Option A: [Name]
-Brief description and trade-offs.
-
-### Option B: [Name]
-Brief description and trade-offs.
 
 ## Agent Perspectives
 
@@ -112,15 +115,15 @@ done)
 
 ## Decision
 
-**Chosen**: [Pending user approval]
+[To be filled after user approval]
 
-## Rationale
+---
 
-[To be filled after deliberation]
+## Deliberation Log
 
-## Implementation Notes
-
-[To be filled after decision]
+### ${ISO_TIMESTAMP} - Council Convened
+Agents: ${PARTICIPANTS[*]}
+Composition selected by orchestrator.
 EOF
 
 echo "Created: $FILEPATH"

--- a/dist/opencode/skills/orchestration/scripts/validate-council.py
+++ b/dist/opencode/skills/orchestration/scripts/validate-council.py
@@ -57,26 +57,32 @@ def validate_frontmatter(fm: dict) -> list[str]:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Status follows the canonical council lifecycle (SPEC-049)
+    # Status follows the canonical council lifecycle (SPEC-049).
+    # Empty or null values are invalid, so validate whenever the key exists.
     valid_statuses = ['draft', 'done', 'archived']
-    if council.get('status') and council['status'] not in valid_statuses:
+    if 'status' in council and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 created timestamp
-    created = council.get('created', '')
-    if created:
-        try:
-            datetime.fromisoformat(created.replace('Z', '+00:00'))
-        except ValueError:
-            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
+    # Validate ISO 8601 created timestamp; YAML may parse an unquoted
+    # timestamp into a datetime already
+    if 'created' in council:
+        created = council['created']
+        if not isinstance(created, datetime):
+            try:
+                datetime.fromisoformat(str(created).replace('Z', '+00:00'))
+            except (TypeError, ValueError):
+                errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate composition
-    composition = council.get('composition', [])
-    if composition:
-        if len(composition) < 5:
-            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
-        if len(composition) % 2 == 0:
-            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
+    # Validate composition; an empty or non-list value fails
+    if 'composition' in council:
+        composition = council['composition']
+        if not isinstance(composition, list):
+            errors.append(f"council.composition must be a list of agents (got {type(composition).__name__})")
+        else:
+            if len(composition) < 5:
+                errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+            if len(composition) % 2 == 0:
+                errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
     # session_reference and linear_issue are optional free-form references
 

--- a/dist/opencode/skills/orchestration/scripts/validate-council.py
+++ b/dist/opencode/skills/orchestration/scripts/validate-council.py
@@ -51,39 +51,34 @@ def validate_frontmatter(fm: dict) -> list[str]:
         errors.append("Missing 'council' block in frontmatter")
         return errors
 
-    # Required council fields
-    required_fields = ['topic', 'timestamp', 'status', 'session', 'participants', 'decision']
+    # Required council fields — must match council/templates/council.md
+    required_fields = ['topic', 'created', 'status', 'composition']
     for field in required_fields:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Validate status values
-    valid_statuses = ['pending', 'approved', 'rejected', 'deferred']
+    # Status follows the canonical council lifecycle (SPEC-049)
+    valid_statuses = ['draft', 'done', 'archived']
     if council.get('status') and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 timestamp
-    timestamp = council.get('timestamp', '')
-    if timestamp:
+    # Validate ISO 8601 created timestamp
+    created = council.get('created', '')
+    if created:
         try:
-            datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+            datetime.fromisoformat(created.replace('Z', '+00:00'))
         except ValueError:
-            errors.append(f"Invalid ISO 8601 timestamp: {timestamp}")
+            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate participants
-    participants = council.get('participants', [])
-    if participants:
-        if len(participants) < 5:
-            errors.append(f"Council requires at least 5 participants (got {len(participants)})")
-        if len(participants) % 2 == 0:
-            errors.append(f"Council requires an ODD number of participants (got {len(participants)})")
+    # Validate composition
+    composition = council.get('composition', [])
+    if composition:
+        if len(composition) < 5:
+            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+        if len(composition) % 2 == 0:
+            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
-    # Validate session link (file should exist, but we just check format here)
-    session = council.get('session', '')
-    if session:
-        session_pattern = r'^\d{8}-\d{6}-[a-z0-9-]+$'
-        if not re.match(session_pattern, session):
-            errors.append(f"Invalid session reference format: {session}")
+    # session_reference and linear_issue are optional free-form references
 
     return errors
 
@@ -91,10 +86,12 @@ def validate_frontmatter(fm: dict) -> list[str]:
 def validate_sections(body: str) -> list[str]:
     """Validate required markdown sections."""
     errors = []
-    required_sections = ['## Context', '## Decision', '## Rationale']
+    required_sections = ['## Decision Question', '## Context', '## Agent Perspectives', '## Synthesis', '## Decision']
 
+    # Exact heading match so '## Decision Question' does not satisfy '## Decision'
+    headings = {line.strip() for line in body.splitlines() if line.strip().startswith('##')}
     for section in required_sections:
-        if section not in body:
+        if section not in headings:
             errors.append(f"Missing required section: {section}")
 
     return errors

--- a/dist/skills/council/templates/council.md
+++ b/dist/skills/council/templates/council.md
@@ -7,7 +7,7 @@
 council:
   topic: "[Clear decision description]"
   created: "[ISO timestamp]"
-  status: in_progress
+  status: draft  # draft | done | archived
   composition:
     - [agent1]
     - [agent2]

--- a/dist/skills/orchestration/scripts/new-council.sh
+++ b/dist/skills/orchestration/scripts/new-council.sh
@@ -47,39 +47,42 @@ if [[ -f "$FILEPATH" ]]; then
     exit 1
 fi
 
-# Build participants YAML
-PARTICIPANTS_YAML=""
+# Build composition YAML
+COMPOSITION_YAML=""
 for p in "${PARTICIPANTS[@]}"; do
-    PARTICIPANTS_YAML="${PARTICIPANTS_YAML}    - ${p}
+    COMPOSITION_YAML="${COMPOSITION_YAML}    - ${p}
 "
 done
 
-# Generate council file
+# Generate council file (shape must match council/templates/council.md)
 cat > "$FILEPATH" << EOF
 ---
 council:
   topic: "${TOPIC//-/ }"
-  timestamp: "${ISO_TIMESTAMP}"
-  status: pending
-  session: "${SESSION}"
-  participants:
-${PARTICIPANTS_YAML}  decision: ""
+  created: "${ISO_TIMESTAMP}"
+  status: draft
+  composition:
+${COMPOSITION_YAML}  session_reference: "${SESSION}"
 ---
 
 # Council: ${TOPIC//-/ }
+
+## Decision Question
+
+[Clear, specific question being decided]
+
+## Options
+
+### Option 1: [Name]
+Brief description and trade-offs.
+
+### Option 2: [Name]
+Brief description and trade-offs.
 
 ## Context
 
 Why this council was convened.
 What problem or decision needed multiple perspectives.
-
-## Options Considered
-
-### Option A: [Name]
-Brief description and trade-offs.
-
-### Option B: [Name]
-Brief description and trade-offs.
 
 ## Agent Perspectives
 
@@ -112,15 +115,15 @@ done)
 
 ## Decision
 
-**Chosen**: [Pending user approval]
+[To be filled after user approval]
 
-## Rationale
+---
 
-[To be filled after deliberation]
+## Deliberation Log
 
-## Implementation Notes
-
-[To be filled after decision]
+### ${ISO_TIMESTAMP} - Council Convened
+Agents: ${PARTICIPANTS[*]}
+Composition selected by orchestrator.
 EOF
 
 echo "Created: $FILEPATH"

--- a/dist/skills/orchestration/scripts/validate-council.py
+++ b/dist/skills/orchestration/scripts/validate-council.py
@@ -57,26 +57,32 @@ def validate_frontmatter(fm: dict) -> list[str]:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Status follows the canonical council lifecycle (SPEC-049)
+    # Status follows the canonical council lifecycle (SPEC-049).
+    # Empty or null values are invalid, so validate whenever the key exists.
     valid_statuses = ['draft', 'done', 'archived']
-    if council.get('status') and council['status'] not in valid_statuses:
+    if 'status' in council and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 created timestamp
-    created = council.get('created', '')
-    if created:
-        try:
-            datetime.fromisoformat(created.replace('Z', '+00:00'))
-        except ValueError:
-            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
+    # Validate ISO 8601 created timestamp; YAML may parse an unquoted
+    # timestamp into a datetime already
+    if 'created' in council:
+        created = council['created']
+        if not isinstance(created, datetime):
+            try:
+                datetime.fromisoformat(str(created).replace('Z', '+00:00'))
+            except (TypeError, ValueError):
+                errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate composition
-    composition = council.get('composition', [])
-    if composition:
-        if len(composition) < 5:
-            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
-        if len(composition) % 2 == 0:
-            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
+    # Validate composition; an empty or non-list value fails
+    if 'composition' in council:
+        composition = council['composition']
+        if not isinstance(composition, list):
+            errors.append(f"council.composition must be a list of agents (got {type(composition).__name__})")
+        else:
+            if len(composition) < 5:
+                errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+            if len(composition) % 2 == 0:
+                errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
     # session_reference and linear_issue are optional free-form references
 

--- a/dist/skills/orchestration/scripts/validate-council.py
+++ b/dist/skills/orchestration/scripts/validate-council.py
@@ -51,39 +51,34 @@ def validate_frontmatter(fm: dict) -> list[str]:
         errors.append("Missing 'council' block in frontmatter")
         return errors
 
-    # Required council fields
-    required_fields = ['topic', 'timestamp', 'status', 'session', 'participants', 'decision']
+    # Required council fields — must match council/templates/council.md
+    required_fields = ['topic', 'created', 'status', 'composition']
     for field in required_fields:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Validate status values
-    valid_statuses = ['pending', 'approved', 'rejected', 'deferred']
+    # Status follows the canonical council lifecycle (SPEC-049)
+    valid_statuses = ['draft', 'done', 'archived']
     if council.get('status') and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 timestamp
-    timestamp = council.get('timestamp', '')
-    if timestamp:
+    # Validate ISO 8601 created timestamp
+    created = council.get('created', '')
+    if created:
         try:
-            datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+            datetime.fromisoformat(created.replace('Z', '+00:00'))
         except ValueError:
-            errors.append(f"Invalid ISO 8601 timestamp: {timestamp}")
+            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate participants
-    participants = council.get('participants', [])
-    if participants:
-        if len(participants) < 5:
-            errors.append(f"Council requires at least 5 participants (got {len(participants)})")
-        if len(participants) % 2 == 0:
-            errors.append(f"Council requires an ODD number of participants (got {len(participants)})")
+    # Validate composition
+    composition = council.get('composition', [])
+    if composition:
+        if len(composition) < 5:
+            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+        if len(composition) % 2 == 0:
+            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
-    # Validate session link (file should exist, but we just check format here)
-    session = council.get('session', '')
-    if session:
-        session_pattern = r'^\d{8}-\d{6}-[a-z0-9-]+$'
-        if not re.match(session_pattern, session):
-            errors.append(f"Invalid session reference format: {session}")
+    # session_reference and linear_issue are optional free-form references
 
     return errors
 
@@ -91,10 +86,12 @@ def validate_frontmatter(fm: dict) -> list[str]:
 def validate_sections(body: str) -> list[str]:
     """Validate required markdown sections."""
     errors = []
-    required_sections = ['## Context', '## Decision', '## Rationale']
+    required_sections = ['## Decision Question', '## Context', '## Agent Perspectives', '## Synthesis', '## Decision']
 
+    # Exact heading match so '## Decision Question' does not satisfy '## Decision'
+    headings = {line.strip() for line in body.splitlines() if line.strip().startswith('##')}
     for section in required_sections:
-        if section not in body:
+        if section not in headings:
             errors.append(f"Missing required section: {section}")
 
     return errors

--- a/internal/cli/council_contract_test.go
+++ b/internal/cli/council_contract_test.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 // councilValidatorContract holds the requirement literals declared in
@@ -35,8 +37,13 @@ func TestCouncilTemplateSatisfiesValidatorContract(t *testing.T) {
 	doc := parseCouncilDocument(t, fencedCouncilBlock(t, readCouncilContractFile(t, templatePath)))
 
 	for _, field := range contract.requiredFields {
-		if _, ok := doc.fields[field]; !ok {
+		value, ok := doc.fields[field]
+		if !ok {
 			t.Errorf("council template frontmatter is missing field %q required by validate-council.py", field)
+			continue
+		}
+		if field != "composition" && value == "" {
+			t.Errorf("council template frontmatter field %q is empty; validate-council.py rejects empty values", field)
 		}
 	}
 
@@ -77,12 +84,92 @@ func TestNewCouncilScaffoldSatisfiesValidatorContract(t *testing.T) {
 		t.Errorf("new-council.sh scaffold status %q is not accepted by validate-council.py (valid: %v)", status, contract.validStatuses)
 	}
 
-	// Composition entries are interpolated at runtime; the scaffold itself
-	// enforces the >=5 and odd participant checks before writing the file.
+	// Composition entries are interpolated at runtime;
+	// TestNewCouncilScaffoldOutputSatisfiesValidatorContract runs the script
+	// and validates the generated file including the composition list.
 
 	for _, section := range contract.requiredSections {
 		if !doc.headings[section] {
 			t.Errorf("new-council.sh scaffold body is missing section %q required by validate-council.py", section)
+		}
+	}
+}
+
+// TestNewCouncilScaffoldOutputSatisfiesValidatorContract executes
+// new-council.sh and validates the file it actually writes, so regressions in
+// runtime interpolation (not just the heredoc text) are caught.
+func TestNewCouncilScaffoldOutputSatisfiesValidatorContract(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("new-council.sh requires bash")
+	}
+	root := councilContractRepoRoot(t)
+	contract := readCouncilValidatorContract(t, root)
+	scriptPath := filepath.Join(root, "content", "skills", "orchestration", "scripts", "new-council.sh")
+
+	workDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workDir, ".agents", "councils"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	agents := []string{"agent-one", "agent-two", "agent-three", "agent-four", "agent-five"}
+	cmd := exec.Command("bash", append([]string{scriptPath, "test-topic", "20260101-000000-session"}, agents...)...)
+	cmd.Dir = workDir
+	// Keep loaf off PATH so the scaffold skips its session-existence check.
+	cmd.Env = []string{"PATH=/usr/bin:/bin"}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("new-council.sh error = %v\noutput:\n%s", err, output)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(workDir, ".agents", "councils"))
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 generated council file, got %d", len(entries))
+	}
+
+	filename := entries[0].Name()
+	filenamePattern := councilValidatorFilenamePattern(t, root)
+	if !regexp.MustCompile(filenamePattern).MatchString(filename) {
+		t.Errorf("generated filename %q does not match validate-council.py pattern %q", filename, filenamePattern)
+	}
+
+	generated := readCouncilContractFile(t, filepath.Join(workDir, ".agents", "councils", filename))
+	doc := parseCouncilDocument(t, generated)
+
+	for _, field := range contract.requiredFields {
+		value, ok := doc.fields[field]
+		if !ok {
+			t.Errorf("generated council file is missing field %q required by validate-council.py", field)
+			continue
+		}
+		if field != "composition" && value == "" {
+			t.Errorf("generated council file field %q is empty; validate-council.py rejects empty values", field)
+		}
+	}
+
+	status := doc.fields["status"]
+	if !slices.Contains(contract.validStatuses, status) {
+		t.Errorf("generated council file status %q is not accepted by validate-council.py (valid: %v)", status, contract.validStatuses)
+	}
+
+	if created := doc.fields["created"]; created != "" {
+		if _, err := time.Parse(time.RFC3339, created); err != nil {
+			t.Errorf("generated council file created %q is not ISO 8601: %v", created, err)
+		}
+	}
+
+	if doc.composition != len(agents) {
+		t.Errorf("generated council file has %d composition entries, want %d", doc.composition, len(agents))
+	}
+	if doc.composition < 5 || doc.composition%2 == 0 {
+		t.Errorf("generated council file composition count %d violates the >=5 odd rule", doc.composition)
+	}
+
+	for _, section := range contract.requiredSections {
+		if !doc.headings[section] {
+			t.Errorf("generated council file is missing section %q required by validate-council.py", section)
 		}
 	}
 }
@@ -113,6 +200,18 @@ func readCouncilValidatorContract(t *testing.T, root string) councilValidatorCon
 		validStatuses:    councilPythonListLiteral(t, source, "valid_statuses"),
 		requiredSections: councilPythonListLiteral(t, source, "required_sections"),
 	}
+}
+
+// councilValidatorFilenamePattern extracts the filename regex literal from
+// validate-council.py so the exec test checks against the same rule.
+func councilValidatorFilenamePattern(t *testing.T, root string) string {
+	t.Helper()
+	source := readCouncilContractFile(t, filepath.Join(root, "content", "skills", "orchestration", "scripts", "validate-council.py"))
+	match := regexp.MustCompile(`pattern\s*=\s*r'(\^[^']+)'`).FindStringSubmatch(source)
+	if match == nil {
+		t.Fatal("validate-council.py no longer declares the filename pattern as a raw-string literal")
+	}
+	return match[1]
 }
 
 func councilPythonListLiteral(t *testing.T, source, name string) []string {

--- a/internal/cli/council_contract_test.go
+++ b/internal/cli/council_contract_test.go
@@ -1,0 +1,211 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// councilValidatorContract holds the requirement literals declared in
+// content/skills/orchestration/scripts/validate-council.py.
+type councilValidatorContract struct {
+	requiredFields   []string
+	validStatuses    []string
+	requiredSections []string
+}
+
+// councilDocument is the parsed shape of a council markdown file: its
+// frontmatter fields under the council block, the number of composition
+// entries, and the exact section headings in the body.
+type councilDocument struct {
+	fields      map[string]string
+	composition int
+	headings    map[string]bool
+}
+
+func TestCouncilTemplateSatisfiesValidatorContract(t *testing.T) {
+	root := councilContractRepoRoot(t)
+	contract := readCouncilValidatorContract(t, root)
+
+	templatePath := filepath.Join(root, "content", "skills", "council", "templates", "council.md")
+	doc := parseCouncilDocument(t, fencedCouncilBlock(t, readCouncilContractFile(t, templatePath)))
+
+	for _, field := range contract.requiredFields {
+		if _, ok := doc.fields[field]; !ok {
+			t.Errorf("council template frontmatter is missing field %q required by validate-council.py", field)
+		}
+	}
+
+	status := doc.fields["status"]
+	if !slices.Contains(contract.validStatuses, status) {
+		t.Errorf("council template status %q is not accepted by validate-council.py (valid: %v)", status, contract.validStatuses)
+	}
+
+	if doc.composition < 5 {
+		t.Errorf("council template composition has %d entries; validate-council.py requires at least 5", doc.composition)
+	}
+	if doc.composition%2 == 0 {
+		t.Errorf("council template composition has %d entries; validate-council.py requires an odd count", doc.composition)
+	}
+
+	for _, section := range contract.requiredSections {
+		if !doc.headings[section] {
+			t.Errorf("council template body is missing section %q required by validate-council.py", section)
+		}
+	}
+}
+
+func TestNewCouncilScaffoldSatisfiesValidatorContract(t *testing.T) {
+	root := councilContractRepoRoot(t)
+	contract := readCouncilValidatorContract(t, root)
+
+	scriptPath := filepath.Join(root, "content", "skills", "orchestration", "scripts", "new-council.sh")
+	doc := parseCouncilDocument(t, councilScaffoldHeredoc(t, readCouncilContractFile(t, scriptPath)))
+
+	for _, field := range contract.requiredFields {
+		if _, ok := doc.fields[field]; !ok {
+			t.Errorf("new-council.sh scaffold frontmatter is missing field %q required by validate-council.py", field)
+		}
+	}
+
+	status := doc.fields["status"]
+	if !slices.Contains(contract.validStatuses, status) {
+		t.Errorf("new-council.sh scaffold status %q is not accepted by validate-council.py (valid: %v)", status, contract.validStatuses)
+	}
+
+	// Composition entries are interpolated at runtime; the scaffold itself
+	// enforces the >=5 and odd participant checks before writing the file.
+
+	for _, section := range contract.requiredSections {
+		if !doc.headings[section] {
+			t.Errorf("new-council.sh scaffold body is missing section %q required by validate-council.py", section)
+		}
+	}
+}
+
+func councilContractRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller() failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+}
+
+func readCouncilContractFile(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	return string(body)
+}
+
+func readCouncilValidatorContract(t *testing.T, root string) councilValidatorContract {
+	t.Helper()
+	source := readCouncilContractFile(t, filepath.Join(root, "content", "skills", "orchestration", "scripts", "validate-council.py"))
+	return councilValidatorContract{
+		requiredFields:   councilPythonListLiteral(t, source, "required_fields"),
+		validStatuses:    councilPythonListLiteral(t, source, "valid_statuses"),
+		requiredSections: councilPythonListLiteral(t, source, "required_sections"),
+	}
+}
+
+func councilPythonListLiteral(t *testing.T, source, name string) []string {
+	t.Helper()
+	listPattern := regexp.MustCompile(name + `\s*=\s*\[([^\]]*)\]`)
+	match := listPattern.FindStringSubmatch(source)
+	if match == nil {
+		t.Fatalf("validate-council.py no longer declares %s as a list literal", name)
+	}
+	var items []string
+	for _, item := range regexp.MustCompile(`'([^']*)'`).FindAllStringSubmatch(match[1], -1) {
+		items = append(items, item[1])
+	}
+	if len(items) == 0 {
+		t.Fatalf("no items parsed from %s in validate-council.py", name)
+	}
+	return items
+}
+
+// fencedCouncilBlock extracts the council file inside the template's fenced
+// yaml code block.
+func fencedCouncilBlock(t *testing.T, template string) string {
+	t.Helper()
+	const fence = "```yaml\n"
+	start := strings.Index(template, fence)
+	if start == -1 {
+		t.Fatal("council template has no ```yaml fenced block")
+	}
+	block := template[start+len(fence):]
+	end := strings.Index(block, "\n```")
+	if end == -1 {
+		t.Fatal("council template fenced block is not closed")
+	}
+	return block[:end]
+}
+
+// councilScaffoldHeredoc extracts the council file heredoc that new-council.sh
+// writes.
+func councilScaffoldHeredoc(t *testing.T, script string) string {
+	t.Helper()
+	const open = "<< EOF\n"
+	start := strings.Index(script, open)
+	if start == -1 {
+		t.Fatal("new-council.sh has no << EOF heredoc")
+	}
+	block := script[start+len(open):]
+	end := strings.Index(block, "\nEOF")
+	if end == -1 {
+		t.Fatal("new-council.sh heredoc is not closed")
+	}
+	return block[:end]
+}
+
+func parseCouncilDocument(t *testing.T, doc string) councilDocument {
+	t.Helper()
+	lines := strings.Split(doc, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		t.Fatalf("council document does not start with frontmatter delimiter, got %q", lines[0])
+	}
+	frontmatterEnd := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			frontmatterEnd = i
+			break
+		}
+	}
+	if frontmatterEnd == -1 {
+		t.Fatal("council document frontmatter is not closed")
+	}
+
+	parsed := councilDocument{fields: map[string]string{}, headings: map[string]bool{}}
+	fieldPattern := regexp.MustCompile(`^  ([a-z_]+):(.*)$`)
+	compositionEntry := regexp.MustCompile(`^    - `)
+	inComposition := false
+	for _, line := range lines[1:frontmatterEnd] {
+		if inComposition && compositionEntry.MatchString(line) {
+			parsed.composition++
+			continue
+		}
+		inComposition = false
+		if match := fieldPattern.FindStringSubmatch(line); match != nil {
+			key := match[1]
+			value := strings.SplitN(match[2], "#", 2)[0]
+			parsed.fields[key] = strings.Trim(strings.TrimSpace(value), `"`)
+			inComposition = key == "composition"
+		}
+	}
+
+	for _, line := range lines[frontmatterEnd+1:] {
+		heading := strings.TrimSpace(line)
+		if strings.HasPrefix(heading, "##") {
+			parsed.headings[heading] = true
+		}
+	}
+	return parsed
+}

--- a/internal/cli/release_dry_run.go
+++ b/internal/cli/release_dry_run.go
@@ -247,6 +247,7 @@ func runReleaseDryRun(root string, options releaseOptions, out io.Writer, errOut
 	}
 	if len(commits) == 0 {
 		fmt.Fprintf(out, "  %s\n\n", ansiGray("No unreleased changes found."))
+		return nil
 	}
 	for _, commit := range commits {
 		if commit.Section == "" {

--- a/internal/cli/release_test.go
+++ b/internal/cli/release_test.go
@@ -323,6 +323,39 @@ func TestRunnerReleaseDryRunIsNative(t *testing.T) {
 	}
 }
 
+func TestRunnerReleaseDryRunStopsWhenNoUnreleasedChanges(t *testing.T) {
+	repo := seedReleaseTaggedRepo(t)
+	var stdout bytes.Buffer
+
+	err := Runner{
+		Stdout:     &stdout,
+		WorkingDir: repo,
+	}.Run([]string{"release", "--dry-run"})
+	if err != nil {
+		t.Fatalf("release --dry-run error = %v\n%s", err, stdout.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"Commits since tag:",
+		"No unreleased changes found.",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("stdout = %q, want %q", output, want)
+		}
+	}
+	for _, unwanted := range []string{
+		"Generated changelog:",
+		"Version files:",
+		"Suggested bump:",
+		"New version:",
+		"Actions:",
+	} {
+		if strings.Contains(output, unwanted) {
+			t.Fatalf("stdout = %q, did not want %q for empty release range", output, unwanted)
+		}
+	}
+}
+
 func TestRunnerReleaseDryRunValidatesFlagsNatively(t *testing.T) {
 	repo := seedReleaseDryRunRepo(t, "fix: keep validation native")
 	err := Runner{
@@ -385,7 +418,7 @@ func TestRunnerReleaseDryRunNormalizesSkipFlagsNatively(t *testing.T) {
 
 func TestRunnerReleaseDryRunPreMergeOverridesAreNative(t *testing.T) {
 	repo := seedReleaseDryRunRepo(t, "fix: prepare release branch natively")
-	gitCLI(t, repo, "config", "loaf.release.base", "HEAD")
+	gitCLI(t, repo, "config", "loaf.release.base", "v1.0.0")
 
 	tests := []struct {
 		name       string
@@ -401,19 +434,19 @@ func TestRunnerReleaseDryRunPreMergeOverridesAreNative(t *testing.T) {
 		},
 		{
 			name:       "tag override",
-			args:       []string{"release", "--dry-run", "--pre-merge", "--tag", "--base", "HEAD"},
+			args:       []string{"release", "--dry-run", "--pre-merge", "--tag", "--base", "v1.0.0"},
 			wantErr:    []string{"--tag overrides --pre-merge default"},
 			wantOut:    []string{"--no-gh — skipped"},
 			notWantOut: []string{"--no-tag — skipped"},
 		},
 		{
 			name:    "gh override warning",
-			args:    []string{"release", "--dry-run", "--pre-merge", "--gh", "--base", "HEAD"},
+			args:    []string{"release", "--dry-run", "--pre-merge", "--gh", "--base", "v1.0.0"},
 			wantErr: []string{"--gh overrides --pre-merge default"},
 		},
 		{
 			name:       "tag and gh override",
-			args:       []string{"release", "--dry-run", "--pre-merge", "--tag", "--gh", "--base", "HEAD"},
+			args:       []string{"release", "--dry-run", "--pre-merge", "--tag", "--gh", "--base", "v1.0.0"},
 			wantErr:    []string{"--tag overrides --pre-merge default", "--gh overrides --pre-merge default"},
 			notWantOut: []string{"--no-tag — skipped", "--no-gh — skipped"},
 		},
@@ -601,6 +634,15 @@ func TestRunnerReleaseRefusesUnignoredVirtualenvFromUvSyncNatively(t *testing.T)
 
 func seedReleaseDryRunRepo(t *testing.T, commitSubject string) string {
 	t.Helper()
+	repo := seedReleaseTaggedRepo(t)
+	writeFile(t, filepath.Join(repo, "feature.txt"), commitSubject+"\n")
+	gitCLI(t, repo, "add", "feature.txt")
+	gitCLI(t, repo, "commit", "-m", commitSubject)
+	return repo
+}
+
+func seedReleaseTaggedRepo(t *testing.T) string {
+	t.Helper()
 	repo := realpath(t, t.TempDir())
 	gitCLI(t, repo, "init", "-b", "main")
 	gitCLI(t, repo, "config", "user.name", "Loaf Test")
@@ -619,9 +661,6 @@ func seedReleaseDryRunRepo(t *testing.T, commitSubject string) string {
 	gitCLI(t, repo, "add", ".")
 	gitCLI(t, repo, "commit", "-m", "chore: initial release")
 	gitCLI(t, repo, "tag", "v1.0.0")
-	writeFile(t, filepath.Join(repo, "feature.txt"), commitSubject+"\n")
-	gitCLI(t, repo, "add", "feature.txt")
-	gitCLI(t, repo, "commit", "-m", commitSubject)
 	return repo
 }
 

--- a/internal/state/status.go
+++ b/internal/state/status.go
@@ -767,7 +767,7 @@ WHERE origin IS NULL OR TRIM(origin) = ''
 	unknownRows, err := store.db.QueryContext(ctx, `
 SELECT origin, COUNT(*)
 FROM relationships
-WHERE origin IS NOT NULL AND TRIM(origin) != '' AND origin NOT IN ('imported', 'manual')
+WHERE origin IS NOT NULL AND TRIM(origin) != '' AND origin NOT IN ('imported', 'manual', 'command')
 GROUP BY origin
 ORDER BY origin
 `)

--- a/internal/state/status_test.go
+++ b/internal/state/status_test.go
@@ -613,6 +613,30 @@ VALUES ('relationship-without-origin', ?, 'task', 'task-one', 'spec', 'spec-one'
 	}
 }
 
+func TestInspectAcceptsCommandRelationshipOrigin(t *testing.T) {
+	root := projectRoot(t)
+	stateHome := t.TempDir()
+	if _, err := Initialize(context.Background(), root, PathResolver{StateHome: stateHome}); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	store := openTestStore(t, root, stateHome)
+	defer store.Close()
+
+	projectID := projectIDForTest(t, store, root)
+	if _, err := store.db.ExecContext(context.Background(), `
+	INSERT INTO relationships (id, project_id, from_entity_kind, from_entity_id, to_entity_kind, to_entity_id, relationship_type, reason, origin, created_at, updated_at)
+	VALUES ('relationship-from-command', ?, 'task', 'task-one', 'spec', 'spec-one', 'implements', 'recorded by task create', 'command', '2026-06-13T10:00:00Z', '2026-06-13T10:00:00Z')
+	`, projectID); err != nil {
+		t.Fatalf("insert command relationship error = %v", err)
+	}
+
+	status, err := Inspect(root, PathResolver{StateHome: stateHome})
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	assertNoDiagnostic(t, status.Diagnostics, "relationship-origin-unknown")
+}
+
 func TestInspectReportsInvalidBackendMappingMissingEntity(t *testing.T) {
 	root := projectRoot(t)
 	stateHome := t.TempDir()

--- a/plugins/loaf/skills/council/templates/council.md
+++ b/plugins/loaf/skills/council/templates/council.md
@@ -7,7 +7,7 @@
 council:
   topic: "[Clear decision description]"
   created: "[ISO timestamp]"
-  status: in_progress
+  status: draft  # draft | done | archived
   composition:
     - [agent1]
     - [agent2]

--- a/plugins/loaf/skills/orchestration/scripts/new-council.sh
+++ b/plugins/loaf/skills/orchestration/scripts/new-council.sh
@@ -47,39 +47,42 @@ if [[ -f "$FILEPATH" ]]; then
     exit 1
 fi
 
-# Build participants YAML
-PARTICIPANTS_YAML=""
+# Build composition YAML
+COMPOSITION_YAML=""
 for p in "${PARTICIPANTS[@]}"; do
-    PARTICIPANTS_YAML="${PARTICIPANTS_YAML}    - ${p}
+    COMPOSITION_YAML="${COMPOSITION_YAML}    - ${p}
 "
 done
 
-# Generate council file
+# Generate council file (shape must match council/templates/council.md)
 cat > "$FILEPATH" << EOF
 ---
 council:
   topic: "${TOPIC//-/ }"
-  timestamp: "${ISO_TIMESTAMP}"
-  status: pending
-  session: "${SESSION}"
-  participants:
-${PARTICIPANTS_YAML}  decision: ""
+  created: "${ISO_TIMESTAMP}"
+  status: draft
+  composition:
+${COMPOSITION_YAML}  session_reference: "${SESSION}"
 ---
 
 # Council: ${TOPIC//-/ }
+
+## Decision Question
+
+[Clear, specific question being decided]
+
+## Options
+
+### Option 1: [Name]
+Brief description and trade-offs.
+
+### Option 2: [Name]
+Brief description and trade-offs.
 
 ## Context
 
 Why this council was convened.
 What problem or decision needed multiple perspectives.
-
-## Options Considered
-
-### Option A: [Name]
-Brief description and trade-offs.
-
-### Option B: [Name]
-Brief description and trade-offs.
 
 ## Agent Perspectives
 
@@ -112,15 +115,15 @@ done)
 
 ## Decision
 
-**Chosen**: [Pending user approval]
+[To be filled after user approval]
 
-## Rationale
+---
 
-[To be filled after deliberation]
+## Deliberation Log
 
-## Implementation Notes
-
-[To be filled after decision]
+### ${ISO_TIMESTAMP} - Council Convened
+Agents: ${PARTICIPANTS[*]}
+Composition selected by orchestrator.
 EOF
 
 echo "Created: $FILEPATH"

--- a/plugins/loaf/skills/orchestration/scripts/validate-council.py
+++ b/plugins/loaf/skills/orchestration/scripts/validate-council.py
@@ -57,26 +57,32 @@ def validate_frontmatter(fm: dict) -> list[str]:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Status follows the canonical council lifecycle (SPEC-049)
+    # Status follows the canonical council lifecycle (SPEC-049).
+    # Empty or null values are invalid, so validate whenever the key exists.
     valid_statuses = ['draft', 'done', 'archived']
-    if council.get('status') and council['status'] not in valid_statuses:
+    if 'status' in council and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 created timestamp
-    created = council.get('created', '')
-    if created:
-        try:
-            datetime.fromisoformat(created.replace('Z', '+00:00'))
-        except ValueError:
-            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
+    # Validate ISO 8601 created timestamp; YAML may parse an unquoted
+    # timestamp into a datetime already
+    if 'created' in council:
+        created = council['created']
+        if not isinstance(created, datetime):
+            try:
+                datetime.fromisoformat(str(created).replace('Z', '+00:00'))
+            except (TypeError, ValueError):
+                errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate composition
-    composition = council.get('composition', [])
-    if composition:
-        if len(composition) < 5:
-            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
-        if len(composition) % 2 == 0:
-            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
+    # Validate composition; an empty or non-list value fails
+    if 'composition' in council:
+        composition = council['composition']
+        if not isinstance(composition, list):
+            errors.append(f"council.composition must be a list of agents (got {type(composition).__name__})")
+        else:
+            if len(composition) < 5:
+                errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+            if len(composition) % 2 == 0:
+                errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
     # session_reference and linear_issue are optional free-form references
 

--- a/plugins/loaf/skills/orchestration/scripts/validate-council.py
+++ b/plugins/loaf/skills/orchestration/scripts/validate-council.py
@@ -51,39 +51,34 @@ def validate_frontmatter(fm: dict) -> list[str]:
         errors.append("Missing 'council' block in frontmatter")
         return errors
 
-    # Required council fields
-    required_fields = ['topic', 'timestamp', 'status', 'session', 'participants', 'decision']
+    # Required council fields — must match council/templates/council.md
+    required_fields = ['topic', 'created', 'status', 'composition']
     for field in required_fields:
         if field not in council:
             errors.append(f"Missing required field: council.{field}")
 
-    # Validate status values
-    valid_statuses = ['pending', 'approved', 'rejected', 'deferred']
+    # Status follows the canonical council lifecycle (SPEC-049)
+    valid_statuses = ['draft', 'done', 'archived']
     if council.get('status') and council['status'] not in valid_statuses:
         errors.append(f"Invalid council.status: {council['status']} (must be one of: {', '.join(valid_statuses)})")
 
-    # Validate ISO 8601 timestamp
-    timestamp = council.get('timestamp', '')
-    if timestamp:
+    # Validate ISO 8601 created timestamp
+    created = council.get('created', '')
+    if created:
         try:
-            datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+            datetime.fromisoformat(created.replace('Z', '+00:00'))
         except ValueError:
-            errors.append(f"Invalid ISO 8601 timestamp: {timestamp}")
+            errors.append(f"Invalid ISO 8601 created timestamp: {created}")
 
-    # Validate participants
-    participants = council.get('participants', [])
-    if participants:
-        if len(participants) < 5:
-            errors.append(f"Council requires at least 5 participants (got {len(participants)})")
-        if len(participants) % 2 == 0:
-            errors.append(f"Council requires an ODD number of participants (got {len(participants)})")
+    # Validate composition
+    composition = council.get('composition', [])
+    if composition:
+        if len(composition) < 5:
+            errors.append(f"Council requires at least 5 agents in composition (got {len(composition)})")
+        if len(composition) % 2 == 0:
+            errors.append(f"Council requires an ODD number of agents in composition (got {len(composition)})")
 
-    # Validate session link (file should exist, but we just check format here)
-    session = council.get('session', '')
-    if session:
-        session_pattern = r'^\d{8}-\d{6}-[a-z0-9-]+$'
-        if not re.match(session_pattern, session):
-            errors.append(f"Invalid session reference format: {session}")
+    # session_reference and linear_issue are optional free-form references
 
     return errors
 
@@ -91,10 +86,12 @@ def validate_frontmatter(fm: dict) -> list[str]:
 def validate_sections(body: str) -> list[str]:
     """Validate required markdown sections."""
     errors = []
-    required_sections = ['## Context', '## Decision', '## Rationale']
+    required_sections = ['## Decision Question', '## Context', '## Agent Perspectives', '## Synthesis', '## Decision']
 
+    # Exact heading match so '## Decision Question' does not satisfy '## Decision'
+    headings = {line.strip() for line in body.splitlines() if line.strip().startswith('##')}
     for section in required_sections:
-        if section not in body:
+        if section not in headings:
             errors.append(f"Missing required section: {section}")
 
     return errors


### PR DESCRIPTION
## Summary

`validate-council.py` and the council skill's template disagreed on the council file contract, and `new-council.sh` scaffolded a third variant. This PR converges all three surfaces on one contract and adds a test so they cannot drift again.

- **Field names follow the template** (`content/skills/council/templates/council.md`), since the council skill points agents at it for creating council files: `topic` / `created` / `status` / `composition`, with `session_reference` optional. The validator's old `timestamp` / `session` / `participants` / `decision` requirements are gone.
- **Status follows the canonical SPEC-049 lifecycle registry** (`internal/state/lifecycle_status.go`): councils allow `draft` / `done` / `archived`. Neither surface matched it before — the validator demanded `pending/approved/rejected/deferred` and the template emitted `in_progress` (invalid per the registry); the template now starts at `draft`.
- **`new-council.sh`** emits the template shape instead of the old frontmatter, with body sections matching the template.
- **Required sections** are now `Decision Question` / `Context` / `Agent Perspectives` / `Synthesis` / `Decision`, matched as exact headings — the old substring check let `## Decision Question` satisfy a missing `## Decision`.
- **New contract test** (`internal/cli/council_contract_test.go`) parses the validator's requirement literals and checks them against the template's fenced frontmatter and the scaffold's heredoc. Pure Go by design: the validator needs PyYAML, which is absent locally and in CI, so an exec-based test would always skip. (PyYAML dependency for the skill scripts is being fixed separately.)
- `plugins/` and `dist/` regenerated via `npm run build`.

## Verification

- `go test ./internal/cli/` passes, including the two new contract tests.
- Mutation-checked the guard: restoring the old template makes the test fail with `status "in_progress" is not accepted`.
- `python3 -m py_compile` / `bash -n` pass on the changed scripts.
- Full `go test ./...` has one pre-existing environmental failure (`TestSessionModelConvergenceAnointsWrapInTopLevelGuidance` reads `.agents/AGENTS.md`, absent in worktrees); unrelated to this change.