### PR TITLE
feat: advise the sanctioned release flow from the CLI and skill

### DIFF
--- a/content/skills/release/SKILL.md
+++ b/content/skills/release/SKILL.md
@@ -23,7 +23,7 @@ Publish a coherent version from work that has already landed.
 - Step 2: Change Collection
 - Step 3: Version + Changelog
 - Step 4: Release Execution
-- Step 5: Protected-Branch Handoff
+- Step 5: Release-PR Flow
 - Step 6: Publication Verification
 - Step 7: Post-Release Follow-Up
 - Hook Interaction
@@ -37,6 +37,7 @@ Publish a coherent version from work that has already landed.
 
 - **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
 - **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Release-PR flow is the default** -- prepare on a release branch with `loaf release --pre-merge`, squash-merge the release PR, then finalize with `loaf release --post-merge` on the base branch. Direct `--bump` on the base branch is a named exception used only on explicit user request.
 - **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
 - **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
 - **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
@@ -60,7 +61,7 @@ Publish a coherent version from work that has already landed.
 | Readiness | clean/current base branch, no unresolved release collisions | Yes |
 | Change Collection | landed work since last tag grouped into release themes | Yes |
 | Version + Changelog | bump selected, notes curated, files updated | Yes |
-| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Execution | release commit prepared via `--pre-merge`, release PR landed, `--post-merge` finalizes | Yes |
 | Verification | release and install paths checked | Yes |
 | Follow-Up | reflect/housekeeping suggested when useful | No |
 
@@ -69,7 +70,7 @@ Publish a coherent version from work that has already landed.
 | Topic | Use When |
 |-------|----------|
 | [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
-| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
+| [Release-PR Flow](#step-5-release-pr-flow) | Preparing, landing, and finalizing every release |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
@@ -85,9 +86,9 @@ Before anything, establish the release surface:
    ```
 2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
 3. Verify the current branch:
-   - If already on the release base, continue.
+   - If already on the release base, continue; the release-PR flow in Step 5 branches from here.
+   - If on a dedicated release branch, resume the release-PR flow at the matching step.
    - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
-   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
 4. Find the previous release tag:
    ```bash
    git describe --tags --abbrev=0
@@ -182,23 +183,17 @@ Choose the bump and curate the changelog from the grouped landed work.
 
 ## Step 4: Release Execution
 
-For a direct release from the base branch, run:
+Every release routes through the release-PR flow in Step 5: prepare the release commit on a release branch with `loaf release --pre-merge`, land the release PR, then finalize with `loaf release --post-merge` on the base branch.
 
-```bash
-loaf release --bump <type> --yes
-```
-
-This should:
+Release preparation should:
 
 1. Update version files
 2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
 3. Reinsert a fresh empty `[Unreleased]` section
 4. Run configured release artifact commands
 5. Create the release commit
-6. Create/push the release tag
-7. Create the GitHub Release when enabled
 
-After execution, verify generated artifacts are current:
+After preparation, verify generated artifacts are current:
 
 ```bash
 npm run build
@@ -207,17 +202,21 @@ git diff --exit-code -- dist plugins content/skills/loaf-reference/SKILL.md
 
 Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
+### Direct Release (Named Exception)
+
+`loaf release --bump <type> --yes` on the base branch prepares, commits, tags, and publishes in a single shot. Use it only when the user explicitly requests a direct release; never select it by default. Skipping the release PR means nothing runs the suite against the prepared tree before the tag exists — the v2.0.0-alpha.16 cut took this door and a capability-evidence canary surfaced only in tag CI, after publication. The CLI prints a flow advisory when a mutating release starts on the default branch; treat it as a routing signal, not noise.
+
 ---
 
-## Step 5: Protected-Branch Handoff
+## Step 5: Release-PR Flow
 
-If branch protection prevents direct release commits on the base branch:
+The default for every release: PR CI runs the full suite against the prepared tree, so evidence canaries surface before any tag or GitHub Release exists. This holds regardless of repository settings — where branch protection is enabled it is satisfied as a side effect, not the reason for the flow.
 
-1. Create a dedicated release branch.
-2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+1. Create a dedicated release branch from the release base.
+2. Run `loaf release --pre-merge` on it: this creates the version/changelog/artifact release commit but no tag and no GitHub Release.
 3. Open a release PR with a concise release-focused body.
-4. Hand the PR to `/ship` for review and landing.
-5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
+4. Hand the PR to `/ship` for review and landing; squash-merge it into one `chore: release vX.Y.Z (#PR)` commit carrying the curated changelog.
+5. After the release PR lands, run `loaf release --post-merge` on the base branch to tag, publish the GitHub Release, and verify installability.
 
 Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
@@ -268,7 +267,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 |------|------|---------------------|
 | `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
-| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-pr` | Advisory | Fires when the release PR is opened |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
 | `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
 | `check-secrets` | Blocking | Always respected before writes or shell actions |

--- a/dist/amp/skills/release/SKILL.md
+++ b/dist/amp/skills/release/SKILL.md
@@ -24,7 +24,7 @@ Publish a coherent version from work that has already landed.
 - Step 2: Change Collection
 - Step 3: Version + Changelog
 - Step 4: Release Execution
-- Step 5: Protected-Branch Handoff
+- Step 5: Release-PR Flow
 - Step 6: Publication Verification
 - Step 7: Post-Release Follow-Up
 - Hook Interaction
@@ -38,6 +38,7 @@ Publish a coherent version from work that has already landed.
 
 - **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
 - **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Release-PR flow is the default** -- prepare on a release branch with `loaf release --pre-merge`, squash-merge the release PR, then finalize with `loaf release --post-merge` on the base branch. Direct `--bump` on the base branch is a named exception used only on explicit user request.
 - **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
 - **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
 - **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
@@ -61,7 +62,7 @@ Publish a coherent version from work that has already landed.
 | Readiness | clean/current base branch, no unresolved release collisions | Yes |
 | Change Collection | landed work since last tag grouped into release themes | Yes |
 | Version + Changelog | bump selected, notes curated, files updated | Yes |
-| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Execution | release commit prepared via `--pre-merge`, release PR landed, `--post-merge` finalizes | Yes |
 | Verification | release and install paths checked | Yes |
 | Follow-Up | reflect/housekeeping suggested when useful | No |
 
@@ -70,7 +71,7 @@ Publish a coherent version from work that has already landed.
 | Topic | Use When |
 |-------|----------|
 | [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
-| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
+| [Release-PR Flow](#step-5-release-pr-flow) | Preparing, landing, and finalizing every release |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
@@ -86,9 +87,9 @@ Before anything, establish the release surface:
    ```
 2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
 3. Verify the current branch:
-   - If already on the release base, continue.
+   - If already on the release base, continue; the release-PR flow in Step 5 branches from here.
+   - If on a dedicated release branch, resume the release-PR flow at the matching step.
    - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
-   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
 4. Find the previous release tag:
    ```bash
    git describe --tags --abbrev=0
@@ -183,23 +184,17 @@ Choose the bump and curate the changelog from the grouped landed work.
 
 ## Step 4: Release Execution
 
-For a direct release from the base branch, run:
+Every release routes through the release-PR flow in Step 5: prepare the release commit on a release branch with `loaf release --pre-merge`, land the release PR, then finalize with `loaf release --post-merge` on the base branch.
 
-```bash
-loaf release --bump <type> --yes
-```
-
-This should:
+Release preparation should:
 
 1. Update version files
 2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
 3. Reinsert a fresh empty `[Unreleased]` section
 4. Run configured release artifact commands
 5. Create the release commit
-6. Create/push the release tag
-7. Create the GitHub Release when enabled
 
-After execution, verify generated artifacts are current:
+After preparation, verify generated artifacts are current:
 
 ```bash
 npm run build
@@ -208,17 +203,21 @@ git diff --exit-code -- dist plugins content/skills/loaf-reference/SKILL.md
 
 Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
+### Direct Release (Named Exception)
+
+`loaf release --bump <type> --yes` on the base branch prepares, commits, tags, and publishes in a single shot. Use it only when the user explicitly requests a direct release; never select it by default. Skipping the release PR means nothing runs the suite against the prepared tree before the tag exists — the v2.0.0-alpha.16 cut took this door and a capability-evidence canary surfaced only in tag CI, after publication. The CLI prints a flow advisory when a mutating release starts on the default branch; treat it as a routing signal, not noise.
+
 ---
 
-## Step 5: Protected-Branch Handoff
+## Step 5: Release-PR Flow
 
-If branch protection prevents direct release commits on the base branch:
+The default for every release: PR CI runs the full suite against the prepared tree, so evidence canaries surface before any tag or GitHub Release exists. This holds regardless of repository settings — where branch protection is enabled it is satisfied as a side effect, not the reason for the flow.
 
-1. Create a dedicated release branch.
-2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+1. Create a dedicated release branch from the release base.
+2. Run `loaf release --pre-merge` on it: this creates the version/changelog/artifact release commit but no tag and no GitHub Release.
 3. Open a release PR with a concise release-focused body.
-4. Hand the PR to `/ship` for review and landing.
-5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
+4. Hand the PR to `/ship` for review and landing; squash-merge it into one `chore: release vX.Y.Z (#PR)` commit carrying the curated changelog.
+5. After the release PR lands, run `loaf release --post-merge` on the base branch to tag, publish the GitHub Release, and verify installability.
 
 Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
@@ -269,7 +268,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 |------|------|---------------------|
 | `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
-| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-pr` | Advisory | Fires when the release PR is opened |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
 | `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
 | `check-secrets` | Blocking | Always respected before writes or shell actions |

--- a/dist/codex/skills/release/SKILL.md
+++ b/dist/codex/skills/release/SKILL.md
@@ -24,7 +24,7 @@ Publish a coherent version from work that has already landed.
 - Step 2: Change Collection
 - Step 3: Version + Changelog
 - Step 4: Release Execution
-- Step 5: Protected-Branch Handoff
+- Step 5: Release-PR Flow
 - Step 6: Publication Verification
 - Step 7: Post-Release Follow-Up
 - Hook Interaction
@@ -38,6 +38,7 @@ Publish a coherent version from work that has already landed.
 
 - **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
 - **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Release-PR flow is the default** -- prepare on a release branch with `loaf release --pre-merge`, squash-merge the release PR, then finalize with `loaf release --post-merge` on the base branch. Direct `--bump` on the base branch is a named exception used only on explicit user request.
 - **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
 - **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
 - **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
@@ -61,7 +62,7 @@ Publish a coherent version from work that has already landed.
 | Readiness | clean/current base branch, no unresolved release collisions | Yes |
 | Change Collection | landed work since last tag grouped into release themes | Yes |
 | Version + Changelog | bump selected, notes curated, files updated | Yes |
-| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Execution | release commit prepared via `--pre-merge`, release PR landed, `--post-merge` finalizes | Yes |
 | Verification | release and install paths checked | Yes |
 | Follow-Up | reflect/housekeeping suggested when useful | No |
 
@@ -70,7 +71,7 @@ Publish a coherent version from work that has already landed.
 | Topic | Use When |
 |-------|----------|
 | [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
-| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
+| [Release-PR Flow](#step-5-release-pr-flow) | Preparing, landing, and finalizing every release |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
@@ -86,9 +87,9 @@ Before anything, establish the release surface:
    ```
 2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
 3. Verify the current branch:
-   - If already on the release base, continue.
+   - If already on the release base, continue; the release-PR flow in Step 5 branches from here.
+   - If on a dedicated release branch, resume the release-PR flow at the matching step.
    - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
-   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
 4. Find the previous release tag:
    ```bash
    git describe --tags --abbrev=0
@@ -183,23 +184,17 @@ Choose the bump and curate the changelog from the grouped landed work.
 
 ## Step 4: Release Execution
 
-For a direct release from the base branch, run:
+Every release routes through the release-PR flow in Step 5: prepare the release commit on a release branch with `loaf release --pre-merge`, land the release PR, then finalize with `loaf release --post-merge` on the base branch.
 
-```bash
-loaf release --bump <type> --yes
-```
-
-This should:
+Release preparation should:
 
 1. Update version files
 2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
 3. Reinsert a fresh empty `[Unreleased]` section
 4. Run configured release artifact commands
 5. Create the release commit
-6. Create/push the release tag
-7. Create the GitHub Release when enabled
 
-After execution, verify generated artifacts are current:
+After preparation, verify generated artifacts are current:
 
 ```bash
 npm run build
@@ -208,17 +203,21 @@ git diff --exit-code -- dist plugins content/skills/loaf-reference/SKILL.md
 
 Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
+### Direct Release (Named Exception)
+
+`loaf release --bump <type> --yes` on the base branch prepares, commits, tags, and publishes in a single shot. Use it only when the user explicitly requests a direct release; never select it by default. Skipping the release PR means nothing runs the suite against the prepared tree before the tag exists — the v2.0.0-alpha.16 cut took this door and a capability-evidence canary surfaced only in tag CI, after publication. The CLI prints a flow advisory when a mutating release starts on the default branch; treat it as a routing signal, not noise.
+
 ---
 
-## Step 5: Protected-Branch Handoff
+## Step 5: Release-PR Flow
 
-If branch protection prevents direct release commits on the base branch:
+The default for every release: PR CI runs the full suite against the prepared tree, so evidence canaries surface before any tag or GitHub Release exists. This holds regardless of repository settings — where branch protection is enabled it is satisfied as a side effect, not the reason for the flow.
 
-1. Create a dedicated release branch.
-2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+1. Create a dedicated release branch from the release base.
+2. Run `loaf release --pre-merge` on it: this creates the version/changelog/artifact release commit but no tag and no GitHub Release.
 3. Open a release PR with a concise release-focused body.
-4. Hand the PR to `/ship` for review and landing.
-5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
+4. Hand the PR to `/ship` for review and landing; squash-merge it into one `chore: release vX.Y.Z (#PR)` commit carrying the curated changelog.
+5. After the release PR lands, run `loaf release --post-merge` on the base branch to tag, publish the GitHub Release, and verify installability.
 
 Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
@@ -269,7 +268,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 |------|------|---------------------|
 | `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
-| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-pr` | Advisory | Fires when the release PR is opened |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
 | `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
 | `check-secrets` | Blocking | Always respected before writes or shell actions |

--- a/dist/cursor/skills/release/SKILL.md
+++ b/dist/cursor/skills/release/SKILL.md
@@ -24,7 +24,7 @@ Publish a coherent version from work that has already landed.
 - Step 2: Change Collection
 - Step 3: Version + Changelog
 - Step 4: Release Execution
-- Step 5: Protected-Branch Handoff
+- Step 5: Release-PR Flow
 - Step 6: Publication Verification
 - Step 7: Post-Release Follow-Up
 - Hook Interaction
@@ -38,6 +38,7 @@ Publish a coherent version from work that has already landed.
 
 - **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
 - **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Release-PR flow is the default** -- prepare on a release branch with `loaf release --pre-merge`, squash-merge the release PR, then finalize with `loaf release --post-merge` on the base branch. Direct `--bump` on the base branch is a named exception used only on explicit user request.
 - **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
 - **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
 - **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
@@ -61,7 +62,7 @@ Publish a coherent version from work that has already landed.
 | Readiness | clean/current base branch, no unresolved release collisions | Yes |
 | Change Collection | landed work since last tag grouped into release themes | Yes |
 | Version + Changelog | bump selected, notes curated, files updated | Yes |
-| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Execution | release commit prepared via `--pre-merge`, release PR landed, `--post-merge` finalizes | Yes |
 | Verification | release and install paths checked | Yes |
 | Follow-Up | reflect/housekeeping suggested when useful | No |
 
@@ -70,7 +71,7 @@ Publish a coherent version from work that has already landed.
 | Topic | Use When |
 |-------|----------|
 | [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
-| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
+| [Release-PR Flow](#step-5-release-pr-flow) | Preparing, landing, and finalizing every release |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
@@ -86,9 +87,9 @@ Before anything, establish the release surface:
    ```
 2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
 3. Verify the current branch:
-   - If already on the release base, continue.
+   - If already on the release base, continue; the release-PR flow in Step 5 branches from here.
+   - If on a dedicated release branch, resume the release-PR flow at the matching step.
    - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
-   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
 4. Find the previous release tag:
    ```bash
    git describe --tags --abbrev=0
@@ -183,23 +184,17 @@ Choose the bump and curate the changelog from the grouped landed work.
 
 ## Step 4: Release Execution
 
-For a direct release from the base branch, run:
+Every release routes through the release-PR flow in Step 5: prepare the release commit on a release branch with `loaf release --pre-merge`, land the release PR, then finalize with `loaf release --post-merge` on the base branch.
 
-```bash
-loaf release --bump <type> --yes
-```
-
-This should:
+Release preparation should:
 
 1. Update version files
 2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
 3. Reinsert a fresh empty `[Unreleased]` section
 4. Run configured release artifact commands
 5. Create the release commit
-6. Create/push the release tag
-7. Create the GitHub Release when enabled
 
-After execution, verify generated artifacts are current:
+After preparation, verify generated artifacts are current:
 
 ```bash
 npm run build
@@ -208,17 +203,21 @@ git diff --exit-code -- dist plugins content/skills/loaf-reference/SKILL.md
 
 Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
+### Direct Release (Named Exception)
+
+`loaf release --bump <type> --yes` on the base branch prepares, commits, tags, and publishes in a single shot. Use it only when the user explicitly requests a direct release; never select it by default. Skipping the release PR means nothing runs the suite against the prepared tree before the tag exists — the v2.0.0-alpha.16 cut took this door and a capability-evidence canary surfaced only in tag CI, after publication. The CLI prints a flow advisory when a mutating release starts on the default branch; treat it as a routing signal, not noise.
+
 ---
 
-## Step 5: Protected-Branch Handoff
+## Step 5: Release-PR Flow
 
-If branch protection prevents direct release commits on the base branch:
+The default for every release: PR CI runs the full suite against the prepared tree, so evidence canaries surface before any tag or GitHub Release exists. This holds regardless of repository settings — where branch protection is enabled it is satisfied as a side effect, not the reason for the flow.
 
-1. Create a dedicated release branch.
-2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+1. Create a dedicated release branch from the release base.
+2. Run `loaf release --pre-merge` on it: this creates the version/changelog/artifact release commit but no tag and no GitHub Release.
 3. Open a release PR with a concise release-focused body.
-4. Hand the PR to `/ship` for review and landing.
-5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
+4. Hand the PR to `/ship` for review and landing; squash-merge it into one `chore: release vX.Y.Z (#PR)` commit carrying the curated changelog.
+5. After the release PR lands, run `loaf release --post-merge` on the base branch to tag, publish the GitHub Release, and verify installability.
 
 Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
@@ -269,7 +268,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 |------|------|---------------------|
 | `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
-| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-pr` | Advisory | Fires when the release PR is opened |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
 | `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
 | `check-secrets` | Blocking | Always respected before writes or shell actions |

--- a/dist/opencode/commands/release.md
+++ b/dist/opencode/commands/release.md
@@ -23,7 +23,7 @@ Publish a coherent version from work that has already landed.
 - Step 2: Change Collection
 - Step 3: Version + Changelog
 - Step 4: Release Execution
-- Step 5: Protected-Branch Handoff
+- Step 5: Release-PR Flow
 - Step 6: Publication Verification
 - Step 7: Post-Release Follow-Up
 - Hook Interaction
@@ -37,6 +37,7 @@ Publish a coherent version from work that has already landed.
 
 - **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
 - **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Release-PR flow is the default** -- prepare on a release branch with `loaf release --pre-merge`, squash-merge the release PR, then finalize with `loaf release --post-merge` on the base branch. Direct `--bump` on the base branch is a named exception used only on explicit user request.
 - **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
 - **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
 - **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
@@ -60,7 +61,7 @@ Publish a coherent version from work that has already landed.
 | Readiness | clean/current base branch, no unresolved release collisions | Yes |
 | Change Collection | landed work since last tag grouped into release themes | Yes |
 | Version + Changelog | bump selected, notes curated, files updated | Yes |
-| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Execution | release commit prepared via `--pre-merge`, release PR landed, `--post-merge` finalizes | Yes |
 | Verification | release and install paths checked | Yes |
 | Follow-Up | reflect/housekeeping suggested when useful | No |
 
@@ -69,7 +70,7 @@ Publish a coherent version from work that has already landed.
 | Topic | Use When |
 |-------|----------|
 | [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
-| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
+| [Release-PR Flow](#step-5-release-pr-flow) | Preparing, landing, and finalizing every release |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
@@ -85,9 +86,9 @@ Before anything, establish the release surface:
    ```
 2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
 3. Verify the current branch:
-   - If already on the release base, continue.
+   - If already on the release base, continue; the release-PR flow in Step 5 branches from here.
+   - If on a dedicated release branch, resume the release-PR flow at the matching step.
    - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
-   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
 4. Find the previous release tag:
    ```bash
    git describe --tags --abbrev=0
@@ -182,23 +183,17 @@ Choose the bump and curate the changelog from the grouped landed work.
 
 ## Step 4: Release Execution
 
-For a direct release from the base branch, run:
+Every release routes through the release-PR flow in Step 5: prepare the release commit on a release branch with `loaf release --pre-merge`, land the release PR, then finalize with `loaf release --post-merge` on the base branch.
 
-```bash
-loaf release --bump <type> --yes
-```
-
-This should:
+Release preparation should:
 
 1. Update version files
 2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
 3. Reinsert a fresh empty `[Unreleased]` section
 4. Run configured release artifact commands
 5. Create the release commit
-6. Create/push the release tag
-7. Create the GitHub Release when enabled
 
-After execution, verify generated artifacts are current:
+After preparation, verify generated artifacts are current:
 
 ```bash
 npm run build
@@ -207,17 +202,21 @@ git diff --exit-code -- dist plugins content/skills/loaf-reference/SKILL.md
 
 Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
+### Direct Release (Named Exception)
+
+`loaf release --bump <type> --yes` on the base branch prepares, commits, tags, and publishes in a single shot. Use it only when the user explicitly requests a direct release; never select it by default. Skipping the release PR means nothing runs the suite against the prepared tree before the tag exists — the v2.0.0-alpha.16 cut took this door and a capability-evidence canary surfaced only in tag CI, after publication. The CLI prints a flow advisory when a mutating release starts on the default branch; treat it as a routing signal, not noise.
+
 ---
 
-## Step 5: Protected-Branch Handoff
+## Step 5: Release-PR Flow
 
-If branch protection prevents direct release commits on the base branch:
+The default for every release: PR CI runs the full suite against the prepared tree, so evidence canaries surface before any tag or GitHub Release exists. This holds regardless of repository settings — where branch protection is enabled it is satisfied as a side effect, not the reason for the flow.
 
-1. Create a dedicated release branch.
-2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+1. Create a dedicated release branch from the release base.
+2. Run `loaf release --pre-merge` on it: this creates the version/changelog/artifact release commit but no tag and no GitHub Release.
 3. Open a release PR with a concise release-focused body.
-4. Hand the PR to `/ship` for review and landing.
-5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
+4. Hand the PR to `/ship` for review and landing; squash-merge it into one `chore: release vX.Y.Z (#PR)` commit carrying the curated changelog.
+5. After the release PR lands, run `loaf release --post-merge` on the base branch to tag, publish the GitHub Release, and verify installability.
 
 Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
@@ -268,7 +267,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 |------|------|---------------------|
 | `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
-| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-pr` | Advisory | Fires when the release PR is opened |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
 | `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
 | `check-secrets` | Blocking | Always respected before writes or shell actions |

--- a/dist/opencode/skills/release/SKILL.md
+++ b/dist/opencode/skills/release/SKILL.md
@@ -24,7 +24,7 @@ Publish a coherent version from work that has already landed.
 - Step 2: Change Collection
 - Step 3: Version + Changelog
 - Step 4: Release Execution
-- Step 5: Protected-Branch Handoff
+- Step 5: Release-PR Flow
 - Step 6: Publication Verification
 - Step 7: Post-Release Follow-Up
 - Hook Interaction
@@ -38,6 +38,7 @@ Publish a coherent version from work that has already landed.
 
 - **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
 - **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Release-PR flow is the default** -- prepare on a release branch with `loaf release --pre-merge`, squash-merge the release PR, then finalize with `loaf release --post-merge` on the base branch. Direct `--bump` on the base branch is a named exception used only on explicit user request.
 - **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
 - **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
 - **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
@@ -61,7 +62,7 @@ Publish a coherent version from work that has already landed.
 | Readiness | clean/current base branch, no unresolved release collisions | Yes |
 | Change Collection | landed work since last tag grouped into release themes | Yes |
 | Version + Changelog | bump selected, notes curated, files updated | Yes |
-| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Execution | release commit prepared via `--pre-merge`, release PR landed, `--post-merge` finalizes | Yes |
 | Verification | release and install paths checked | Yes |
 | Follow-Up | reflect/housekeeping suggested when useful | No |
 
@@ -70,7 +71,7 @@ Publish a coherent version from work that has already landed.
 | Topic | Use When |
 |-------|----------|
 | [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
-| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
+| [Release-PR Flow](#step-5-release-pr-flow) | Preparing, landing, and finalizing every release |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
@@ -86,9 +87,9 @@ Before anything, establish the release surface:
    ```
 2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
 3. Verify the current branch:
-   - If already on the release base, continue.
+   - If already on the release base, continue; the release-PR flow in Step 5 branches from here.
+   - If on a dedicated release branch, resume the release-PR flow at the matching step.
    - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
-   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
 4. Find the previous release tag:
    ```bash
    git describe --tags --abbrev=0
@@ -183,23 +184,17 @@ Choose the bump and curate the changelog from the grouped landed work.
 
 ## Step 4: Release Execution
 
-For a direct release from the base branch, run:
+Every release routes through the release-PR flow in Step 5: prepare the release commit on a release branch with `loaf release --pre-merge`, land the release PR, then finalize with `loaf release --post-merge` on the base branch.
 
-```bash
-loaf release --bump <type> --yes
-```
-
-This should:
+Release preparation should:
 
 1. Update version files
 2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
 3. Reinsert a fresh empty `[Unreleased]` section
 4. Run configured release artifact commands
 5. Create the release commit
-6. Create/push the release tag
-7. Create the GitHub Release when enabled
 
-After execution, verify generated artifacts are current:
+After preparation, verify generated artifacts are current:
 
 ```bash
 npm run build
@@ -208,17 +203,21 @@ git diff --exit-code -- dist plugins content/skills/loaf-reference/SKILL.md
 
 Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
+### Direct Release (Named Exception)
+
+`loaf release --bump <type> --yes` on the base branch prepares, commits, tags, and publishes in a single shot. Use it only when the user explicitly requests a direct release; never select it by default. Skipping the release PR means nothing runs the suite against the prepared tree before the tag exists — the v2.0.0-alpha.16 cut took this door and a capability-evidence canary surfaced only in tag CI, after publication. The CLI prints a flow advisory when a mutating release starts on the default branch; treat it as a routing signal, not noise.
+
 ---
 
-## Step 5: Protected-Branch Handoff
+## Step 5: Release-PR Flow
 
-If branch protection prevents direct release commits on the base branch:
+The default for every release: PR CI runs the full suite against the prepared tree, so evidence canaries surface before any tag or GitHub Release exists. This holds regardless of repository settings — where branch protection is enabled it is satisfied as a side effect, not the reason for the flow.
 
-1. Create a dedicated release branch.
-2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+1. Create a dedicated release branch from the release base.
+2. Run `loaf release --pre-merge` on it: this creates the version/changelog/artifact release commit but no tag and no GitHub Release.
 3. Open a release PR with a concise release-focused body.
-4. Hand the PR to `/ship` for review and landing.
-5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
+4. Hand the PR to `/ship` for review and landing; squash-merge it into one `chore: release vX.Y.Z (#PR)` commit carrying the curated changelog.
+5. After the release PR lands, run `loaf release --post-merge` on the base branch to tag, publish the GitHub Release, and verify installability.
 
 Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
@@ -269,7 +268,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 |------|------|---------------------|
 | `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
-| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-pr` | Advisory | Fires when the release PR is opened |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
 | `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
 | `check-secrets` | Blocking | Always respected before writes or shell actions |

--- a/dist/skills/release/SKILL.md
+++ b/dist/skills/release/SKILL.md
@@ -23,7 +23,7 @@ Publish a coherent version from work that has already landed.
 - Step 2: Change Collection
 - Step 3: Version + Changelog
 - Step 4: Release Execution
-- Step 5: Protected-Branch Handoff
+- Step 5: Release-PR Flow
 - Step 6: Publication Verification
 - Step 7: Post-Release Follow-Up
 - Hook Interaction
@@ -37,6 +37,7 @@ Publish a coherent version from work that has already landed.
 
 - **Release is not merge** -- do not use `/release` to review, approve, or land a feature PR. Use `/ship` for PR correctness and landing.
 - **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Release-PR flow is the default** -- prepare on a release branch with `loaf release --pre-merge`, squash-merge the release PR, then finalize with `loaf release --post-merge` on the base branch. Direct `--bump` on the base branch is a named exception used only on explicit user request.
 - **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
 - **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
 - **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
@@ -60,7 +61,7 @@ Publish a coherent version from work that has already landed.
 | Readiness | clean/current base branch, no unresolved release collisions | Yes |
 | Change Collection | landed work since last tag grouped into release themes | Yes |
 | Version + Changelog | bump selected, notes curated, files updated | Yes |
-| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Execution | release commit prepared via `--pre-merge`, release PR landed, `--post-merge` finalizes | Yes |
 | Verification | release and install paths checked | Yes |
 | Follow-Up | reflect/housekeeping suggested when useful | No |
 
@@ -69,7 +70,7 @@ Publish a coherent version from work that has already landed.
 | Topic | Use When |
 |-------|----------|
 | [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
-| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
+| [Release-PR Flow](#step-5-release-pr-flow) | Preparing, landing, and finalizing every release |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
@@ -85,9 +86,9 @@ Before anything, establish the release surface:
    ```
 2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
 3. Verify the current branch:
-   - If already on the release base, continue.
+   - If already on the release base, continue; the release-PR flow in Step 5 branches from here.
+   - If on a dedicated release branch, resume the release-PR flow at the matching step.
    - If on a feature branch, stop and explain that `/release` publishes from landed work. Offer `/ship` if the active PR needs landing first.
-   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
 4. Find the previous release tag:
    ```bash
    git describe --tags --abbrev=0
@@ -182,23 +183,17 @@ Choose the bump and curate the changelog from the grouped landed work.
 
 ## Step 4: Release Execution
 
-For a direct release from the base branch, run:
+Every release routes through the release-PR flow in Step 5: prepare the release commit on a release branch with `loaf release --pre-merge`, land the release PR, then finalize with `loaf release --post-merge` on the base branch.
 
-```bash
-loaf release --bump <type> --yes
-```
-
-This should:
+Release preparation should:
 
 1. Update version files
 2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
 3. Reinsert a fresh empty `[Unreleased]` section
 4. Run configured release artifact commands
 5. Create the release commit
-6. Create/push the release tag
-7. Create the GitHub Release when enabled
 
-After execution, verify generated artifacts are current:
+After preparation, verify generated artifacts are current:
 
 ```bash
 npm run build
@@ -207,17 +202,21 @@ git diff --exit-code -- dist plugins content/skills/loaf-reference/SKILL.md
 
 Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
+### Direct Release (Named Exception)
+
+`loaf release --bump <type> --yes` on the base branch prepares, commits, tags, and publishes in a single shot. Use it only when the user explicitly requests a direct release; never select it by default. Skipping the release PR means nothing runs the suite against the prepared tree before the tag exists — the v2.0.0-alpha.16 cut took this door and a capability-evidence canary surfaced only in tag CI, after publication. The CLI prints a flow advisory when a mutating release starts on the default branch; treat it as a routing signal, not noise.
+
 ---
 
-## Step 5: Protected-Branch Handoff
+## Step 5: Release-PR Flow
 
-If branch protection prevents direct release commits on the base branch:
+The default for every release: PR CI runs the full suite against the prepared tree, so evidence canaries surface before any tag or GitHub Release exists. This holds regardless of repository settings — where branch protection is enabled it is satisfied as a side effect, not the reason for the flow.
 
-1. Create a dedicated release branch.
-2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+1. Create a dedicated release branch from the release base.
+2. Run `loaf release --pre-merge` on it: this creates the version/changelog/artifact release commit but no tag and no GitHub Release.
 3. Open a release PR with a concise release-focused body.
-4. Hand the PR to `/ship` for review and landing.
-5. After `/ship` lands the release PR, resume `/release` on the base branch to tag, publish the GitHub Release, and verify installability.
+4. Hand the PR to `/ship` for review and landing; squash-merge it into one `chore: release vX.Y.Z (#PR)` commit carrying the curated changelog.
+5. After the release PR lands, run `loaf release --post-merge` on the base branch to tag, publish the GitHub Release, and verify installability.
 
 Do not hide this handoff inside `/release`: `/ship` remains the PR correctness and merge gate.
 
@@ -268,7 +267,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 |------|------|---------------------|
 | `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
-| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-pr` | Advisory | Fires when the release PR is opened |
 | `workflow-pre-merge` | Advisory | Belongs to `/ship` when a release PR must land |
 | `workflow-post-merge` | Advisory | Belongs to `/ship` after PR landing |
 | `check-secrets` | Blocking | Always respected before writes or shell actions |

--- a/docs/changes/20260730-release-flow-guidance/change.json
+++ b/docs/changes/20260730-release-flow-guidance/change.json
@@ -1,0 +1,5 @@
+{
+  "branch": "release-flow-guidance",
+  "change": "release-flow-guidance",
+  "created": "2026-07-30"
+}

--- a/docs/changes/20260730-release-flow-guidance/receipts/verify.json
+++ b/docs/changes/20260730-release-flow-guidance/receipts/verify.json
@@ -1,16 +1,53 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "change": "release-flow-guidance",
-  "verified_commit": "e6ee0bd46023a8413fea5694c00683220ab891ef",
-  "verified_at": "2026-07-30T12:25:41Z",
-  "criteria_digest": "869a3309c093eee3279f0f894bc172141f4aa99eea7bf58d4574e6ee0799b9d3",
-  "cwd": "/Users/levifig/.cursor/worktrees/loaf/eubj",
+  "verified_commit": "711d20dd7c32d71a45aab19f2d4213bfe661658a",
+  "verified_root_tree": "4360c045658f3045470d66ae4f9caa8249105fa2",
+  "verified_at": "2026-07-30T13:35:30Z",
+  "criteria_digest": "4d44b6623928084c69897d8e48bd450e231ac29f92580b2976997a366a897a51",
+  "scope_digest": "6575496fe3b582eaabceb9461d86841d59dc0bc829caca73d2ad463497f4a158",
+  "scope_sections": {
+    ".agents": "0cdcb499203f22e1faebbef89e211e4b6d4b253bc5486866ed28a50e15c2dd9e",
+    ".claude": "8dc123c00b953695edd9ccc4bb966e986bcea05607d9a125e71038a4c2ebb6be",
+    ".github": "42529d8eb65b5025a2a641309b5c789e771402b63fb6093468b2f04ababfabc1",
+    ".gitignore": "bdca2d6bd9b911e4c840fa1471c55e380fccfe92f0c5b352e6536d5f346d7249",
+    ".serena": "749668b92acde130ae6a4514f59b9e08bf7095c8bdd47b6b2e5929b0729ba91f",
+    "AGENTS.md": "5310119234b7665c6d64f2d1b5768f9eedc6f69aba35cfe083255f2d4b2c2fad",
+    "README.md": "9b30876ddbbf893778865069a28ea215bd3b2ce9ebee913d2cf2e60e0c958152",
+    "cli": "702ff0c12b611f68cd970ea1a7dfef4a38fa1be7a9c221544bd44ec9e75bac53",
+    "cmd": "b2666d27e62ce6fc437436bdc891f05355d29c945300b776d75e662a358b3918",
+    "config": "c438af3bcd76afdf5bd561aa26535cf05b6b9b3e3664488aa85bb9f1c65791aa",
+    "content": "da59557fbce33d9966de439f4fb34ac1d15d255fb4ccc233753fb8723a35ba86",
+    "docs": "56009be5d5eedbaa622a08e93783369473cc8e0cab7a6edcaa83f39fc1a0555e",
+    "go.mod": "5f494108c9f9ba4911bbcb82ece8168d5af253742eb632ccac5519348e34ef1c",
+    "go.sum": "44a5d68a99a05f3d9aff3321f4b5645d0870cc1afd36e183fbc08c07d8550d6b",
+    "internal": "06d25293f4f148f05fcebe7552db7ebf8aa162314bc2f823ee7514d2a87cdb2e",
+    "package-lock.json": "afd3f2eea505b8289f8b16c35364d4b892b25663b42b2a7ba967cf8c71feb44f"
+  },
+  "exclusions": [
+    "docs/changes/*/receipts/**",
+    "docs/changes/*/reports/**",
+    "package.json",
+    ".claude-plugin/marketplace.json",
+    "CHANGELOG.md",
+    "dist/**",
+    "plugins/**",
+    "bin/**"
+  ],
+  "digest_spec": "v1",
+  "tool_version": "2.0.0-alpha.16",
+  "toolchain": {
+    "go": "1.26.5",
+    "os": "darwin",
+    "arch": "arm64"
+  },
+  "worktree_clean": true,
   "results": [
     {
       "id": "V1",
       "command": "go test ./internal/cli -run 'TestReleaseFlowAdvisory' -count=1",
       "exit_code": 0,
-      "output_digest": "3405b11542b298ac43ae591c7b2a14116a90ef5de2d83c214808ae72edd6a9c4",
+      "output_digest": "53f43c7a43aa78ac5aaf591477359750944195c8bfa9d655f453fc94c47b21b2",
       "ok": true,
       "expect": "exit 0.",
       "expect_checks": [
@@ -25,7 +62,7 @@
       "id": "V2",
       "command": "go test ./internal/cli -run 'TestReleaseGuardrailRemediation' -count=1",
       "exit_code": 0,
-      "output_digest": "5af245d0c998cf2af78c62862b78484d9d48818b61f80db5995e60581d1576bd",
+      "output_digest": "1ab3665c5005ab0423bde251cd70e5817221d4ff5ffa20afbb59567090ff6792",
       "ok": true,
       "expect": "exit 0.",
       "expect_checks": [
@@ -40,7 +77,7 @@
       "id": "V3",
       "command": "bin/loaf build",
       "exit_code": 0,
-      "output_digest": "814fd36bcdf100ea1da704b4f07244d5f7cc54ea7133ac3752ec9eea2f5891e9",
+      "output_digest": "36649b688b540420b4dd14cfab1da5cab4cbaa56b0939d9ed78fe3887ca322ae",
       "ok": true,
       "expect": "exit 0.",
       "expect_checks": [
@@ -55,7 +92,7 @@
       "id": "V4",
       "command": "go test ./...",
       "exit_code": 0,
-      "output_digest": "1f04d223d325c36ef7fd1227fbabbee37d705aa959b81e161b6ea78a9c10db50",
+      "output_digest": "ba661aa397dc1f99384b932f2e303f36ccab9c4a2db078eee56be73a82385484",
       "ok": true,
       "expect": "exit 0.",
       "expect_checks": [

--- a/docs/changes/20260730-release-flow-guidance/receipts/verify.json
+++ b/docs/changes/20260730-release-flow-guidance/receipts/verify.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "change": "release-flow-guidance",
+  "verified_commit": "e6ee0bd46023a8413fea5694c00683220ab891ef",
+  "verified_at": "2026-07-30T12:25:41Z",
+  "criteria_digest": "869a3309c093eee3279f0f894bc172141f4aa99eea7bf58d4574e6ee0799b9d3",
+  "cwd": "/Users/levifig/.cursor/worktrees/loaf/eubj",
+  "results": [
+    {
+      "id": "V1",
+      "command": "go test ./internal/cli -run 'TestReleaseFlowAdvisory' -count=1",
+      "exit_code": 0,
+      "output_digest": "3405b11542b298ac43ae591c7b2a14116a90ef5de2d83c214808ae72edd6a9c4",
+      "ok": true,
+      "expect": "exit 0.",
+      "expect_checks": [
+        {
+          "kind": "exit",
+          "value": "0",
+          "ok": true
+        }
+      ]
+    },
+    {
+      "id": "V2",
+      "command": "go test ./internal/cli -run 'TestReleaseGuardrailRemediation' -count=1",
+      "exit_code": 0,
+      "output_digest": "5af245d0c998cf2af78c62862b78484d9d48818b61f80db5995e60581d1576bd",
+      "ok": true,
+      "expect": "exit 0.",
+      "expect_checks": [
+        {
+          "kind": "exit",
+          "value": "0",
+          "ok": true
+        }
+      ]
+    },
+    {
+      "id": "V3",
+      "command": "bin/loaf build",
+      "exit_code": 0,
+      "output_digest": "814fd36bcdf100ea1da704b4f07244d5f7cc54ea7133ac3752ec9eea2f5891e9",
+      "ok": true,
+      "expect": "exit 0.",
+      "expect_checks": [
+        {
+          "kind": "exit",
+          "value": "0",
+          "ok": true
+        }
+      ]
+    },
+    {
+      "id": "V4",
+      "command": "go test ./...",
+      "exit_code": 0,
+      "output_digest": "1f04d223d325c36ef7fd1227fbabbee37d705aa959b81e161b6ea78a9c10db50",
+      "ok": true,
+      "expect": "exit 0.",
+      "expect_checks": [
+        {
+          "kind": "exit",
+          "value": "0",
+          "ok": true
+        }
+      ]
+    }
+  ]
+}

--- a/docs/changes/20260730-release-flow-guidance/reports/20260730-143315-review-codex.html
+++ b/docs/changes/20260730-release-flow-guidance/reports/20260730-143315-review-codex.html
@@ -1,0 +1,113 @@
+<!-- source: release-flow-guidance · kind review · slug codex · stamped 2026-07-30 · authored report (snapshot semantics) · never auto-updated · dispositions recorded -->
+<meta charset="utf-8">
+<title>Review — Release Flow Guidance</title>
+<style>
+  :root {
+    --bg: #FBFAF6; --panel: #FFFFFF; --line: #E4E0D6; --ink: #23262A; --muted: #6B7076;
+    --accent: #9A6A00; --accent-soft: #F6EBD2;
+    --machine: #44618C; --machine-soft: #E5ECF5;
+    --ok: #3E7C4F; --ok-soft: #E2F0E5; --bad: #A94438; --bad-soft: #F6E3E0;
+    --state: #7A5EA6; --state-soft: #EEE8F6;
+    --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+    --serif: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+    --sans: system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  @media (prefers-color-scheme: dark) { :root {
+    --bg: #15171B; --panel: #1D2025; --line: #33373D; --ink: #E7E4DD; --muted: #9BA0A6;
+    --accent: #E2AC4B; --accent-soft: #2E2714;
+    --machine: #8FB0DA; --machine-soft: #232B38;
+    --ok: #7CC08D; --ok-soft: #1E2E22; --bad: #E08A7E; --bad-soft: #382220;
+    --state: #B9A3DE; --state-soft: #2A2436;
+  } }
+  :root[data-theme="light"] {
+    --bg: #FBFAF6; --panel: #FFFFFF; --line: #E4E0D6; --ink: #23262A; --muted: #6B7076;
+    --accent: #9A6A00; --accent-soft: #F6EBD2;
+    --machine: #44618C; --machine-soft: #E5ECF5;
+    --ok: #3E7C4F; --ok-soft: #E2F0E5; --bad: #A94438; --bad-soft: #F6E3E0;
+    --state: #7A5EA6; --state-soft: #EEE8F6;
+  }
+  :root[data-theme="dark"] {
+    --bg: #15171B; --panel: #1D2025; --line: #33373D; --ink: #E7E4DD; --muted: #9BA0A6;
+    --accent: #E2AC4B; --accent-soft: #2E2714;
+    --machine: #8FB0DA; --machine-soft: #232B38;
+    --ok: #7CC08D; --ok-soft: #1E2E22; --bad: #E08A7E; --bad-soft: #382220;
+    --state: #B9A3DE; --state-soft: #2A2436;
+  }
+  * { box-sizing: border-box; }
+  body { background: var(--bg); color: var(--ink); font-family: var(--sans); line-height: 1.55; margin: 0; }
+  main { max-width: 1080px; margin: 0 auto; padding: 44px 24px 90px; }
+  h1 { font-family: var(--serif); font-weight: 600; font-size: 1.95rem; margin: 6px 0 8px; text-wrap: balance; }
+  h2 { font-family: var(--serif); font-weight: 600; font-size: 1.3rem; margin: 44px 0 12px; }
+  h3 { font-family: var(--serif); font-weight: 600; font-size: 1.05rem; margin: 0 0 6px; }
+  p { margin: 0 0 10px; }
+  .eyebrow { font-size: .72rem; letter-spacing: .14em; text-transform: uppercase; color: var(--accent); font-weight: 700; }
+  .stamp { font-family: var(--mono); font-size: .8rem; color: var(--muted); }
+  .stamp b { color: var(--ink); }
+  code { font-family: var(--mono); font-size: .84em; background: var(--machine-soft); color: var(--machine); padding: 1px 4px; border-radius: 3px; }
+  .panel { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 18px 20px; }
+  .verdict { border-left: 4px solid var(--ok); margin-bottom: 28px; }
+  .finding { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 16px 18px; margin-bottom: 14px; }
+  .fhead { display: flex; flex-wrap: wrap; gap: 8px; align-items: baseline; margin-bottom: 8px; }
+  .fname { font-weight: 700; font-size: 1.02rem; flex: 1 1 320px; }
+  .chip { font-size: .7rem; letter-spacing: .06em; text-transform: uppercase; font-weight: 700; padding: 2px 8px; border-radius: 999px; white-space: nowrap; }
+  .sev-high { background: var(--bad); color: #fff; }
+  .sev-medium { background: var(--bad-soft); color: var(--bad); }
+  .disp-accepted { background: var(--ok-soft); color: var(--ok); }
+  .disp-rejected { background: var(--state-soft); color: var(--state); }
+  .frow { display: grid; grid-template-columns: 110px 1fr; gap: 4px 14px; font-size: .93rem; }
+  .frow dt { color: var(--muted); font-size: .78rem; letter-spacing: .08em; text-transform: uppercase; font-weight: 700; padding-top: 2px; }
+  .frow dd { margin: 0 0 6px; }
+  @media (max-width: 640px) { .frow { grid-template-columns: 1fr; } .frow dt { padding-top: 8px; } }
+</style>
+<main>
+  <div class="eyebrow">Review · Codex ×2 · Grok fixes</div>
+  <h1>Release Flow Guidance — Review Loop</h1>
+  <p class="stamp">change <b>docs/changes/20260730-release-flow-guidance</b> · reviewer <b>Codex (gpt-5.6-sol, xhigh)</b> · fixer <b>Grok CLI</b> · reviewed <b>2026-07-30</b> · dispositions folded in <b>711d20dd</b> · receipt redone in <b>c5337255</b></p>
+
+  <div class="panel verdict">
+    <h3>Verdict: pass 1 four findings → pass 2 approved, no remaining findings</h3>
+    <p>Pre-push loop per owner direction: Codex reviews, orchestrator dispositions, Grok applies accepted fixes. Pass 1 returned four findings (three accepted, one rejected on precedent); Grok folded the two code fixes in <code>711d20dd</code>, the orchestrator re-recorded the receipt with the branch source in <code>c5337255</code>, and pass 2 approved with the fixes' tests verified and the receipt's digests independently recomputed.</p>
+  </div>
+
+  <h2>Findings</h2>
+
+  <div class="finding">
+    <div class="fhead"><span class="fname">P1 — Shipped native binaries do not contain this branch's CLI changes</span><span class="chip sev-high">high</span><span class="chip disp-rejected">rejected</span></div>
+    <dl class="frow">
+      <dt>Claim</dt><dd>The tracked platform binaries are unchanged from main, so <code>bin/loaf release</code> keeps the old wordings until a rebuild ships.</dd>
+      <dt>Disposition</dt><dd>Rejected — deliberate repo precedent: Go changes land without the bundled binary (#144 identically), because the installed-smoke capability evidence pins the committed binary's SHA-256; the release ceremony rebuilds and commits it together with the evidence re-record. True of every Go change between releases, not a branch defect.</dd>
+    </dl>
+  </div>
+
+  <div class="finding">
+    <div class="fhead"><span class="fname">P2 — Committed verification receipt was legacy schema v1</span><span class="chip sev-high">high</span><span class="chip disp-accepted">accepted</span></div>
+    <dl class="frow">
+      <dt>Claim</dt><dd>The receipt declared <code>schema_version: 1</code> with the removed <code>cwd</code> field, which the current gate refuses before reading results.</dd>
+      <dt>Disposition</dt><dd>Accepted — orchestration error, not implementation: the verify ceremony ran under the Homebrew-installed alpha.15 binary on PATH instead of the branch source. The v2 gate refusing the v1 receipt is the schema clean-break working exactly as shipped.</dd>
+      <dt>Fix</dt><dd><code>c5337255</code>: receipt re-recorded via <code>go run ./cmd/loaf change verify</code>; pass 2 independently recomputed tree, criteria, scope, and section digests — all match, V1–V4 green, change derives <code>complete</code>.</dd>
+    </dl>
+  </div>
+
+  <div class="finding">
+    <div class="fhead"><span class="fname">P3 — A local tag masked an existing GitHub release into deletion advice</span><span class="chip sev-high">high</span><span class="chip disp-accepted">accepted</span></div>
+    <dl class="frow">
+      <dt>Claim</dt><dd><code>checkReleasePostMergeNoExistingTagOrRelease</code> returned the <code>git tag -d</code> remedy for a local tag before the GitHub release lookup ran, so local tag + failed <code>ls-remote</code> + published release yielded destructive advice — against Decision 3.</dd>
+      <dt>Disposition</dt><dd>Accepted.</dd>
+      <dt>Fix</dt><dd><code>711d20dd</code>: all three states gathered before remedy choice; remote or GH-release presence always outranks local deletion advice; a failed lookup can no longer unlock it. Masking combination pinned in <code>TestReleaseGuardrailRemediation</code>.</dd>
+    </dl>
+  </div>
+
+  <div class="finding">
+    <div class="fhead"><span class="fname">P4 — Advisory emitted after snapshot resolution and cohort preflight</span><span class="chip sev-medium">medium</span><span class="chip disp-accepted">accepted</span></div>
+    <dl class="frow">
+      <dt>Claim</dt><dd>A preflight-blocked mutating invocation on the default branch exited without the advisory, deviating from the shape's before-analysis placement.</dd>
+      <dt>Disposition</dt><dd>Accepted.</dd>
+      <dt>Fix</dt><dd><code>711d20dd</code>: emission hoisted to <code>runRelease</code> before snapshot and preflight, duplicate removed, exactly-once asserted including the preflight-block path in <code>TestReleaseFlowAdvisory</code>.</dd>
+    </dl>
+  </div>
+
+  <h2>Provenance</h2>
+  <div class="panel">
+    <p>Pass 1 fresh thread and pass 2 resumed thread, Codex gpt-5.6-sol xhigh via the companion runtime, session <code>019fb32e-9f7a-7d42-8275-2365dfb273df</code>; fixes authored headless by Grok CLI under orchestrator brief; dispositions and the loop decision recorded as journal <code>decision(release-flow-guidance)</code> / <code>finding(release-flow-guidance)</code> entries 2026-07-30. Related: shape.md Decisions 1–3; the alpha.16 incident journal entries that motivated the change.</p>
+  </div>
+</main>

--- a/docs/changes/20260730-release-flow-guidance/shape.md
+++ b/docs/changes/20260730-release-flow-guidance/shape.md
@@ -1,0 +1,86 @@
+<!-- shape.md is the change contract. Identity lives in change.json — no status-like frontmatter. Readiness is derived: a draft PR is shaping; `loaf change check` derives structural executability from the sections below. -->
+
+# Release Flow Guidance — the CLI Names the Sanctioned Door
+
+## Problem
+
+The v2.0.0-alpha.16 cut (2026-07-30) veered from the project's release convention because nothing at the decision point named it. `loaf release` supports the sanctioned two-phase flow (`--pre-merge` on a release branch → PR squash into one `chore: release vX (#PR)` commit → `--post-merge` on the default branch), but it equally permits single-shot `--bump <type> --yes` directly on the default branch, and the release skill presents the PR flow as conditional on branch protection. A model operator on an unprotected `main` takes the direct door and every subsequent guardrail is a symptom of the wrong mode: the clean-worktree refusal forces changelog curation into a stray `docs:` commit, the GitHub-release step fails because the tag was created before any push, `--post-merge` then refuses with `guardrail 7 failed: tag … already exists locally — run git tag -d … and rerun` (advice that is destructive once the tag is pushed), and the capability-evidence canary surfaces only in tag CI because nothing ran the suite against the prepared tree. Journal: `decision(release)` and `spark(release)` entries 2026-07-30.
+
+## Hypothesis
+
+When the CLI itself names the sanctioned flow at the two decision points that matter — a mutating invocation on the default branch, and each guardrail refusal — a model operator self-corrects mid-ceremony, and making the skill's release-PR flow unconditional removes the wrong door from the instructions entirely.
+
+## Scope
+
+**In**
+
+- Contextual flow advisory: mutating `loaf release` modes (interactive or `--bump`) invoked on the repository default branch print a model-facing advisory before acting — naming the release-branch + `--pre-merge` → PR squash → `--post-merge` sequence and the reason (PR CI runs the suite against the prepared tree, so evidence canaries surface before tagging). Advisory only, never blocking; suppressed when running `--pre-merge`, `--post-merge`, or any read-only mode (`--dry-run`, help).
+- Guardrail remediation text: the clean-worktree refusal states that changelog curation belongs on the release branch in the `--pre-merge` flow; the `--post-merge` tag-exists guardrail distinguishes an unpushed local tag (safe to `git tag -d`) from a pushed tag or existing GitHub release (name the non-destructive repair instead of advising deletion).
+- Release skill: Step 5 rewritten so the release-PR flow is the default for every release regardless of branch protection; direct `--bump` on the default branch demoted to a named exception used only on explicit user request; Step 4 reframed to route through the PR flow.
+- Rebuilt distribution targets committed with the source change.
+
+**Out** (deferred, not rejected)
+
+- Any blocking enforcement of the PR flow — a config knob or hard refusal is a later decision if the advisory proves insufficient.
+- Decoupling capability evidence from binary rebuilds (`INTENT-20260719-decouple-installed-smoke-evidence-from-binary-rebuilds`).
+- Running the Go suite inside `loaf release` after artifact refresh — candidate follow-up recorded as `spark(release)` 2026-07-30; interacts with release latency and belongs with the promotion-model ceremony work.
+- Promotion-model surfaces (`docs/changes/20260728-release-promotion-model/`, PR #143).
+
+## Observable Workflow
+
+```
+# on main, direct mutating invocation:
+loaf release --bump prerelease
+# advisory: releases are prepared on a release branch: loaf release --pre-merge there,
+# squash-merge the release PR, then loaf release --post-merge here; PR CI verifies the
+# prepared tree so evidence canaries surface before tagging. Proceeding directly skips that.
+
+# post-merge with a pushed tag already present:
+loaf release --post-merge
+# guardrail: tag v2.0.0-alpha.16 already exists and is pushed — do not delete a published
+# tag; if the GitHub release is missing assets, re-run the Release workflow or recreate the
+# release from the existing tag instead.
+```
+
+## Rabbit Holes and No-Gos
+
+- **Do not block the direct mode.** Consumers of Loaf may legitimately release single-shot; the advisory informs, the operator decides.
+- **Do not detect the default branch via the network.** Resolve from local git state (`refs/remotes/origin/HEAD`, falling back to `main`/`master` heuristics); a release ceremony must not add a network dependency to print advice.
+- **Do not reword unrelated guardrails** — only the two named surfaces change; the guardrail numbering and semantics stay.
+
+## Decisions
+
+1. **Advisory, not enforcement.** The incident was a routing error under ambiguous instructions, not a malicious bypass; naming the door is the proportionate fix, and the skill rewrite removes the ambiguity for skill-following operators.
+2. **The CLI carries the convention, the skill defers to it.** The two-phase flags already encode the flow; the skill's job is routing, so its Step 5 stops conditioning the PR flow on branch protection.
+3. **Tag-exists advice must be state-aware.** `git tag -d` on a pushed tag is destructive advice; the guardrail checks whether the tag exists on the remote before prescribing deletion.
+
+## Planning Contract
+
+Advisory emission: a helper resolves the repository default branch from local refs and reports whether the current invocation is a mutating release mode on that branch outside the two-phase flags; the release run prints the advisory block to the command's writer before the analysis phase when it is. Guardrail text: the clean-worktree refusal and the post-merge tag-exists guardrail gain the wordings pinned in Observable Workflow, with the tag-exists branch consulting the remote tag state guarded so a network failure degrades to the current wording, never an error.
+
+## Implementation Units
+
+- **TASK-001 — CLI advisory and guardrail remediation.** Default-branch resolution helper, advisory emission in mutating modes, the two guardrail wordings, unit tests.
+- **TASK-002 — Skill rewrite and distribution rebuild.** Release skill Steps 4–5 reframed around the PR-flow default, direct mode as named exception; `loaf build`; rebuilt `dist/` and `plugins/` committed.
+
+## Verification Contract
+
+- **V1.** Advisory prints for mutating modes on the default branch and never in `--pre-merge`, `--post-merge`, or `--dry-run`. Command: `go test ./internal/cli -run 'TestReleaseFlowAdvisory' -count=1`. Expect: exit 0.
+- **V2.** Guardrail wordings: clean-worktree names the pre-merge flow; tag-exists distinguishes pushed from unpushed tags and never advises deleting a pushed tag. Command: `go test ./internal/cli -run 'TestReleaseGuardrailRemediation' -count=1`. Expect: exit 0.
+- **V3.** Distribution targets rebuild cleanly with the skill change. Command: `bin/loaf build`. Expect: exit 0.
+- **V4.** The full suite is green. Command: `go test ./...`. Expect: exit 0.
+
+<!-- Human review (H-tier): review material, never gate input. -->
+
+- **H1.** A transcript of `loaf release --bump prerelease` on main reads as one clear advisory naming the two-phase sequence, not a wall of text.
+
+## Definition of Done
+
+- All V-entries green at HEAD via `loaf change verify` with the receipt committed.
+- `loaf change check` reports zero violations and the change derives executable.
+- The release skill contains no branch-protection conditional around the release-PR flow.
+
+## Durable Outputs
+
+- Release skill Steps 4–5 as the lasting statement of the release flow.
+- Journal `decision(release-flow-guidance)` entries for the three decisions above.

--- a/docs/changes/20260730-release-flow-guidance/tasks/TASK-001-cli-advisory-and-guardrail-remediation.md
+++ b/docs/changes/20260730-release-flow-guidance/tasks/TASK-001-cli-advisory-and-guardrail-remediation.md
@@ -1,0 +1,39 @@
+---
+change: release-flow-guidance
+id: TASK-001
+title: CLI advisory and guardrail remediation
+blocks:
+  - TASK-002
+---
+
+# TASK-001 — CLI advisory and guardrail remediation
+
+## Objective
+
+Mutating `loaf release` invocations (interactive or `--bump`) on the repository default branch print a model-facing advisory before analysis: releases are prepared on a release branch with `loaf release --pre-merge`, squash-merged via a release PR, then finalized with `loaf release --post-merge` — because PR CI runs the suite against the prepared tree, so evidence canaries surface before tagging. The advisory never prints for `--pre-merge`, `--post-merge`, `--dry-run`, or help. Two guardrails gain state-aware remediation: the clean-worktree refusal names the pre-merge flow as where changelog curation belongs, and the post-merge tag-exists guardrail distinguishes an unpushed local tag (safe to delete) from a pushed tag (never advise deletion; name the non-destructive repair).
+
+## Scope boundaries
+
+**In:** Release command surface in `internal/cli` (advisory emission, default-branch resolution from local refs only, the two guardrail wordings), unit tests.
+
+**Out:** Any blocking behavior; guardrail renumbering; skill prose (TASK-002); network-dependent default-branch detection.
+
+## Context pointers
+
+- Contract: `shape.md` — Scope → In; Decisions 1–3; Planning Contract; Observable Workflow (pinned wordings).
+- Incident: journal `decision(release)` / `spark(release)` 2026-07-30; the alpha.16 release transcript.
+- Default-branch resolution: local `refs/remotes/origin/HEAD`, falling back to `main` then `master`; no network calls.
+- Remote-tag state for the guardrail: consult the remote guardedly — on failure degrade to the current wording, never error.
+
+## Steps
+
+- [ ] Add the default-branch resolution helper (local refs only) and the invocation-context predicate (mutating mode ∧ default branch ∧ not pre/post-merge).
+- [ ] Emit the advisory block before analysis in matching invocations; keep it one short paragraph.
+- [ ] Reword the clean-worktree refusal to name the pre-merge flow.
+- [ ] Make the post-merge tag-exists guardrail state-aware (pushed vs unpushed) with the pinned wordings.
+- [ ] Tests: `TestReleaseFlowAdvisory` (prints on default-branch mutating runs; absent in --pre-merge/--post-merge/--dry-run) and `TestReleaseGuardrailRemediation` (both wordings; pushed tag never gets deletion advice).
+
+## Verification
+
+- `go test ./internal/cli -run 'TestReleaseFlowAdvisory' -count=1` green.
+- `go test ./internal/cli -run 'TestReleaseGuardrailRemediation' -count=1` green.

--- a/docs/changes/20260730-release-flow-guidance/tasks/TASK-001-cli-advisory-and-guardrail-remediation.md
+++ b/docs/changes/20260730-release-flow-guidance/tasks/TASK-001-cli-advisory-and-guardrail-remediation.md
@@ -27,11 +27,11 @@ Mutating `loaf release` invocations (interactive or `--bump`) on the repository 
 
 ## Steps
 
-- [ ] Add the default-branch resolution helper (local refs only) and the invocation-context predicate (mutating mode ∧ default branch ∧ not pre/post-merge).
-- [ ] Emit the advisory block before analysis in matching invocations; keep it one short paragraph.
-- [ ] Reword the clean-worktree refusal to name the pre-merge flow.
-- [ ] Make the post-merge tag-exists guardrail state-aware (pushed vs unpushed) with the pinned wordings.
-- [ ] Tests: `TestReleaseFlowAdvisory` (prints on default-branch mutating runs; absent in --pre-merge/--post-merge/--dry-run) and `TestReleaseGuardrailRemediation` (both wordings; pushed tag never gets deletion advice).
+- [x] Add the default-branch resolution helper (local refs only) and the invocation-context predicate (mutating mode ∧ default branch ∧ not pre/post-merge).
+- [x] Emit the advisory block before analysis in matching invocations; keep it one short paragraph.
+- [x] Reword the clean-worktree refusal to name the pre-merge flow.
+- [x] Make the post-merge tag-exists guardrail state-aware (pushed vs unpushed) with the pinned wordings.
+- [x] Tests: `TestReleaseFlowAdvisory` (prints on default-branch mutating runs; absent in --pre-merge/--post-merge/--dry-run) and `TestReleaseGuardrailRemediation` (both wordings; pushed tag never gets deletion advice).
 
 ## Verification
 

--- a/docs/changes/20260730-release-flow-guidance/tasks/TASK-002-skill-rewrite-and-distribution-rebuild.md
+++ b/docs/changes/20260730-release-flow-guidance/tasks/TASK-002-skill-rewrite-and-distribution-rebuild.md
@@ -1,0 +1,37 @@
+---
+change: release-flow-guidance
+id: TASK-002
+title: Skill rewrite and distribution rebuild
+blocked-by:
+  - TASK-001
+---
+
+# TASK-002 — Skill rewrite and distribution rebuild
+
+## Objective
+
+The release skill states the release-PR flow as the default for every release: prepare on a release branch (`loaf release --pre-merge`), squash-merge the release PR into one `chore: release vX (#PR)` commit carrying the curated changelog, then finalize with `loaf release --post-merge` on the default branch. Step 5 loses its branch-protection conditional entirely; direct `--bump` on the default branch is demoted to a named exception used only on explicit user request, with the alpha.16 incident as the recorded reason. Distribution targets are rebuilt and committed.
+
+## Scope boundaries
+
+**In:** `content/skills/release/SKILL.md` Steps 4–5 (and any cross-references to them in the same file), `loaf build`, committed `dist/` and `plugins/` outputs.
+
+**Out:** CLI code (TASK-001); other skills; changelog format guidance.
+
+## Context pointers
+
+- Contract: `shape.md` — Scope → In; Decision 2; Definition of Done (no branch-protection conditional survives).
+- Current text: `content/skills/release/SKILL.md` — Step 5 "Protected-Branch Handoff".
+- Prose rule: paragraphs are single lines, never hard-wrapped.
+
+## Steps
+
+- [ ] Rewrite Step 5 as the default release-PR flow (rename away from "Protected-Branch Handoff"); fold branch protection in as one sentence of rationale, not a condition.
+- [ ] Reframe Step 4 to route through the PR flow; document the direct mode as the explicit exception.
+- [ ] Update the Quick Reference table and Critical Rules to match.
+- [ ] `loaf build`; commit rebuilt `dist/` and `plugins/` with the source change.
+
+## Verification
+
+- `bin/loaf build` exit 0.
+- `grep -i "branch protection" content/skills/release/SKILL.md` shows no conditional gating of the PR flow.

--- a/docs/changes/20260730-release-flow-guidance/tasks/TASK-002-skill-rewrite-and-distribution-rebuild.md
+++ b/docs/changes/20260730-release-flow-guidance/tasks/TASK-002-skill-rewrite-and-distribution-rebuild.md
@@ -26,10 +26,10 @@ The release skill states the release-PR flow as the default for every release: p
 
 ## Steps
 
-- [ ] Rewrite Step 5 as the default release-PR flow (rename away from "Protected-Branch Handoff"); fold branch protection in as one sentence of rationale, not a condition.
-- [ ] Reframe Step 4 to route through the PR flow; document the direct mode as the explicit exception.
-- [ ] Update the Quick Reference table and Critical Rules to match.
-- [ ] `loaf build`; commit rebuilt `dist/` and `plugins/` with the source change.
+- [x] Rewrite Step 5 as the default release-PR flow (rename away from "Protected-Branch Handoff"); fold branch protection in as one sentence of rationale, not a condition.
+- [x] Reframe Step 4 to route through the PR flow; document the direct mode as the explicit exception.
+- [x] Update the Quick Reference table and Critical Rules to match.
+- [x] `loaf build`; commit rebuilt `dist/` and `plugins/` with the source change.
 
 ## Verification
 

--- a/internal/cli/release.go
+++ b/internal/cli/release.go
@@ -16,6 +16,11 @@ func (r Runner) runRelease(args []string, out io.Writer, runtimeRoot string) err
 		writeReleaseHelp(out)
 		return nil
 	}
+	// Print the flow advisory before candidate analysis and cohort preflight so
+	// a preflight-blocked mutating invocation still names the sanctioned door.
+	if releaseInvocationWantsFlowAdvisory(runtimeRoot, options) {
+		printReleaseFlowAdvisory(out)
+	}
 	snapshot, err := resolveReleaseSnapshot(runtimeRoot, options)
 	if err != nil {
 		return fmt.Errorf("release blocked: cannot compute candidate version: %w", err)

--- a/internal/cli/release_dry_run.go
+++ b/internal/cli/release_dry_run.go
@@ -349,9 +349,7 @@ func runReleaseApply(root string, options releaseOptions, in io.Reader, out io.W
 	if !releaseIsGitRepo(root) {
 		return fmt.Errorf("Not a git repository")
 	}
-	if releaseInvocationWantsFlowAdvisory(root, options) {
-		printReleaseFlowAdvisory(out)
-	}
+	// Flow advisory is emitted once from runRelease, before snapshot/preflight.
 	if err := requireReleaseCleanWorktree(root); err != nil {
 		return err
 	}

--- a/internal/cli/release_dry_run.go
+++ b/internal/cli/release_dry_run.go
@@ -349,6 +349,9 @@ func runReleaseApply(root string, options releaseOptions, in io.Reader, out io.W
 	if !releaseIsGitRepo(root) {
 		return fmt.Errorf("Not a git repository")
 	}
+	if releaseInvocationWantsFlowAdvisory(root, options) {
+		printReleaseFlowAdvisory(out)
+	}
 	if err := requireReleaseCleanWorktree(root); err != nil {
 		return err
 	}
@@ -579,7 +582,7 @@ func requireReleaseCleanWorktree(root string) error {
 		return fmt.Errorf("Refusing to prepare release: cannot inspect worktree cleanliness: %w", err)
 	}
 	if len(dirtyPaths) != 0 {
-		return fmt.Errorf("Refusing to prepare release: mutating release modes require a clean unignored worktree; commit, stash, or remove: %s", strings.Join(dirtyPaths, ", "))
+		return fmt.Errorf("Refusing to prepare release: mutating release modes require a clean unignored worktree; changelog curation belongs on a release branch in the --pre-merge flow — commit, stash, or remove: %s", strings.Join(dirtyPaths, ", "))
 	}
 	return nil
 }

--- a/internal/cli/release_flow_advisory.go
+++ b/internal/cli/release_flow_advisory.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// releaseFlowAdvisoryText names the sanctioned release-PR flow at the decision point where a direct mutating invocation is about to skip it. Advisory only, never blocking.
+const releaseFlowAdvisoryText = "releases are prepared on a release branch: loaf release --pre-merge there, squash-merge the release PR, then loaf release --post-merge here; PR CI verifies the prepared tree so evidence canaries surface before tagging. Proceeding directly skips that."
+
+// resolveReleaseDefaultBranch resolves the repository default branch from local git state only — refs/remotes/origin/HEAD when present, then a local main or master branch. A release ceremony must not add a network dependency to print advice.
+func resolveReleaseDefaultBranch(root string) string {
+	if symRef := releaseCommandOutput(root, "git", "symbolic-ref", "refs/remotes/origin/HEAD"); strings.HasPrefix(symRef, "refs/remotes/origin/") {
+		return strings.TrimPrefix(symRef, "refs/remotes/origin/")
+	}
+	for _, candidate := range []string{"main", "master"} {
+		if releaseCommandOK(root, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// releaseInvocationWantsFlowAdvisory reports whether this invocation is a mutating release mode (interactive or --bump) on the repository default branch outside the two-phase flags. Read-only modes and the two-phase flags never advise.
+func releaseInvocationWantsFlowAdvisory(root string, options releaseOptions) bool {
+	if options.help || options.dryRun || options.preMerge || options.postMerge {
+		return false
+	}
+	defaultBranch := resolveReleaseDefaultBranch(root)
+	if defaultBranch == "" {
+		return false
+	}
+	return releaseCommandOutput(root, "git", "symbolic-ref", "--short", "HEAD") == defaultBranch
+}
+
+// printReleaseFlowAdvisory emits the advisory as one short paragraph before the analysis phase.
+func printReleaseFlowAdvisory(out io.Writer) {
+	fmt.Fprintf(out, "  %s %s\n\n", ansiYellow("advisory:"), releaseFlowAdvisoryText)
+}

--- a/internal/cli/release_flow_advisory_test.go
+++ b/internal/cli/release_flow_advisory_test.go
@@ -1,0 +1,260 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const releaseFlowAdvisoryProbe = "releases are prepared on a release branch"
+
+func TestReleaseFlowAdvisory(t *testing.T) {
+	t.Run("prints for interactive mutating run on the default branch", func(t *testing.T) {
+		repo := seedReleaseApplyRepo(t, "feat: advise the sanctioned flow")
+		var stdout bytes.Buffer
+		err := Runner{
+			Stdout:     &stdout,
+			Stdin:      strings.NewReader("n\n"),
+			WorkingDir: repo,
+		}.Run([]string{"release", "--no-tag", "--no-gh"})
+		if err != nil {
+			t.Fatalf("interactive release error = %v\n%s", err, stdout.String())
+		}
+		output := stdout.String()
+		if !strings.Contains(output, releaseFlowAdvisoryProbe) {
+			t.Fatalf("stdout = %q, want flow advisory", output)
+		}
+		if !strings.Contains(output, "--pre-merge") || !strings.Contains(output, "--post-merge") || !strings.Contains(output, "squash-merge the release PR") {
+			t.Fatalf("stdout = %q, want advisory naming the two-phase sequence", output)
+		}
+		if advisoryIndex, analyzingIndex := strings.Index(output, releaseFlowAdvisoryProbe), strings.Index(output, "Analyzing"); analyzingIndex != -1 && advisoryIndex > analyzingIndex {
+			t.Fatalf("stdout = %q, want advisory before the analysis phase", output)
+		}
+	})
+
+	t.Run("prints for bump mutating run on the default branch", func(t *testing.T) {
+		repo := seedReleaseApplyRepo(t, "feat: advise the sanctioned flow for bump")
+		var stdout bytes.Buffer
+		err := Runner{
+			Stdout:     &stdout,
+			Stdin:      strings.NewReader("n\n"),
+			WorkingDir: repo,
+		}.Run([]string{"release", "--bump", "patch", "--no-tag", "--no-gh"})
+		if err != nil {
+			t.Fatalf("release --bump error = %v\n%s", err, stdout.String())
+		}
+		if !strings.Contains(stdout.String(), releaseFlowAdvisoryProbe) {
+			t.Fatalf("stdout = %q, want flow advisory", stdout.String())
+		}
+	})
+
+	t.Run("absent for dry run", func(t *testing.T) {
+		repo := seedReleaseApplyRepo(t, "feat: keep dry run silent")
+		var stdout bytes.Buffer
+		err := Runner{
+			Stdout:     &stdout,
+			WorkingDir: repo,
+		}.Run([]string{"release", "--dry-run"})
+		if err != nil {
+			t.Fatalf("release --dry-run error = %v\n%s", err, stdout.String())
+		}
+		if strings.Contains(stdout.String(), releaseFlowAdvisoryProbe) {
+			t.Fatalf("stdout = %q, advisory must not print for --dry-run", stdout.String())
+		}
+	})
+
+	t.Run("absent for pre-merge", func(t *testing.T) {
+		repo := seedReleaseApplyRepo(t, "feat: keep pre-merge silent")
+		var stdout, stderr bytes.Buffer
+		err := Runner{
+			Stdout:     &stdout,
+			Stderr:     &stderr,
+			Stdin:      strings.NewReader("n\n"),
+			WorkingDir: repo,
+		}.Run([]string{"release", "--pre-merge", "--base", "v1.0.0"})
+		if err != nil {
+			t.Fatalf("release --pre-merge error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+		if strings.Contains(stdout.String(), releaseFlowAdvisoryProbe) || strings.Contains(stderr.String(), releaseFlowAdvisoryProbe) {
+			t.Fatalf("stdout = %q stderr = %q, advisory must not print for --pre-merge", stdout.String(), stderr.String())
+		}
+	})
+
+	t.Run("predicate excludes two-phase and read-only modes on the default branch", func(t *testing.T) {
+		repo := seedReleaseApplyRepo(t, "feat: gate the predicate")
+		cases := []struct {
+			name    string
+			options releaseOptions
+			want    bool
+		}{
+			{name: "interactive", options: releaseOptions{}, want: true},
+			{name: "bump", options: releaseOptions{bump: "patch"}, want: true},
+			{name: "dry-run", options: releaseOptions{dryRun: true}, want: false},
+			{name: "pre-merge", options: releaseOptions{preMerge: true}, want: false},
+			{name: "post-merge", options: releaseOptions{postMerge: true}, want: false},
+			{name: "help", options: releaseOptions{help: true}, want: false},
+		}
+		for _, tc := range cases {
+			if got := releaseInvocationWantsFlowAdvisory(repo, tc.options); got != tc.want {
+				t.Fatalf("releaseInvocationWantsFlowAdvisory(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		}
+	})
+
+	t.Run("absent on a non-default branch", func(t *testing.T) {
+		repo := seedReleaseApplyRepo(t, "feat: keep release branches silent")
+		gitCLI(t, repo, "checkout", "-b", "release/v1.1.0")
+		var stdout bytes.Buffer
+		err := Runner{
+			Stdout:     &stdout,
+			Stdin:      strings.NewReader("n\n"),
+			WorkingDir: repo,
+		}.Run([]string{"release", "--bump", "patch", "--no-tag", "--no-gh"})
+		if err != nil {
+			t.Fatalf("release --bump on feature branch error = %v\n%s", err, stdout.String())
+		}
+		if strings.Contains(stdout.String(), releaseFlowAdvisoryProbe) {
+			t.Fatalf("stdout = %q, advisory must not print off the default branch", stdout.String())
+		}
+	})
+
+	t.Run("default branch resolves from local refs only", func(t *testing.T) {
+		repo := seedReleaseApplyRepo(t, "feat: resolve default branch locally")
+		if got := resolveReleaseDefaultBranch(repo); got != "main" {
+			t.Fatalf("resolveReleaseDefaultBranch = %q, want main fallback", got)
+		}
+		head := gitOutputReleaseTest(t, repo, "rev-parse", "HEAD")
+		gitCLI(t, repo, "update-ref", "refs/remotes/origin/trunk", head)
+		gitCLI(t, repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/trunk")
+		if got := resolveReleaseDefaultBranch(repo); got != "trunk" {
+			t.Fatalf("resolveReleaseDefaultBranch = %q, want trunk via refs/remotes/origin/HEAD", got)
+		}
+		if releaseInvocationWantsFlowAdvisory(repo, releaseOptions{}) {
+			t.Fatalf("predicate = true on main while origin/HEAD names trunk, want false")
+		}
+	})
+
+	t.Run("predicate is false when no default branch resolves", func(t *testing.T) {
+		repo := seedReleaseApplyRepo(t, "feat: tolerate unknown default branch")
+		gitCLI(t, repo, "branch", "-m", "main", "develop")
+		if got := resolveReleaseDefaultBranch(repo); got != "" {
+			t.Fatalf("resolveReleaseDefaultBranch = %q, want empty without origin/HEAD or main/master", got)
+		}
+		if releaseInvocationWantsFlowAdvisory(repo, releaseOptions{}) {
+			t.Fatalf("predicate = true without a resolvable default branch, want false")
+		}
+	})
+}
+
+func TestReleaseGuardrailRemediation(t *testing.T) {
+	t.Run("clean worktree refusal names the pre-merge flow", func(t *testing.T) {
+		repo := seedReleaseApplyRepo(t, "feat: route curation to the release branch")
+		writeFile(t, filepath.Join(repo, "notes.txt"), "uncommitted curation\n")
+		err := (Runner{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}, WorkingDir: repo}).Run([]string{"release", "--bump", "patch", "--yes", "--no-tag", "--no-gh"})
+		if err == nil {
+			t.Fatalf("release on dirty worktree error = nil, want refusal")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "require a clean unignored worktree") {
+			t.Fatalf("error = %q, want clean-worktree refusal", msg)
+		}
+		if !strings.Contains(msg, "changelog curation belongs on a release branch in the --pre-merge flow") {
+			t.Fatalf("error = %q, want the pre-merge flow named as where curation belongs", msg)
+		}
+		if !strings.Contains(msg, "notes.txt") {
+			t.Fatalf("error = %q, want dirty path listed", msg)
+		}
+	})
+
+	t.Run("unpushed local tag keeps deletion advice", func(t *testing.T) {
+		repo := seedReleasePostMergeFiles(t, "1.2.3")
+		responses := releasePostMergeHappyResponses("1.2.3")
+		responses["git tag --list v1.2.3"] = releasePostMergeOK("v1.2.3")
+		runner, _ := scriptedReleasePostMergeRunner(responses)
+		snap := mustResolveReleaseSnapshot(t, repo, releaseOptions{postMerge: true})
+
+		result := checkReleasePostMergeGuardrails(repo, snap, runner)
+		if result.ok || result.guardrail != 7 {
+			t.Fatalf("result = %#v, want guardrail 7 failure", result)
+		}
+		if result.message != "tag v1.2.3 already exists locally — run `git tag -d v1.2.3` and rerun" {
+			t.Fatalf("message = %q, want unpushed local tag deletion advice", result.message)
+		}
+	})
+
+	t.Run("pushed local tag never gets deletion advice", func(t *testing.T) {
+		repo := seedReleasePostMergeFiles(t, "1.2.3")
+		responses := releasePostMergeHappyResponses("1.2.3")
+		responses["git tag --list v1.2.3"] = releasePostMergeOK("v1.2.3")
+		responses["git ls-remote --tags origin refs/tags/v1.2.3"] = releasePostMergeOK("deadbeef\trefs/tags/v1.2.3")
+		runner, _ := scriptedReleasePostMergeRunner(responses)
+		snap := mustResolveReleaseSnapshot(t, repo, releaseOptions{postMerge: true})
+
+		result := checkReleasePostMergeGuardrails(repo, snap, runner)
+		if result.ok || result.guardrail != 7 {
+			t.Fatalf("result = %#v, want guardrail 7 failure", result)
+		}
+		if !strings.Contains(result.message, "tag v1.2.3 already exists and is pushed") || !strings.Contains(result.message, "do not delete a published tag") {
+			t.Fatalf("message = %q, want pushed-tag non-destructive remediation", result.message)
+		}
+		if !strings.Contains(result.message, "re-run the Release workflow or recreate the release from the existing tag") {
+			t.Fatalf("message = %q, want the non-destructive repair named", result.message)
+		}
+		if strings.Contains(result.message, "tag -d") {
+			t.Fatalf("message = %q, must never advise deleting a pushed tag", result.message)
+		}
+	})
+
+	t.Run("remote lookup failure degrades to the local wording", func(t *testing.T) {
+		repo := seedReleasePostMergeFiles(t, "1.2.3")
+		responses := releasePostMergeHappyResponses("1.2.3")
+		responses["git tag --list v1.2.3"] = releasePostMergeOK("v1.2.3")
+		responses["git ls-remote --tags origin refs/tags/v1.2.3"] = releasePostMergeExit(128)
+		runner, _ := scriptedReleasePostMergeRunner(responses)
+		snap := mustResolveReleaseSnapshot(t, repo, releaseOptions{postMerge: true})
+
+		result := checkReleasePostMergeGuardrails(repo, snap, runner)
+		if result.ok || result.guardrail != 7 {
+			t.Fatalf("result = %#v, want guardrail 7 failure", result)
+		}
+		if result.message != "tag v1.2.3 already exists locally — run `git tag -d v1.2.3` and rerun" {
+			t.Fatalf("message = %q, want degraded local wording when the remote lookup fails", result.message)
+		}
+	})
+
+	t.Run("remote-only tag gets non-destructive advice", func(t *testing.T) {
+		repo := seedReleasePostMergeFiles(t, "1.2.3")
+		responses := releasePostMergeHappyResponses("1.2.3")
+		responses["git ls-remote --tags origin refs/tags/v1.2.3"] = releasePostMergeOK("deadbeef\trefs/tags/v1.2.3")
+		runner, _ := scriptedReleasePostMergeRunner(responses)
+		snap := mustResolveReleaseSnapshot(t, repo, releaseOptions{postMerge: true})
+
+		result := checkReleasePostMergeGuardrails(repo, snap, runner)
+		if result.ok || result.guardrail != 7 {
+			t.Fatalf("result = %#v, want guardrail 7 failure", result)
+		}
+		if !strings.Contains(result.message, "tag v1.2.3 already exists on remote") || !strings.Contains(result.message, "do not delete a published tag") {
+			t.Fatalf("message = %q, want remote-tag non-destructive remediation", result.message)
+		}
+		if strings.Contains(result.message, ":refs/tags/") || strings.Contains(result.message, "tag -d") {
+			t.Fatalf("message = %q, must never advise deleting a pushed tag", result.message)
+		}
+	})
+
+	t.Run("existing GH release gets non-destructive advice", func(t *testing.T) {
+		repo := seedReleasePostMergeFiles(t, "1.2.3")
+		responses := releasePostMergeHappyResponses("1.2.3")
+		responses["gh release view v1.2.3"] = releasePostMergeOK("v1.2.3 draft")
+		runner, _ := scriptedReleasePostMergeRunner(responses)
+		snap := mustResolveReleaseSnapshot(t, repo, releaseOptions{postMerge: true})
+
+		result := checkReleasePostMergeGuardrails(repo, snap, runner)
+		if result.ok || result.guardrail != 7 {
+			t.Fatalf("result = %#v, want guardrail 7 failure", result)
+		}
+		if !strings.Contains(result.message, "GH release v1.2.3 already exists") || !strings.Contains(result.message, "do not delete a published release") {
+			t.Fatalf("message = %q, want non-destructive GH release remediation", result.message)
+		}
+	})
+}

--- a/internal/cli/release_flow_advisory_test.go
+++ b/internal/cli/release_flow_advisory_test.go
@@ -145,6 +145,41 @@ func TestReleaseFlowAdvisory(t *testing.T) {
 			t.Fatalf("predicate = true without a resolvable default branch, want false")
 		}
 	})
+
+	t.Run("prints once when preflight blocks on the default branch", func(t *testing.T) {
+		// Incomplete stable cohort blocks before apply analysis; the advisory
+		// must still print exactly once from the runRelease entry path.
+		repo := seedReleaseApplyRepo(t, "feat: preflight still names the door")
+		dir := writeNewLayoutChange(t, repo, "20260727-preflight-advisory", "preflight-advisory", "1.1.0", "")
+		task := filepath.Join(dir, "tasks", "TASK-001-work.md")
+		unchecked := "---\nchange: preflight-advisory\nid: TASK-001\ntitle: Work\n---\n\n# Work\n\n## Steps\n\n- [ ] Do it\n"
+		writeFile(t, task, unchecked)
+		gitCLI(t, repo, "add", ".")
+		gitCLI(t, repo, "commit", "-m", "docs: shape incomplete stable cohort")
+
+		var stdout bytes.Buffer
+		err := Runner{
+			Stdout:     &stdout,
+			Stderr:     &bytes.Buffer{},
+			WorkingDir: repo,
+		}.Run([]string{"release", "--bump", "minor", "--yes", "--no-tag", "--no-gh"})
+		if err == nil {
+			t.Fatalf("release error = nil, want cohort preflight block")
+		}
+		if !strings.Contains(err.Error(), "targets 1.1.0 but is not executed") {
+			t.Fatalf("error = %v, want incomplete cohort preflight block", err)
+		}
+		output := stdout.String()
+		if !strings.Contains(output, releaseFlowAdvisoryProbe) {
+			t.Fatalf("stdout = %q, want flow advisory before preflight failure", output)
+		}
+		if count := strings.Count(output, releaseFlowAdvisoryProbe); count != 1 {
+			t.Fatalf("stdout advisory count = %d, want exactly once\n%s", count, output)
+		}
+		if strings.Contains(output, "Analyzing") {
+			t.Fatalf("stdout = %q, preflight block must not reach apply analysis", output)
+		}
+	})
 }
 
 func TestReleaseGuardrailRemediation(t *testing.T) {
@@ -220,6 +255,29 @@ func TestReleaseGuardrailRemediation(t *testing.T) {
 		}
 		if result.message != "tag v1.2.3 already exists locally — run `git tag -d v1.2.3` and rerun" {
 			t.Fatalf("message = %q, want degraded local wording when the remote lookup fails", result.message)
+		}
+	})
+
+	t.Run("local tag with failed remote lookup still defers to an existing GH release", func(t *testing.T) {
+		// Masking combination: local tag exists, ls-remote fails (remote unknown),
+		// but gh release view succeeds — must never advise git tag -d.
+		repo := seedReleasePostMergeFiles(t, "1.2.3")
+		responses := releasePostMergeHappyResponses("1.2.3")
+		responses["git tag --list v1.2.3"] = releasePostMergeOK("v1.2.3")
+		responses["git ls-remote --tags origin refs/tags/v1.2.3"] = releasePostMergeExit(128)
+		responses["gh release view v1.2.3"] = releasePostMergeOK("v1.2.3")
+		runner, _ := scriptedReleasePostMergeRunner(responses)
+		snap := mustResolveReleaseSnapshot(t, repo, releaseOptions{postMerge: true})
+
+		result := checkReleasePostMergeGuardrails(repo, snap, runner)
+		if result.ok || result.guardrail != 7 {
+			t.Fatalf("result = %#v, want guardrail 7 failure", result)
+		}
+		if !strings.Contains(result.message, "GH release v1.2.3 already exists") || !strings.Contains(result.message, "do not delete a published release") {
+			t.Fatalf("message = %q, want non-destructive GH release remediation", result.message)
+		}
+		if strings.Contains(result.message, "git tag -d") {
+			t.Fatalf("message = %q, must not advise deletion when a GH release exists", result.message)
 		}
 	})
 

--- a/internal/cli/release_post_merge.go
+++ b/internal/cli/release_post_merge.go
@@ -301,17 +301,24 @@ func extractReleasePostMergeChangelogSection(content string, version string) []s
 
 func checkReleasePostMergeNoExistingTagOrRelease(root string, runner releasePostMergeCommandRunner, version string) string {
 	tag := "v" + version
+	pushedRemedy := "do not delete a published tag; if the GitHub release is missing assets, re-run the Release workflow or recreate the release from the existing tag instead"
 	local := runner(root, "git", "tag", "--list", tag)
-	if local.exitCode == 0 && strings.TrimSpace(local.stdout) == tag {
-		return fmt.Sprintf("tag v%s already exists locally — run `git tag -d v%s` and rerun", version, version)
-	}
+	localExists := local.exitCode == 0 && strings.TrimSpace(local.stdout) == tag
+	// The remote lookup distinguishes a pushed tag from an unpushed one; on any lookup failure remoteExists stays false and the guardrail degrades to the local-only wording instead of erroring.
 	remote := runner(root, "git", "ls-remote", "--tags", "origin", "refs/tags/"+tag)
-	if remote.exitCode == 0 && strings.TrimSpace(remote.stdout) != "" {
-		return fmt.Sprintf("tag v%s already exists on remote — run `git push origin :refs/tags/v%s` and rerun", version, version)
+	remoteExists := remote.exitCode == 0 && strings.TrimSpace(remote.stdout) != ""
+	if localExists {
+		if remoteExists {
+			return fmt.Sprintf("tag %s already exists and is pushed — %s", tag, pushedRemedy)
+		}
+		return fmt.Sprintf("tag %s already exists locally — run `git tag -d %s` and rerun", tag, tag)
+	}
+	if remoteExists {
+		return fmt.Sprintf("tag %s already exists on remote — %s", tag, pushedRemedy)
 	}
 	gh := runner(root, "gh", "release", "view", tag)
 	if !gh.notFound && gh.exitCode == 0 {
-		return fmt.Sprintf("GH release v%s already exists — visit the release page and delete it manually before rerunning", version)
+		return fmt.Sprintf("GH release %s already exists — do not delete a published release; re-run the Release workflow or update it from the existing tag instead; delete it and rerun only if it is an unpublished draft", tag)
 	}
 	return ""
 }

--- a/internal/cli/release_post_merge.go
+++ b/internal/cli/release_post_merge.go
@@ -302,23 +302,28 @@ func extractReleasePostMergeChangelogSection(content string, version string) []s
 func checkReleasePostMergeNoExistingTagOrRelease(root string, runner releasePostMergeCommandRunner, version string) string {
 	tag := "v" + version
 	pushedRemedy := "do not delete a published tag; if the GitHub release is missing assets, re-run the Release workflow or recreate the release from the existing tag instead"
+	// Gather all three states before choosing a remedy. Deletion advice is only
+	// safe for a purely local tag; a failed remote lookup leaves remoteExists
+	// false (degrade, never error) but must not unlock git tag -d when a GitHub
+	// release is present.
 	local := runner(root, "git", "tag", "--list", tag)
 	localExists := local.exitCode == 0 && strings.TrimSpace(local.stdout) == tag
-	// The remote lookup distinguishes a pushed tag from an unpushed one; on any lookup failure remoteExists stays false and the guardrail degrades to the local-only wording instead of erroring.
 	remote := runner(root, "git", "ls-remote", "--tags", "origin", "refs/tags/"+tag)
 	remoteExists := remote.exitCode == 0 && strings.TrimSpace(remote.stdout) != ""
-	if localExists {
-		if remoteExists {
+	gh := runner(root, "gh", "release", "view", tag)
+	ghReleaseExists := !gh.notFound && gh.exitCode == 0
+
+	if remoteExists {
+		if localExists {
 			return fmt.Sprintf("tag %s already exists and is pushed — %s", tag, pushedRemedy)
 		}
-		return fmt.Sprintf("tag %s already exists locally — run `git tag -d %s` and rerun", tag, tag)
-	}
-	if remoteExists {
 		return fmt.Sprintf("tag %s already exists on remote — %s", tag, pushedRemedy)
 	}
-	gh := runner(root, "gh", "release", "view", tag)
-	if !gh.notFound && gh.exitCode == 0 {
+	if ghReleaseExists {
 		return fmt.Sprintf("GH release %s already exists — do not delete a published release; re-run the Release workflow or update it from the existing tag instead; delete it and rerun only if it is an unpublished draft", tag)
+	}
+	if localExists {
+		return fmt.Sprintf("tag %s already exists locally — run `git tag -d %s` and rerun", tag, tag)
 	}
 	return ""
 }

--- a/plugins/loaf/skills/release/SKILL.md
+++ b/plugins/loaf/skills/release/SKILL.md
@@ -24,7 +24,7 @@ Publish a coherent version from work that has already landed.
 - Step 2: Change Collection
 - Step 3: Version + Changelog
 - Step 4: Release Execution
-- Step 5: Protected-Branch Handoff
+- Step 5: Release-PR Flow
 - Step 6: Publication Verification
 - Step 7: Post-Release Follow-Up
 - Hook Interaction
@@ -38,6 +38,7 @@ Publish a coherent version from work that has already landed.
 
 - **Release is not merge** -- do not use `/loaf:release` to review, approve, or land a feature PR. Use `/loaf:ship` for PR correctness and landing.
 - **Release from landed work** -- collect changes from the release base branch, normally the repo default branch, since the last release tag.
+- **Release-PR flow is the default** -- prepare on a release branch with `loaf release --pre-merge`, squash-merge the release PR, then finalize with `loaf release --post-merge` on the base branch. Direct `--bump` on the base branch is a named exception used only on explicit user request.
 - **Batch by intent** -- group release notes by user-facing outcome, `CR-*` change bundle, spec, or related PRs; do not mirror individual commits mechanically.
 - **Keep landed and released distinct** -- a PR may be landed without being released; a release may contain multiple landed PRs.
 - **Block on release-readiness failure** -- do not publish if build, tests, version files, changelog, tag, or GitHub release state is inconsistent.
@@ -61,7 +62,7 @@ Publish a coherent version from work that has already landed.
 | Readiness | clean/current base branch, no unresolved release collisions | Yes |
 | Change Collection | landed work since last tag grouped into release themes | Yes |
 | Version + Changelog | bump selected, notes curated, files updated | Yes |
-| Execution | release commit/tag/GitHub Release created or release PR prepared | Yes |
+| Execution | release commit prepared via `--pre-merge`, release PR landed, `--post-merge` finalizes | Yes |
 | Verification | release and install paths checked | Yes |
 | Follow-Up | reflect/loaf:housekeeping suggested when useful | No |
 
@@ -70,7 +71,7 @@ Publish a coherent version from work that has already landed.
 | Topic | Use When |
 |-------|----------|
 | [Context Detection](#context-detection) | Determining release base, last tag, and current branch |
-| [Protected-Branch Handoff](#step-5-protected-branch-handoff) | Branch protection requires a release PR |
+| [Release-PR Flow](#step-5-release-pr-flow) | Preparing, landing, and finalizing every release |
 | [Hook Interaction](#hook-interaction) | Understanding coexistence with git hooks |
 
 ---
@@ -86,9 +87,9 @@ Before anything, establish the release surface:
    ```
 2. Parse `$ARGUMENTS` for an explicit base, tag, or version. If omitted, use the repo default branch as the release base.
 3. Verify the current branch:
-   - If already on the release base, continue.
+   - If already on the release base, continue; the release-PR flow in Step 5 branches from here.
+   - If on a dedicated release branch, resume the release-PR flow at the matching step.
    - If on a feature branch, stop and explain that `/loaf:release` publishes from landed work. Offer `/loaf:ship` if the active PR needs landing first.
-   - If preparing a release branch because direct base-branch pushes are blocked, continue only after the user confirms that release-PR strategy.
 4. Find the previous release tag:
    ```bash
    git describe --tags --abbrev=0
@@ -183,23 +184,17 @@ Choose the bump and curate the changelog from the grouped landed work.
 
 ## Step 4: Release Execution
 
-For a direct release from the base branch, run:
+Every release routes through the release-PR flow in Step 5: prepare the release commit on a release branch with `loaf release --pre-merge`, land the release PR, then finalize with `loaf release --post-merge` on the base branch.
 
-```bash
-loaf release --bump <type> --yes
-```
-
-This should:
+Release preparation should:
 
 1. Update version files
 2. Convert `[Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`
 3. Reinsert a fresh empty `[Unreleased]` section
 4. Run configured release artifact commands
 5. Create the release commit
-6. Create/push the release tag
-7. Create the GitHub Release when enabled
 
-After execution, verify generated artifacts are current:
+After preparation, verify generated artifacts are current:
 
 ```bash
 npm run build
@@ -208,17 +203,21 @@ git diff --exit-code -- dist plugins content/skills/loaf-reference/SKILL.md
 
 Adjust the path list to the project. For Loaf itself, tracked generated outputs under `dist/`, `plugins/`, and native binaries must match the source changes.
 
+### Direct Release (Named Exception)
+
+`loaf release --bump <type> --yes` on the base branch prepares, commits, tags, and publishes in a single shot. Use it only when the user explicitly requests a direct release; never select it by default. Skipping the release PR means nothing runs the suite against the prepared tree before the tag exists — the v2.0.0-alpha.16 cut took this door and a capability-evidence canary surfaced only in tag CI, after publication. The CLI prints a flow advisory when a mutating release starts on the default branch; treat it as a routing signal, not noise.
+
 ---
 
-## Step 5: Protected-Branch Handoff
+## Step 5: Release-PR Flow
 
-If branch protection prevents direct release commits on the base branch:
+The default for every release: PR CI runs the full suite against the prepared tree, so evidence canaries surface before any tag or GitHub Release exists. This holds regardless of repository settings — where branch protection is enabled it is satisfied as a side effect, not the reason for the flow.
 
-1. Create a dedicated release branch.
-2. Run the release command in a mode that creates the version/changelog/artifact commit but does not publish final tags or GitHub Release artifacts until the release commit lands on the base branch.
+1. Create a dedicated release branch from the release base.
+2. Run `loaf release --pre-merge` on it: this creates the version/changelog/artifact release commit but no tag and no GitHub Release.
 3. Open a release PR with a concise release-focused body.
-4. Hand the PR to `/loaf:ship` for review and landing.
-5. After `/loaf:ship` lands the release PR, resume `/loaf:release` on the base branch to tag, publish the GitHub Release, and verify installability.
+4. Hand the PR to `/loaf:ship` for review and landing; squash-merge it into one `chore: release vX.Y.Z (#PR)` commit carrying the curated changelog.
+5. After the release PR lands, run `loaf release --post-merge` on the base branch to tag, publish the GitHub Release, and verify installability.
 
 Do not hide this handoff inside `/loaf:release`: `/loaf:ship` remains the PR correctness and merge gate.
 
@@ -269,7 +268,7 @@ configured otherwise; security and secret-scanning hooks remain blocking.
 |------|------|---------------------|
 | `github-account` | Force-switch | Switches to the configured GitHub account before `gh` release operations; blocks only if the switch fails |
 | `validate-push` | Advisory | Cross-checks version bump, changelog, and build on push |
-| `workflow-pre-pr` | Advisory | May fire only for protected-branch release PRs |
+| `workflow-pre-pr` | Advisory | Fires when the release PR is opened |
 | `workflow-pre-merge` | Advisory | Belongs to `/loaf:ship` when a release PR must land |
 | `workflow-post-merge` | Advisory | Belongs to `/loaf:ship` after PR landing |
 | `check-secrets` | Blocking | Always respected before writes or shell actions |


### PR DESCRIPTION
## Change

docs/changes/20260730-release-flow-guidance/

## What & Why

The v2.0.0-alpha.16 cut veered from the release convention because nothing at the decision point named it: the CLI permits single-shot `--bump` on the default branch, and the release skill conditioned the release-PR flow on branch protection. Mutating `loaf release` invocations on the default branch now print a one-paragraph advisory naming the two-phase flow (`--pre-merge` → release PR squash → `--post-merge`) before snapshot resolution and cohort preflight; the clean-worktree refusal names where changelog curation belongs; the post-merge tag-exists guardrail is state-aware and never advises deleting a pushed tag or published release. The release skill makes the release-PR flow the unconditional default, with direct `--bump` demoted to a named exception citing the incident.

## Verification

Schema-v2 receipt committed at HEAD (`receipts/verify.json`): V1–V4 green including the full suite; `loaf change check` derives `complete`, zero violations. Pre-push review loop: Codex (gpt-5.6-sol, xhigh) pass 1 found four issues (three accepted and fixed, one rejected on precedent), pass 2 approved with no remaining findings and the receipt digests independently recomputed — board at `reports/20260730-143315-review-codex.html`.

## Notes

Tracked native binaries are deliberately unchanged (repo precedent: the release ceremony rebuilds and commits them with the capability-evidence re-record).