### PR TITLE
docs: update AGENTS.md for the Go CLI port

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -57,7 +57,7 @@ config/                         # Build configuration
 | Agents | `content/agents/{name}.md` | - |
 | Hooks | `content/hooks/{pre,post}-tool/` | - |
 | Config | `config/` | `hooks.yaml`, `targets.yaml` |
-| CLI | `internal/cli/` | `cmd/loaf/main.go` |
+| CLI | `internal/cli/` | `cli.go` |
 
 ## Agent Profiles
 
@@ -79,7 +79,7 @@ See [SOUL.md](../SOUL.md) for the Warden identity and fellowship conventions.
 
 **Add template:** Create in `content/skills/{name}/templates/` (skill-specific) or `content/templates/` + register in `shared-templates` in `targets.yaml`
 
-**Add target:** Create `cli/lib/build/targets/{target}.ts`, register in `cli/commands/build.ts`
+**Add target:** Create `internal/cli/build_{target}.go`, add the name to `defaultBuildTargets` and the target switch in `internal/cli/build.go` (see `build_amp.go` for the pattern)
 
 ## Skill Development
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -18,20 +18,23 @@ loaf install --to all          # Install to detected tools
 ## Project Structure
 
 ```
-cli/                            # CLI tool (TypeScript, bundled by tsup)
-├── index.ts                    # Entry point (Commander.js)
-├── commands/
-│   ├── build.ts                # loaf build
-│   ├── check.ts                # loaf check
-│   ├── install.ts              # loaf install
-│   └── journal.ts              # loaf journal
-└── lib/
-    ├── build/                  # Build system
-    │   ├── types.ts            # Shared types
-    │   ├── targets/            # Target transformers (claude-code, opencode, cursor, codex, amp)
-    │   └── lib/                # Build utilities (version, sidecar, shared-templates, etc.)
-    ├── detect/                 # Tool detection
-    └── install/                # Installation logic
+cmd/loaf/main.go                # CLI entry point (func main → internal/cli Runner)
+
+internal/                       # CLI implementation (Go)
+├── cli/                        # Command surface: Runner dispatch (cli.go), one runX per command
+│   ├── build.go                # loaf build
+│   ├── build_{target}.go       # Per-target builders (claude-code, opencode, cursor, codex, amp)
+│   ├── check.go                # loaf check
+│   ├── install.go              # loaf install
+│   └── journal.go              # loaf journal
+├── state/                      # SQLite-backed state (journal, specs, tasks, findings, ...)
+└── project/                    # Project identity and root resolution
+
+cli/                            # Node-side build tooling (not the CLI itself)
+├── runtime/loaf-launcher.cjs   # Node launcher shim (copied to bin/loaf)
+└── scripts/                    # build-go, build-release, verify-go-artifacts, etc.
+
+bin/loaf                        # Installed Node launcher; execs the native binary in bin/native/
 
 content/                        # Distributable content
 ├── skills/{name}/SKILL.md      # Domain knowledge + references/ + templates/
@@ -54,7 +57,7 @@ config/                         # Build configuration
 | Agents | `content/agents/{name}.md` | - |
 | Hooks | `content/hooks/{pre,post}-tool/` | - |
 | Config | `config/` | `hooks.yaml`, `targets.yaml` |
-| CLI | `cli/` | `index.ts` |
+| CLI | `internal/cli/` | `cmd/loaf/main.go` |
 
 ## Agent Profiles
 
@@ -381,10 +384,11 @@ loaf journal context           # Emit the layered continuity digest
 
 ```bash
 npm install                    # Install dependencies
-npm run build:cli              # Build CLI only (tsup)
-npm run build                  # Build CLI + all content targets
-npm run typecheck              # Type check (tsc --noEmit)
-npm link                       # Make `loaf` available globally
+npm run build:go               # Build the native Go binary only (cli/scripts/build-go.mjs)
+npm run build                  # Build binary + CLI reference + all content targets, then verify
+npm run typecheck              # Compile check (go test ./... -run=^$)
+npm run test                   # Run Go tests (go test ./...)
+npm link                       # Make `loaf` available globally (symlinks bin/loaf onto PATH)
 ```
 
 ### Dev Isolation (avoid polluting the global DB)


### PR DESCRIPTION
## What & Why

`.agents/AGENTS.md` (the file every session loads as CLAUDE.md) still documented the retired TypeScript CLI: `cli/index.ts` with Commander.js bundled by tsup, `npm run build:cli`, and `tsc --noEmit` type checking — none of which exist since the Go port. Every fresh agent session inherited a false map of the codebase.

This updates the three stale sections to shipped reality, each claim verified against the repo:

- **Project Structure** — `cmd/loaf/main.go` entry point, `internal/cli/` command surface (Runner dispatch, one `runX` per command, per-target builders), `internal/state/` + `internal/project/`, `cli/` as Node-side build tooling only, `bin/loaf` as the launcher exec-ing the native binary.
- **Quick Reference** — CLI row now points at `internal/cli/` / `cmd/loaf/main.go`.
- **Development commands** — real package.json scripts: `build:go`, `build`, `typecheck` (a `go test -run=^$` compile check), `test`, and `npm link` annotated.

## Review focus

Accuracy only — every line should match the repo. Verified-correct-and-left-alone: the Quick Start (`npm install && npm run build` still works), and Version Management (version genuinely lives in package.json; `version.go` reads it at runtime and the build injects it into the plugin manifests).

## Verification

```bash
grep -n "tsup\|index.ts\|tsc --noEmit" .agents/AGENTS.md   # zero hits
npm run build && npm run test                               # unchanged behavior
```

## Migration / breaking changes

None — documentation only.
