### PR TITLE
fix: stop upgrade nags for vendor skills Loaf no longer ships

### DIFF
--- a/config/deprecations.json
+++ b/config/deprecations.json
@@ -16,20 +16,6 @@
     }
   ],
   "retired_agents": [],
-  "externalized_skills": [
-    {
-      "skill": "thermo-nuclear-code-quality-review",
-      "since": "v2.0.0-pre.20260614235428",
-      "reason": "externalized by SPEC-053 taxonomy decision; install as a vendor skill instead of a Loaf core skill",
-      "signoff": "report-spec-053-taxonomy-signoff",
-      "source": "https://github.com/cursor/plugins/tree/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review",
-      "skill_homes": [
-        "${HOME}/.agents/skills",
-        "${HOME}/.config/agents/skills",
-        "${HOME}/.config/opencode/skills"
-      ]
-    }
-  ],
   "relocations": [
     {
       "id": "opencode-skills-to-agents-home",

--- a/internal/cli/install_deprecations.go
+++ b/internal/cli/install_deprecations.go
@@ -25,13 +25,12 @@ const (
 )
 
 type installDeprecationManifest struct {
-	Version            int                         `json:"version"`
-	RetiredTargets     []retiredInstallTarget      `json:"retired_targets"`
-	RetiredSkills      []retiredInstallSkill       `json:"retired_skills"`
-	RetiredAgents      []retiredInstallAgent       `json:"retired_agents"`
-	ExternalizedSkills []externalizedInstallSkill  `json:"externalized_skills"`
-	Relocations        []installRelocationManifest `json:"relocations"`
-	Aliases            []installAliasManifest      `json:"aliases"`
+	Version        int                         `json:"version"`
+	RetiredTargets []retiredInstallTarget      `json:"retired_targets"`
+	RetiredSkills  []retiredInstallSkill       `json:"retired_skills"`
+	RetiredAgents  []retiredInstallAgent       `json:"retired_agents"`
+	Relocations    []installRelocationManifest `json:"relocations"`
+	Aliases        []installAliasManifest      `json:"aliases"`
 }
 
 type retiredInstallTarget struct {
@@ -61,17 +60,6 @@ type retiredInstallAgent struct {
 	AgentHomes []string `json:"agent_homes"`
 }
 
-type externalizedInstallSkill struct {
-	Skill          string   `json:"skill"`
-	Since          string   `json:"since"`
-	Window         string   `json:"window"`
-	Reason         string   `json:"reason"`
-	Signoff        string   `json:"signoff"`
-	Source         string   `json:"source"`
-	InstallCommand string   `json:"install_command"`
-	SkillHomes     []string `json:"skill_homes"`
-}
-
 type installRelocationManifest struct {
 	ID          string `json:"id"`
 	From        string `json:"from"`
@@ -93,13 +81,12 @@ type installAliasManifest struct {
 }
 
 type installDeprecationCleanupResult struct {
-	Removed      []installDeprecationCleanupAction
-	Unmanaged    []installDeprecationCleanupAction
-	Externalized []installDeprecationCleanupAction
-	Aliases      []installDeprecationCleanupAction
-	Skipped      []installDeprecationCleanupAction
-	Receipt      installMigrationReceipt
-	Mutated      bool
+	Removed   []installDeprecationCleanupAction
+	Unmanaged []installDeprecationCleanupAction
+	Aliases   []installDeprecationCleanupAction
+	Skipped   []installDeprecationCleanupAction
+	Receipt   installMigrationReceipt
+	Mutated   bool
 }
 
 type installDeprecationCleanupAction struct {
@@ -110,8 +97,6 @@ type installDeprecationCleanupAction struct {
 	Since   string
 	Window  string
 	Signoff string
-	Source  string
-	Command string
 	Action  string
 }
 
@@ -199,7 +184,6 @@ func (m installDeprecationManifest) isEmpty() bool {
 	return len(m.RetiredTargets) == 0 &&
 		len(m.RetiredSkills) == 0 &&
 		len(m.RetiredAgents) == 0 &&
-		len(m.ExternalizedSkills) == 0 &&
 		len(m.Relocations) == 0 &&
 		len(m.Aliases) == 0
 }
@@ -450,54 +434,6 @@ func applyInstallDeprecationCleanup(manifest installDeprecationManifest, pathCon
 			// agent file is Loaf-authored. Without an agent digest, never delete.
 			action.Action = "unmanaged"
 			result.Unmanaged = append(result.Unmanaged, action)
-		}
-	}
-	for _, skill := range manifest.ExternalizedSkills {
-		for _, rawHome := range skill.SkillHomes {
-			home, err := expandInstallDeprecationPath(rawHome, pathContext)
-			if err != nil {
-				return result, err
-			}
-			path := filepath.Join(home, skill.Skill)
-			dirInfo, dirErr := os.Lstat(path)
-			if dirErr != nil {
-				if os.IsNotExist(dirErr) {
-					continue
-				}
-				if shouldSurfaceMigrationInspectionError(dirErr) {
-					return result, fmt.Errorf("inspect externalized skill %s: %w", path, dirErr)
-				}
-				continue
-			}
-			if !dirInfo.IsDir() || dirInfo.Mode()&os.ModeSymlink != 0 {
-				continue
-			}
-			skillMD := filepath.Join(path, "SKILL.md")
-			fileInfo, fileErr := os.Lstat(skillMD)
-			if fileErr != nil {
-				if os.IsNotExist(fileErr) {
-					continue
-				}
-				if shouldSurfaceMigrationInspectionError(fileErr) {
-					return result, fmt.Errorf("inspect externalized skill %s: %w", skillMD, fileErr)
-				}
-				continue
-			}
-			if !fileInfo.Mode().IsRegular() || fileInfo.Mode()&os.ModeSymlink != 0 {
-				continue
-			}
-			result.Externalized = append(result.Externalized, installDeprecationCleanupAction{
-				Kind:    "skill",
-				Name:    skill.Skill,
-				Path:    path,
-				Reason:  skill.Reason,
-				Since:   skill.Since,
-				Window:  deprecationWindow(skill.Window),
-				Signoff: skill.Signoff,
-				Source:  skill.Source,
-				Command: skill.InstallCommand,
-				Action:  "externalized",
-			})
 		}
 	}
 	for _, relocation := range manifest.Relocations {
@@ -2097,7 +2033,7 @@ func expandInstallDeprecationPath(path string, context map[string]string) (strin
 }
 
 func writeInstallDeprecationCleanup(out io.Writer, result installDeprecationCleanupResult) {
-	if len(result.Removed) == 0 && len(result.Unmanaged) == 0 && len(result.Externalized) == 0 && len(result.Aliases) == 0 && len(result.Skipped) == 0 {
+	if len(result.Removed) == 0 && len(result.Unmanaged) == 0 && len(result.Aliases) == 0 && len(result.Skipped) == 0 {
 		return
 	}
 	fmt.Fprintf(out, "  %s install deprecation cleanup\n", ansiGray("•"))
@@ -2130,17 +2066,6 @@ func writeInstallDeprecationCleanup(out io.Writer, result installDeprecationClea
 			fmt.Fprintf(out, "    %s un-managed %s %s at %s; left in place (ownership not proven)", ansiYellow("⚠"), action.Kind, action.Name, ansiGray(action.Path))
 		}
 		writeInstallDeprecationMetadata(out, action)
-		fmt.Fprintln(out)
-	}
-	for _, action := range result.Externalized {
-		fmt.Fprintf(out, "    %s externalized %s %s at %s", ansiGray("-"), action.Kind, action.Name, ansiGray(action.Path))
-		writeInstallDeprecationMetadata(out, action)
-		if action.Source != "" {
-			fmt.Fprintf(out, " source: %s", action.Source)
-		}
-		if action.Command != "" {
-			fmt.Fprintf(out, " command: %s", action.Command)
-		}
 		fmt.Fprintln(out)
 	}
 	for _, action := range result.Aliases {

--- a/internal/cli/install_deprecations_ownership_test.go
+++ b/internal/cli/install_deprecations_ownership_test.go
@@ -98,21 +98,11 @@ func TestDestructiveMigrationPreservesUnowned(t *testing.T) {
     }
   ],
   "retired_agents": [],
-  "externalized_skills": [
-    {
-      "skill": "thermo-nuclear-code-quality-review",
-      "since": "v9.9.0",
-      "reason": "report-only externalized skill",
-      "source": "https://example.com/vendor-skill",
-      "install_command": "loaf skill add https://example.com/vendor-skill",
-      "skill_homes": ["${HOME}/.agents/skills"]
-    }
-  ],
   "relocations": [],
   "aliases": []
 }`)
 
-	// Externalized skill present — report only, never remove.
+	// Unclaimed vendor tree — upgrade must not delete it.
 	extPath := filepath.Join(canonical, "thermo-nuclear-code-quality-review", "SKILL.md")
 	writeInstallFile(t, extPath, "# Vendor externalized\n")
 
@@ -130,7 +120,7 @@ func TestDestructiveMigrationPreservesUnowned(t *testing.T) {
 	if info, err := os.Lstat(dangling); err != nil || info.Mode()&os.ModeSymlink == 0 {
 		t.Fatalf("dangling symlink Lstat = %v info=%v, want preserved symlink", err, info)
 	}
-	// Externalized report-only: still present.
+	// Vendor tree must survive upgrade.
 	assertInstallFile(t, extPath, "# Vendor externalized\n")
 
 	// Every derived prior home: owned retired skill removed.
@@ -154,10 +144,6 @@ func TestDestructiveMigrationPreservesUnowned(t *testing.T) {
 	if !strings.Contains(out, "migration receipt") || !strings.Contains(out, "before=") || !strings.Contains(out, "after=") {
 		t.Fatalf("stdout missing before/after migration receipt:\n%s", out)
 	}
-	if !strings.Contains(out, "externalized skill thermo-nuclear-code-quality-review") {
-		t.Fatalf("stdout missing externalized report-only line:\n%s", out)
-	}
-
 	// Manifest no longer claims mismatched / dangling / retired entries.
 	state, err := readManagedSkillsState(canonical)
 	if err != nil {
@@ -1363,31 +1349,29 @@ func TestDestructiveMigrationInspectionIOErrorsSurface(t *testing.T) {
 			},
 		},
 		{
-			name: "externalized_skill_path",
+			name: "retired_skill_path",
 			prep: func(t *testing.T, root, home string) ([]string, string) {
 				skillHome := filepath.Join(home, ".agents", "skills")
-				skillPath := filepath.Join(skillHome, "thermo-nuclear-code-quality-review")
-				writeInstallFile(t, filepath.Join(skillPath, "SKILL.md"), "# Vendor\n")
+				skillPath := filepath.Join(skillHome, "old-skill")
+				writeInstallFile(t, filepath.Join(skillPath, "SKILL.md"), "# present\n")
 				writeInstallDeprecationManifest(t, root, `{
   "version": 1,
   "retired_targets": [],
-  "retired_skills": [],
-  "retired_agents": [],
-  "externalized_skills": [{
-    "skill": "thermo-nuclear-code-quality-review",
+  "retired_skills": [{
+    "skill": "old-skill",
     "since": "v9.9.0",
-    "reason": "must surface EACCES on externalized inspect",
-    "source": "https://example.com/vendor-skill",
-    "install_command": "loaf skill add https://example.com/vendor-skill",
+    "reason": "must surface EACCES on retired skill inspect",
     "skill_homes": ["${HOME}/.agents/skills"]
   }],
+  "retired_agents": [],
   "relocations": [],
   "aliases": []
 }`)
 				// Deny traversal into the skill tree only — skill home stays readable so
-				// quarantine orphan scanning does not preempt this path.
+				// quarantine orphan scanning does not preempt this path. --yes so the
+				// destructive home-hash inspects the tree and surfaces EACCES.
 				chmodForTest(t, skillPath, 0o000)
-				return []string{"upgrade"}, skillPath
+				return []string{"upgrade", "--yes"}, skillPath
 			},
 		}}
 

--- a/internal/cli/install_plan.go
+++ b/internal/cli/install_plan.go
@@ -83,8 +83,6 @@ type deprecationPlanEntry struct {
 	Since           string `json:"since,omitempty"`
 	Window          string `json:"window,omitempty"`
 	Signoff         string `json:"signoff,omitempty"`
-	Source          string `json:"source,omitempty"`
-	Command         string `json:"command,omitempty"`
 }
 
 type projectFilePlanEntry struct {
@@ -811,12 +809,7 @@ func planInstallDeprecations(loafRoot string, explicitYes bool) ([]deprecationPl
 			Since:           action.Since,
 			Window:          action.Window,
 			Signoff:         action.Signoff,
-			Source:          action.Source,
-			Command:         action.Command,
 		})
-	}
-	for _, action := range result.Externalized {
-		appendEntry(action, "externalized", false)
 	}
 	for _, action := range result.Aliases {
 		appendEntry(action, "alias", false)

--- a/internal/cli/upgrade_maintenance_test.go
+++ b/internal/cli/upgrade_maintenance_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -488,46 +489,51 @@ func TestRunnerUpgradeReportsAliasTombstoneFromManifest(t *testing.T) {
 	}
 }
 
-func TestRunnerUpgradeReportsExternalizedSkillWithoutRemoving(t *testing.T) {
+func TestExternalizedSkillsFeatureRemoved(t *testing.T) {
+	repoRoot := testRepositoryRoot(t)
+	body, err := os.ReadFile(filepath.Join(repoRoot, "config", "deprecations.json"))
+	if err != nil {
+		t.Fatalf("read shipped deprecations.json: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("decode shipped deprecations.json: %v", err)
+	}
+	if _, ok := raw["externalized_skills"]; ok {
+		t.Fatal("shipped config/deprecations.json still has externalized_skills")
+	}
+	if _, _, err := loadInstallDeprecationManifest(repoRoot); err != nil {
+		t.Fatalf("loadInstallDeprecationManifest(repo root): %v", err)
+	}
+
 	root, home := setupInstallCommandFixture(t)
-	externalizedSkill := filepath.Join(home, ".agents", "skills", "vendor-skill")
-	writeInstallFile(t, filepath.Join(externalizedSkill, "SKILL.md"), "# Vendor skill\n")
+	vendorSkill := filepath.Join(home, ".agents", "skills", "thermo-nuclear-code-quality-review", "SKILL.md")
+	writeInstallFile(t, vendorSkill, "# Vendor skill\n")
 	writeInstallDeprecationManifest(t, root, `{
   "version": 1,
   "retired_targets": [],
   "retired_skills": [],
   "retired_agents": [],
-  "externalized_skills": [
-    {
-      "skill": "vendor-skill",
-      "since": "v9.9.0",
-      "reason": "vendor-skill moved out of Loaf core",
-      "signoff": "report-spec-053-taxonomy-signoff",
-      "source": "https://github.com/example/skills/tree/main/skills/vendor-skill",
-      "install_command": "loaf skill add https://github.com/example/skills/tree/main/skills/vendor-skill",
-      "skill_homes": ["${HOME}/.agents/skills"]
-    }
-  ],
   "relocations": [],
   "aliases": []
 }`)
 
 	var stdout bytes.Buffer
-	err := Runner{Stdout: &stdout, WorkingDir: root, Executable: distributionFixtureExecutable(root)}.Run([]string{"upgrade", "--yes"})
+	err = Runner{Stdout: &stdout, WorkingDir: root, Executable: distributionFixtureExecutable(root)}.Run([]string{"upgrade", "--yes"})
 	if err != nil {
 		t.Fatalf("upgrade error = %v\n%s", err, stdout.String())
 	}
-	assertInstallFile(t, filepath.Join(externalizedSkill, "SKILL.md"), "# Vendor skill\n")
-	for _, want := range []string{
+	assertInstallFile(t, vendorSkill, "# Vendor skill\n")
+	out := stdout.String()
+	for _, banned := range []string{
+		"externalized",
+		"thermo-nuclear-code-quality-review",
+		"SPEC-053",
+		"report-spec-053",
 		"install deprecation cleanup",
-		"externalized skill vendor-skill",
-		"vendor-skill moved out of Loaf core",
-		"source: https://github.com/example/skills/tree/main/skills/vendor-skill",
-		"command: loaf skill add https://github.com/example/skills/tree/main/skills/vendor-skill",
-		"[signoff: report-spec-053-taxonomy-signoff]",
 	} {
-		if !strings.Contains(stdout.String(), want) {
-			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+		if strings.Contains(out, banned) {
+			t.Fatalf("stdout must not contain %q:\n%s", banned, out)
 		}
 	}
 }


### PR DESCRIPTION
# Remove unused externalized_skills deprecation

`loaf upgrade` reprints an `externalized skill thermo-nuclear-code-quality-review` line whenever that directory exists under a scanned skill home. The shared skill home is the correct place to install vendor skills. The line dumps SPEC, signoff, since, window, and source, and does not say what to do.

That name is the only `externalized_skills` row Loaf has ever shipped. The skill left core in SPEC-053 and already lives as a vendor skill. A one-skill catalog plus a standing report path is leftover machinery, not a migration still in flight.

Decided: delete the feature. Remove the catalog entry, the `externalized_skills` manifest field, the apply/report/plan path, and the tests that lock the nag. An unclaimed vendor copy in `~/.agents/skills` is not Loaf's business. Dry-run/JSON plan stays aligned with apply.

Retirement of leftover Loaf-owned skills (`cli-reference`) and the OpenCode/Amp skill-home relocations stay. Those still do work.

Out of scope: deleting the operator's skill; acknowledgement persistence; ageing `cli-reference` or relocation entries; rewriting retirement/relocation ownership rules; progressive-deprecation capability (LOAF-12); historical SPEC-053 / signoff records.

## Definition of Done

- [ ] Shipped deprecations.json and the upgrade/plan path have no externalized_skills feature; a present vendor skill is silent and left in place
- [ ] Existing deprecation report and upgrade cleanup tests still pass after the feature is removed