### PR TITLE
fix: close spec terminal-status vocabulary on canonical done

### DIFF
--- a/cli/scripts/u8-claude-smoke.mjs
+++ b/cli/scripts/u8-claude-smoke.mjs
@@ -9,8 +9,8 @@ import { spawnSync } from "node:child_process";
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "../..");
 const researchDir = join(repoRoot, "docs/changes/20260710-journal-reliability-foundation/research");
-const evidencePath = join(researchDir, "u8-claude-code-2.1.215-candidate-smoke.json");
-const expectedVersion = "2.1.215";
+const evidencePath = join(researchDir, "u8-claude-code-2.1.218-candidate-smoke.json");
+const expectedVersion = "2.1.218";
 const platform = `${process.platform}-${process.arch}`;
 const candidatePluginPath = "plugins/loaf";
 
@@ -92,7 +92,7 @@ function main() {
     if (buildClaude.status !== 0) throw new Error("candidate Claude build failed");
     if (!existsSync(candidateBinary)) throw new Error("candidate plugin binary is missing");
     const version = run("claude", ["--version"], repoRoot);
-    if (version.status !== 0 || !claudeVersionMatches(version.stdout, expectedVersion)) throw new Error("installed Claude version is not 2.1.215");
+    if (version.status !== 0 || !claudeVersionMatches(version.stdout, expectedVersion)) throw new Error("installed Claude version is not 2.1.218");
     if (run("git", ["init", "-q"], disposableRepo).status !== 0) throw new Error("disposable Git initialization failed");
     const candidateEnv = { LOAF_DB: dbPath };
     if (run(candidateBinary, ["state", "init", "--json"], disposableRepo, candidateEnv).status !== 0) throw new Error("isolated Loaf state initialization failed");
@@ -154,7 +154,7 @@ function main() {
     cleanup();
   }
   writeFileSync(evidencePath, `${JSON.stringify(smoke, null, 2)}\n`);
-  process.stdout.write(`${JSON.stringify({ evidence_path: "docs/changes/20260710-journal-reliability-foundation/research/u8-claude-code-2.1.215-candidate-smoke.json", exit_code: smoke.exit_code, assistant_marker_match: smoke.assistant_marker_match }, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify({ evidence_path: "docs/changes/20260710-journal-reliability-foundation/research/u8-claude-code-2.1.218-candidate-smoke.json", exit_code: smoke.exit_code, assistant_marker_match: smoke.assistant_marker_match }, null, 2)}\n`);
   if (smoke.exit_code !== 0 || !smoke.assistant_marker_match) process.exitCode = 1;
 }
 

--- a/cli/scripts/u8-codex-smoke.mjs
+++ b/cli/scripts/u8-codex-smoke.mjs
@@ -10,8 +10,8 @@ import { tmpdir } from "node:os";
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "../..");
 const researchDir = join(repoRoot, "docs/changes/20260710-journal-reliability-foundation/research");
-const evidencePath = join(researchDir, "u8-codex-0.144.5-isolated-smoke.json");
-const expectedVersion = "0.144.5";
+const evidencePath = join(researchDir, "u8-codex-0.145.0-isolated-smoke.json");
+const expectedVersion = "0.145.0";
 const platform = `${process.platform}-${process.arch}`;
 const candidateHooksPath = "dist/codex/.codex/hooks.json";
 const candidateNativeRoot = join(repoRoot, "bin", "native");
@@ -148,7 +148,7 @@ function main() {
     if (buildCodex.status !== 0) throw new Error("candidate Codex build failed");
     if (!existsSync(candidateBinary)) throw new Error("candidate native binary is missing");
     const version = run("codex", ["--version"], repoRoot);
-    if (version.status !== 0 || !codexVersionMatches(version.stdout, expectedVersion)) throw new Error("installed Codex version is not 0.144.5");
+    if (version.status !== 0 || !codexVersionMatches(version.stdout, expectedVersion)) throw new Error("installed Codex version is not 0.145.0");
     if (run("git", ["init", "-q"], disposableRepo).status !== 0) throw new Error("disposable Git initialization failed");
     const authPath = join(process.env.CODEX_HOME ?? join(process.env.HOME ?? "", ".codex"), "auth.json");
     if (!existsSync(authPath)) throw new Error("installed Codex auth.json is unavailable");
@@ -219,7 +219,7 @@ function main() {
     cleanup();
   }
   writeFileSync(evidencePath, `${JSON.stringify(smoke, null, 2)}\n`);
-  process.stdout.write(`${JSON.stringify({ evidence_path: "docs/changes/20260710-journal-reliability-foundation/research/u8-codex-0.144.5-isolated-smoke.json", exit_code: smoke.exit_code, assistant_marker_match: smoke.assistant_marker_match }, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify({ evidence_path: "docs/changes/20260710-journal-reliability-foundation/research/u8-codex-0.145.0-isolated-smoke.json", exit_code: smoke.exit_code, assistant_marker_match: smoke.assistant_marker_match }, null, 2)}\n`);
   if (smoke.exit_code !== 0 || !smoke.assistant_marker_match) process.exitCode = 1;
 }
 

--- a/cli/scripts/u8-opencode-smoke.mjs
+++ b/cli/scripts/u8-opencode-smoke.mjs
@@ -10,8 +10,8 @@ import { tmpdir } from "node:os";
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "../..");
 const researchDir = join(repoRoot, "docs/changes/20260710-journal-reliability-foundation/research");
-const evidencePath = join(researchDir, "u8-opencode-1.18.3-isolated-smoke.json");
-const expectedVersion = "1.18.3";
+const evidencePath = join(researchDir, "u8-opencode-1.18.4-isolated-smoke.json");
+const expectedVersion = "1.18.4";
 const platform = `${process.platform}-${process.arch}`;
 const candidateHooksPath = "dist/opencode/plugins/hooks.ts";
 const candidateNativePath = `bin/native/${platform}/loaf`;
@@ -25,7 +25,7 @@ const setupSteps = [
   "observe candidate hook stdout through a mode-0700 wrapper and mode-0600 file",
 ];
 
-const safeEnvironmentKeys = ["LANG", "LC_ALL", "PATH", "TERM", "TZ"];
+const safeEnvironmentKeys = ["LANG", "LC_ALL", "PATH", "TERM", "TZ", "XDG_CACHE_HOME"];
 
 export function opencodeVersionMatches(output, expected = expectedVersion) {
   return output.trim() === expected;
@@ -273,7 +273,7 @@ function main() {
     const pluginURL = pathToFileURL(candidatePlugin).href;
     const env = disposableEnvironment(tempRoot, dbPath, pluginURL);
     const version = run(installedOpenCode, ["--version"], repoRoot, env);
-    if (version.status !== 0 || !opencodeVersionMatches(version.stdout)) throw new Error("installed OpenCode version is not exactly 1.18.3");
+    if (version.status !== 0 || !opencodeVersionMatches(version.stdout)) throw new Error("installed OpenCode version is not exactly 1.18.4");
     if (run("git", ["init", "-q"], disposableRepo, env).status !== 0) throw new Error("disposable Git initialization failed");
     if (run(candidateBinary, ["state", "init", "--json"], disposableRepo, env).status !== 0) throw new Error("isolated Loaf state initialization failed");
     if (run(candidateBinary, ["journal", "log", `discover(smoke): ${marker}`], disposableRepo, env).status !== 0) throw new Error("isolated journal marker write failed");
@@ -312,7 +312,7 @@ function main() {
     smoke.cleanup_succeeded = cleanupSucceeded;
   }
   writeFileSync(evidencePath, `${JSON.stringify(smoke, null, 2)}\n`);
-  process.stdout.write(`${JSON.stringify({ evidence_path: "docs/changes/20260710-journal-reliability-foundation/research/u8-opencode-1.18.3-isolated-smoke.json", exit_code: smoke.exit_code, assistant_marker_match: smoke.assistant_marker_match, plugin_loaded: smoke.plugin_loaded, root_session_lookup_proven: smoke.root_session_lookup_proven, cleanup_succeeded: smoke.cleanup_succeeded }, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify({ evidence_path: "docs/changes/20260710-journal-reliability-foundation/research/u8-opencode-1.18.4-isolated-smoke.json", exit_code: smoke.exit_code, assistant_marker_match: smoke.assistant_marker_match, plugin_loaded: smoke.plugin_loaded, root_session_lookup_proven: smoke.root_session_lookup_proven, cleanup_succeeded: smoke.cleanup_succeeded }, null, 2)}\n`);
   if (smoke.exit_code !== 0 || !smoke.assistant_marker_match || !smoke.plugin_loaded || !smoke.root_session_lookup_proven || !smoke.cleanup_succeeded) process.exitCode = 1;
 }
 

--- a/cli/scripts/u8-opencode-smoke.test.mjs
+++ b/cli/scripts/u8-opencode-smoke.test.mjs
@@ -3,10 +3,10 @@ import assert from "node:assert/strict";
 import { collectTextValues, modelVisibleProof, opencodeVersionMatches, parseOpenCodeJSONL, sanitizeError, sanitizedStderr } from "./u8-opencode-smoke.mjs";
 
 test("requires the exact OpenCode version token", () => {
-  assert.equal(opencodeVersionMatches("1.18.3\n"), true);
-  assert.equal(opencodeVersionMatches("1.18.30"), false);
-  assert.equal(opencodeVersionMatches("v1.18.3"), false);
-  assert.equal(opencodeVersionMatches("1.18.3-dev"), false);
+  assert.equal(opencodeVersionMatches("1.18.4\n"), true);
+  assert.equal(opencodeVersionMatches("1.18.40"), false);
+  assert.equal(opencodeVersionMatches("v1.18.4"), false);
+  assert.equal(opencodeVersionMatches("1.18.4-dev"), false);
 });
 
 test("recursively extracts only string values at text keys", () => {

--- a/config/target-capabilities.json
+++ b/config/target-capabilities.json
@@ -4,7 +4,7 @@
     {
       "target": "claude-code",
       "surface": "cli",
-      "version": "2.1.215",
+      "version": "2.1.218",
       "platform": "darwin-arm64",
       "installed_mode": "plugin-dir",
       "context": {
@@ -20,9 +20,9 @@
             "status": "supported",
             "model_visible": true,
             "evidence": {
-              "source": "docs/changes/20260710-journal-reliability-foundation/research/u8-claude-code-2.1.215-candidate-smoke.json",
+              "source": "docs/changes/20260710-journal-reliability-foundation/research/u8-claude-code-2.1.218-candidate-smoke.json",
               "level": "installed-smoke",
-              "summary": "Claude Code 2.1.215 startup smoke returned SessionStart additionalContext and the isolated marker was model-visible exactly."
+              "summary": "Claude Code 2.1.218 startup smoke returned SessionStart additionalContext and the isolated marker was model-visible exactly."
             }
           },
           {
@@ -243,7 +243,7 @@
     {
       "target": "codex",
       "surface": "cli",
-      "version": "0.144.5",
+      "version": "0.145.0",
       "platform": "darwin-arm64",
       "installed_mode": "isolated-codex-home",
       "context": {
@@ -259,9 +259,9 @@
             "status": "supported",
             "model_visible": true,
             "evidence": {
-              "source": "docs/changes/20260710-journal-reliability-foundation/research/u8-codex-0.144.5-isolated-smoke.json",
+              "source": "docs/changes/20260710-journal-reliability-foundation/research/u8-codex-0.145.0-isolated-smoke.json",
               "level": "installed-smoke",
-              "summary": "Codex 0.144.5 isolated CODEX_HOME startup smoke observed exact native SessionStart hookSpecificOutput and the random marker was returned by the model."
+              "summary": "Codex 0.145.0 isolated CODEX_HOME startup smoke observed exact native SessionStart hookSpecificOutput and the random marker was returned by the model."
             }
           },
           {
@@ -324,7 +324,7 @@
     {
       "target": "opencode",
       "surface": "cli",
-      "version": "1.18.3",
+      "version": "1.18.4",
       "platform": "darwin-arm64",
       "installed_mode": "isolated-xdg",
       "context": {
@@ -340,9 +340,9 @@
             "status": "supported",
             "model_visible": true,
             "evidence": {
-              "source": "docs/changes/20260710-journal-reliability-foundation/research/u8-opencode-1.18.3-isolated-smoke.json",
+              "source": "docs/changes/20260710-journal-reliability-foundation/research/u8-opencode-1.18.4-isolated-smoke.json",
               "level": "installed-smoke",
-              "summary": "OpenCode 1.18.3 isolated-XDG request smoke returned the exact random continuity marker through the model-visible plugin system transformation."
+              "summary": "OpenCode 1.18.4 isolated-XDG request smoke returned the exact random continuity marker through the model-visible plugin system transformation."
             }
           },
           {

--- a/content/skills/housekeeping/SKILL.md
+++ b/content/skills/housekeeping/SKILL.md
@@ -105,10 +105,10 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `done` or `archived`, verify the Linear
-   parent issue is in a `completed`-type state. If not (e.g., still "In
-   Progress"), flag as **status mismatch** — "Spec marked complete locally
-   but Linear parent ENG-198 is still 'In Progress'."
+2. If the spec's local status is `done` (or legacy `complete`) or `archived`,
+   verify the Linear parent issue is in a `completed`-type state. If not
+   (e.g., still "In Progress"), flag as **status mismatch** — "Spec marked
+   complete locally but Linear parent ENG-198 is still 'In Progress'."
 3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
    `done` and archived.

--- a/content/skills/housekeeping/SKILL.md
+++ b/content/skills/housekeeping/SKILL.md
@@ -105,13 +105,13 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `complete` or `archived`, verify the Linear
+2. If the spec's local status is `done` or `archived`, verify the Linear
    parent issue is in a `completed`-type state. If not (e.g., still "In
    Progress"), flag as **status mismatch** — "Spec marked complete locally
    but Linear parent ENG-198 is still 'In Progress'."
-3. If the spec's local status is `implementing` and the Linear parent is
+3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
-   `complete` and archived.
+   `done` and archived.
 
 Treat all three as **warnings**, not auto-fixes. The user decides resolution.
 

--- a/content/skills/reflect/SKILL.md
+++ b/content/skills/reflect/SKILL.md
@@ -84,7 +84,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`; legacy files may still read `complete`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/content/skills/reflect/SKILL.md
+++ b/content/skills/reflect/SKILL.md
@@ -84,7 +84,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/amp/skills/housekeeping/SKILL.md
+++ b/dist/amp/skills/housekeeping/SKILL.md
@@ -107,10 +107,10 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `done` or `archived`, verify the Linear
-   parent issue is in a `completed`-type state. If not (e.g., still "In
-   Progress"), flag as **status mismatch** — "Spec marked complete locally
-   but Linear parent ENG-198 is still 'In Progress'."
+2. If the spec's local status is `done` (or legacy `complete`) or `archived`,
+   verify the Linear parent issue is in a `completed`-type state. If not
+   (e.g., still "In Progress"), flag as **status mismatch** — "Spec marked
+   complete locally but Linear parent ENG-198 is still 'In Progress'."
 3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
    `done` and archived.

--- a/dist/amp/skills/housekeeping/SKILL.md
+++ b/dist/amp/skills/housekeeping/SKILL.md
@@ -107,13 +107,13 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `complete` or `archived`, verify the Linear
+2. If the spec's local status is `done` or `archived`, verify the Linear
    parent issue is in a `completed`-type state. If not (e.g., still "In
    Progress"), flag as **status mismatch** — "Spec marked complete locally
    but Linear parent ENG-198 is still 'In Progress'."
-3. If the spec's local status is `implementing` and the Linear parent is
+3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
-   `complete` and archived.
+   `done` and archived.
 
 Treat all three as **warnings**, not auto-fixes. The user decides resolution.
 

--- a/dist/amp/skills/reflect/SKILL.md
+++ b/dist/amp/skills/reflect/SKILL.md
@@ -86,7 +86,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/amp/skills/reflect/SKILL.md
+++ b/dist/amp/skills/reflect/SKILL.md
@@ -86,7 +86,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`; legacy files may still read `complete`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/codex/skills/housekeeping/SKILL.md
+++ b/dist/codex/skills/housekeeping/SKILL.md
@@ -107,10 +107,10 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `done` or `archived`, verify the Linear
-   parent issue is in a `completed`-type state. If not (e.g., still "In
-   Progress"), flag as **status mismatch** — "Spec marked complete locally
-   but Linear parent ENG-198 is still 'In Progress'."
+2. If the spec's local status is `done` (or legacy `complete`) or `archived`,
+   verify the Linear parent issue is in a `completed`-type state. If not
+   (e.g., still "In Progress"), flag as **status mismatch** — "Spec marked
+   complete locally but Linear parent ENG-198 is still 'In Progress'."
 3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
    `done` and archived.

--- a/dist/codex/skills/housekeeping/SKILL.md
+++ b/dist/codex/skills/housekeeping/SKILL.md
@@ -107,13 +107,13 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `complete` or `archived`, verify the Linear
+2. If the spec's local status is `done` or `archived`, verify the Linear
    parent issue is in a `completed`-type state. If not (e.g., still "In
    Progress"), flag as **status mismatch** — "Spec marked complete locally
    but Linear parent ENG-198 is still 'In Progress'."
-3. If the spec's local status is `implementing` and the Linear parent is
+3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
-   `complete` and archived.
+   `done` and archived.
 
 Treat all three as **warnings**, not auto-fixes. The user decides resolution.
 

--- a/dist/codex/skills/reflect/SKILL.md
+++ b/dist/codex/skills/reflect/SKILL.md
@@ -86,7 +86,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/codex/skills/reflect/SKILL.md
+++ b/dist/codex/skills/reflect/SKILL.md
@@ -86,7 +86,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`; legacy files may still read `complete`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/cursor/skills/housekeeping/SKILL.md
+++ b/dist/cursor/skills/housekeeping/SKILL.md
@@ -107,10 +107,10 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `done` or `archived`, verify the Linear
-   parent issue is in a `completed`-type state. If not (e.g., still "In
-   Progress"), flag as **status mismatch** — "Spec marked complete locally
-   but Linear parent ENG-198 is still 'In Progress'."
+2. If the spec's local status is `done` (or legacy `complete`) or `archived`,
+   verify the Linear parent issue is in a `completed`-type state. If not
+   (e.g., still "In Progress"), flag as **status mismatch** — "Spec marked
+   complete locally but Linear parent ENG-198 is still 'In Progress'."
 3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
    `done` and archived.

--- a/dist/cursor/skills/housekeeping/SKILL.md
+++ b/dist/cursor/skills/housekeeping/SKILL.md
@@ -107,13 +107,13 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `complete` or `archived`, verify the Linear
+2. If the spec's local status is `done` or `archived`, verify the Linear
    parent issue is in a `completed`-type state. If not (e.g., still "In
    Progress"), flag as **status mismatch** — "Spec marked complete locally
    but Linear parent ENG-198 is still 'In Progress'."
-3. If the spec's local status is `implementing` and the Linear parent is
+3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
-   `complete` and archived.
+   `done` and archived.
 
 Treat all three as **warnings**, not auto-fixes. The user decides resolution.
 

--- a/dist/cursor/skills/reflect/SKILL.md
+++ b/dist/cursor/skills/reflect/SKILL.md
@@ -86,7 +86,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/cursor/skills/reflect/SKILL.md
+++ b/dist/cursor/skills/reflect/SKILL.md
@@ -86,7 +86,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`; legacy files may still read `complete`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/opencode/commands/housekeeping.md
+++ b/dist/opencode/commands/housekeeping.md
@@ -107,10 +107,10 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `done` or `archived`, verify the Linear
-   parent issue is in a `completed`-type state. If not (e.g., still "In
-   Progress"), flag as **status mismatch** — "Spec marked complete locally
-   but Linear parent ENG-198 is still 'In Progress'."
+2. If the spec's local status is `done` (or legacy `complete`) or `archived`,
+   verify the Linear parent issue is in a `completed`-type state. If not
+   (e.g., still "In Progress"), flag as **status mismatch** — "Spec marked
+   complete locally but Linear parent ENG-198 is still 'In Progress'."
 3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
    `done` and archived.

--- a/dist/opencode/commands/housekeeping.md
+++ b/dist/opencode/commands/housekeeping.md
@@ -107,13 +107,13 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `complete` or `archived`, verify the Linear
+2. If the spec's local status is `done` or `archived`, verify the Linear
    parent issue is in a `completed`-type state. If not (e.g., still "In
    Progress"), flag as **status mismatch** — "Spec marked complete locally
    but Linear parent ENG-198 is still 'In Progress'."
-3. If the spec's local status is `implementing` and the Linear parent is
+3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
-   `complete` and archived.
+   `done` and archived.
 
 Treat all three as **warnings**, not auto-fixes. The user decides resolution.
 

--- a/dist/opencode/commands/reflect.md
+++ b/dist/opencode/commands/reflect.md
@@ -86,7 +86,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/opencode/commands/reflect.md
+++ b/dist/opencode/commands/reflect.md
@@ -86,7 +86,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`; legacy files may still read `complete`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/opencode/skills/housekeeping/SKILL.md
+++ b/dist/opencode/skills/housekeeping/SKILL.md
@@ -108,10 +108,10 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `done` or `archived`, verify the Linear
-   parent issue is in a `completed`-type state. If not (e.g., still "In
-   Progress"), flag as **status mismatch** — "Spec marked complete locally
-   but Linear parent ENG-198 is still 'In Progress'."
+2. If the spec's local status is `done` (or legacy `complete`) or `archived`,
+   verify the Linear parent issue is in a `completed`-type state. If not
+   (e.g., still "In Progress"), flag as **status mismatch** — "Spec marked
+   complete locally but Linear parent ENG-198 is still 'In Progress'."
 3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
    `done` and archived.

--- a/dist/opencode/skills/housekeeping/SKILL.md
+++ b/dist/opencode/skills/housekeeping/SKILL.md
@@ -108,13 +108,13 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `complete` or `archived`, verify the Linear
+2. If the spec's local status is `done` or `archived`, verify the Linear
    parent issue is in a `completed`-type state. If not (e.g., still "In
    Progress"), flag as **status mismatch** — "Spec marked complete locally
    but Linear parent ENG-198 is still 'In Progress'."
-3. If the spec's local status is `implementing` and the Linear parent is
+3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
-   `complete` and archived.
+   `done` and archived.
 
 Treat all three as **warnings**, not auto-fixes. The user decides resolution.
 

--- a/dist/opencode/skills/reflect/SKILL.md
+++ b/dist/opencode/skills/reflect/SKILL.md
@@ -87,7 +87,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`; legacy files may still read `complete`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/opencode/skills/reflect/SKILL.md
+++ b/dist/opencode/skills/reflect/SKILL.md
@@ -87,7 +87,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/skills/housekeeping/SKILL.md
+++ b/dist/skills/housekeeping/SKILL.md
@@ -106,13 +106,13 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `complete` or `archived`, verify the Linear
+2. If the spec's local status is `done` or `archived`, verify the Linear
    parent issue is in a `completed`-type state. If not (e.g., still "In
    Progress"), flag as **status mismatch** — "Spec marked complete locally
    but Linear parent ENG-198 is still 'In Progress'."
-3. If the spec's local status is `implementing` and the Linear parent is
+3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
-   `complete` and archived.
+   `done` and archived.
 
 Treat all three as **warnings**, not auto-fixes. The user decides resolution.
 

--- a/dist/skills/housekeeping/SKILL.md
+++ b/dist/skills/housekeeping/SKILL.md
@@ -106,10 +106,10 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `done` or `archived`, verify the Linear
-   parent issue is in a `completed`-type state. If not (e.g., still "In
-   Progress"), flag as **status mismatch** — "Spec marked complete locally
-   but Linear parent ENG-198 is still 'In Progress'."
+2. If the spec's local status is `done` (or legacy `complete`) or `archived`,
+   verify the Linear parent issue is in a `completed`-type state. If not
+   (e.g., still "In Progress"), flag as **status mismatch** — "Spec marked
+   complete locally but Linear parent ENG-198 is still 'In Progress'."
 3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
    `done` and archived.

--- a/dist/skills/reflect/SKILL.md
+++ b/dist/skills/reflect/SKILL.md
@@ -85,7 +85,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/dist/skills/reflect/SKILL.md
+++ b/dist/skills/reflect/SKILL.md
@@ -85,7 +85,7 @@ After completing work, `/reflect` extracts learnings and proposes updates to str
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`; legacy files may still read `complete`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/docs/changes/20260710-journal-reliability-foundation/research/u8-claude-code-2.1.218-candidate-smoke.json
+++ b/docs/changes/20260710-journal-reliability-foundation/research/u8-claude-code-2.1.218-candidate-smoke.json
@@ -1,6 +1,6 @@
 {
   "evidence_version": 2,
-  "timestamp": "2026-07-23T12:52:10.699Z",
+  "timestamp": "2026-07-23T15:56:10.169Z",
   "target": "claude-code",
   "surface": "cli",
   "version": "2.1.218",
@@ -41,7 +41,7 @@
   "stderr_empty": true,
   "model_visible_marker_observed": true,
   "assistant_marker_match": true,
-  "marker": "LOAF_U8_SMOKE_F7BD1D9F41B1",
+  "marker": "LOAF_U8_SMOKE_ACBF20EB1F6C",
   "hook_observation": {
     "event_name": "SessionStart:startup",
     "native_json": true,
@@ -52,6 +52,6 @@
     "hooks_path": "plugins/loaf/hooks/hooks.json",
     "hooks_sha256": "5c7343a34af37d6c6e930981f71e405b8023975de4146822058f98c15251b7c2",
     "native_binary_path": "plugins/loaf/bin/native/darwin-arm64/loaf",
-    "native_binary_sha256": "aa07e98777923105a6950d65637a672f6f65ec7a8ece9ad2e5ed38f37b38164a"
+    "native_binary_sha256": "49cfbe3805980e40ccbdd13ee473f0bb049a95c15ac59c8646858cfa68a8e451"
   }
 }

--- a/docs/changes/20260710-journal-reliability-foundation/research/u8-claude-code-2.1.218-candidate-smoke.json
+++ b/docs/changes/20260710-journal-reliability-foundation/research/u8-claude-code-2.1.218-candidate-smoke.json
@@ -1,9 +1,9 @@
 {
   "evidence_version": 2,
-  "timestamp": "2026-07-19T20:41:33.994Z",
+  "timestamp": "2026-07-23T12:52:10.699Z",
   "target": "claude-code",
   "surface": "cli",
-  "version": "2.1.215",
+  "version": "2.1.218",
   "platform": "darwin-arm64",
   "installed_mode": "plugin-dir",
   "context_mode": "startup",
@@ -41,7 +41,7 @@
   "stderr_empty": true,
   "model_visible_marker_observed": true,
   "assistant_marker_match": true,
-  "marker": "LOAF_U8_SMOKE_1E69C06FCEDC",
+  "marker": "LOAF_U8_SMOKE_F7BD1D9F41B1",
   "hook_observation": {
     "event_name": "SessionStart:startup",
     "native_json": true,
@@ -52,6 +52,6 @@
     "hooks_path": "plugins/loaf/hooks/hooks.json",
     "hooks_sha256": "5c7343a34af37d6c6e930981f71e405b8023975de4146822058f98c15251b7c2",
     "native_binary_path": "plugins/loaf/bin/native/darwin-arm64/loaf",
-    "native_binary_sha256": "0aa8f3f4babf64a9eb34dbcba9fb90b0f09b7978e6e2d6eadb395d7636908bd9"
+    "native_binary_sha256": "aa07e98777923105a6950d65637a672f6f65ec7a8ece9ad2e5ed38f37b38164a"
   }
 }

--- a/docs/changes/20260710-journal-reliability-foundation/research/u8-codex-0.145.0-isolated-smoke.json
+++ b/docs/changes/20260710-journal-reliability-foundation/research/u8-codex-0.145.0-isolated-smoke.json
@@ -1,6 +1,6 @@
 {
   "evidence_version": 2,
-  "timestamp": "2026-07-23T12:52:21.455Z",
+  "timestamp": "2026-07-23T15:56:25.178Z",
   "target": "codex",
   "surface": "cli",
   "version": "0.145.0",
@@ -40,7 +40,7 @@
   "stderr": "Reading additional input from stdin...",
   "model_visible_marker_observed": true,
   "assistant_marker_match": true,
-  "marker": "LOAF_CODEX_U8_F5F75B2C1B1D",
+  "marker": "LOAF_CODEX_U8_F9B138F25E2C",
   "hook_observation": {
     "event_name": "SessionStart:startup",
     "native_json": true,
@@ -51,6 +51,6 @@
     "hooks_path": "dist/codex/.codex/hooks.json",
     "hooks_sha256": "0f9e3feb7204c3309a7db6a02224ad881f6801a8cdd126ec6222e6d9a804c33d",
     "native_binary_path": "bin/native/darwin-arm64/loaf",
-    "native_binary_sha256": "aa07e98777923105a6950d65637a672f6f65ec7a8ece9ad2e5ed38f37b38164a"
+    "native_binary_sha256": "49cfbe3805980e40ccbdd13ee473f0bb049a95c15ac59c8646858cfa68a8e451"
   }
 }

--- a/docs/changes/20260710-journal-reliability-foundation/research/u8-codex-0.145.0-isolated-smoke.json
+++ b/docs/changes/20260710-journal-reliability-foundation/research/u8-codex-0.145.0-isolated-smoke.json
@@ -1,9 +1,9 @@
 {
   "evidence_version": 2,
-  "timestamp": "2026-07-19T20:41:22.121Z",
+  "timestamp": "2026-07-23T12:52:21.455Z",
   "target": "codex",
   "surface": "cli",
-  "version": "0.144.5",
+  "version": "0.145.0",
   "platform": "darwin-arm64",
   "installed_mode": "isolated-codex-home",
   "context_mode": "startup",
@@ -40,7 +40,7 @@
   "stderr": "Reading additional input from stdin...",
   "model_visible_marker_observed": true,
   "assistant_marker_match": true,
-  "marker": "LOAF_CODEX_U8_45E98BA70001",
+  "marker": "LOAF_CODEX_U8_F5F75B2C1B1D",
   "hook_observation": {
     "event_name": "SessionStart:startup",
     "native_json": true,
@@ -51,6 +51,6 @@
     "hooks_path": "dist/codex/.codex/hooks.json",
     "hooks_sha256": "0f9e3feb7204c3309a7db6a02224ad881f6801a8cdd126ec6222e6d9a804c33d",
     "native_binary_path": "bin/native/darwin-arm64/loaf",
-    "native_binary_sha256": "0aa8f3f4babf64a9eb34dbcba9fb90b0f09b7978e6e2d6eadb395d7636908bd9"
+    "native_binary_sha256": "aa07e98777923105a6950d65637a672f6f65ec7a8ece9ad2e5ed38f37b38164a"
   }
 }

--- a/docs/changes/20260710-journal-reliability-foundation/research/u8-opencode-1.18.4-isolated-smoke.json
+++ b/docs/changes/20260710-journal-reliability-foundation/research/u8-opencode-1.18.4-isolated-smoke.json
@@ -1,6 +1,6 @@
 {
   "evidence_version": 2,
-  "timestamp": "2026-07-23T12:56:12.928Z",
+  "timestamp": "2026-07-23T15:57:55.327Z",
   "target": "opencode",
   "surface": "cli",
   "version": "1.18.4",
@@ -39,11 +39,11 @@
   "root_session_lookup_proven": true,
   "no_auth_supplied": true,
   "cleanup_succeeded": true,
-  "marker": "LOAF_OPENCODE_U8_99369A792C56",
+  "marker": "LOAF_OPENCODE_U8_D3828AEB64CB",
   "candidate_artifacts": {
     "hooks_path": "dist/opencode/plugins/hooks.ts",
     "hooks_sha256": "936aa1c7b106156596f99461454abf77740b4fe5171a071a44ffcef4f1d418b1",
     "native_binary_path": "bin/native/darwin-arm64/loaf",
-    "native_binary_sha256": "aa07e98777923105a6950d65637a672f6f65ec7a8ece9ad2e5ed38f37b38164a"
+    "native_binary_sha256": "49cfbe3805980e40ccbdd13ee473f0bb049a95c15ac59c8646858cfa68a8e451"
   }
 }

--- a/docs/changes/20260710-journal-reliability-foundation/research/u8-opencode-1.18.4-isolated-smoke.json
+++ b/docs/changes/20260710-journal-reliability-foundation/research/u8-opencode-1.18.4-isolated-smoke.json
@@ -1,9 +1,9 @@
 {
   "evidence_version": 2,
-  "timestamp": "2026-07-20T12:14:46.271Z",
+  "timestamp": "2026-07-23T12:56:12.928Z",
   "target": "opencode",
   "surface": "cli",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "platform": "darwin-arm64",
   "installed_mode": "isolated-xdg",
   "context_mode": "request",
@@ -39,11 +39,11 @@
   "root_session_lookup_proven": true,
   "no_auth_supplied": true,
   "cleanup_succeeded": true,
-  "marker": "LOAF_OPENCODE_U8_A303AB34B844",
+  "marker": "LOAF_OPENCODE_U8_99369A792C56",
   "candidate_artifacts": {
     "hooks_path": "dist/opencode/plugins/hooks.ts",
     "hooks_sha256": "936aa1c7b106156596f99461454abf77740b4fe5171a071a44ffcef4f1d418b1",
     "native_binary_path": "bin/native/darwin-arm64/loaf",
-    "native_binary_sha256": "0aa8f3f4babf64a9eb34dbcba9fb90b0f09b7978e6e2d6eadb395d7636908bd9"
+    "native_binary_sha256": "aa07e98777923105a6950d65637a672f6f65ec7a8ece9ad2e5ed38f37b38164a"
   }
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -728,12 +728,12 @@ type markdownHousekeepingSectionSpec struct {
 }
 
 var markdownHousekeepingSectionSpecs = []markdownHousekeepingSectionSpec{
-	{name: "brainstorms", relativeDir: filepath.Join("drafts", "brainstorms"), cleanupStatuses: cleanupStatusSet("resolved", "archived")},
-	{name: "ideas", relativeDir: "ideas", cleanupStatuses: cleanupStatusSet("resolved", "archived")},
-	{name: "reports", relativeDir: "reports", cleanupStatuses: cleanupStatusSet("final", "archived")},
+	{name: "brainstorms", relativeDir: filepath.Join("drafts", "brainstorms"), cleanupStatuses: cleanupStatusSet("done", "resolved", "archived")},
+	{name: "ideas", relativeDir: "ideas", cleanupStatuses: cleanupStatusSet("done", "resolved", "archived")},
+	{name: "reports", relativeDir: "reports", cleanupStatuses: cleanupStatusSet("done", "final", "archived")},
 	{name: "shaping_drafts", relativeDir: "drafts", cleanupStatuses: cleanupStatusSet("absorbed", "archived")},
-	{name: "sparks", relativeDir: "sparks", cleanupStatuses: cleanupStatusSet("resolved", "archived")},
-	{name: "specs", relativeDir: "specs", cleanupStatuses: cleanupStatusSet("complete", "archived")},
+	{name: "sparks", relativeDir: "sparks", cleanupStatuses: cleanupStatusSet("done", "resolved", "archived")},
+	{name: "specs", relativeDir: "specs", cleanupStatuses: cleanupStatusSet("done", "complete", "archived")},
 	{name: "tasks", relativeDir: "tasks", cleanupStatuses: cleanupStatusSet("done", "archived")},
 }
 
@@ -8193,26 +8193,27 @@ func markdownSpecArchive(rootPath string, refs []string) (state.SpecArchiveResul
 		}
 		title := jsonObjectString(entry, "title")
 		status := jsonObjectString(entry, "status")
+		canonical := state.LifecycleStatusForDisplay(state.LifecycleEntitySpec, status)
 		spec := state.TraceEntity{Kind: "spec", ID: ref, Alias: ref, Title: title, Status: status}
-		if status != "complete" {
-			result.Skipped = append(result.Skipped, state.SpecArchiveItem{Spec: &spec, Ref: ref, Previous: status, Status: status, Reason: fmt.Sprintf("status is %s, must be complete", status)})
+		if !state.LifecycleStatusMatches(state.LifecycleEntitySpec, status, state.LifecycleStatusDone) {
+			result.Skipped = append(result.Skipped, state.SpecArchiveItem{Spec: &spec, Ref: ref, Previous: canonical, Status: canonical, Reason: fmt.Sprintf("status is %s, must be done", canonical)})
 			continue
 		}
 		file := jsonObjectString(entry, "file")
 		if strings.HasPrefix(file, "archive/") {
-			result.Skipped = append(result.Skipped, state.SpecArchiveItem{Spec: &spec, Ref: ref, Previous: status, Status: status, Reason: "already archived"})
+			result.Skipped = append(result.Skipped, state.SpecArchiveItem{Spec: &spec, Ref: ref, Previous: canonical, Status: canonical, Reason: "already archived"})
 			continue
 		}
 		if file == "" {
 			file = markdownSpecFileForAlias(rootPath, ref)
 		}
 		if file == "" {
-			result.Skipped = append(result.Skipped, state.SpecArchiveItem{Spec: &spec, Ref: ref, Previous: status, Status: status, Reason: "file not found in index"})
+			result.Skipped = append(result.Skipped, state.SpecArchiveItem{Spec: &spec, Ref: ref, Previous: canonical, Status: canonical, Reason: "file not found in index"})
 			continue
 		}
 		srcPath := filepath.Join(rootPath, ".agents", "specs", filepath.FromSlash(file))
 		if _, err := os.Stat(srcPath); os.IsNotExist(err) {
-			result.Skipped = append(result.Skipped, state.SpecArchiveItem{Spec: &spec, Ref: ref, Previous: status, Status: status, Reason: fmt.Sprintf("file not found at %s", file)})
+			result.Skipped = append(result.Skipped, state.SpecArchiveItem{Spec: &spec, Ref: ref, Previous: canonical, Status: canonical, Reason: fmt.Sprintf("file not found at %s", file)})
 			continue
 		} else if err != nil {
 			return state.SpecArchiveResult{}, fmt.Errorf("inspect markdown spec %s: %w", file, err)
@@ -8220,7 +8221,7 @@ func markdownSpecArchive(rootPath string, refs []string) (state.SpecArchiveResul
 		archivedFile := filepath.ToSlash(filepath.Join("archive", filepath.FromSlash(file)))
 		destPath := filepath.Join(rootPath, ".agents", "specs", filepath.FromSlash(archivedFile))
 		if _, err := os.Stat(destPath); err == nil {
-			result.Skipped = append(result.Skipped, state.SpecArchiveItem{Spec: &spec, Ref: ref, Previous: status, Status: status, Reason: fmt.Sprintf("%s already exists", archivedFile)})
+			result.Skipped = append(result.Skipped, state.SpecArchiveItem{Spec: &spec, Ref: ref, Previous: canonical, Status: canonical, Reason: fmt.Sprintf("%s already exists", archivedFile)})
 			continue
 		} else if err != nil && !os.IsNotExist(err) {
 			return state.SpecArchiveResult{}, fmt.Errorf("inspect archived markdown spec %s: %w", archivedFile, err)
@@ -8234,7 +8235,7 @@ func markdownSpecArchive(rootPath string, refs []string) (state.SpecArchiveResul
 		entry["file"] = archivedFile
 		changed = true
 		spec.Status = "archived"
-		result.Archived = append(result.Archived, state.SpecArchiveItem{Spec: &spec, Ref: ref, Previous: "complete", Status: "archived"})
+		result.Archived = append(result.Archived, state.SpecArchiveItem{Spec: &spec, Ref: ref, Previous: canonical, Status: "archived"})
 	}
 	if changed {
 		updated, err := json.MarshalIndent(index, "", "  ")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8194,7 +8194,7 @@ func markdownSpecArchive(rootPath string, refs []string) (state.SpecArchiveResul
 		title := jsonObjectString(entry, "title")
 		status := jsonObjectString(entry, "status")
 		canonical := state.LifecycleStatusForDisplay(state.LifecycleEntitySpec, status)
-		spec := state.TraceEntity{Kind: "spec", ID: ref, Alias: ref, Title: title, Status: status}
+		spec := state.TraceEntity{Kind: "spec", ID: ref, Alias: ref, Title: title, Status: canonical}
 		if !state.LifecycleStatusMatches(state.LifecycleEntitySpec, status, state.LifecycleStatusDone) {
 			result.Skipped = append(result.Skipped, state.SpecArchiveItem{Spec: &spec, Ref: ref, Previous: canonical, Status: canonical, Reason: fmt.Sprintf("status is %s, must be done", canonical)})
 			continue

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -286,6 +286,11 @@ status: complete
 ---
 # Done Spec
 `)
+	writeCLIAgentsFile(t, workingDir, "specs/SPEC-002-done.md", `---
+status: done
+---
+# Canonical Done Spec
+`)
 	writeCLIAgentsFile(t, workingDir, "tasks/TASK-001-done.md", `---
 status: done
 ---
@@ -313,13 +318,13 @@ status: absorbed
 	if summary.ContractVersion != 0 || summary.DatabaseScope != "" || summary.ProjectID != "" || summary.ProjectName != "" || summary.ProjectCurrentPath != "" {
 		t.Fatalf("markdown housekeeping context = %#v, want empty", summary)
 	}
-	if summary.Sections["specs"].ByStatus["complete"] != 1 || summary.Sections["tasks"].ByStatus["done"] != 1 || summary.Sections["shaping_drafts"].ByStatus["absorbed"] != 1 {
+	if summary.Sections["specs"].ByStatus["complete"] != 1 || summary.Sections["specs"].ByStatus["done"] != 1 || summary.Sections["tasks"].ByStatus["done"] != 1 || summary.Sections["shaping_drafts"].ByStatus["absorbed"] != 1 {
 		t.Fatalf("summary = %#v, want markdown artifact lifecycle counts", summary)
 	}
 	if _, ok := summary.Sections["sessions"]; ok {
 		t.Fatalf("summary = %#v, want no sessions housekeeping section", summary)
 	}
-	if summary.Sections["specs"].CleanupCandidate != 1 || summary.Sections["tasks"].CleanupCandidate != 1 || summary.Sections["shaping_drafts"].CleanupCandidate != 1 {
+	if summary.Sections["specs"].CleanupCandidate != 2 || summary.Sections["tasks"].CleanupCandidate != 1 || summary.Sections["shaping_drafts"].CleanupCandidate != 1 {
 		t.Fatalf("summary = %#v, want markdown cleanup candidates", summary)
 	}
 
@@ -12296,10 +12301,10 @@ status: drafting
 		t.Fatalf("spec archive markdown --json error = %v", err)
 	}
 	archive := decodeSpecArchiveResult(t, jsonOut.Bytes())
-	if len(archive.Archived) != 1 || archive.Archived[0].Spec == nil || archive.Archived[0].Spec.Alias != "SPEC-001" || archive.Archived[0].Previous != "complete" || archive.Archived[0].Status != "archived" {
+	if len(archive.Archived) != 1 || archive.Archived[0].Spec == nil || archive.Archived[0].Spec.Alias != "SPEC-001" || archive.Archived[0].Previous != "done" || archive.Archived[0].Status != "archived" {
 		t.Fatalf("Archived = %#v, want SPEC-001 archived", archive.Archived)
 	}
-	if len(archive.Skipped) != 2 || archive.Skipped[0].Ref != "SPEC-002" || !strings.Contains(archive.Skipped[0].Reason, "status is drafting") || archive.Skipped[1].Ref != "SPEC-999" || archive.Skipped[1].Reason != "not found in index" {
+	if len(archive.Skipped) != 2 || archive.Skipped[0].Ref != "SPEC-002" || archive.Skipped[0].Reason != "status is draft, must be done" || archive.Skipped[1].Ref != "SPEC-999" || archive.Skipped[1].Reason != "not found in index" {
 		t.Fatalf("Skipped = %#v, want draft and missing skips", archive.Skipped)
 	}
 	if archive.ContractVersion != state.StateJSONContractVersion {
@@ -12351,6 +12356,65 @@ status: drafting
 	output := humanOut.String()
 	if !strings.Contains(output, "loaf spec archive") || !strings.Contains(output, "skipped SPEC-001: already archived") || !strings.Contains(output, "Skipped 1 spec(s)") {
 		t.Fatalf("output = %q, want already-archived human summary", output)
+	}
+	assertNoStateDatabase(t, workingDir, stateHome)
+}
+
+func TestRunnerSpecArchiveAcceptsCanonicalDoneWhenMarkdownOnly(t *testing.T) {
+	workingDir := realpath(t, t.TempDir())
+	stateHome := t.TempDir()
+	writeCLIAgentsFile(t, workingDir, "specs/SPEC-001-done.md", `---
+id: SPEC-001
+title: Done Spec
+status: done
+---
+# Done Spec
+`)
+	writeCLIAgentsFile(t, workingDir, "specs/SPEC-002-active.md", `---
+id: SPEC-002
+title: Active Spec
+status: in_progress
+---
+# Active Spec
+`)
+	writeCLIAgentsFile(t, workingDir, "TASKS.json", `{
+  "version": 1,
+  "tasks": {},
+  "specs": {
+    "SPEC-001": {
+      "title": "Done Spec",
+      "status": "done",
+      "file": "SPEC-001-done.md"
+    },
+    "SPEC-002": {
+      "title": "Active Spec",
+      "status": "in_progress",
+      "file": "SPEC-002-active.md"
+    }
+  }
+}`)
+
+	var jsonOut bytes.Buffer
+	err := Runner{
+		Stdout:     &jsonOut,
+		WorkingDir: workingDir,
+		StateHome:  stateHome,
+	}.Run([]string{"spec", "archive", "SPEC-001", "SPEC-002", "--json"})
+	if err != nil {
+		t.Fatalf("spec archive markdown --json error = %v", err)
+	}
+	archive := decodeSpecArchiveResult(t, jsonOut.Bytes())
+	if len(archive.Archived) != 1 || archive.Archived[0].Spec == nil || archive.Archived[0].Spec.Alias != "SPEC-001" || archive.Archived[0].Previous != "done" || archive.Archived[0].Status != "archived" {
+		t.Fatalf("Archived = %#v, want SPEC-001 archived from canonical done", archive.Archived)
+	}
+	if len(archive.Skipped) != 1 || archive.Skipped[0].Ref != "SPEC-002" || archive.Skipped[0].Reason != "status is in_progress, must be done" || archive.Skipped[0].Previous != "in_progress" {
+		t.Fatalf("Skipped = %#v, want in_progress skip with must-be-done reason", archive.Skipped)
+	}
+	if _, err := os.Stat(filepath.Join(workingDir, ".agents", "specs", "archive", "SPEC-001-done.md")); err != nil {
+		t.Fatalf("archived spec missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workingDir, ".agents", "specs", "SPEC-002-active.md")); err != nil {
+		t.Fatalf("active spec missing: %v", err)
 	}
 	assertNoStateDatabase(t, workingDir, stateHome)
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -130,7 +130,7 @@ status: complete
 	}
 	summary := decodeHousekeepingSummary(t, jsonOut.Bytes())
 	assertCLIProjectContext(t, workingDir, summary.ContractVersion, summary.DatabaseScope, summary.DatabasePath, summary.ProjectID, summary.ProjectName, summary.ProjectCurrentPath)
-	if summary.Sections["specs"].ByStatus["complete"] != 1 || summary.Sections["tasks"].ByStatus["done"] != 1 {
+	if summary.Sections["specs"].ByStatus["done"] != 1 || summary.Sections["tasks"].ByStatus["done"] != 1 {
 		t.Fatalf("summary = %#v, want SQLite spec/task lifecycle counts", summary)
 	}
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -12419,6 +12419,73 @@ status: in_progress
 	assertNoStateDatabase(t, workingDir, stateHome)
 }
 
+func TestRunnerSpecArchiveCanonicalizesNestedSpecStatusWhenMarkdownOnly(t *testing.T) {
+	workingDir := realpath(t, t.TempDir())
+	stateHome := t.TempDir()
+	writeCLIAgentsFile(t, workingDir, "specs/archive/SPEC-001-complete.md", `---
+id: SPEC-001
+title: Complete Spec
+status: complete
+---
+# Complete Spec
+`)
+	writeCLIAgentsFile(t, workingDir, "specs/SPEC-002-draft.md", `---
+id: SPEC-002
+title: Draft Spec
+status: drafting
+---
+# Draft Spec
+`)
+	writeCLIAgentsFile(t, workingDir, "TASKS.json", `{
+  "version": 1,
+  "tasks": {},
+  "specs": {
+    "SPEC-001": {
+      "title": "Complete Spec",
+      "status": "complete",
+      "file": "archive/SPEC-001-complete.md"
+    },
+    "SPEC-002": {
+      "title": "Draft Spec",
+      "status": "drafting",
+      "file": "SPEC-002-draft.md"
+    }
+  }
+}`)
+
+	var jsonOut bytes.Buffer
+	err := Runner{
+		Stdout:     &jsonOut,
+		WorkingDir: workingDir,
+		StateHome:  stateHome,
+	}.Run([]string{"spec", "archive", "SPEC-001", "SPEC-002", "--json"})
+	if err != nil {
+		t.Fatalf("spec archive markdown --json error = %v", err)
+	}
+	archive := decodeSpecArchiveResult(t, jsonOut.Bytes())
+	if len(archive.Archived) != 0 {
+		t.Fatalf("Archived = %#v, want none", archive.Archived)
+	}
+	if len(archive.Skipped) != 2 || archive.Skipped[0].Ref != "SPEC-001" || archive.Skipped[1].Ref != "SPEC-002" {
+		t.Fatalf("Skipped = %#v, want SPEC-001 and SPEC-002 skips", archive.Skipped)
+	}
+	archived := archive.Skipped[0]
+	if archived.Reason != "already archived" || archived.Previous != "done" || archived.Status != "done" {
+		t.Fatalf("Skipped[0] = %#v, want already-archived skip with canonical done statuses", archived)
+	}
+	if archived.Spec == nil || archived.Spec.Status != "done" {
+		t.Fatalf("Skipped[0].Spec = %#v, want nested spec status canonicalized to done", archived.Spec)
+	}
+	draft := archive.Skipped[1]
+	if draft.Reason != "status is draft, must be done" || draft.Previous != "draft" || draft.Status != "draft" {
+		t.Fatalf("Skipped[1] = %#v, want draft skip with canonical draft statuses", draft)
+	}
+	if draft.Spec == nil || draft.Spec.Status != "draft" {
+		t.Fatalf("Skipped[1].Spec = %#v, want nested spec status canonicalized to draft", draft.Spec)
+	}
+	assertNoStateDatabase(t, workingDir, stateHome)
+}
+
 func TestRunnerSpecArchiveReportsInvalidSQLiteState(t *testing.T) {
 	workingDir := realpath(t, t.TempDir())
 	stateHome := t.TempDir()

--- a/internal/cli/target_capability_contract_test.go
+++ b/internal/cli/target_capability_contract_test.go
@@ -22,11 +22,11 @@ func TestTargetCapabilityEvidenceContractLoadsCurrentRecords(t *testing.T) {
 		t.Fatalf("records = %d, want six exact target surface records", len(contract.Records))
 	}
 	want := map[string]string{
-		"claude-code\x00cli":     "2.1.215\x00plugin-dir",
+		"claude-code\x00cli":     "2.1.218\x00plugin-dir",
 		"cursor\x00ide":          "3.11.19\x00candidate-build",
 		"cursor\x00cursor-agent": "2026.05.09-0afadcc\x00candidate-build",
-		"codex\x00cli":           "0.144.5\x00isolated-codex-home",
-		"opencode\x00cli":        "1.18.3\x00isolated-xdg",
+		"codex\x00cli":           "0.145.0\x00isolated-codex-home",
+		"opencode\x00cli":        "1.18.4\x00isolated-xdg",
 		"amp\x00cli":             "0.0.1783873056-g278461\x00candidate-build",
 	}
 	for _, record := range contract.Records {
@@ -421,7 +421,7 @@ func TestTargetCapabilityEvidenceLoadRequiresRetainedRegularSources(t *testing.T
 }
 
 func TestInstalledSmokeEvidenceRejectsUnknownVersionsAndHashDrift(t *testing.T) {
-	data, err := os.ReadFile(filepath.Join(filepath.Dir(filepath.Dir(testTargetCapabilityEvidencePath(t))), "docs/changes/20260710-journal-reliability-foundation/research/u8-claude-code-2.1.215-candidate-smoke.json"))
+	data, err := os.ReadFile(filepath.Join(filepath.Dir(filepath.Dir(testTargetCapabilityEvidencePath(t))), "docs/changes/20260710-journal-reliability-foundation/research/u8-claude-code-2.1.218-candidate-smoke.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -483,7 +483,7 @@ func TestOpenCodeInstalledSmokeEvidenceAcceptsFixture(t *testing.T) {
 }
 
 func TestOpenCodeInstalledSmokeEvidenceRejectsFalseBooleansIdentityInvocationHashAndCleanup(t *testing.T) {
-	receiptPath := filepath.Join(testRepositoryRoot(t), "docs/changes/20260710-journal-reliability-foundation/research/u8-opencode-1.18.3-isolated-smoke.json")
+	receiptPath := filepath.Join(testRepositoryRoot(t), "docs/changes/20260710-journal-reliability-foundation/research/u8-opencode-1.18.4-isolated-smoke.json")
 	data, err := os.ReadFile(receiptPath)
 	if err != nil {
 		t.Fatal(err)
@@ -546,7 +546,7 @@ func TestOpenCodeInstalledSmokeEvidenceRejectsFalseBooleansIdentityInvocationHas
 }
 
 func TestClaudeInstalledSmokeEvidenceRejectsPlatformSwappedNativeBinaryPath(t *testing.T) {
-	receiptPath := filepath.Join(testRepositoryRoot(t), "docs/changes/20260710-journal-reliability-foundation/research/u8-claude-code-2.1.215-candidate-smoke.json")
+	receiptPath := filepath.Join(testRepositoryRoot(t), "docs/changes/20260710-journal-reliability-foundation/research/u8-claude-code-2.1.218-candidate-smoke.json")
 	raw := readSmokeReceiptRaw(t, receiptPath)
 	artifacts := raw["candidate_artifacts"].(map[string]any)
 	sourceNativePath := artifacts["native_binary_path"].(string)
@@ -568,7 +568,7 @@ func TestClaudeInstalledSmokeEvidenceRejectsPlatformSwappedNativeBinaryPath(t *t
 }
 
 func TestCodexInstalledSmokeEvidenceRejectsPlatformSwappedNativeBinaryPath(t *testing.T) {
-	receiptPath := filepath.Join(testRepositoryRoot(t), "docs/changes/20260710-journal-reliability-foundation/research/u8-codex-0.144.5-isolated-smoke.json")
+	receiptPath := filepath.Join(testRepositoryRoot(t), "docs/changes/20260710-journal-reliability-foundation/research/u8-codex-0.145.0-isolated-smoke.json")
 	raw := readSmokeReceiptRaw(t, receiptPath)
 	artifacts := raw["candidate_artifacts"].(map[string]any)
 	sourceNativePath := artifacts["native_binary_path"].(string)
@@ -601,7 +601,7 @@ func TestInstalledSmokeEvidenceRejectsCrossTargetNativeBinaryPaths(t *testing.T)
 		{
 			name:       "claude-receives-codex-path",
 			target:     "claude-code",
-			receipt:    "u8-claude-code-2.1.215-candidate-smoke.json",
+			receipt:    "u8-claude-code-2.1.218-candidate-smoke.json",
 			modeName:   "startup",
 			wrongPath:  "bin/native/darwin-arm64/loaf",
 			validateFn: validateInstalledSmokeEvidence,
@@ -609,7 +609,7 @@ func TestInstalledSmokeEvidenceRejectsCrossTargetNativeBinaryPaths(t *testing.T)
 		{
 			name:       "codex-receives-claude-path",
 			target:     "codex",
-			receipt:    "u8-codex-0.144.5-isolated-smoke.json",
+			receipt:    "u8-codex-0.145.0-isolated-smoke.json",
 			modeName:   "startup",
 			wrongPath:  "plugins/loaf/bin/native/darwin-arm64/loaf",
 			validateFn: validateCodexInstalledSmokeEvidence,

--- a/internal/state/housekeeping.go
+++ b/internal/state/housekeeping.go
@@ -52,7 +52,7 @@ func (s *Store) Housekeeping(ctx context.Context, root project.Root, databasePat
 		return HousekeepingSummary{}, err
 	}
 	sections := map[string]HousekeepingSection{}
-	specs, err := s.housekeepingStatusSection(ctx, "specs", projectID, "complete", "archived")
+	specs, err := s.housekeepingStatusSection(ctx, "specs", projectID, "done", "complete", "archived")
 	if err != nil {
 		return HousekeepingSummary{}, err
 	}
@@ -62,22 +62,22 @@ func (s *Store) Housekeeping(ctx context.Context, root project.Root, databasePat
 		return HousekeepingSummary{}, err
 	}
 	sections["tasks"] = tasks
-	ideas, err := s.housekeepingStatusSection(ctx, "ideas", projectID, "resolved", "archived")
+	ideas, err := s.housekeepingStatusSection(ctx, "ideas", projectID, "done", "resolved", "archived")
 	if err != nil {
 		return HousekeepingSummary{}, err
 	}
 	sections["ideas"] = ideas
-	sparks, err := s.housekeepingStatusSection(ctx, "sparks", projectID, "resolved", "archived")
+	sparks, err := s.housekeepingStatusSection(ctx, "sparks", projectID, "done", "resolved", "archived")
 	if err != nil {
 		return HousekeepingSummary{}, err
 	}
 	sections["sparks"] = sparks
-	brainstorms, err := s.housekeepingStatusSection(ctx, "brainstorms", projectID, "resolved", "archived")
+	brainstorms, err := s.housekeepingStatusSection(ctx, "brainstorms", projectID, "done", "resolved", "archived")
 	if err != nil {
 		return HousekeepingSummary{}, err
 	}
 	sections["brainstorms"] = brainstorms
-	reports, err := s.housekeepingStatusSection(ctx, "reports", projectID, "final", "archived")
+	reports, err := s.housekeepingStatusSection(ctx, "reports", projectID, "done", "final", "archived")
 	if err != nil {
 		return HousekeepingSummary{}, err
 	}

--- a/internal/state/housekeeping_test.go
+++ b/internal/state/housekeeping_test.go
@@ -55,6 +55,44 @@ func TestHousekeepingSummarizesSQLiteLifecycleState(t *testing.T) {
 	}
 }
 
+func TestHousekeepingCountsCanonicalDoneAsCleanupCandidate(t *testing.T) {
+	root := projectRoot(t)
+	stateHome := t.TempDir()
+	result, err := Initialize(context.Background(), root, PathResolver{StateHome: stateHome})
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	store, err := OpenStore(result.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+
+	projectID := projectIDForTest(t, store, root)
+	now := "2026-07-23T00:00:00Z"
+	insertHousekeepingEntity(t, store, "specs", projectID, "spec-complete", "Complete Spec", "complete", now)
+	insertHousekeepingEntity(t, store, "specs", projectID, "spec-done", "Done Spec", "done", now)
+	insertHousekeepingEntity(t, store, "ideas", projectID, "idea-resolved", "Resolved Idea", "resolved", now)
+	insertHousekeepingEntity(t, store, "ideas", projectID, "idea-done", "Done Idea", "done", now)
+	insertHousekeepingSpark(t, store, projectID, "spark-resolved", "resolved spark", "resolved", now)
+	insertHousekeepingSpark(t, store, projectID, "spark-done", "done spark", "done", now)
+	insertHousekeepingEntity(t, store, "brainstorms", projectID, "brainstorm-resolved", "Resolved Brainstorm", "resolved", now)
+	insertHousekeepingEntity(t, store, "brainstorms", projectID, "brainstorm-done", "Done Brainstorm", "done", now)
+	insertHousekeepingReport(t, store, projectID, "report-final", "Final Report", "final", now)
+	insertHousekeepingReport(t, store, projectID, "report-done", "Done Report", "done", now)
+
+	summary, err := Housekeeping(context.Background(), root, PathResolver{StateHome: stateHome})
+	if err != nil {
+		t.Fatalf("Housekeeping() error = %v", err)
+	}
+	for _, name := range []string{"specs", "ideas", "sparks", "brainstorms", "reports"} {
+		section := summary.Sections[name]
+		if section.Total != 2 || section.ByStatus["done"] != 1 || section.CleanupCandidate != 2 {
+			t.Fatalf("section %s = %#v, want legacy and canonical done cleanup candidates", name, section)
+		}
+	}
+}
+
 func insertHousekeepingEntity(t *testing.T, store *Store, table string, projectID string, id string, title string, status string, now string) {
 	t.Helper()
 	if _, err := store.db.ExecContext(context.Background(), `INSERT INTO `+table+` (id, project_id, title, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`, id, projectID, title, status, now, now); err != nil {

--- a/internal/state/markdown_import.go
+++ b/internal/state/markdown_import.go
@@ -48,6 +48,11 @@ type taskIndexEntry struct {
 	File      string   `json:"file"`
 }
 
+type specIndexEntry struct {
+	Title  string `json:"title"`
+	Status string `json:"status"`
+}
+
 const frontmatterListSeparator = "\x1f"
 
 type markdownImporter struct {
@@ -56,6 +61,7 @@ type markdownImporter struct {
 	projectID    string
 	now          string
 	taskIndex    map[string]taskIndexEntry
+	specIndex    map[string]specIndexEntry
 	sparkAliases map[string]string
 }
 
@@ -111,6 +117,7 @@ func (s *Store) ImportMarkdown(ctx context.Context, root project.Root) error {
 		projectID:    projectID,
 		now:          time.Now().UTC().Format(time.RFC3339),
 		taskIndex:    loadTaskIndex(root.Path()),
+		specIndex:    loadSpecIndex(root.Path()),
 		sparkAliases: map[string]string{},
 	}
 	if err := importer.importAll(ctx); err != nil {
@@ -174,12 +181,16 @@ func (m markdownImporter) importSpecs(ctx context.Context, agentsPath string) er
 		}
 		alias := firstNonEmpty(artifact.Frontmatter["id"], specAliasFromPath(path), artifact.Stem)
 		id := stableMigrationID("spec", m.projectID, alias)
+		meta := m.specIndex[alias]
 		sourceID, err := m.upsertSource(ctx, artifact, "markdown")
 		if err != nil {
 			return err
 		}
-		title := firstNonEmpty(artifact.Frontmatter["title"], artifact.Heading, alias)
-		status := firstNonEmpty(artifact.Frontmatter["status"], "unknown")
+		title := firstNonEmpty(meta.Title, artifact.Frontmatter["title"], artifact.Heading, alias)
+		status := firstNonEmpty(meta.Status, artifact.Frontmatter["status"], "unknown")
+		if canonical, ok := CanonicalLifecycleStatus(LifecycleEntitySpec, status); ok {
+			status = canonical
+		}
 		if err := m.upsertSpec(ctx, id, title, status, sourceID); err != nil {
 			return err
 		}
@@ -923,6 +934,21 @@ func loadTaskIndex(rootPath string) map[string]taskIndexEntry {
 		return index
 	}
 	return parsed.Tasks
+}
+
+func loadSpecIndex(rootPath string) map[string]specIndexEntry {
+	index := map[string]specIndexEntry{}
+	content, err := os.ReadFile(filepath.Join(rootPath, ".agents", "TASKS.json"))
+	if err != nil {
+		return index
+	}
+	var parsed struct {
+		Specs map[string]specIndexEntry `json:"specs"`
+	}
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		return index
+	}
+	return parsed.Specs
 }
 
 func taskDependencies(meta taskIndexEntry, frontmatterDependsOn string) []string {

--- a/internal/state/markdown_import_test.go
+++ b/internal/state/markdown_import_test.go
@@ -229,6 +229,99 @@ depends_on: []
 	assertTableCount(t, store, "relationships", 0)
 }
 
+func TestApplyMarkdownMigrationSpecStatusPrefersIndexOverFrontmatter(t *testing.T) {
+	root := projectRoot(t)
+	stateHome := t.TempDir()
+	writeMarkdownImportSpecStatusFixture(t, root.Path())
+
+	result, err := ApplyMarkdownMigration(context.Background(), root, PathResolver{StateHome: stateHome})
+	if err != nil {
+		t.Fatalf("ApplyMarkdownMigration() error = %v", err)
+	}
+	store, err := OpenStore(result.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+
+	for alias, want := range map[string]string{
+		"SPEC-001": "done",
+		"SPEC-002": "in_progress",
+		"SPEC-003": "unknown",
+	} {
+		if got := rawSpecStatusByAlias(t, store, result.ProjectID, alias); got != want {
+			t.Fatalf("%s status = %q, want %q", alias, got, want)
+		}
+	}
+}
+
+func TestApplyMarkdownMigrationRerunRepairsSpecStatus(t *testing.T) {
+	root := projectRoot(t)
+	stateHome := t.TempDir()
+	writeMarkdownImportSpecStatusFixture(t, root.Path())
+
+	result, err := ApplyMarkdownMigration(context.Background(), root, PathResolver{StateHome: stateHome})
+	if err != nil {
+		t.Fatalf("ApplyMarkdownMigration() error = %v", err)
+	}
+	store, err := OpenStore(result.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+
+	specID := stableMigrationID("spec", result.ProjectID, "SPEC-001")
+	if _, err := store.db.ExecContext(context.Background(), `UPDATE specs SET status = 'in_progress' WHERE project_id = ? AND id = ?`, result.ProjectID, specID); err != nil {
+		t.Fatalf("seed mis-migrated status error = %v", err)
+	}
+
+	if _, err := ApplyMarkdownMigration(context.Background(), root, PathResolver{StateHome: stateHome}); err != nil {
+		t.Fatalf("second ApplyMarkdownMigration() error = %v", err)
+	}
+	if got := rawSpecStatusByAlias(t, store, result.ProjectID, "SPEC-001"); got != "done" {
+		t.Fatalf("SPEC-001 status after rerun = %q, want done", got)
+	}
+}
+
+func writeMarkdownImportSpecStatusFixture(t *testing.T, root string) {
+	t.Helper()
+	writeAgentsFile(t, root, "specs/SPEC-001-indexed.md", `---
+id: SPEC-001
+title: Indexed Spec
+status: implementing
+---
+# Indexed Spec
+`)
+	writeAgentsFile(t, root, "specs/SPEC-002-frontmatter.md", `---
+id: SPEC-002
+title: Frontmatter Spec
+status: implementing
+---
+# Frontmatter Spec
+`)
+	writeAgentsFile(t, root, "specs/SPEC-003-bare.md", "# Bare Spec\n")
+	writeAgentsFile(t, root, "TASKS.json", `{
+  "specs": {
+    "SPEC-001": {
+      "title": "Indexed Spec",
+      "status": "complete",
+      "file": "SPEC-001-indexed.md"
+    }
+  },
+  "tasks": {}
+}
+`)
+}
+
+func rawSpecStatusByAlias(t *testing.T, store *Store, projectID string, alias string) string {
+	t.Helper()
+	var status string
+	if err := store.db.QueryRowContext(context.Background(), `SELECT status FROM specs WHERE project_id = ? AND id = ?`, projectID, stableMigrationID("spec", projectID, alias)).Scan(&status); err != nil {
+		t.Fatalf("read spec %s status: %v", alias, err)
+	}
+	return status
+}
+
 func TestImportMarkdownRebuildsChangedJournalContentWithoutStaleRows(t *testing.T) {
 	ctx := context.Background()
 	root := projectRoot(t)

--- a/internal/state/spec_archive.go
+++ b/internal/state/spec_archive.go
@@ -103,11 +103,13 @@ func (s *Store) archiveSpec(ctx context.Context, projectID string, ref string) (
 		return SpecArchiveItem{}, false, fmt.Errorf("read spec status: %w", err)
 	}
 
-	if previousStatus == "archived" {
-		return SpecArchiveItem{Spec: &spec, Ref: ref, Previous: previousStatus, Status: previousStatus, Reason: "already archived"}, false, nil
+	previousCanonical := LifecycleStatusForDisplay(LifecycleEntitySpec, previousStatus)
+
+	if LifecycleStatusMatches(LifecycleEntitySpec, previousStatus, LifecycleStatusArchived) {
+		return SpecArchiveItem{Spec: &spec, Ref: ref, Previous: previousCanonical, Status: previousCanonical, Reason: "already archived"}, false, nil
 	}
-	if previousStatus != "complete" {
-		return SpecArchiveItem{Spec: &spec, Ref: ref, Previous: previousStatus, Status: previousStatus, Reason: fmt.Sprintf("status is %s, must be complete", previousStatus)}, false, nil
+	if !LifecycleStatusMatches(LifecycleEntitySpec, previousStatus, LifecycleStatusDone) {
+		return SpecArchiveItem{Spec: &spec, Ref: ref, Previous: previousCanonical, Status: previousCanonical, Reason: fmt.Sprintf("status is %s, must be done", previousCanonical)}, false, nil
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -115,12 +117,12 @@ func (s *Store) archiveSpec(ctx context.Context, projectID string, ref string) (
 		return SpecArchiveItem{}, false, fmt.Errorf("update spec status: %w", err)
 	}
 
-	eventID := stableMigrationID("event", projectID, "spec", spec.ID, "status", previousStatus, "archived")
+	eventID := stableMigrationID("event", projectID, "spec", spec.ID, "status", previousCanonical, "archived")
 	_, err = tx.ExecContext(ctx, `
 INSERT INTO events (id, project_id, entity_kind, entity_id, event_type, from_status, to_status, note, created_at, updated_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO NOTHING
-`, eventID, projectID, "spec", spec.ID, "status_changed", previousStatus, "archived", "recorded by spec archive", now, now)
+`, eventID, projectID, "spec", spec.ID, "status_changed", previousCanonical, "archived", "recorded by spec archive", now, now)
 	if err != nil {
 		return SpecArchiveItem{}, false, fmt.Errorf("record spec archive event: %w", err)
 	}
@@ -130,5 +132,5 @@ ON CONFLICT(id) DO NOTHING
 	}
 
 	spec.Status = "archived"
-	return SpecArchiveItem{Spec: &spec, Ref: ref, Previous: previousStatus, Status: "archived", EventID: eventID}, true, nil
+	return SpecArchiveItem{Spec: &spec, Ref: ref, Previous: previousCanonical, Status: "archived", EventID: eventID}, true, nil
 }

--- a/internal/state/spec_archive_test.go
+++ b/internal/state/spec_archive_test.go
@@ -25,7 +25,7 @@ status: complete
 	if err != nil {
 		t.Fatalf("ArchiveSpecs() error = %v", err)
 	}
-	if len(result.Archived) != 1 || result.Archived[0].Spec == nil || result.Archived[0].Spec.Alias != "SPEC-001" || result.Archived[0].Previous != "complete" || result.Archived[0].Status != "archived" || result.Archived[0].EventID == "" {
+	if len(result.Archived) != 1 || result.Archived[0].Spec == nil || result.Archived[0].Spec.Alias != "SPEC-001" || result.Archived[0].Previous != "done" || result.Archived[0].Status != "archived" || result.Archived[0].EventID == "" {
 		t.Fatalf("Archived = %#v, want SPEC-001 archived with event", result.Archived)
 	}
 	if result.ContractVersion != StateJSONContractVersion {
@@ -74,6 +74,84 @@ status: complete
 	}
 }
 
+func TestArchiveSpecsArchivesSpecSetDoneViaSetSpecStatus(t *testing.T) {
+	root := projectRoot(t)
+	stateHome := t.TempDir()
+	writeAgentsFile(t, root.Path(), "specs/SPEC-001-draft.md", `---
+id: SPEC-001
+title: Draft Spec
+status: draft
+---
+# Draft Spec
+`)
+	writeAgentsFile(t, root.Path(), "TASKS.json", `{"tasks":{}}`)
+	if _, err := ApplyMarkdownMigration(context.Background(), root, PathResolver{StateHome: stateHome}); err != nil {
+		t.Fatalf("ApplyMarkdownMigration() error = %v", err)
+	}
+	if _, err := SetSpecStatus(context.Background(), root, PathResolver{StateHome: stateHome}, "SPEC-001", "complete"); err != nil {
+		t.Fatalf("SetSpecStatus(complete) error = %v", err)
+	}
+
+	result, err := ArchiveSpecs(context.Background(), root, PathResolver{StateHome: stateHome}, []string{"SPEC-001"})
+	if err != nil {
+		t.Fatalf("ArchiveSpecs() error = %v", err)
+	}
+	if len(result.Archived) != 1 || result.Archived[0].Spec == nil || result.Archived[0].Spec.Alias != "SPEC-001" || result.Archived[0].Previous != "done" || result.Archived[0].Status != "archived" || result.Archived[0].EventID == "" {
+		t.Fatalf("Archived = %#v, want SPEC-001 archived from done with event", result.Archived)
+	}
+	if got := rawLifecycleEventFromStatus(t, result.DatabasePath, result.Archived[0].EventID); got != "done" {
+		t.Fatalf("event from_status = %q, want done", got)
+	}
+	if got := rawLifecycleEventToStatus(t, result.DatabasePath, result.Archived[0].EventID); got != "archived" {
+		t.Fatalf("event to_status = %q, want archived", got)
+	}
+
+	again, err := ArchiveSpecs(context.Background(), root, PathResolver{StateHome: stateHome}, []string{"SPEC-001"})
+	if err != nil {
+		t.Fatalf("idempotent ArchiveSpecs() error = %v", err)
+	}
+	if len(again.Archived) != 0 || len(again.Skipped) != 1 || again.Skipped[0].Reason != "already archived" {
+		t.Fatalf("second ArchiveSpecs() = %#v, want already archived skip", again)
+	}
+}
+
+func TestArchiveSpecsAcceptsRawLegacyCompleteStatus(t *testing.T) {
+	root := projectRoot(t)
+	stateHome := t.TempDir()
+	writeAgentsFile(t, root.Path(), "specs/SPEC-001-draft.md", `---
+id: SPEC-001
+title: Draft Spec
+status: draft
+---
+# Draft Spec
+`)
+	writeAgentsFile(t, root.Path(), "TASKS.json", `{"tasks":{}}`)
+	migration, err := ApplyMarkdownMigration(context.Background(), root, PathResolver{StateHome: stateHome})
+	if err != nil {
+		t.Fatalf("ApplyMarkdownMigration() error = %v", err)
+	}
+	store, err := OpenStore(migration.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `UPDATE specs SET status = 'complete' WHERE project_id = ?`, migration.ProjectID); err != nil {
+		store.Close()
+		t.Fatalf("seed raw legacy status error = %v", err)
+	}
+	store.Close()
+
+	result, err := ArchiveSpecs(context.Background(), root, PathResolver{StateHome: stateHome}, []string{"SPEC-001"})
+	if err != nil {
+		t.Fatalf("ArchiveSpecs() error = %v", err)
+	}
+	if len(result.Archived) != 1 || result.Archived[0].Spec == nil || result.Archived[0].Spec.Alias != "SPEC-001" || result.Archived[0].Previous != "done" || result.Archived[0].Status != "archived" || result.Archived[0].EventID == "" {
+		t.Fatalf("Archived = %#v, want SPEC-001 archived from raw legacy complete", result.Archived)
+	}
+	if got := rawLifecycleEventFromStatus(t, result.DatabasePath, result.Archived[0].EventID); got != "done" {
+		t.Fatalf("event from_status = %q, want done", got)
+	}
+}
+
 func TestArchiveSpecsSkipsUnarchiveableRefs(t *testing.T) {
 	root := projectRoot(t)
 	stateHome := t.TempDir()
@@ -111,7 +189,7 @@ status: complete
 	for _, skipped := range result.Skipped {
 		reasons[skipped.Ref] = skipped.Reason
 	}
-	if reasons["SPEC-001"] != "status is drafting, must be complete" {
+	if reasons["SPEC-001"] != "status is draft, must be done" {
 		t.Fatalf("SPEC-001 reason = %q, want status skip", reasons["SPEC-001"])
 	}
 	if reasons["TASK-001"] != `"TASK-001" resolves to task, not spec` {

--- a/plugins/loaf/skills/housekeeping/SKILL.md
+++ b/plugins/loaf/skills/housekeeping/SKILL.md
@@ -107,10 +107,10 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `done` or `archived`, verify the Linear
-   parent issue is in a `completed`-type state. If not (e.g., still "In
-   Progress"), flag as **status mismatch** — "Spec marked complete locally
-   but Linear parent ENG-198 is still 'In Progress'."
+2. If the spec's local status is `done` (or legacy `complete`) or `archived`,
+   verify the Linear parent issue is in a `completed`-type state. If not
+   (e.g., still "In Progress"), flag as **status mismatch** — "Spec marked
+   complete locally but Linear parent ENG-198 is still 'In Progress'."
 3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
    `done` and archived.

--- a/plugins/loaf/skills/housekeeping/SKILL.md
+++ b/plugins/loaf/skills/housekeeping/SKILL.md
@@ -107,13 +107,13 @@ For each spec file (active and archive) with a `linear_parent:` frontmatter key:
 1. Call `get_issue` with the issue identifier. If it 404s or returns
    archived/deleted, flag as **orphaned linear_parent** — the local spec
    references a Linear issue that no longer exists.
-2. If the spec's local status is `complete` or `archived`, verify the Linear
+2. If the spec's local status is `done` or `archived`, verify the Linear
    parent issue is in a `completed`-type state. If not (e.g., still "In
    Progress"), flag as **status mismatch** — "Spec marked complete locally
    but Linear parent ENG-198 is still 'In Progress'."
-3. If the spec's local status is `implementing` and the Linear parent is
+3. If the spec's local status is `in_progress` and the Linear parent is
    already `completed`, flag the inverse — spec likely needs to be moved to
-   `complete` and archived.
+   `done` and archived.
 
 Treat all three as **warnings**, not auto-fixes. The user decides resolution.
 

--- a/plugins/loaf/skills/reflect/SKILL.md
+++ b/plugins/loaf/skills/reflect/SKILL.md
@@ -87,7 +87,7 @@ After completing work, `/loaf:reflect` extracts learnings and proposes updates t
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `complete`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?

--- a/plugins/loaf/skills/reflect/SKILL.md
+++ b/plugins/loaf/skills/reflect/SKILL.md
@@ -87,7 +87,7 @@ After completing work, `/loaf:reflect` extracts learnings and proposes updates t
 ### Step 2: Gather Evidence
 
 Sources:
-1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`) -- look for "Lessons Learned"
+1. **Completed specs** (`.agents/specs/SPEC-*.md` with status `done`; legacy files may still read `complete`) -- look for "Lessons Learned"
 2. **Project journal** (`loaf journal recent --json`, `loaf journal search <topic>`) -- insights, surprises, pivots
 3. **Recent commits** (`git log --oneline -30`)
 4. **Implementation reality** -- what was harder/easier than expected? What assumptions were wrong?


### PR DESCRIPTION
## What & Why

Spec terminal-status handling now speaks one vocabulary: canonical `done`. Spec archive gates through `LifecycleStatusMatches` so canonical `done` and raw legacy `complete` rows both archive, with skip reasons, `previous_status`, event `from_status`, and the nested `spec` entity all recording the canonical spelling on both the SQLite and markdown-only paths. Markdown import gives the TASKS.json specs index precedence over stale frontmatter and canonicalizes mappable statuses at write, so terminal specs no longer migrate as `in_progress`. Housekeeping cleanup gates accept canonical `done` alongside legacy spellings for specs, ideas, sparks, brainstorms, and reports, and skill docs use the canonical vocabulary. Installed-smoke evidence was re-recorded against the rebuilt binary (claude-code 2.1.218, codex 0.145.0, opencode 1.18.4).

## Review focus

The markdown-import precedence decision (specs index wins over frontmatter) and the canonicalization boundary: raw legacy spellings survive in storage but every JSON response surface reports canonical statuses, including the nested `TraceEntity` fixed after adversarial review.

## Verification

`npm run build` (with Go artifact verification), `npm run typecheck`, `npm run test` including the strict target-capability contract suite against the regenerated evidence, 19 Node smoke-parser tests, and `git diff --check` all pass; reviewers can re-run `go test ./internal/cli/ -run 'SpecArchive' -count=1` for the focused regression tests.

## Migration / breaking changes

Legacy `complete` spec rows now archive instead of being skipped; re-running `loaf migrate markdown --apply` repairs previously mis-migrated terminal specs while markdown sources exist.

## Deferred

Renaming the `u8-`-prefixed smoke scripts, relocating their evidence out of the shipped change's research directory, and fixing mise-shim executable resolution in the OpenCode smoke — handled in a separate thread.