### PR TITLE
docs: record adversarial-review and per-state fixture learnings

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -204,7 +204,7 @@ Substantive changes to skills, guidance docs, or operating principles warrant re
 
 Codex is plugin-dependent — it may not be available in all environments. `loaf:reviewer` is the floor; the adversarial pass is recommended when the change is substantive enough that a design defect would compound across many future invocations (skill rewrites, lifecycle codifications, hook-policy changes).
 
-This principle shapes how Loaf evolves substantive guidance. Evidence: the architecture-skill tightening + ADR deprecations (PR #46) shipped through three review-driven refinement rounds, with each reviewer catching defect classes the other missed.
+This principle shapes how Loaf evolves substantive guidance. Evidence: the architecture-skill tightening + ADR deprecations (PR #46) shipped through three review-driven refinement rounds, with each reviewer catching defect classes the other missed. PR #122 extended the evidence beyond guidance: after two independent Claude reviews of the intent-exploration foundation, a Codex adversarial pass over the same diff found a state-integrity defect (legacy operation-key capture), a schema constraint gap (cross-intent deferral references), and eleven further findings. Treat the adversarial pass as recommended for foundational state-model and persistence changes as well, not only guidance.
 
 ### Recategorization as a General Lifecycle Pattern
 
@@ -385,6 +385,8 @@ CWD-relative fixtures are forbidden for subprocess tests. The old Vitest suite e
 `realpath` is required on macOS because the system tmpdir (`/var/folders/...`) is reached through a `/private/var/folders/...` symlink; without realpath, subprocess cwd comparisons can fail.
 
 The active test harness is now Go. `npm test` delegates to `go test ./...`, and `npm run typecheck` compiles all Go packages with `go test ./... -run=^$`.
+
+Migration and state-classification code gets one explicit fixture per supported starting state — every schema version a classifier branches on — never transitive coverage through neighboring versions. The v2.0.0-alpha.10 regression shipped exactly through an accepted "covered transitively" gap: schema-11 databases were unclassifiable and unupgradeable until the same-day alpha.11 hotfix (#124). A review note of "unproven but transitively covered" on classification code is blocking, not advisory.
 
 ## Cross-Cutting Patterns
 


### PR DESCRIPTION
Reflect updates from shipping the intent and exploration foundation (#122) and the alpha.10/alpha.11 hotfix cycle (#124), approved during /reflect:

- Extend the Adversarial Review operating principle with PR #122 evidence: a Codex adversarial pass after two independent Claude reviews found a state-integrity defect, a schema constraint gap, and eleven further findings; the pass is now recommended for foundational state-model and persistence changes, not only guidance.
- Add a Test Fixture Hygiene rule: one explicit fixture per supported starting state for migration and classification code; the alpha.10 regression shipped through an accepted transitive-coverage gap.