### PR TITLE
fix: generate audit-safe Homebrew formula

### DIFF
--- a/cli/scripts/update-homebrew-formula.mjs
+++ b/cli/scripts/update-homebrew-formula.mjs
@@ -27,27 +27,26 @@ function formula(versionValue, repoValue, values) {
   return `class Loaf < Formula
   desc "Opinionated agentic framework for AI coding assistants"
   homepage "https://github.com/${repoValue}"
-  version "${versionValue}"
   license "MIT"
 
   depends_on "git"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/${repoValue}/releases/download/v#{version}/loaf_#{version}_darwin-arm64.tar.gz"
+      url "https://github.com/${repoValue}/releases/download/v${versionValue}/loaf_${versionValue}_darwin-arm64.tar.gz"
       sha256 "${values["darwin-arm64"]}"
     else
-      url "https://github.com/${repoValue}/releases/download/v#{version}/loaf_#{version}_darwin-x64.tar.gz"
+      url "https://github.com/${repoValue}/releases/download/v${versionValue}/loaf_${versionValue}_darwin-x64.tar.gz"
       sha256 "${values["darwin-x64"]}"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/${repoValue}/releases/download/v#{version}/loaf_#{version}_linux-arm64.tar.gz"
+      url "https://github.com/${repoValue}/releases/download/v${versionValue}/loaf_${versionValue}_linux-arm64.tar.gz"
       sha256 "${values["linux-arm64"]}"
     else
-      url "https://github.com/${repoValue}/releases/download/v#{version}/loaf_#{version}_linux-x64.tar.gz"
+      url "https://github.com/${repoValue}/releases/download/v${versionValue}/loaf_${versionValue}_linux-x64.tar.gz"
       sha256 "${values["linux-x64"]}"
     end
   end

--- a/cmd/loaf/native_cutover_files_test.go
+++ b/cmd/loaf/native_cutover_files_test.go
@@ -241,6 +241,69 @@ func TestNativeGoReleaseBuildUsesPublishTargetPolicy(t *testing.T) {
 	}
 }
 
+func TestHomebrewFormulaUpdaterGeneratesAuditSafePrereleaseURLs(t *testing.T) {
+	node := requireNode(t)
+	root := repoRoot(t)
+	tempDir := t.TempDir()
+	formulaPath := filepath.Join(tempDir, "loaf.rb")
+	checksumsPath := filepath.Join(tempDir, "checksums.txt")
+	version := "2.0.0-alpha.4"
+	checksums := map[string]string{
+		"darwin-arm64": strings.Repeat("a", 64),
+		"darwin-x64":   strings.Repeat("b", 64),
+		"linux-arm64":  strings.Repeat("c", 64),
+		"linux-x64":    strings.Repeat("d", 64),
+	}
+	checksumLines := []string{
+		checksums["darwin-arm64"] + "  loaf_" + version + "_darwin-arm64.tar.gz",
+		checksums["darwin-x64"] + "  loaf_" + version + "_darwin-x64.tar.gz",
+		checksums["linux-arm64"] + "  loaf_" + version + "_linux-arm64.tar.gz",
+		checksums["linux-x64"] + "  loaf_" + version + "_linux-x64.tar.gz",
+	}
+	if err := os.WriteFile(checksumsPath, []byte(strings.Join(checksumLines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(checksums.txt) error = %v", err)
+	}
+
+	output, err := runNodeScriptArgs(t, node, root, nil, "cli/scripts/update-homebrew-formula.mjs",
+		"--formula", formulaPath,
+		"--checksums", checksumsPath,
+		"--version", version,
+	)
+	if err != nil {
+		t.Fatalf("update-homebrew-formula error = %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "Updated "+formulaPath) || !strings.Contains(output, "Loaf "+version) {
+		t.Fatalf("update-homebrew-formula output = %q, want successful update message", output)
+	}
+
+	data, err := os.ReadFile(formulaPath)
+	if err != nil {
+		t.Fatalf("ReadFile(generated formula) error = %v", err)
+	}
+	formula := string(data)
+	for _, forbidden := range []string{`version "`, "#{version}"} {
+		if strings.Contains(formula, forbidden) {
+			t.Fatalf("generated formula contains %q:\n%s", forbidden, formula)
+		}
+	}
+	for _, want := range []string{
+		`url "https://github.com/levifig/loaf/releases/download/v2.0.0-alpha.4/loaf_2.0.0-alpha.4_darwin-arm64.tar.gz"`,
+		`url "https://github.com/levifig/loaf/releases/download/v2.0.0-alpha.4/loaf_2.0.0-alpha.4_darwin-x64.tar.gz"`,
+		`url "https://github.com/levifig/loaf/releases/download/v2.0.0-alpha.4/loaf_2.0.0-alpha.4_linux-arm64.tar.gz"`,
+		`url "https://github.com/levifig/loaf/releases/download/v2.0.0-alpha.4/loaf_2.0.0-alpha.4_linux-x64.tar.gz"`,
+	} {
+		if !strings.Contains(formula, want) {
+			t.Fatalf("generated formula missing %q:\n%s", want, formula)
+		}
+	}
+	for target, checksum := range checksums {
+		want := `sha256 "` + checksum + `"`
+		if !strings.Contains(formula, want) {
+			t.Fatalf("generated formula missing checksum for %s: %q\n%s", target, want, formula)
+		}
+	}
+}
+
 type packageManifest struct {
 	Scripts         map[string]string      `json:"scripts"`
 	Exports         map[string]interface{} `json:"exports"`
@@ -264,7 +327,13 @@ func readPackageManifest(t *testing.T, root string) packageManifest {
 
 func runNodeScript(t *testing.T, node string, root string, env []string, script string) (string, error) {
 	t.Helper()
-	cmd := exec.Command(node, script)
+	return runNodeScriptArgs(t, node, root, env, script)
+}
+
+func runNodeScriptArgs(t *testing.T, node string, root string, env []string, script string, args ...string) (string, error) {
+	t.Helper()
+	cmdArgs := append([]string{script}, args...)
+	cmd := exec.Command(node, cmdArgs...)
 	cmd.Dir = root
 	cmd.Env = envWith(env...)
 	output, err := cmd.CombinedOutput()

--- a/docs/changes/20260706-homebrew-formula-generation-fix/change.md
+++ b/docs/changes/20260706-homebrew-formula-generation-fix/change.md
@@ -1,0 +1,106 @@
+---
+change: homebrew-formula-generation-fix
+created: 2026-07-06
+branch: homebrew-formula-generation-fix
+---
+
+<!-- Frontmatter must open the file at byte one. No status-like frontmatter: readiness is derived from the executable sections below. -->
+
+# Homebrew Formula Generation Fix
+
+## Problem
+
+The `v2.0.0-alpha.4` Homebrew tap update exposed that `cli/scripts/update-homebrew-formula.mjs` emits an explicit `version` line while also building URLs with Ruby `#{version}` interpolation. Homebrew audit treats that as a redundant explicit version because it can infer the version from the release URL, so a future generated formula would repeat the same tap CI failure we manually repaired.
+
+## Hypothesis
+
+If the generator emits literal versioned release URLs and omits the explicit `version` line, Homebrew can infer the package version from each URL and the generated formula will match the audit-safe shape we want to keep in the tap.
+
+## Scope
+
+**In**
+
+- Update `cli/scripts/update-homebrew-formula.mjs` to generate literal release asset URLs for each supported Homebrew target.
+- Remove the generated explicit `version` declaration.
+- Add regression coverage that executes the `.mjs` script and pins the output against independent expected formula properties.
+
+**Out** (deferred, not rejected)
+
+- Automating tap PR creation or tap CI polling.
+- Reworking release scripts into Go.
+- Changing package archive names or release asset layout.
+
+**Cut** (explicitly rejected)
+
+- Reintroducing Ruby interpolation in formula URLs.
+- Adding a Node test framework or runtime dependency for this small script.
+
+## Observable Workflow
+
+During release, `node cli/scripts/update-homebrew-formula.mjs --formula <path> --checksums checksums.txt --version <semver>` rewrites the formula so each platform block has a concrete GitHub release URL containing that version. The formula has no explicit `version` declaration, leaving Homebrew to infer the version from the URL.
+
+## Rabbit Holes and No-Gos
+
+- Do not broaden this into a full release pipeline redesign.
+- Do not mutate the live tap from tests.
+- Do not test by recomputing the same URL template in the same way the implementation does; the regression must look for fixed, literal expected strings.
+
+## Decisions
+
+Provenance: dogfooding the `alpha.4` release failure and user direction to keep the updater as `.mjs`.
+
+1. **Keep the updater as `.mjs`.** The script is already release-adjacent, dependency-free, and easy to execute from npm scripts; moving it now would add churn without improving the failure mode.
+2. **Use Go test coverage for the Node script.** Existing release-script coverage in `cmd/loaf/native_cutover_files_test.go` already shells out to Node, so the regression belongs beside neighboring release tooling tests.
+3. **Assert literal output, not reconstructed behavior.** The test must pin the absence of `version "` and `#{version}`, plus the presence of concrete `v2.0.0-alpha.4` release URLs, so it cannot pass by repeating the implementation algorithm.
+
+## Planning Contract
+
+### Implementation
+
+Patch `formula(versionValue, repoValue, values)` so generated URL strings interpolate `versionValue` at generation time and no longer emit `version "${versionValue}"`.
+
+### Coverage
+
+Add a Go test that creates a temp checksum file with all four Homebrew targets, runs `node cli/scripts/update-homebrew-formula.mjs`, reads the generated formula, and checks:
+
+- no explicit `version "` line appears;
+- no `#{version}` interpolation appears;
+- all four expected concrete GitHub release URLs appear;
+- all four expected checksum values appear;
+- the script reports a successful update.
+
+## Implementation Units
+
+- **U1 - Generator output.** Change the `.mjs` formula template to produce Homebrew-audit-safe formula output for prerelease versions.
+- **U2 - Regression coverage.** Add focused script execution coverage in the existing native cutover test file.
+
+## Verification Contract
+
+<!-- Executable (machine-checkable): -->
+
+- **V1.** `go test ./cmd/loaf -run TestHomebrewFormulaUpdaterGeneratesAuditSafePrereleaseURLs` passes.
+- **V2.** `go test ./...` passes.
+- **V3.** `loaf change check --require-executable docs/changes/20260706-homebrew-formula-generation-fix` passes.
+
+<!-- Human review: -->
+
+- **H1.** Reviewer confirms the generated formula shape matches the repaired tap formula from the `v2.0.0-alpha.4` release.
+
+## Definition of Done
+
+- The formula updater can generate a prerelease formula without Homebrew's redundant-version audit issue.
+- The regression test fails against the old `version`/`#{version}` output and passes against the new literal URL output.
+- No new dependencies or broad release-flow changes are introduced.
+
+## Durable Outputs
+
+No new durable spec or ADR is expected. This is a narrow release tooling bug fix; the durable output is the executable regression test.
+
+## Open Questions
+
+- None for this change.
+
+## Source Inputs
+
+- `v2.0.0-alpha.4` release dogfooding: Homebrew tap audit failed until the formula was manually changed to remove explicit `version` and use literal asset URLs.
+- User direction in this conversation: keep the updater as `.mjs` and add coverage.


### PR DESCRIPTION
## Summary

Fixes Loaf's Homebrew formula generator so prerelease formulas are emitted in the audit-safe shape we repaired manually during the `v2.0.0-alpha.4` release.

- removes the generated explicit `version` declaration
- emits concrete release asset URLs instead of Ruby `#{version}` interpolation
- adds regression coverage that executes the `.mjs` updater and pins literal expected output

## Why

The alpha.4 tap update exposed that the generated formula could fail Homebrew audit because Homebrew can infer the version from the release URL. This makes future generated tap updates match the repaired formula shape.

## Verification

- `go test ./cmd/loaf -run TestHomebrewFormulaUpdaterGeneratesAuditSafePrereleaseURLs -count=1`
- `go test ./...`
- `go vet ./...`
- `git diff --check main...HEAD`
- `loaf change check --require-executable docs/changes/20260706-homebrew-formula-generation-fix`