### PR TITLE
fix: github-account hook converges the active account instead of blocking

### DIFF
--- a/config/hooks.yaml
+++ b/config/hooks.yaml
@@ -69,9 +69,9 @@ hooks:
       skill: git-workflow
       matcher: "Bash"
       blocking: true
-      timeout: 5000
+      timeout: 10000
       failClosed: true
-      description: Block gh commands when the active GitHub account differs from project config
+      description: Switch the active GitHub account to project config before gh commands; block only if the switch fails
 
     # Git Workflow - Push and PR guards (ADVISORY)
     # These are safety nets, not gates — ship/release skills orchestrate the same checks.

--- a/content/skills/git-workflow/references/commits.md
+++ b/content/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), exempting `gh auth` administration, and blocks only when the switch fails. It writes the shared global account pointer on every mismatched `gh` call -- read-only ones included -- so concurrent sessions on different identities collide on that pointer more often. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/content/skills/git-workflow/references/commits.md
+++ b/content/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Blocking: prevents `gh` commands from using the wrong configured GitHub account. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/content/skills/release/SKILL.md
+++ b/content/skills/release/SKILL.md
@@ -266,7 +266,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` release operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
 | `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |

--- a/content/skills/ship/SKILL.md
+++ b/content/skills/ship/SKILL.md
@@ -219,7 +219,7 @@ This skill coexists with existing hooks.
 
 | Hook | Type | When `/ship` Runs |
 |------|------|------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` PR operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` PR operations; blocks only if the switch fails |
 | `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
 | `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
 | `validate-push` | Advisory | May fire if branch updates are needed before merge |

--- a/dist/amp/.amp/plugins/loaf.ts
+++ b/dist/amp/.amp/plugins/loaf.ts
@@ -262,7 +262,7 @@ const preToolHooks: Record<string, HookEntry[]> = {
     {
       "id": "github-account",
       "command": "loaf check --hook github-account",
-      "timeout": 5000,
+      "timeout": 10000,
       "failClosed": true
     },
     {

--- a/dist/amp/skills/git-workflow/references/commits.md
+++ b/dist/amp/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), exempting `gh auth` administration, and blocks only when the switch fails. It writes the shared global account pointer on every mismatched `gh` call -- read-only ones included -- so concurrent sessions on different identities collide on that pointer more often. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/dist/amp/skills/git-workflow/references/commits.md
+++ b/dist/amp/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Blocking: prevents `gh` commands from using the wrong configured GitHub account. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/dist/amp/skills/release/SKILL.md
+++ b/dist/amp/skills/release/SKILL.md
@@ -267,7 +267,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` release operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
 | `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |

--- a/dist/amp/skills/ship/SKILL.md
+++ b/dist/amp/skills/ship/SKILL.md
@@ -220,7 +220,7 @@ This skill coexists with existing hooks.
 
 | Hook | Type | When `/ship` Runs |
 |------|------|------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` PR operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` PR operations; blocks only if the switch fails |
 | `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
 | `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
 | `validate-push` | Advisory | May fire if branch updates are needed before merge |

--- a/dist/codex/.codex/hooks.json
+++ b/dist/codex/.codex/hooks.json
@@ -43,10 +43,10 @@
         "loaf-managed": true,
         "matcher": "Bash",
         "command": "loaf check --hook github-account",
-        "timeout": 5,
+        "timeout": 10,
         "failClosed": true,
         "blocking": true,
-        "description": "Block gh commands when the active GitHub account differs from project config"
+        "description": "Switch the active GitHub account to project config before gh commands; block only if the switch fails"
       },
       {
         "loaf-managed": true,

--- a/dist/codex/skills/git-workflow/references/commits.md
+++ b/dist/codex/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), exempting `gh auth` administration, and blocks only when the switch fails. It writes the shared global account pointer on every mismatched `gh` call -- read-only ones included -- so concurrent sessions on different identities collide on that pointer more often. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/dist/codex/skills/git-workflow/references/commits.md
+++ b/dist/codex/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Blocking: prevents `gh` commands from using the wrong configured GitHub account. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/dist/codex/skills/release/SKILL.md
+++ b/dist/codex/skills/release/SKILL.md
@@ -267,7 +267,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` release operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
 | `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |

--- a/dist/codex/skills/ship/SKILL.md
+++ b/dist/codex/skills/ship/SKILL.md
@@ -220,7 +220,7 @@ This skill coexists with existing hooks.
 
 | Hook | Type | When `/ship` Runs |
 |------|------|------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` PR operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` PR operations; blocks only if the switch fails |
 | `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
 | `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
 | `validate-push` | Advisory | May fire if branch updates are needed before merge |

--- a/dist/cursor/hooks.json
+++ b/dist/cursor/hooks.json
@@ -41,7 +41,7 @@
       },
       {
         "loaf-managed": true,
-        "timeout": 5,
+        "timeout": 10,
         "matcher": "Bash",
         "failClosed": true,
         "command": "loaf check --hook github-account"

--- a/dist/cursor/skills/git-workflow/references/commits.md
+++ b/dist/cursor/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), exempting `gh auth` administration, and blocks only when the switch fails. It writes the shared global account pointer on every mismatched `gh` call -- read-only ones included -- so concurrent sessions on different identities collide on that pointer more often. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/dist/cursor/skills/git-workflow/references/commits.md
+++ b/dist/cursor/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Blocking: prevents `gh` commands from using the wrong configured GitHub account. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/dist/cursor/skills/release/SKILL.md
+++ b/dist/cursor/skills/release/SKILL.md
@@ -267,7 +267,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` release operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
 | `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |

--- a/dist/cursor/skills/ship/SKILL.md
+++ b/dist/cursor/skills/ship/SKILL.md
@@ -220,7 +220,7 @@ This skill coexists with existing hooks.
 
 | Hook | Type | When `/ship` Runs |
 |------|------|------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` PR operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` PR operations; blocks only if the switch fails |
 | `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
 | `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
 | `validate-push` | Advisory | May fire if branch updates are needed before merge |

--- a/dist/opencode/commands/release.md
+++ b/dist/opencode/commands/release.md
@@ -266,7 +266,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` release operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
 | `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |

--- a/dist/opencode/commands/ship.md
+++ b/dist/opencode/commands/ship.md
@@ -219,7 +219,7 @@ This skill coexists with existing hooks.
 
 | Hook | Type | When `/ship` Runs |
 |------|------|------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` PR operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` PR operations; blocks only if the switch fails |
 | `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
 | `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
 | `validate-push` | Advisory | May fire if branch updates are needed before merge |

--- a/dist/opencode/plugins/hooks.ts
+++ b/dist/opencode/plugins/hooks.ts
@@ -261,7 +261,7 @@ const preToolHooks: Record<string, HookEntry[]> = {
     {
       "id": "github-account",
       "command": "loaf check --hook github-account",
-      "timeout": 5000,
+      "timeout": 10000,
       "failClosed": true
     },
     {

--- a/dist/opencode/skills/git-workflow/references/commits.md
+++ b/dist/opencode/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), exempting `gh auth` administration, and blocks only when the switch fails. It writes the shared global account pointer on every mismatched `gh` call -- read-only ones included -- so concurrent sessions on different identities collide on that pointer more often. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/dist/opencode/skills/git-workflow/references/commits.md
+++ b/dist/opencode/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Blocking: prevents `gh` commands from using the wrong configured GitHub account. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/dist/opencode/skills/release/SKILL.md
+++ b/dist/opencode/skills/release/SKILL.md
@@ -267,7 +267,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` release operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
 | `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |

--- a/dist/opencode/skills/ship/SKILL.md
+++ b/dist/opencode/skills/ship/SKILL.md
@@ -220,7 +220,7 @@ This skill coexists with existing hooks.
 
 | Hook | Type | When `/ship` Runs |
 |------|------|------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` PR operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` PR operations; blocks only if the switch fails |
 | `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
 | `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
 | `validate-push` | Advisory | May fire if branch updates are needed before merge |

--- a/dist/skills/git-workflow/references/commits.md
+++ b/dist/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), exempting `gh auth` administration, and blocks only when the switch fails. It writes the shared global account pointer on every mismatched `gh` call -- read-only ones included -- so concurrent sessions on different identities collide on that pointer more often. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/dist/skills/git-workflow/references/commits.md
+++ b/dist/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Blocking: prevents `gh` commands from using the wrong configured GitHub account. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/dist/skills/release/SKILL.md
+++ b/dist/skills/release/SKILL.md
@@ -266,7 +266,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/release` Runs |
 |------|------|---------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` release operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
 | `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |

--- a/dist/skills/ship/SKILL.md
+++ b/dist/skills/ship/SKILL.md
@@ -219,7 +219,7 @@ This skill coexists with existing hooks.
 
 | Hook | Type | When `/ship` Runs |
 |------|------|------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` PR operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` PR operations; blocks only if the switch fails |
 | `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
 | `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
 | `validate-push` | Advisory | May fire if branch updates are needed before merge |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -315,7 +315,7 @@ Hard-won constraints validated during SPEC-030 implementation:
 
 ### Hook Categories
 
-**Enforcement hooks** — quality gates that block bad actions. Run by `loaf check` through the native Go backend. Exit non-zero to block. `failClosed: true` means failures block the action. `github-account` blocks `gh` commands when the active GitHub CLI account differs from `.agents/loaf.json`; `validate-push` restricts direct pushes to the default branch to `.agents/` and `docs/` files only. Code changes require a feature branch and pull request.
+**Enforcement hooks** — quality gates that block bad actions. Run by `loaf check` through the native Go backend. Exit non-zero to block. `failClosed: true` means failures block the action. `github-account` converges the active GitHub CLI account on `.agents/loaf.json` before `gh` commands run — switching accounts when they differ (passing with a warning so the mutation is visible) and blocking only when the switch cannot be performed; `validate-push` restricts direct pushes to the default branch to `.agents/` and `docs/` files only. Code changes require a feature branch and pull request.
 
 **Instruction hooks** — context injection at tool invocation. Triggered by `matcher` patterns (tool name) and optionally filtered by `if` conditions (tool input). Inject relevant skill instructions or nudges.
 

--- a/docs/knowledge/hook-system.md
+++ b/docs/knowledge/hook-system.md
@@ -83,7 +83,7 @@ Native enforcement and workflow checks run via `loaf check --hook <id>` in `inte
 |------|-------|---------|:--------:|-------------|
 | `check-secrets` | security-compliance | Edit\|Write\|Bash | Yes (failClosed) | Scans file content and Bash commands for hardcoded secrets |
 | `security-audit` | security-compliance | Bash | Yes (failClosed) | Blocks dangerous shell patterns; runs Trivy/Semgrep/npm-audit when available |
-| `github-account` | git-workflow | Bash | Yes (failClosed) | Blocks `gh` commands when the active GitHub CLI account differs from `.agents/loaf.json` |
+| `github-account` | git-workflow | Bash | Yes (failClosed) | Switches the active GitHub CLI account to match `.agents/loaf.json` before `gh` commands (pass-with-warning); blocks only when the switch fails |
 | `validate-push` | git-workflow | Bash | Advisory | Verifies version bump, CHANGELOG, build before push |
 | `workflow-pre-pr` | git-workflow | Bash | Advisory | Checks PR format, CHANGELOG entry, unpushed base-branch commits |
 | `validate-commit` | orchestration | Bash | Yes (failClosed) | Validates Conventional Commits format, blocks AI attribution |

--- a/docs/knowledge/hook-system.md
+++ b/docs/knowledge/hook-system.md
@@ -83,12 +83,14 @@ Native enforcement and workflow checks run via `loaf check --hook <id>` in `inte
 |------|-------|---------|:--------:|-------------|
 | `check-secrets` | security-compliance | Edit\|Write\|Bash | Yes (failClosed) | Scans file content and Bash commands for hardcoded secrets |
 | `security-audit` | security-compliance | Bash | Yes (failClosed) | Blocks dangerous shell patterns; runs Trivy/Semgrep/npm-audit when available |
-| `github-account` | git-workflow | Bash | Yes (failClosed) | Switches the active GitHub CLI account to match `.agents/loaf.json` before `gh` commands (pass-with-warning); blocks only when the switch fails |
+| `github-account` | git-workflow | Bash | Yes (failClosed) | Switches the active GitHub CLI account to match `.agents/loaf.json` before `gh` commands (pass-with-warning), exempting `gh auth` administration; blocks only when the switch fails |
 | `validate-push` | git-workflow | Bash | Advisory | Verifies version bump, CHANGELOG, build before push |
 | `workflow-pre-pr` | git-workflow | Bash | Advisory | Checks PR format, CHANGELOG entry, unpushed base-branch commits |
 | `validate-commit` | orchestration | Bash | Yes (failClosed) | Validates Conventional Commits format, blocks AI attribution |
 
 Security hooks (`check-secrets`, `security-audit`), `github-account`, and `validate-commit` use `failClosed: true`. Workflow hooks (`validate-push`, `workflow-pre-pr`) are advisory (`blocking: false`) -- they warn but do not block, since `/ship` and `/release` orchestrate the same checks at their respective PR-landing and publication gates.
+
+Residual risk on `github-account`: convergence *writes* the shared global gh account pointer on every mismatched `gh` call -- including read-only ones like `gh pr view`, which the earlier pure-read check only observed -- so concurrent sessions on different identities collide on that pointer more frequently; the race window's shape is unchanged, its trigger rate is not. `gh auth` administration is exempt (identity management is the user's domain), passing through with no probe or switch.
 
 ## Instruction Hooks
 

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -807,6 +807,12 @@ func runNativeGitHubAccountWithRunner(
 	if checkContextToolName(hookContext) != "Bash" || !shellCommandUsesGitHubCLI(command) {
 		return result
 	}
+	// Identity administration (`gh auth ...`) is the user's domain: pass it
+	// through untouched — no status probe, no switch — so convergence never
+	// misdirects the command onto the configured account.
+	if shellCommandOnlyManagesGitHubAuth(command) {
+		return result
+	}
 	expected, err := configuredGitHubAccount(cwd)
 	if err != nil {
 		result.Passed = false

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -793,10 +793,15 @@ func runNativeWorkflowPrePR(hookContext checkHookContext, cwd string) checkResul
 }
 
 func runNativeGitHubAccount(hookContext checkHookContext, cwd string) checkResult {
-	return runNativeGitHubAccountWithRunner(hookContext, cwd, activeGitHubAccount)
+	return runNativeGitHubAccountWithRunner(hookContext, cwd, activeGitHubAccount, switchGitHubAccount)
 }
 
-func runNativeGitHubAccountWithRunner(hookContext checkHookContext, cwd string, runner func(string) githubAccountCommandResult) checkResult {
+func runNativeGitHubAccountWithRunner(
+	hookContext checkHookContext,
+	cwd string,
+	status func(string) githubAccountCommandResult,
+	switcher func(string, string) githubAccountCommandResult,
+) checkResult {
 	result := checkResult{Passed: true, Warnings: []string{}, Errors: []string{}, Findings: []string{}}
 	command := checkContextCommand(hookContext)
 	if checkContextToolName(hookContext) != "Bash" || !shellCommandUsesGitHubCLI(command) {
@@ -812,13 +817,27 @@ func runNativeGitHubAccountWithRunner(hookContext checkHookContext, cwd string, 
 	if expected == "" {
 		return result
 	}
-	if diagnostic := githubAccountDiagnostic(expected, runner(cwd)); diagnostic != "" {
+	resolution := resolveGitHubAccount(cwd, expected, status, switcher)
+	switch resolution.outcome {
+	case githubAccountOutcomeMatch:
+		return result
+	case githubAccountOutcomeSwitched:
+		// Converge instead of dead-ending, but surface the mutation as a
+		// pass-with-warnings finding so the switch is never silent.
+		result.Warnings = append(result.Warnings, githubAccountSwitchNotice(resolution))
+		return result
+	case githubAccountOutcomeUnavailable:
 		result.Passed = false
 		result.Blocked = true
-		result.Errors = append(result.Errors, diagnostic)
-		result.Findings = append(result.Findings, "GitHub account mismatch would run gh with the wrong project identity")
+		result.Errors = append(result.Errors, resolution.reason)
+		return result
+	default:
+		result.Passed = false
+		result.Blocked = true
+		result.Errors = append(result.Errors, githubAccountSwitchFailureMessages(resolution)...)
+		result.Findings = append(result.Findings, "gh could not switch to the configured account, so gh would run with the wrong project identity")
+		return result
 	}
-	return result
 }
 
 func runNativeValidatePush(hookContext checkHookContext, cwd string) checkResult {

--- a/internal/cli/check_test.go
+++ b/internal/cli/check_test.go
@@ -412,6 +412,131 @@ func TestGitHubAccountHookPassesMatchingConfiguredAccount(t *testing.T) {
 	}
 }
 
+func TestGitHubAccountHookExemptsGitHubAuthAdministration(t *testing.T) {
+	// gh auth administration is the user's domain: under an account mismatch it
+	// must pass through untouched — no status probe, no switch — so convergence
+	// never misdirects the command (e.g. logging out the configured account).
+	for _, command := range []string{
+		"gh auth logout",
+		"gh auth switch --user other",
+		"gh auth status",
+	} {
+		t.Run(command, func(t *testing.T) {
+			repo := initCLIGitRepo(t)
+			writeCheckFile(t, repo, ".agents/loaf.json", `{"integrations":{"github":{"account":"levifig"}}}`+"\n")
+			hookContext := checkHookContext{
+				ToolName:  "Bash",
+				ToolInput: checkHookInput{Command: command},
+			}
+
+			statusCalled := false
+			switchCalled := false
+			result := runNativeGitHubAccountWithRunner(hookContext, repo, func(root string) githubAccountCommandResult {
+				statusCalled = true
+				return githubAccountCommandResult{stdout: githubAuthStatusJSON("work-account"), exitCode: 0}
+			}, func(root, user string) githubAccountCommandResult {
+				switchCalled = true
+				return githubAccountCommandResult{exitCode: 0}
+			})
+
+			if statusCalled || switchCalled {
+				t.Fatalf("gh probed for auth-administration command (status=%v switch=%v), want pass-through with no gh execution", statusCalled, switchCalled)
+			}
+			if !result.Passed || result.Blocked || len(result.Errors) != 0 || len(result.Warnings) != 0 {
+				t.Fatalf("result = %#v, want clean pass-through for %q", result, command)
+			}
+		})
+	}
+}
+
+func TestGitHubAccountHookConvergesCompoundAuthAndResourceCommand(t *testing.T) {
+	// A compound that mixes gh auth with resource-touching gh usage is not
+	// exempt: it still converges on the configured account.
+	repo := initCLIGitRepo(t)
+	writeCheckFile(t, repo, ".agents/loaf.json", `{"integrations":{"github":{"account":"levifig"}}}`+"\n")
+	hookContext := checkHookContext{
+		ToolName:  "Bash",
+		ToolInput: checkHookInput{Command: "gh auth switch --user x && gh pr create"},
+	}
+
+	statusCalls := 0
+	status := func(root string) githubAccountCommandResult {
+		statusCalls++
+		if statusCalls == 1 {
+			return githubAccountCommandResult{stdout: githubAuthStatusJSON("work-account"), exitCode: 0}
+		}
+		return githubAccountCommandResult{stdout: githubAuthStatusJSON("levifig"), exitCode: 0}
+	}
+	switchCalls := 0
+	switcher := func(root, user string) githubAccountCommandResult {
+		switchCalls++
+		return githubAccountCommandResult{exitCode: 0}
+	}
+
+	result := runNativeGitHubAccountWithRunner(hookContext, repo, status, switcher)
+	if !result.Passed || result.Blocked {
+		t.Fatalf("result = %#v, want pass-with-warning after convergence", result)
+	}
+	if switchCalls != 1 {
+		t.Fatalf("switchCalls = %d, want the mixed compound to converge with one switch", switchCalls)
+	}
+}
+
+func TestGitHubAccountHookPassesMatchingReadOnlyResourceCommand(t *testing.T) {
+	// Regression: a resource-touching gh command against a matching account
+	// still probes once and passes cleanly, unaffected by the auth exemption.
+	repo := initCLIGitRepo(t)
+	writeCheckFile(t, repo, ".agents/loaf.json", `{"integrations":{"github":{"account":"levifig"}}}`+"\n")
+	hookContext := checkHookContext{
+		ToolName:  "Bash",
+		ToolInput: checkHookInput{Command: "gh pr list"},
+	}
+
+	statusCalls := 0
+	switchCalled := false
+	result := runNativeGitHubAccountWithRunner(hookContext, repo, func(root string) githubAccountCommandResult {
+		statusCalls++
+		return githubAccountCommandResult{stdout: githubAuthStatusJSON("levifig"), exitCode: 0}
+	}, func(root, user string) githubAccountCommandResult {
+		switchCalled = true
+		return githubAccountCommandResult{exitCode: 0}
+	})
+	if !result.Passed || result.Blocked || len(result.Errors) != 0 || len(result.Warnings) != 0 {
+		t.Fatalf("result = %#v, want clean matching-account pass", result)
+	}
+	if switchCalled {
+		t.Fatalf("switch attempted for already-matching account, want none")
+	}
+	if statusCalls != 1 {
+		t.Fatalf("statusCalls = %d, want single probe when already matching", statusCalls)
+	}
+}
+
+func TestShellCommandOnlyManagesGitHubAuth(t *testing.T) {
+	cases := []struct {
+		command string
+		want    bool
+	}{
+		{command: "gh auth logout", want: true},
+		{command: "gh auth switch --user other", want: true},
+		{command: "gh auth status", want: true},
+		{command: "gh auth refresh", want: true},
+		{command: "env GH_HOST=github.com gh auth status", want: true},
+		{command: "cd repo && gh auth switch --user levifig", want: true},
+		{command: "gh pr list", want: false},
+		{command: "gh auth switch --user x && gh pr create", want: false},
+		{command: "gh pr view 91 && gh auth status", want: false},
+		{command: "gh", want: false},
+		{command: `echo "gh auth"`, want: false},
+		{command: "grep ghp_ fixture.txt", want: false},
+	}
+	for _, tc := range cases {
+		if got := shellCommandOnlyManagesGitHubAuth(tc.command); got != tc.want {
+			t.Fatalf("shellCommandOnlyManagesGitHubAuth(%q) = %v, want %v", tc.command, got, tc.want)
+		}
+	}
+}
+
 func TestShellCommandUsesGitHubCLI(t *testing.T) {
 	cases := []struct {
 		command string

--- a/internal/cli/check_test.go
+++ b/internal/cli/check_test.go
@@ -202,7 +202,11 @@ func TestRunnerCheckValidHooksAreHandledNatively(t *testing.T) {
 	}
 }
 
-func TestGitHubAccountHookBlocksMismatchedConfiguredAccount(t *testing.T) {
+func githubAuthStatusNoActiveJSON() string {
+	return `{"hosts":{"github.com":[{"state":"success","active":false,"login":"work-account"},{"state":"success","active":false,"login":"levifig"}]}}`
+}
+
+func TestGitHubAccountHookSwitchesMismatchedAccountThenPasses(t *testing.T) {
 	repo := initCLIGitRepo(t)
 	writeCheckFile(t, repo, ".agents/loaf.json", `{"integrations":{"github":{"account":"levifig"}}}`+"\n")
 	hookContext := checkHookContext{
@@ -212,17 +216,143 @@ func TestGitHubAccountHookBlocksMismatchedConfiguredAccount(t *testing.T) {
 		},
 	}
 
-	result := runNativeGitHubAccountWithRunner(hookContext, repo, func(root string) githubAccountCommandResult {
+	statusCalls := 0
+	status := func(root string) githubAccountCommandResult {
+		statusCalls++
+		if statusCalls == 1 {
+			return githubAccountCommandResult{stdout: githubAuthStatusJSON("work-account"), exitCode: 0}
+		}
+		return githubAccountCommandResult{stdout: githubAuthStatusJSON("levifig"), exitCode: 0}
+	}
+	var switchRoot, switchUser string
+	switchCalls := 0
+	switcher := func(root, user string) githubAccountCommandResult {
+		switchCalls++
+		switchRoot, switchUser = root, user
+		return githubAccountCommandResult{exitCode: 0}
+	}
+
+	result := runNativeGitHubAccountWithRunner(hookContext, repo, status, switcher)
+	if !result.Passed || result.Blocked {
+		t.Fatalf("result = %#v, want pass-with-warning after switch", result)
+	}
+	if switchCalls != 1 {
+		t.Fatalf("switchCalls = %d, want exactly one switch", switchCalls)
+	}
+	if switchRoot != repo || switchUser != "levifig" {
+		t.Fatalf("switch invoked with (%q, %q), want (%q, %q)", switchRoot, switchUser, repo, "levifig")
+	}
+	if statusCalls != 2 {
+		t.Fatalf("statusCalls = %d, want re-check after switch", statusCalls)
+	}
+	want := `switched active gh account to "levifig" (was "work-account") for this project`
+	if len(result.Warnings) != 1 || result.Warnings[0] != want {
+		t.Fatalf("result.Warnings = %#v, want [%q]", result.Warnings, want)
+	}
+}
+
+func TestGitHubAccountHookSwitchesWhenNoActiveAccount(t *testing.T) {
+	repo := initCLIGitRepo(t)
+	writeCheckFile(t, repo, ".agents/loaf.json", `{"integrations":{"github":{"account":"levifig"}}}`+"\n")
+	hookContext := checkHookContext{
+		ToolName:  "Bash",
+		ToolInput: checkHookInput{Command: "gh pr view 91"},
+	}
+
+	statusCalls := 0
+	status := func(root string) githubAccountCommandResult {
+		statusCalls++
+		if statusCalls == 1 {
+			return githubAccountCommandResult{stdout: githubAuthStatusNoActiveJSON(), exitCode: 0}
+		}
+		return githubAccountCommandResult{stdout: githubAuthStatusJSON("levifig"), exitCode: 0}
+	}
+	switchCalls := 0
+	switcher := func(root, user string) githubAccountCommandResult {
+		switchCalls++
+		return githubAccountCommandResult{exitCode: 0}
+	}
+
+	result := runNativeGitHubAccountWithRunner(hookContext, repo, status, switcher)
+	if !result.Passed || result.Blocked {
+		t.Fatalf("result = %#v, want pass-with-warning after activating account", result)
+	}
+	if switchCalls != 1 {
+		t.Fatalf("switchCalls = %d, want exactly one switch", switchCalls)
+	}
+	want := `switched active gh account to "levifig" (was none active) for this project`
+	if len(result.Warnings) != 1 || result.Warnings[0] != want {
+		t.Fatalf("result.Warnings = %#v, want [%q]", result.Warnings, want)
+	}
+}
+
+func TestGitHubAccountHookBlocksWhenSwitchFails(t *testing.T) {
+	repo := initCLIGitRepo(t)
+	writeCheckFile(t, repo, ".agents/loaf.json", `{"integrations":{"github":{"account":"levifig"}}}`+"\n")
+	hookContext := checkHookContext{
+		ToolName:  "Bash",
+		ToolInput: checkHookInput{Command: "gh pr comment 91 --body-file review.md"},
+	}
+
+	statusCalls := 0
+	status := func(root string) githubAccountCommandResult {
+		statusCalls++
 		return githubAccountCommandResult{stdout: githubAuthStatusJSON("work-account"), exitCode: 0}
-	})
+	}
+	switchCalls := 0
+	switcher := func(root, user string) githubAccountCommandResult {
+		switchCalls++
+		return githubAccountCommandResult{stderr: "no accounts matched the given user \"levifig\"", exitCode: 1}
+	}
+
+	result := runNativeGitHubAccountWithRunner(hookContext, repo, status, switcher)
 	if result.Passed || !result.Blocked {
-		t.Fatalf("result = %#v, want blocked account mismatch", result)
+		t.Fatalf("result = %#v, want block after failed switch", result)
+	}
+	if switchCalls != 1 {
+		t.Fatalf("switchCalls = %d, want one switch attempt", switchCalls)
+	}
+	if statusCalls != 1 {
+		t.Fatalf("statusCalls = %d, want no re-check after failed switch", statusCalls)
 	}
 	joined := strings.Join(append(result.Errors, result.Findings...), "\n")
-	for _, want := range []string{`project requires GitHub account "levifig"`, `active gh account is "work-account"`, "gh auth switch --hostname github.com --user levifig"} {
+	for _, want := range []string{
+		`project requires GitHub account "levifig", but switching to it failed: no accounts matched the given user "levifig"`,
+		"gh auth login --hostname github.com` as levifig",
+		"wrong project identity",
+	} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("result = %#v, want %q", result, want)
 		}
+	}
+}
+
+func TestGitHubAccountHookBlocksWhenGhUnavailable(t *testing.T) {
+	repo := initCLIGitRepo(t)
+	writeCheckFile(t, repo, ".agents/loaf.json", `{"integrations":{"github":{"account":"levifig"}}}`+"\n")
+	hookContext := checkHookContext{
+		ToolName:  "Bash",
+		ToolInput: checkHookInput{Command: "gh pr view 91"},
+	}
+
+	switchCalls := 0
+	status := func(root string) githubAccountCommandResult {
+		return githubAccountCommandResult{exitCode: 127, notFound: true}
+	}
+	switcher := func(root, user string) githubAccountCommandResult {
+		switchCalls++
+		return githubAccountCommandResult{exitCode: 0}
+	}
+
+	result := runNativeGitHubAccountWithRunner(hookContext, repo, status, switcher)
+	if result.Passed || !result.Blocked {
+		t.Fatalf("result = %#v, want block when gh unavailable", result)
+	}
+	if switchCalls != 0 {
+		t.Fatalf("switchCalls = %d, want no switch when gh is unavailable", switchCalls)
+	}
+	if !strings.Contains(strings.Join(result.Errors, "\n"), "gh CLI is not installed") {
+		t.Fatalf("result = %#v, want gh-not-installed diagnostic", result)
 	}
 }
 
@@ -234,14 +364,18 @@ func TestGitHubAccountHookSkipsWhenUnconfigured(t *testing.T) {
 			Command: "gh pr view 91",
 		},
 	}
-	called := false
+	statusCalled := false
+	switchCalled := false
 
 	result := runNativeGitHubAccountWithRunner(hookContext, repo, func(root string) githubAccountCommandResult {
-		called = true
+		statusCalled = true
 		return githubAccountCommandResult{stdout: githubAuthStatusJSON("work-account"), exitCode: 0}
+	}, func(root, user string) githubAccountCommandResult {
+		switchCalled = true
+		return githubAccountCommandResult{exitCode: 0}
 	})
-	if called {
-		t.Fatalf("runner called for unconfigured repo, want no account probe")
+	if statusCalled || switchCalled {
+		t.Fatalf("gh probed for unconfigured repo (status=%v switch=%v), want no gh execution", statusCalled, switchCalled)
 	}
 	if !result.Passed || result.Blocked || len(result.Errors) != 0 {
 		t.Fatalf("result = %#v, want unconfigured pass-through", result)
@@ -258,11 +392,23 @@ func TestGitHubAccountHookPassesMatchingConfiguredAccount(t *testing.T) {
 		},
 	}
 
+	statusCalls := 0
+	switchCalled := false
 	result := runNativeGitHubAccountWithRunner(hookContext, repo, func(root string) githubAccountCommandResult {
+		statusCalls++
 		return githubAccountCommandResult{stdout: githubAuthStatusJSON("levifig"), exitCode: 0}
+	}, func(root, user string) githubAccountCommandResult {
+		switchCalled = true
+		return githubAccountCommandResult{exitCode: 0}
 	})
-	if !result.Passed || result.Blocked || len(result.Errors) != 0 {
-		t.Fatalf("result = %#v, want matching account pass", result)
+	if !result.Passed || result.Blocked || len(result.Errors) != 0 || len(result.Warnings) != 0 {
+		t.Fatalf("result = %#v, want clean matching-account pass", result)
+	}
+	if switchCalled {
+		t.Fatalf("switch attempted for already-matching account, want none")
+	}
+	if statusCalls != 1 {
+		t.Fatalf("statusCalls = %d, want single probe when already matching", statusCalls)
 	}
 }
 

--- a/internal/cli/github_account.go
+++ b/internal/cli/github_account.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,10 +17,54 @@ const githubAccountHostname = "github.com"
 
 var githubCommandRE = regexp.MustCompile(`(^|[;&|]\s*|&&\s*|\|\|\s*|\()\s*((env|command|sudo)\s+|\S+=\S+\s+)*gh(\s|$)`)
 
+var errNoActiveGitHubAccount = errors.New("no active GitHub account found")
+
 type githubAccountCommandResult struct {
 	stdout   string
+	stderr   string
 	exitCode int
 	notFound bool
+}
+
+// githubAccountState classifies the relationship between the configured account
+// and the active gh account, so callers branch on intent rather than parsing a
+// diagnostic string.
+type githubAccountState int
+
+const (
+	// githubAccountMatch: the active account already matches the configured one.
+	githubAccountMatch githubAccountState = iota
+	// githubAccountMismatch: gh is available and reachable but the active account
+	// differs (or none is active). This is switchable — `gh auth switch` can
+	// converge the environment.
+	githubAccountMismatch
+	// githubAccountUnavailable: gh is missing or its status probe hard-failed, so
+	// the account can neither be determined nor remedied by switching.
+	githubAccountUnavailable
+)
+
+type githubAccountCheck struct {
+	state      githubAccountState
+	actual     string // active account login; "" when none is active
+	diagnostic string // human-readable reason, populated for the unavailable state
+}
+
+// githubAccountOutcome is the result of trying to converge the environment on the
+// configured account.
+type githubAccountOutcome int
+
+const (
+	githubAccountOutcomeMatch        githubAccountOutcome = iota // already matched; no switch performed
+	githubAccountOutcomeSwitched                                 // switched and converged on the configured account
+	githubAccountOutcomeUnavailable                              // gh missing or status probe hard-failed
+	githubAccountOutcomeSwitchFailed                             // switch attempted but did not converge
+)
+
+type githubAccountResolution struct {
+	outcome  githubAccountOutcome
+	expected string
+	previous string // active account before switching; "" when none
+	reason   string // populated for unavailable / switch-failed outcomes
 }
 
 func configuredGitHubAccount(root string) (string, error) {
@@ -65,9 +111,37 @@ func activeGitHubAccount(root string) githubAccountCommandResult {
 	}
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
-		return githubAccountCommandResult{stdout: string(output), exitCode: exitErr.ExitCode()}
+		return githubAccountCommandResult{stdout: string(output), stderr: string(exitErr.Stderr), exitCode: exitErr.ExitCode()}
 	}
 	return githubAccountCommandResult{exitCode: 1}
+}
+
+// switchGitHubAccount runs `gh auth switch` non-interactively to make the
+// configured account active. Its stderr is captured so a failed switch can
+// surface gh's own diagnostic to the human.
+func switchGitHubAccount(root string, user string) githubAccountCommandResult {
+	cmd := exec.Command("gh", "auth", "switch", "--hostname", githubAccountHostname, "--user", user)
+	cmd.Dir = root
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	result := githubAccountCommandResult{stdout: stdout.String(), stderr: stderr.String()}
+	if err == nil {
+		return result
+	}
+	if errors.Is(err, exec.ErrNotFound) {
+		result.exitCode = 127
+		result.notFound = true
+		return result
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		result.exitCode = exitErr.ExitCode()
+		return result
+	}
+	result.exitCode = 1
+	return result
 }
 
 func activeGitHubAccountFromJSON(output string) (string, error) {
@@ -90,30 +164,128 @@ func activeGitHubAccountFromJSON(output string) (string, error) {
 	if len(accounts) == 1 && strings.TrimSpace(accounts[0].Login) != "" {
 		return strings.TrimSpace(accounts[0].Login), nil
 	}
-	return "", fmt.Errorf("no active GitHub account found for %s", githubAccountHostname)
+	return "", fmt.Errorf("%w for %s", errNoActiveGitHubAccount, githubAccountHostname)
 }
 
+// classifyGitHubAccount maps a gh status probe onto the configured account. It
+// separates the switchable mismatch case (gh reachable, wrong or no active
+// account) from the unavailable case (gh missing or probe hard-failed) so the
+// caller can decide whether converging is even possible.
+func classifyGitHubAccount(expected string, result githubAccountCommandResult) githubAccountCheck {
+	if result.notFound {
+		return githubAccountCheck{
+			state:      githubAccountUnavailable,
+			diagnostic: fmt.Sprintf("project requires GitHub account %q, but gh CLI is not installed", expected),
+		}
+	}
+	if result.exitCode != 0 {
+		return githubAccountCheck{
+			state:      githubAccountUnavailable,
+			diagnostic: fmt.Sprintf("project requires GitHub account %q, but `gh auth status --active --hostname %s --json hosts` failed", expected, githubAccountHostname),
+		}
+	}
+	actual, err := activeGitHubAccountFromJSON(result.stdout)
+	if err != nil {
+		if errors.Is(err, errNoActiveGitHubAccount) {
+			// gh is reachable but no account is active — `gh auth switch` can fix it.
+			return githubAccountCheck{state: githubAccountMismatch}
+		}
+		// Unparseable status output: cannot determine or remedy the account.
+		return githubAccountCheck{
+			state:      githubAccountUnavailable,
+			diagnostic: fmt.Sprintf("project requires GitHub account %q, but %s", expected, err),
+		}
+	}
+	if strings.EqualFold(actual, expected) {
+		return githubAccountCheck{state: githubAccountMatch, actual: actual}
+	}
+	return githubAccountCheck{state: githubAccountMismatch, actual: actual}
+}
+
+// resolveGitHubAccount converges the environment on the configured account: it
+// checks the active account, switches when it differs, and re-checks to confirm
+// the switch took. The guard's job is to make the environment match the project,
+// not to dead-end on a mismatch.
+func resolveGitHubAccount(
+	root string,
+	expected string,
+	status func(string) githubAccountCommandResult,
+	switcher func(string, string) githubAccountCommandResult,
+) githubAccountResolution {
+	check := classifyGitHubAccount(expected, status(root))
+	switch check.state {
+	case githubAccountMatch:
+		return githubAccountResolution{outcome: githubAccountOutcomeMatch, expected: expected, previous: check.actual}
+	case githubAccountUnavailable:
+		return githubAccountResolution{outcome: githubAccountOutcomeUnavailable, expected: expected, reason: check.diagnostic}
+	}
+
+	previous := check.actual
+	switchResult := switcher(root, expected)
+	if switchResult.exitCode == 0 && !switchResult.notFound &&
+		classifyGitHubAccount(expected, status(root)).state == githubAccountMatch {
+		return githubAccountResolution{outcome: githubAccountOutcomeSwitched, expected: expected, previous: previous}
+	}
+	return githubAccountResolution{
+		outcome:  githubAccountOutcomeSwitchFailed,
+		expected: expected,
+		previous: previous,
+		reason:   githubSwitchFailureReason(switchResult),
+	}
+}
+
+func githubSwitchFailureReason(result githubAccountCommandResult) string {
+	if result.notFound {
+		return "gh CLI is not installed"
+	}
+	if reason := strings.TrimSpace(result.stderr); reason != "" {
+		return reason
+	}
+	if result.exitCode == 0 {
+		return "the active account still does not match after switching"
+	}
+	return fmt.Sprintf("gh exited %d", result.exitCode)
+}
+
+func githubAccountSwitchNotice(resolution githubAccountResolution) string {
+	if resolution.previous == "" {
+		return fmt.Sprintf("switched active gh account to %q (was none active) for this project", resolution.expected)
+	}
+	return fmt.Sprintf("switched active gh account to %q (was %q) for this project", resolution.expected, resolution.previous)
+}
+
+func githubAccountSwitchFailureMessages(resolution githubAccountResolution) []string {
+	return []string{
+		fmt.Sprintf("project requires GitHub account %q, but switching to it failed: %s", resolution.expected, resolution.reason),
+		fmt.Sprintf("Authenticate it with `gh auth login --hostname %s` as %s, then rerun.", githubAccountHostname, resolution.expected),
+	}
+}
+
+// githubAccountDiagnostic renders a read-only mismatch diagnostic. It is used by
+// reporting paths (release post-merge readiness) that surface state without
+// mutating it; the enforcement paths converge via resolveGitHubAccount instead.
 func githubAccountDiagnostic(expected string, result githubAccountCommandResult) string {
 	if expected == "" {
 		return ""
 	}
-	if result.notFound {
-		return fmt.Sprintf("project requires GitHub account %q, but gh CLI is not installed", expected)
-	}
-	if result.exitCode != 0 {
-		return fmt.Sprintf("project requires GitHub account %q, but `gh auth status --active --hostname %s --json hosts` failed", expected, githubAccountHostname)
-	}
-	actual, err := activeGitHubAccountFromJSON(result.stdout)
-	if err != nil {
-		return fmt.Sprintf("project requires GitHub account %q, but %s", expected, err)
-	}
-	if strings.EqualFold(actual, expected) {
+	check := classifyGitHubAccount(expected, result)
+	switch check.state {
+	case githubAccountMatch:
 		return ""
+	case githubAccountUnavailable:
+		return check.diagnostic
 	}
-	return fmt.Sprintf("project requires GitHub account %q, but active gh account is %q; run `gh auth switch --hostname %s --user %s`", expected, actual, githubAccountHostname, expected)
+	if check.actual == "" {
+		return fmt.Sprintf("project requires GitHub account %q, but no active GitHub account found for %s", expected, githubAccountHostname)
+	}
+	return fmt.Sprintf("project requires GitHub account %q, but active gh account is %q; run `gh auth switch --hostname %s --user %s`", expected, check.actual, githubAccountHostname, expected)
 }
 
-func verifyConfiguredGitHubAccount(root string) error {
+// verifyConfiguredGitHubAccount converges the environment on the configured
+// account before a gh release operation, switching when needed. A performed
+// switch is announced on out so the mutation is never silent; only an
+// unremediable state returns an error.
+func verifyConfiguredGitHubAccount(root string, out io.Writer) error {
 	expected, err := configuredGitHubAccount(root)
 	if err != nil {
 		return err
@@ -121,8 +293,18 @@ func verifyConfiguredGitHubAccount(root string) error {
 	if expected == "" {
 		return nil
 	}
-	if diagnostic := githubAccountDiagnostic(expected, activeGitHubAccount(root)); diagnostic != "" {
-		return fmt.Errorf("%s", diagnostic)
+	resolution := resolveGitHubAccount(root, expected, activeGitHubAccount, switchGitHubAccount)
+	switch resolution.outcome {
+	case githubAccountOutcomeMatch:
+		return nil
+	case githubAccountOutcomeSwitched:
+		if out != nil {
+			fmt.Fprintf(out, "    %s %s\n", ansiYellow("!"), githubAccountSwitchNotice(resolution))
+		}
+		return nil
+	case githubAccountOutcomeUnavailable:
+		return fmt.Errorf("%s", resolution.reason)
+	default:
+		return fmt.Errorf("%s", strings.Join(githubAccountSwitchFailureMessages(resolution), " "))
 	}
-	return nil
 }

--- a/internal/cli/github_account.go
+++ b/internal/cli/github_account.go
@@ -99,6 +99,36 @@ func shellCommandUsesGitHubCLI(command string) bool {
 	return githubCommandRE.MatchString(strings.TrimSpace(command))
 }
 
+// shellCommandOnlyManagesGitHubAuth reports whether every gh invocation in the
+// command is a `gh auth` administrative subcommand (login, logout, switch,
+// refresh, status, ...). Identity administration is the user's domain, so those
+// invocations bypass account convergence: converging first would misdirect them
+// — e.g. `gh auth logout` under a mismatch would first force-switch the global
+// pointer to the configured account and then log THAT account out, not the one
+// the user targeted. A compound that mixes auth with resource-touching gh usage
+// (e.g. `gh auth switch --user x && gh pr create`) is not exempt and still
+// converges. Because githubCommandRE only matches gh at a command position, a
+// `gh auth` substring living inside an argument (e.g. `echo "gh auth"`) is not
+// mistaken for an invocation.
+func shellCommandOnlyManagesGitHubAuth(command string) bool {
+	trimmed := strings.TrimSpace(command)
+	positions := githubCommandRE.FindAllStringIndex(trimmed, -1)
+	if len(positions) == 0 {
+		return false
+	}
+	for _, pos := range positions {
+		rest := strings.TrimLeft(trimmed[pos[1]:], " \t")
+		subcommand := rest
+		if i := strings.IndexAny(rest, " \t"); i >= 0 {
+			subcommand = rest[:i]
+		}
+		if subcommand != "auth" {
+			return false
+		}
+	}
+	return true
+}
+
 func activeGitHubAccount(root string) githubAccountCommandResult {
 	cmd := exec.Command("gh", "auth", "status", "--active", "--hostname", githubAccountHostname, "--json", "hosts")
 	cmd.Dir = root

--- a/internal/cli/release_dry_run.go
+++ b/internal/cli/release_dry_run.go
@@ -526,7 +526,7 @@ func runReleaseApply(root string, options releaseOptions, in io.Reader, out io.W
 	if skipGh {
 		fmt.Fprintf(out, "    %s GitHub release skipped (--no-gh)\n", ansiGray("-"))
 	} else if releaseGhAvailable() {
-		if err := verifyConfiguredGitHubAccount(root); err != nil {
+		if err := verifyConfiguredGitHubAccount(root, out); err != nil {
 			return fmt.Errorf("Refusing to create GitHub release with the wrong account: %w", err)
 		}
 		if err := releaseCommandRun(root, "gh", "release", "create", tagName, "--draft", "--title", "v"+newVersion, "--notes", changelog); err != nil {

--- a/plugins/loaf/hooks/hooks.json
+++ b/plugins/loaf/hooks/hooks.json
@@ -49,8 +49,8 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}/bin/loaf\" check --hook github-account",
-            "timeout": 5,
-            "description": "Block gh commands when the active GitHub account differs from project config",
+            "timeout": 10,
+            "description": "Switch the active GitHub account to project config before gh commands; block only if the switch fails",
             "failClosed": true
           },
           {

--- a/plugins/loaf/skills/git-workflow/references/commits.md
+++ b/plugins/loaf/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), exempting `gh auth` administration, and blocks only when the switch fails. It writes the shared global account pointer on every mismatched `gh` call -- read-only ones included -- so concurrent sessions on different identities collide on that pointer more often. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/plugins/loaf/skills/git-workflow/references/commits.md
+++ b/plugins/loaf/skills/git-workflow/references/commits.md
@@ -254,7 +254,7 @@ Four hooks automatically enforce the conventions documented in this file:
 
 | Hook | Phase | Behavior |
 |------|-------|----------|
-| `github-account` | Pre-tool (Bash) | Blocking: prevents `gh` commands from using the wrong configured GitHub account. |
+| `github-account` | Pre-tool (Bash) | Force-switch: switches the active `gh` account to the configured one before `gh` commands run (passes with a warning), and blocks only when the switch fails. |
 | `workflow-pre-pr` | Pre-tool (Bash) | Advisory: reminds about CHANGELOG [Unreleased] entries and PR format. Non-blocking. |
 | `workflow-pre-push` | Pre-tool (Bash) | Advisory: reminders on `git push` — branch naming, uncommitted files, force-push safety. Non-blocking. |
 | `workflow-post-merge` | Post-tool (Bash) | Advisory: injects housekeeping checklist after successful `gh pr merge`. Non-blocking. |

--- a/plugins/loaf/skills/release/SKILL.md
+++ b/plugins/loaf/skills/release/SKILL.md
@@ -267,7 +267,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 
 | Hook | Type | When `/loaf:release` Runs |
 |------|------|---------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` release operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
 | `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
 | `workflow-pre-merge` | Advisory | Belongs to `/loaf:ship` when a release PR must land |

--- a/plugins/loaf/skills/ship/SKILL.md
+++ b/plugins/loaf/skills/ship/SKILL.md
@@ -221,7 +221,7 @@ This skill coexists with existing hooks.
 
 | Hook | Type | When `/loaf:ship` Runs |
 |------|------|------------------|
-| `github-account` | Blocking | Validates configured GitHub account before `gh` PR operations |
+| `github-account` | Force-switch | Switches to the configured GitHub account before `gh` PR operations; blocks only if the switch fails |
 | `workflow-pre-merge` | Advisory | Fires on `gh pr merge`; use it as a final squash reminder |
 | `workflow-post-merge` | Advisory | Fires after merge; use it as a cleanup reminder |
 | `validate-push` | Advisory | May fire if branch updates are needed before merge |


### PR DESCRIPTION
## What & Why

The `github-account` guard (shipped in v2.0.0-alpha.5) blocked every `gh` command on account mismatch — **including the `gh auth switch` command its own error message prescribed as the remedy**. In agent sessions, where hooks intercept all `gh` invocations, that's a deadlock: the state being checked can only be changed by the command class being blocked. Hit live on 2026-07-07 while opening PR #97.

Redesign per direction: the guard's job is to **converge the environment on the configured account, not dead-end on it**. On mismatch (or authenticated-but-no-active-account) the check now runs `gh auth switch --hostname github.com --user <configured>` itself, re-checks that the switch took, and passes with a visible warning naming the mutation — never silently. Blocking remains for the genuinely unrecoverable cases: gh not installed, status probe failure, or a failed switch (typically the account isn't authenticated) — the latter surfacing gh's own stderr plus `gh auth login` guidance.

Design notes:

- Mismatch is a typed state (`classifyGitHubAccount` / `resolveGitHubAccount` with injected status/switch runners), not a parsed diagnostic string.
- The read-only release-readiness report path deliberately keeps its non-mutating diagnostic — reporting surfaces state; enforcement converges it.
- Hook timeout doubled (5s → 10s) for the switch + re-check round-trips.

## Review focus

- The six behavioral branches and their tests in `check_test.go`: match → no switch attempted; no-config → no gh execution; mismatch → switch → pass-with-warning (asserts switch args and the re-check); switch-fails → block with login guidance; gh missing / probe failure → block unchanged.
- The warning wording: `switched active gh account to "<expected>" (was "<actual>") for this project` — this mutation is global gh state, so visibility is the safety mechanism.
- Known limitation, deliberately out of scope: the switch mutates the **global** active account, so concurrent sessions in other projects can race it (observed live — a parallel session flipped the account back between check and API call). The endgame is per-invocation identity (`GH_TOKEN` resolved per command), which is skill-guidance territory, not enforceable by a check hook — tracked for the hooks re-evaluation.

## Verification

```bash
go test ./internal/cli -run "GitHubAccount|Check" -count=1
npm run test && npm run build
# live: run any gh command in a repo configured for the non-active account —
# it switches, warns, and proceeds; with an unauthenticated account it blocks with login guidance
```

## Migration / breaking changes

Behavior change to the guard: `gh` commands under a mismatched account now proceed after an automatic switch (with warning) instead of failing. Projects relying on the hard block as an identity firewall should note the block now only fires when convergence is impossible.
