### PR TITLE
fix: verify evidence before release stamping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Build release targets
         shell: bash
         run: |
-          export LOAF_BUILD_COMMIT="${GITHUB_SHA::7}"
+          export LOAF_BUILD_COMMIT="$(git rev-parse --short=7 HEAD)"
           export LOAF_BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           npm run build:release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,15 +72,15 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Verify tests
+        run: go test ./...
+
       - name: Build release targets
         shell: bash
         run: |
           export LOAF_BUILD_COMMIT="${GITHUB_SHA::7}"
           export LOAF_BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           npm run build:release
-
-      - name: Verify tests
-        run: go test ./...
 
       - name: Package release archives
         run: npm run package:release

--- a/cmd/loaf/native_cutover_files_test.go
+++ b/cmd/loaf/native_cutover_files_test.go
@@ -241,6 +241,24 @@ func TestNativeGoReleaseBuildUsesPublishTargetPolicy(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowVerifiesEvidenceBeforeStampedBuild(t *testing.T) {
+	root := repoRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(body)
+	verifyTests := strings.Index(workflow, "      - name: Verify tests\n")
+	buildRelease := strings.Index(workflow, "      - name: Build release targets\n")
+	if verifyTests < 0 || buildRelease < 0 {
+		t.Fatalf("release workflow is missing Verify tests or Build release targets")
+	}
+	if verifyTests > buildRelease {
+		t.Fatalf("release workflow builds metadata-stamped binaries before evidence-bound tests")
+	}
+}
+
 func TestHomebrewFormulaUpdaterGeneratesAuditSafePrereleaseURLs(t *testing.T) {
 	node := requireNode(t)
 	root := repoRoot(t)

--- a/cmd/loaf/native_cutover_files_test.go
+++ b/cmd/loaf/native_cutover_files_test.go
@@ -250,12 +250,19 @@ func TestReleaseWorkflowVerifiesEvidenceBeforeStampedBuild(t *testing.T) {
 
 	workflow := string(body)
 	verifyTests := strings.Index(workflow, "      - name: Verify tests\n")
+	testCommand := strings.Index(workflow, "        run: go test ./...\n")
 	buildRelease := strings.Index(workflow, "      - name: Build release targets\n")
-	if verifyTests < 0 || buildRelease < 0 {
-		t.Fatalf("release workflow is missing Verify tests or Build release targets")
+	stampCommit := strings.Index(workflow, "          export LOAF_BUILD_COMMIT=\"$(git rev-parse --short=7 HEAD)\"\n")
+	buildCommand := strings.Index(workflow, "          npm run build:release\n")
+	packageRelease := strings.Index(workflow, "      - name: Package release archives\n")
+	if verifyTests < 0 || testCommand < 0 || buildRelease < 0 || stampCommit < 0 || buildCommand < 0 || packageRelease < 0 {
+		t.Fatalf("release workflow is missing its evidence verification or checked-out-tree release build contract")
 	}
-	if verifyTests > buildRelease {
-		t.Fatalf("release workflow builds metadata-stamped binaries before evidence-bound tests")
+	if !(verifyTests < testCommand && testCommand < buildRelease && buildRelease < stampCommit && stampCommit < buildCommand && buildCommand < packageRelease) {
+		t.Fatalf("release workflow must verify evidence before stamping and packaging the checked-out tree")
+	}
+	if strings.Count(workflow, "LOAF_BUILD_COMMIT") != 1 || strings.Count(workflow, "LOAF_BUILD_DATE") != 1 {
+		t.Fatalf("release workflow must confine build metadata to the release build step")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Run the release workflow's full Go suite before `build:release` injects commit/date metadata into native binaries.
- Stamp release binaries from the checked-out `HEAD`, not the workflow trigger SHA, so manual repair dispatches report the tag commit they actually package.
- Preserve strict installed-smoke artifact binding instead of weakening or bypassing the evidence contract.
- Add a regression test that fails if release metadata escapes its build step, moves ahead of evidence-bound tests, or stops using the checked-out tree.

## Root cause

Release workflow run `29625403813` built metadata-stamped binaries before `go test ./...`. That intentionally changed the retained candidate binary from `9e557096…` to `b091bb17…`, so the strict installed-smoke contract failed before packaging, asset upload, or Homebrew publication.

The repair dispatch must use the fixed workflow from `main` while checking out the existing alpha.7 tag. Using `GITHUB_SHA` would therefore stamp artifacts with the newer `main` commit; resolving `git rev-parse --short=7 HEAD` after checkout keeps artifact provenance tied to the tag tree.

After this lands, alpha.7 can be repaired by manually dispatching the fixed workflow against the existing signed `v2.0.0-alpha.7` tag. The tag and release commit do not move.

## Verification

- Regression guard failed against the original workflow order and trigger-SHA stamp, then passed after both fixes.
- `LOAF_VALIDATE_TYPESCRIPT=1 npm run build`
- `npm run test` with isolated Go cache and Git configuration
- `npm run typecheck`
- `go vet ./...`
- `CGO_ENABLED=0 go build ./...`
- `render-drift` and `check-secrets`
