### PR TITLE
docs(shape): re-index sizing rule to verification (LOAF-77)

### DIFF
--- a/cmd/loaf/content_hygiene_test.go
+++ b/cmd/loaf/content_hygiene_test.go
@@ -10,6 +10,42 @@ import (
 	"testing"
 )
 
+func TestShapeSizingRuleVerificationIndexed(t *testing.T) {
+	root := repoRoot(t)
+	shapeSkill := readTextFile(t, filepath.Join(root, "content", "skills", "shape", "SKILL.md"))
+	decomposition := readTextFile(t, filepath.Join(root, "content", "skills", "shape", "references", "decomposition.md"))
+	critiqueGate := readTextFile(t, filepath.Join(root, "content", "skills", "shape", "references", "critique-gate.md"))
+	implementSkill := readTextFile(t, filepath.Join(root, "content", "skills", "implement", "SKILL.md"))
+
+	for _, required := range []string{"verifiable alone", "revertible alone"} {
+		if !strings.Contains(shapeSkill, required) {
+			t.Fatalf("content/skills/shape/SKILL.md missing verification-indexed sizing phrase %q", required)
+		}
+		if !strings.Contains(decomposition, required) {
+			t.Fatalf("content/skills/shape/references/decomposition.md missing verification-indexed sizing phrase %q", required)
+		}
+		if !strings.Contains(critiqueGate, required) {
+			t.Fatalf("content/skills/shape/references/critique-gate.md missing verification-indexed sizing phrase %q", required)
+		}
+	}
+
+	if !strings.Contains(shapeSkill, "runtime heuristic") || !strings.Contains(implementSkill, "runtime heuristic") {
+		t.Fatalf("shape and implement skills must demote window-fit to a labeled runtime heuristic")
+	}
+
+	for _, tc := range []struct {
+		rel  string
+		body string
+	}{
+		{"content/skills/shape/SKILL.md", shapeSkill},
+		{"content/skills/shape/references/decomposition.md", decomposition},
+	} {
+		if strings.Contains(tc.body, "fits one fresh context window and is verifiable alone") {
+			t.Fatalf("%s still uses the retired window-fit sizing rule", tc.rel)
+		}
+	}
+}
+
 func TestSkillContentHygieneStaleReferences(t *testing.T) {
 	root := repoRoot(t)
 	cases := []struct {

--- a/content/skills/implement/SKILL.md
+++ b/content/skills/implement/SKILL.md
@@ -44,6 +44,7 @@ You are the coordinator. Work units are issues.
 - **One agent, one worktree.** `loaf issue start <ref>` walks to the shippable root and starts or joins that root workspace (`issue/<root-alias>`). Only the root records `started_branch` / `started_worktree`; a descendant becomes `active` without its own worktree. Before dispatch, run `loaf issue list --started`. Never send two agents into the same worktree.
 - **Definition of done is the completion contract.** `loaf issue verify <ref>` runs V-tier criteria from the repository root and writes nothing. H-tier is reviewed by a human or this orchestrator. Completion is the work landing plus `loaf issue status <ref> done`. Do not flip checkboxes. Provenance is the delivering commits and the PR whose body is `loaf issue render <ref>`.
 - Shape prepares issues. If `loaf issue check <ref>` does not report the delivery issue shaped (or the decision issue ready), stop and send the work to shape. Do not mint a new issue from this skill.
+- **Window-fit is a runtime heuristic, not a tree edge.** Shape sizes slices for verification and revertibility alone. When an executor slice still exceeds one fresh context window, implement sub-decomposes for execution — via handoffs, scratchpad, and agent spawns — without minting child issues. That carving never appears in the issue tree.
 
 ### Orchestrator Can Do Directly
 - Log journal entries, read journal context, create council files

--- a/content/skills/shape/SKILL.md
+++ b/content/skills/shape/SKILL.md
@@ -6,8 +6,8 @@ description: >-
   DoD — validated by loaf issue check. Use when the user asks "shape this,"
   "turn this into an issue," or a diagnosed fix needs a row. Produces a shaped
   issue — never a folder or a plan document. Teaches fog graduation (park, then
-  a decision child) and one-criterion sizing (one fresh context window,
-  verifiable alone). Not for quick capture (use idea), problem discovery that
+  a decision child) and one-criterion sizing (verifiable alone,
+  revertible alone). Not for quick capture (use idea), problem discovery that
   should author a brief first (use pitch), or open-ended divergent thinking
   (agent technique: explore / brainstorm — user entry routes to pitch).
 ---
@@ -30,19 +30,19 @@ Prepare a bounded, reviewable issue.
 
 ## Critical Rules
 
-1. **Log invocation first** — `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
-2. **Produces an issue, never a folder** — the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
-3. **The fog register routes, you don't guess** — every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
-4. **Fog graduates instead of evaporating** — a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
-5. **Blindspot pass precedes grilling, offered not imposed** — run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
-6. **Grill one question at a time, with a recommendation** — using your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
-7. **Techniques return fog entries, not decisions** — blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
-8. **Decomposition is the tail** — a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
-9. **One sizing criterion** — a slice is right-sized when it fits one fresh context window and is verifiable alone. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
-10. **Surface misalignment, never silently adjust** — when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
-11. **Critique before finalizing** — run the Critique Gate as the last shaping step, before `loaf issue check`.
-12. **A diagnosed one-line fix is two commands** — `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
-13. **Log the outcome** — `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
+1. **Log invocation first** — Because shaping is a project-scoped event others may audit, `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
+2. **Produces an issue, never a folder** — Because bounded work lives in SQLite and ships through PRs, the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
+3. **The fog register routes, you don't guess** — Because unknowns have different resolution techniques, every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
+4. **Fog graduates instead of evaporating** — Because parked questions resurface as scope creep, a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
+5. **Blindspot pass precedes grilling, offered not imposed** — Because reconnaissance cost should match unfamiliarity, run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
+6. **Grill one question at a time, with a recommendation** — Because parallel questions hide trade-offs, use your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
+7. **Techniques return fog entries, not decisions** — Because the human adjudicates, blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
+8. **Decomposition is the tail** — Because premature splitting obscures the problem, a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
+9. **One sizing criterion** — Because unattended autonomy appreciates per-slice proof and bounded revert (while executor window-fit decays with better continuity), a slice is right-sized when it is verifiable alone and revertible alone. Window-fit ("fits one fresh context window") is a labeled **runtime heuristic** owned by implement — shape decomposes for verification; implement sub-decomposes for execution per executor via handoffs and scratchpad, and that runtime carving never appears in the issue tree. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
+10. **Surface misalignment, never silently adjust** — Because strategic drift hidden in a reshaped issue wastes implementer time, when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
+11. **Critique before finalizing** — Because agents won't interrogate their own scope without a gate, run the Critique Gate as the last shaping step, before `loaf issue check`.
+12. **A diagnosed one-line fix is two commands** — Because ceremony should match uncertainty, `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
+13. **Log the outcome** — Because shaped issues are audit events, `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
 
 ---
 
@@ -169,7 +169,7 @@ Then shape the child the same way (body, out-of-scope, its own criteria). Order 
 
 ### Step 6: Run the Critique Gate
 
-Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable in one fresh context window?
+Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable alone and revertible alone?
 
 ### Step 7: Validate
 

--- a/content/skills/shape/references/critique-gate.md
+++ b/content/skills/shape/references/critique-gate.md
@@ -4,7 +4,7 @@ The last shaping step, before `loaf issue check` and any review offer. An agent 
 
 Run through these before finalizing:
 
-- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable in one fresh context window?
+- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable alone and revertible alone?
 - **Does every new command, state, or lifecycle verb name its ceremony?** If a command or state can't name the ceremony that exercises it, cut it — don't build it now and hope a use appears.
 - **Is a second progress flag creeping into the body?** `readiness`, `phase`, `stage`, or anything else that reintroduces a declared progress flag. Status lives on the issue row (`loaf issue status`). Shaped, covered, and ready are derived by `loaf issue check`. `loaf issue bucket` is a label only and is never read as a constraint.
 - **Is the CLI/skill boundary drawn correctly?** Is the skill doing deterministic work that belongs in the CLI, or is the CLI claiming judgment that belongs in the skill?

--- a/content/skills/shape/references/decomposition.md
+++ b/content/skills/shape/references/decomposition.md
@@ -20,10 +20,11 @@ Same problem, another slice → another criterion on this issue, or a promoted c
 
 ## The sizing rule
 
-One test, replacing the old four-question checklist: **a slice is right-sized when it fits one fresh context window and is verifiable alone.**
+One test, replacing the old four-question checklist: **a slice is right-sized when it is verifiable alone and revertible alone.**
 
-- If an implementer cannot pick the issue up in a new conversation and finish it without reading a sibling, split.
-- If the done-check cannot run (or be reviewed) without another slice landing first, either split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Verifiable alone** — the done-check can run (or be reviewed) without another slice landing first. If not, split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Revertible alone** — the slice's landing can be reverted without undoing a sibling. If reverting would require coordinated rollback across slices, split or sequence with `blocks` edges.
+- **Window-fit is implement's runtime heuristic** — if an executor slice still exceeds one fresh context window, implement sub-decomposes for execution via handoffs and scratchpad; that carving never appears in the issue tree. Shape sizes for verification and revertibility, not executor memory.
 - If you are splitting just to have more rows, merge back.
 
 Per-slice verification stays with the slice. Never a separate "verify" child; keep tests with the code they test.

--- a/dist/amp/skills/implement/SKILL.md
+++ b/dist/amp/skills/implement/SKILL.md
@@ -45,6 +45,7 @@ You are the coordinator. Work units are issues.
 - **One agent, one worktree.** `loaf issue start <ref>` walks to the shippable root and starts or joins that root workspace (`issue/<root-alias>`). Only the root records `started_branch` / `started_worktree`; a descendant becomes `active` without its own worktree. Before dispatch, run `loaf issue list --started`. Never send two agents into the same worktree.
 - **Definition of done is the completion contract.** `loaf issue verify <ref>` runs V-tier criteria from the repository root and writes nothing. H-tier is reviewed by a human or this orchestrator. Completion is the work landing plus `loaf issue status <ref> done`. Do not flip checkboxes. Provenance is the delivering commits and the PR whose body is `loaf issue render <ref>`.
 - Shape prepares issues. If `loaf issue check <ref>` does not report the delivery issue shaped (or the decision issue ready), stop and send the work to shape. Do not mint a new issue from this skill.
+- **Window-fit is a runtime heuristic, not a tree edge.** Shape sizes slices for verification and revertibility alone. When an executor slice still exceeds one fresh context window, implement sub-decomposes for execution — via handoffs, scratchpad, and agent spawns — without minting child issues. That carving never appears in the issue tree.
 
 ### Orchestrator Can Do Directly
 - Log journal entries, read journal context, create council files

--- a/dist/amp/skills/shape/SKILL.md
+++ b/dist/amp/skills/shape/SKILL.md
@@ -6,10 +6,10 @@ description: >-
   DoD — validated by loaf issue check. Use when the user asks "shape this,"
   "turn this into an issue," or a diagnosed fix needs a row. Produces a shaped
   issue — never a folder or a plan document. Teaches fog graduation (park,
-  then a decision child) and one-criterion sizing (one fresh context window,
-  verifiable alone). Not for quick capture (use idea), problem discovery that
-  should author a brief first (use pitch), or open-ended divergent thinking
-  (agent technique: explore / brainstorm — user entry routes to pitch).
+  then a decision child) and one-criterion sizing (verifiable alone, revertible
+  alone). Not for quick capture (use idea), problem discovery that should author
+  a brief first (use pitch), or open-ended divergent thinking (agent technique:
+  explore / brainstorm — user entry routes to pitch).
 version: 0.3.1
 ---
 
@@ -31,19 +31,19 @@ Prepare a bounded, reviewable issue.
 
 ## Critical Rules
 
-1. **Log invocation first** — `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
-2. **Produces an issue, never a folder** — the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
-3. **The fog register routes, you don't guess** — every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
-4. **Fog graduates instead of evaporating** — a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
-5. **Blindspot pass precedes grilling, offered not imposed** — run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
-6. **Grill one question at a time, with a recommendation** — using your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
-7. **Techniques return fog entries, not decisions** — blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
-8. **Decomposition is the tail** — a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
-9. **One sizing criterion** — a slice is right-sized when it fits one fresh context window and is verifiable alone. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
-10. **Surface misalignment, never silently adjust** — when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
-11. **Critique before finalizing** — run the Critique Gate as the last shaping step, before `loaf issue check`.
-12. **A diagnosed one-line fix is two commands** — `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
-13. **Log the outcome** — `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
+1. **Log invocation first** — Because shaping is a project-scoped event others may audit, `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
+2. **Produces an issue, never a folder** — Because bounded work lives in SQLite and ships through PRs, the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
+3. **The fog register routes, you don't guess** — Because unknowns have different resolution techniques, every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
+4. **Fog graduates instead of evaporating** — Because parked questions resurface as scope creep, a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
+5. **Blindspot pass precedes grilling, offered not imposed** — Because reconnaissance cost should match unfamiliarity, run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
+6. **Grill one question at a time, with a recommendation** — Because parallel questions hide trade-offs, use your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
+7. **Techniques return fog entries, not decisions** — Because the human adjudicates, blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
+8. **Decomposition is the tail** — Because premature splitting obscures the problem, a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
+9. **One sizing criterion** — Because unattended autonomy appreciates per-slice proof and bounded revert (while executor window-fit decays with better continuity), a slice is right-sized when it is verifiable alone and revertible alone. Window-fit ("fits one fresh context window") is a labeled **runtime heuristic** owned by implement — shape decomposes for verification; implement sub-decomposes for execution per executor via handoffs and scratchpad, and that runtime carving never appears in the issue tree. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
+10. **Surface misalignment, never silently adjust** — Because strategic drift hidden in a reshaped issue wastes implementer time, when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
+11. **Critique before finalizing** — Because agents won't interrogate their own scope without a gate, run the Critique Gate as the last shaping step, before `loaf issue check`.
+12. **A diagnosed one-line fix is two commands** — Because ceremony should match uncertainty, `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
+13. **Log the outcome** — Because shaped issues are audit events, `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
 
 ---
 
@@ -170,7 +170,7 @@ Then shape the child the same way (body, out-of-scope, its own criteria). Order 
 
 ### Step 6: Run the Critique Gate
 
-Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable in one fresh context window?
+Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable alone and revertible alone?
 
 ### Step 7: Validate
 

--- a/dist/amp/skills/shape/references/critique-gate.md
+++ b/dist/amp/skills/shape/references/critique-gate.md
@@ -4,7 +4,7 @@ The last shaping step, before `loaf issue check` and any review offer. An agent 
 
 Run through these before finalizing:
 
-- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable in one fresh context window?
+- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable alone and revertible alone?
 - **Does every new command, state, or lifecycle verb name its ceremony?** If a command or state can't name the ceremony that exercises it, cut it — don't build it now and hope a use appears.
 - **Is a second progress flag creeping into the body?** `readiness`, `phase`, `stage`, or anything else that reintroduces a declared progress flag. Status lives on the issue row (`loaf issue status`). Shaped, covered, and ready are derived by `loaf issue check`. `loaf issue bucket` is a label only and is never read as a constraint.
 - **Is the CLI/skill boundary drawn correctly?** Is the skill doing deterministic work that belongs in the CLI, or is the CLI claiming judgment that belongs in the skill?

--- a/dist/amp/skills/shape/references/decomposition.md
+++ b/dist/amp/skills/shape/references/decomposition.md
@@ -20,10 +20,11 @@ Same problem, another slice → another criterion on this issue, or a promoted c
 
 ## The sizing rule
 
-One test, replacing the old four-question checklist: **a slice is right-sized when it fits one fresh context window and is verifiable alone.**
+One test, replacing the old four-question checklist: **a slice is right-sized when it is verifiable alone and revertible alone.**
 
-- If an implementer cannot pick the issue up in a new conversation and finish it without reading a sibling, split.
-- If the done-check cannot run (or be reviewed) without another slice landing first, either split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Verifiable alone** — the done-check can run (or be reviewed) without another slice landing first. If not, split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Revertible alone** — the slice's landing can be reverted without undoing a sibling. If reverting would require coordinated rollback across slices, split or sequence with `blocks` edges.
+- **Window-fit is implement's runtime heuristic** — if an executor slice still exceeds one fresh context window, implement sub-decomposes for execution via handoffs and scratchpad; that carving never appears in the issue tree. Shape sizes for verification and revertibility, not executor memory.
 - If you are splitting just to have more rows, merge back.
 
 Per-slice verification stays with the slice. Never a separate "verify" child; keep tests with the code they test.

--- a/dist/codex/skills/implement/SKILL.md
+++ b/dist/codex/skills/implement/SKILL.md
@@ -45,6 +45,7 @@ You are the coordinator. Work units are issues.
 - **One agent, one worktree.** `loaf issue start <ref>` walks to the shippable root and starts or joins that root workspace (`issue/<root-alias>`). Only the root records `started_branch` / `started_worktree`; a descendant becomes `active` without its own worktree. Before dispatch, run `loaf issue list --started`. Never send two agents into the same worktree.
 - **Definition of done is the completion contract.** `loaf issue verify <ref>` runs V-tier criteria from the repository root and writes nothing. H-tier is reviewed by a human or this orchestrator. Completion is the work landing plus `loaf issue status <ref> done`. Do not flip checkboxes. Provenance is the delivering commits and the PR whose body is `loaf issue render <ref>`.
 - Shape prepares issues. If `loaf issue check <ref>` does not report the delivery issue shaped (or the decision issue ready), stop and send the work to shape. Do not mint a new issue from this skill.
+- **Window-fit is a runtime heuristic, not a tree edge.** Shape sizes slices for verification and revertibility alone. When an executor slice still exceeds one fresh context window, implement sub-decomposes for execution — via handoffs, scratchpad, and agent spawns — without minting child issues. That carving never appears in the issue tree.
 
 ### Orchestrator Can Do Directly
 - Log journal entries, read journal context, create council files

--- a/dist/codex/skills/shape/SKILL.md
+++ b/dist/codex/skills/shape/SKILL.md
@@ -6,10 +6,10 @@ description: >-
   DoD — validated by loaf issue check. Use when the user asks "shape this,"
   "turn this into an issue," or a diagnosed fix needs a row. Produces a shaped
   issue — never a folder or a plan document. Teaches fog graduation (park,
-  then a decision child) and one-criterion sizing (one fresh context window,
-  verifiable alone). Not for quick capture (use idea), problem discovery that
-  should author a brief first (use pitch), or open-ended divergent thinking
-  (agent technique: explore / brainstorm — user entry routes to pitch).
+  then a decision child) and one-criterion sizing (verifiable alone, revertible
+  alone). Not for quick capture (use idea), problem discovery that should author
+  a brief first (use pitch), or open-ended divergent thinking (agent technique:
+  explore / brainstorm — user entry routes to pitch).
 version: 0.3.1
 ---
 
@@ -31,19 +31,19 @@ Prepare a bounded, reviewable issue.
 
 ## Critical Rules
 
-1. **Log invocation first** — `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
-2. **Produces an issue, never a folder** — the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
-3. **The fog register routes, you don't guess** — every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
-4. **Fog graduates instead of evaporating** — a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
-5. **Blindspot pass precedes grilling, offered not imposed** — run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
-6. **Grill one question at a time, with a recommendation** — using your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
-7. **Techniques return fog entries, not decisions** — blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
-8. **Decomposition is the tail** — a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
-9. **One sizing criterion** — a slice is right-sized when it fits one fresh context window and is verifiable alone. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
-10. **Surface misalignment, never silently adjust** — when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
-11. **Critique before finalizing** — run the Critique Gate as the last shaping step, before `loaf issue check`.
-12. **A diagnosed one-line fix is two commands** — `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
-13. **Log the outcome** — `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
+1. **Log invocation first** — Because shaping is a project-scoped event others may audit, `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
+2. **Produces an issue, never a folder** — Because bounded work lives in SQLite and ships through PRs, the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
+3. **The fog register routes, you don't guess** — Because unknowns have different resolution techniques, every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
+4. **Fog graduates instead of evaporating** — Because parked questions resurface as scope creep, a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
+5. **Blindspot pass precedes grilling, offered not imposed** — Because reconnaissance cost should match unfamiliarity, run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
+6. **Grill one question at a time, with a recommendation** — Because parallel questions hide trade-offs, use your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
+7. **Techniques return fog entries, not decisions** — Because the human adjudicates, blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
+8. **Decomposition is the tail** — Because premature splitting obscures the problem, a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
+9. **One sizing criterion** — Because unattended autonomy appreciates per-slice proof and bounded revert (while executor window-fit decays with better continuity), a slice is right-sized when it is verifiable alone and revertible alone. Window-fit ("fits one fresh context window") is a labeled **runtime heuristic** owned by implement — shape decomposes for verification; implement sub-decomposes for execution per executor via handoffs and scratchpad, and that runtime carving never appears in the issue tree. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
+10. **Surface misalignment, never silently adjust** — Because strategic drift hidden in a reshaped issue wastes implementer time, when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
+11. **Critique before finalizing** — Because agents won't interrogate their own scope without a gate, run the Critique Gate as the last shaping step, before `loaf issue check`.
+12. **A diagnosed one-line fix is two commands** — Because ceremony should match uncertainty, `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
+13. **Log the outcome** — Because shaped issues are audit events, `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
 
 ---
 
@@ -170,7 +170,7 @@ Then shape the child the same way (body, out-of-scope, its own criteria). Order 
 
 ### Step 6: Run the Critique Gate
 
-Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable in one fresh context window?
+Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable alone and revertible alone?
 
 ### Step 7: Validate
 

--- a/dist/codex/skills/shape/references/critique-gate.md
+++ b/dist/codex/skills/shape/references/critique-gate.md
@@ -4,7 +4,7 @@ The last shaping step, before `loaf issue check` and any review offer. An agent 
 
 Run through these before finalizing:
 
-- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable in one fresh context window?
+- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable alone and revertible alone?
 - **Does every new command, state, or lifecycle verb name its ceremony?** If a command or state can't name the ceremony that exercises it, cut it — don't build it now and hope a use appears.
 - **Is a second progress flag creeping into the body?** `readiness`, `phase`, `stage`, or anything else that reintroduces a declared progress flag. Status lives on the issue row (`loaf issue status`). Shaped, covered, and ready are derived by `loaf issue check`. `loaf issue bucket` is a label only and is never read as a constraint.
 - **Is the CLI/skill boundary drawn correctly?** Is the skill doing deterministic work that belongs in the CLI, or is the CLI claiming judgment that belongs in the skill?

--- a/dist/codex/skills/shape/references/decomposition.md
+++ b/dist/codex/skills/shape/references/decomposition.md
@@ -20,10 +20,11 @@ Same problem, another slice → another criterion on this issue, or a promoted c
 
 ## The sizing rule
 
-One test, replacing the old four-question checklist: **a slice is right-sized when it fits one fresh context window and is verifiable alone.**
+One test, replacing the old four-question checklist: **a slice is right-sized when it is verifiable alone and revertible alone.**
 
-- If an implementer cannot pick the issue up in a new conversation and finish it without reading a sibling, split.
-- If the done-check cannot run (or be reviewed) without another slice landing first, either split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Verifiable alone** — the done-check can run (or be reviewed) without another slice landing first. If not, split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Revertible alone** — the slice's landing can be reverted without undoing a sibling. If reverting would require coordinated rollback across slices, split or sequence with `blocks` edges.
+- **Window-fit is implement's runtime heuristic** — if an executor slice still exceeds one fresh context window, implement sub-decomposes for execution via handoffs and scratchpad; that carving never appears in the issue tree. Shape sizes for verification and revertibility, not executor memory.
 - If you are splitting just to have more rows, merge back.
 
 Per-slice verification stays with the slice. Never a separate "verify" child; keep tests with the code they test.

--- a/dist/cursor/skills/implement/SKILL.md
+++ b/dist/cursor/skills/implement/SKILL.md
@@ -45,6 +45,7 @@ You are the coordinator. Work units are issues.
 - **One agent, one worktree.** `loaf issue start <ref>` walks to the shippable root and starts or joins that root workspace (`issue/<root-alias>`). Only the root records `started_branch` / `started_worktree`; a descendant becomes `active` without its own worktree. Before dispatch, run `loaf issue list --started`. Never send two agents into the same worktree.
 - **Definition of done is the completion contract.** `loaf issue verify <ref>` runs V-tier criteria from the repository root and writes nothing. H-tier is reviewed by a human or this orchestrator. Completion is the work landing plus `loaf issue status <ref> done`. Do not flip checkboxes. Provenance is the delivering commits and the PR whose body is `loaf issue render <ref>`.
 - Shape prepares issues. If `loaf issue check <ref>` does not report the delivery issue shaped (or the decision issue ready), stop and send the work to shape. Do not mint a new issue from this skill.
+- **Window-fit is a runtime heuristic, not a tree edge.** Shape sizes slices for verification and revertibility alone. When an executor slice still exceeds one fresh context window, implement sub-decomposes for execution — via handoffs, scratchpad, and agent spawns — without minting child issues. That carving never appears in the issue tree.
 
 ### Orchestrator Can Do Directly
 - Log journal entries, read journal context, create council files

--- a/dist/cursor/skills/shape/SKILL.md
+++ b/dist/cursor/skills/shape/SKILL.md
@@ -6,10 +6,10 @@ description: >-
   DoD — validated by loaf issue check. Use when the user asks "shape this,"
   "turn this into an issue," or a diagnosed fix needs a row. Produces a shaped
   issue — never a folder or a plan document. Teaches fog graduation (park,
-  then a decision child) and one-criterion sizing (one fresh context window,
-  verifiable alone). Not for quick capture (use idea), problem discovery that
-  should author a brief first (use pitch), or open-ended divergent thinking
-  (agent technique: explore / brainstorm — user entry routes to pitch).
+  then a decision child) and one-criterion sizing (verifiable alone, revertible
+  alone). Not for quick capture (use idea), problem discovery that should author
+  a brief first (use pitch), or open-ended divergent thinking (agent technique:
+  explore / brainstorm — user entry routes to pitch).
 version: 0.3.1
 ---
 
@@ -31,19 +31,19 @@ Prepare a bounded, reviewable issue.
 
 ## Critical Rules
 
-1. **Log invocation first** — `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
-2. **Produces an issue, never a folder** — the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
-3. **The fog register routes, you don't guess** — every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
-4. **Fog graduates instead of evaporating** — a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
-5. **Blindspot pass precedes grilling, offered not imposed** — run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
-6. **Grill one question at a time, with a recommendation** — using your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
-7. **Techniques return fog entries, not decisions** — blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
-8. **Decomposition is the tail** — a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
-9. **One sizing criterion** — a slice is right-sized when it fits one fresh context window and is verifiable alone. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
-10. **Surface misalignment, never silently adjust** — when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
-11. **Critique before finalizing** — run the Critique Gate as the last shaping step, before `loaf issue check`.
-12. **A diagnosed one-line fix is two commands** — `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
-13. **Log the outcome** — `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
+1. **Log invocation first** — Because shaping is a project-scoped event others may audit, `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
+2. **Produces an issue, never a folder** — Because bounded work lives in SQLite and ships through PRs, the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
+3. **The fog register routes, you don't guess** — Because unknowns have different resolution techniques, every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
+4. **Fog graduates instead of evaporating** — Because parked questions resurface as scope creep, a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
+5. **Blindspot pass precedes grilling, offered not imposed** — Because reconnaissance cost should match unfamiliarity, run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
+6. **Grill one question at a time, with a recommendation** — Because parallel questions hide trade-offs, use your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
+7. **Techniques return fog entries, not decisions** — Because the human adjudicates, blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
+8. **Decomposition is the tail** — Because premature splitting obscures the problem, a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
+9. **One sizing criterion** — Because unattended autonomy appreciates per-slice proof and bounded revert (while executor window-fit decays with better continuity), a slice is right-sized when it is verifiable alone and revertible alone. Window-fit ("fits one fresh context window") is a labeled **runtime heuristic** owned by implement — shape decomposes for verification; implement sub-decomposes for execution per executor via handoffs and scratchpad, and that runtime carving never appears in the issue tree. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
+10. **Surface misalignment, never silently adjust** — Because strategic drift hidden in a reshaped issue wastes implementer time, when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
+11. **Critique before finalizing** — Because agents won't interrogate their own scope without a gate, run the Critique Gate as the last shaping step, before `loaf issue check`.
+12. **A diagnosed one-line fix is two commands** — Because ceremony should match uncertainty, `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
+13. **Log the outcome** — Because shaped issues are audit events, `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
 
 ---
 
@@ -170,7 +170,7 @@ Then shape the child the same way (body, out-of-scope, its own criteria). Order 
 
 ### Step 6: Run the Critique Gate
 
-Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable in one fresh context window?
+Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable alone and revertible alone?
 
 ### Step 7: Validate
 

--- a/dist/cursor/skills/shape/references/critique-gate.md
+++ b/dist/cursor/skills/shape/references/critique-gate.md
@@ -4,7 +4,7 @@ The last shaping step, before `loaf issue check` and any review offer. An agent 
 
 Run through these before finalizing:
 
-- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable in one fresh context window?
+- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable alone and revertible alone?
 - **Does every new command, state, or lifecycle verb name its ceremony?** If a command or state can't name the ceremony that exercises it, cut it — don't build it now and hope a use appears.
 - **Is a second progress flag creeping into the body?** `readiness`, `phase`, `stage`, or anything else that reintroduces a declared progress flag. Status lives on the issue row (`loaf issue status`). Shaped, covered, and ready are derived by `loaf issue check`. `loaf issue bucket` is a label only and is never read as a constraint.
 - **Is the CLI/skill boundary drawn correctly?** Is the skill doing deterministic work that belongs in the CLI, or is the CLI claiming judgment that belongs in the skill?

--- a/dist/cursor/skills/shape/references/decomposition.md
+++ b/dist/cursor/skills/shape/references/decomposition.md
@@ -20,10 +20,11 @@ Same problem, another slice → another criterion on this issue, or a promoted c
 
 ## The sizing rule
 
-One test, replacing the old four-question checklist: **a slice is right-sized when it fits one fresh context window and is verifiable alone.**
+One test, replacing the old four-question checklist: **a slice is right-sized when it is verifiable alone and revertible alone.**
 
-- If an implementer cannot pick the issue up in a new conversation and finish it without reading a sibling, split.
-- If the done-check cannot run (or be reviewed) without another slice landing first, either split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Verifiable alone** — the done-check can run (or be reviewed) without another slice landing first. If not, split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Revertible alone** — the slice's landing can be reverted without undoing a sibling. If reverting would require coordinated rollback across slices, split or sequence with `blocks` edges.
+- **Window-fit is implement's runtime heuristic** — if an executor slice still exceeds one fresh context window, implement sub-decomposes for execution via handoffs and scratchpad; that carving never appears in the issue tree. Shape sizes for verification and revertibility, not executor memory.
 - If you are splitting just to have more rows, merge back.
 
 Per-slice verification stays with the slice. Never a separate "verify" child; keep tests with the code they test.

--- a/dist/opencode/commands/implement.md
+++ b/dist/opencode/commands/implement.md
@@ -45,6 +45,7 @@ You are the coordinator. Work units are issues.
 - **One agent, one worktree.** `loaf issue start <ref>` walks to the shippable root and starts or joins that root workspace (`issue/<root-alias>`). Only the root records `started_branch` / `started_worktree`; a descendant becomes `active` without its own worktree. Before dispatch, run `loaf issue list --started`. Never send two agents into the same worktree.
 - **Definition of done is the completion contract.** `loaf issue verify <ref>` runs V-tier criteria from the repository root and writes nothing. H-tier is reviewed by a human or this orchestrator. Completion is the work landing plus `loaf issue status <ref> done`. Do not flip checkboxes. Provenance is the delivering commits and the PR whose body is `loaf issue render <ref>`.
 - Shape prepares issues. If `loaf issue check <ref>` does not report the delivery issue shaped (or the decision issue ready), stop and send the work to shape. Do not mint a new issue from this skill.
+- **Window-fit is a runtime heuristic, not a tree edge.** Shape sizes slices for verification and revertibility alone. When an executor slice still exceeds one fresh context window, implement sub-decomposes for execution — via handoffs, scratchpad, and agent spawns — without minting child issues. That carving never appears in the issue tree.
 
 ### Orchestrator Can Do Directly
 - Log journal entries, read journal context, create council files

--- a/dist/opencode/commands/shape.md
+++ b/dist/opencode/commands/shape.md
@@ -5,10 +5,10 @@ description: >-
   DoD — validated by loaf issue check. Use when the user asks "shape this,"
   "turn this into an issue," or a diagnosed fix needs a row. Produces a shaped
   issue — never a folder or a plan document. Teaches fog graduation (park,
-  then a decision child) and one-criterion sizing (one fresh context window,
-  verifiable alone). Not for quick capture (use idea), problem discovery that
-  should author a brief first (use pitch), or open-ended divergent thinking
-  (agent technique: explore / brainstorm — user entry routes to pitch).
+  then a decision child) and one-criterion sizing (verifiable alone, revertible
+  alone). Not for quick capture (use idea), problem discovery that should author
+  a brief first (use pitch), or open-ended divergent thinking (agent technique:
+  explore / brainstorm — user entry routes to pitch).
 subtask: false
 version: 0.3.1
 ---
@@ -31,19 +31,19 @@ Prepare a bounded, reviewable issue.
 
 ## Critical Rules
 
-1. **Log invocation first** — `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
-2. **Produces an issue, never a folder** — the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
-3. **The fog register routes, you don't guess** — every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
-4. **Fog graduates instead of evaporating** — a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
-5. **Blindspot pass precedes grilling, offered not imposed** — run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
-6. **Grill one question at a time, with a recommendation** — using your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
-7. **Techniques return fog entries, not decisions** — blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
-8. **Decomposition is the tail** — a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
-9. **One sizing criterion** — a slice is right-sized when it fits one fresh context window and is verifiable alone. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
-10. **Surface misalignment, never silently adjust** — when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
-11. **Critique before finalizing** — run the Critique Gate as the last shaping step, before `loaf issue check`.
-12. **A diagnosed one-line fix is two commands** — `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
-13. **Log the outcome** — `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
+1. **Log invocation first** — Because shaping is a project-scoped event others may audit, `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
+2. **Produces an issue, never a folder** — Because bounded work lives in SQLite and ships through PRs, the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
+3. **The fog register routes, you don't guess** — Because unknowns have different resolution techniques, every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
+4. **Fog graduates instead of evaporating** — Because parked questions resurface as scope creep, a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
+5. **Blindspot pass precedes grilling, offered not imposed** — Because reconnaissance cost should match unfamiliarity, run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
+6. **Grill one question at a time, with a recommendation** — Because parallel questions hide trade-offs, use your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
+7. **Techniques return fog entries, not decisions** — Because the human adjudicates, blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
+8. **Decomposition is the tail** — Because premature splitting obscures the problem, a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
+9. **One sizing criterion** — Because unattended autonomy appreciates per-slice proof and bounded revert (while executor window-fit decays with better continuity), a slice is right-sized when it is verifiable alone and revertible alone. Window-fit ("fits one fresh context window") is a labeled **runtime heuristic** owned by implement — shape decomposes for verification; implement sub-decomposes for execution per executor via handoffs and scratchpad, and that runtime carving never appears in the issue tree. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
+10. **Surface misalignment, never silently adjust** — Because strategic drift hidden in a reshaped issue wastes implementer time, when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
+11. **Critique before finalizing** — Because agents won't interrogate their own scope without a gate, run the Critique Gate as the last shaping step, before `loaf issue check`.
+12. **A diagnosed one-line fix is two commands** — Because ceremony should match uncertainty, `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
+13. **Log the outcome** — Because shaped issues are audit events, `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
 
 ---
 
@@ -170,7 +170,7 @@ Then shape the child the same way (body, out-of-scope, its own criteria). Order 
 
 ### Step 6: Run the Critique Gate
 
-Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable in one fresh context window?
+Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable alone and revertible alone?
 
 ### Step 7: Validate
 

--- a/dist/opencode/skills/implement/SKILL.md
+++ b/dist/opencode/skills/implement/SKILL.md
@@ -46,6 +46,7 @@ You are the coordinator. Work units are issues.
 - **One agent, one worktree.** `loaf issue start <ref>` walks to the shippable root and starts or joins that root workspace (`issue/<root-alias>`). Only the root records `started_branch` / `started_worktree`; a descendant becomes `active` without its own worktree. Before dispatch, run `loaf issue list --started`. Never send two agents into the same worktree.
 - **Definition of done is the completion contract.** `loaf issue verify <ref>` runs V-tier criteria from the repository root and writes nothing. H-tier is reviewed by a human or this orchestrator. Completion is the work landing plus `loaf issue status <ref> done`. Do not flip checkboxes. Provenance is the delivering commits and the PR whose body is `loaf issue render <ref>`.
 - Shape prepares issues. If `loaf issue check <ref>` does not report the delivery issue shaped (or the decision issue ready), stop and send the work to shape. Do not mint a new issue from this skill.
+- **Window-fit is a runtime heuristic, not a tree edge.** Shape sizes slices for verification and revertibility alone. When an executor slice still exceeds one fresh context window, implement sub-decomposes for execution — via handoffs, scratchpad, and agent spawns — without minting child issues. That carving never appears in the issue tree.
 
 ### Orchestrator Can Do Directly
 - Log journal entries, read journal context, create council files

--- a/dist/opencode/skills/shape/SKILL.md
+++ b/dist/opencode/skills/shape/SKILL.md
@@ -6,10 +6,10 @@ description: >-
   DoD — validated by loaf issue check. Use when the user asks "shape this,"
   "turn this into an issue," or a diagnosed fix needs a row. Produces a shaped
   issue — never a folder or a plan document. Teaches fog graduation (park,
-  then a decision child) and one-criterion sizing (one fresh context window,
-  verifiable alone). Not for quick capture (use idea), problem discovery that
-  should author a brief first (use pitch), or open-ended divergent thinking
-  (agent technique: explore / brainstorm — user entry routes to pitch).
+  then a decision child) and one-criterion sizing (verifiable alone, revertible
+  alone). Not for quick capture (use idea), problem discovery that should author
+  a brief first (use pitch), or open-ended divergent thinking (agent technique:
+  explore / brainstorm — user entry routes to pitch).
 subtask: false
 version: 0.3.1
 ---
@@ -32,19 +32,19 @@ Prepare a bounded, reviewable issue.
 
 ## Critical Rules
 
-1. **Log invocation first** — `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
-2. **Produces an issue, never a folder** — the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
-3. **The fog register routes, you don't guess** — every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
-4. **Fog graduates instead of evaporating** — a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
-5. **Blindspot pass precedes grilling, offered not imposed** — run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
-6. **Grill one question at a time, with a recommendation** — using your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
-7. **Techniques return fog entries, not decisions** — blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
-8. **Decomposition is the tail** — a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
-9. **One sizing criterion** — a slice is right-sized when it fits one fresh context window and is verifiable alone. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
-10. **Surface misalignment, never silently adjust** — when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
-11. **Critique before finalizing** — run the Critique Gate as the last shaping step, before `loaf issue check`.
-12. **A diagnosed one-line fix is two commands** — `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
-13. **Log the outcome** — `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
+1. **Log invocation first** — Because shaping is a project-scoped event others may audit, `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
+2. **Produces an issue, never a folder** — Because bounded work lives in SQLite and ships through PRs, the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
+3. **The fog register routes, you don't guess** — Because unknowns have different resolution techniques, every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
+4. **Fog graduates instead of evaporating** — Because parked questions resurface as scope creep, a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
+5. **Blindspot pass precedes grilling, offered not imposed** — Because reconnaissance cost should match unfamiliarity, run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
+6. **Grill one question at a time, with a recommendation** — Because parallel questions hide trade-offs, use your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
+7. **Techniques return fog entries, not decisions** — Because the human adjudicates, blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
+8. **Decomposition is the tail** — Because premature splitting obscures the problem, a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
+9. **One sizing criterion** — Because unattended autonomy appreciates per-slice proof and bounded revert (while executor window-fit decays with better continuity), a slice is right-sized when it is verifiable alone and revertible alone. Window-fit ("fits one fresh context window") is a labeled **runtime heuristic** owned by implement — shape decomposes for verification; implement sub-decomposes for execution per executor via handoffs and scratchpad, and that runtime carving never appears in the issue tree. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
+10. **Surface misalignment, never silently adjust** — Because strategic drift hidden in a reshaped issue wastes implementer time, when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
+11. **Critique before finalizing** — Because agents won't interrogate their own scope without a gate, run the Critique Gate as the last shaping step, before `loaf issue check`.
+12. **A diagnosed one-line fix is two commands** — Because ceremony should match uncertainty, `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
+13. **Log the outcome** — Because shaped issues are audit events, `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
 
 ---
 
@@ -171,7 +171,7 @@ Then shape the child the same way (body, out-of-scope, its own criteria). Order 
 
 ### Step 6: Run the Critique Gate
 
-Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable in one fresh context window?
+Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable alone and revertible alone?
 
 ### Step 7: Validate
 

--- a/dist/opencode/skills/shape/references/critique-gate.md
+++ b/dist/opencode/skills/shape/references/critique-gate.md
@@ -4,7 +4,7 @@ The last shaping step, before `loaf issue check` and any review offer. An agent 
 
 Run through these before finalizing:
 
-- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable in one fresh context window?
+- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable alone and revertible alone?
 - **Does every new command, state, or lifecycle verb name its ceremony?** If a command or state can't name the ceremony that exercises it, cut it — don't build it now and hope a use appears.
 - **Is a second progress flag creeping into the body?** `readiness`, `phase`, `stage`, or anything else that reintroduces a declared progress flag. Status lives on the issue row (`loaf issue status`). Shaped, covered, and ready are derived by `loaf issue check`. `loaf issue bucket` is a label only and is never read as a constraint.
 - **Is the CLI/skill boundary drawn correctly?** Is the skill doing deterministic work that belongs in the CLI, or is the CLI claiming judgment that belongs in the skill?

--- a/dist/opencode/skills/shape/references/decomposition.md
+++ b/dist/opencode/skills/shape/references/decomposition.md
@@ -20,10 +20,11 @@ Same problem, another slice → another criterion on this issue, or a promoted c
 
 ## The sizing rule
 
-One test, replacing the old four-question checklist: **a slice is right-sized when it fits one fresh context window and is verifiable alone.**
+One test, replacing the old four-question checklist: **a slice is right-sized when it is verifiable alone and revertible alone.**
 
-- If an implementer cannot pick the issue up in a new conversation and finish it without reading a sibling, split.
-- If the done-check cannot run (or be reviewed) without another slice landing first, either split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Verifiable alone** — the done-check can run (or be reviewed) without another slice landing first. If not, split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Revertible alone** — the slice's landing can be reverted without undoing a sibling. If reverting would require coordinated rollback across slices, split or sequence with `blocks` edges.
+- **Window-fit is implement's runtime heuristic** — if an executor slice still exceeds one fresh context window, implement sub-decomposes for execution via handoffs and scratchpad; that carving never appears in the issue tree. Shape sizes for verification and revertibility, not executor memory.
 - If you are splitting just to have more rows, merge back.
 
 Per-slice verification stays with the slice. Never a separate "verify" child; keep tests with the code they test.

--- a/dist/skills/implement/SKILL.md
+++ b/dist/skills/implement/SKILL.md
@@ -44,6 +44,7 @@ You are the coordinator. Work units are issues.
 - **One agent, one worktree.** `loaf issue start <ref>` walks to the shippable root and starts or joins that root workspace (`issue/<root-alias>`). Only the root records `started_branch` / `started_worktree`; a descendant becomes `active` without its own worktree. Before dispatch, run `loaf issue list --started`. Never send two agents into the same worktree.
 - **Definition of done is the completion contract.** `loaf issue verify <ref>` runs V-tier criteria from the repository root and writes nothing. H-tier is reviewed by a human or this orchestrator. Completion is the work landing plus `loaf issue status <ref> done`. Do not flip checkboxes. Provenance is the delivering commits and the PR whose body is `loaf issue render <ref>`.
 - Shape prepares issues. If `loaf issue check <ref>` does not report the delivery issue shaped (or the decision issue ready), stop and send the work to shape. Do not mint a new issue from this skill.
+- **Window-fit is a runtime heuristic, not a tree edge.** Shape sizes slices for verification and revertibility alone. When an executor slice still exceeds one fresh context window, implement sub-decomposes for execution — via handoffs, scratchpad, and agent spawns — without minting child issues. That carving never appears in the issue tree.
 
 ### Orchestrator Can Do Directly
 - Log journal entries, read journal context, create council files

--- a/dist/skills/shape/SKILL.md
+++ b/dist/skills/shape/SKILL.md
@@ -6,10 +6,10 @@ description: >-
   DoD — validated by loaf issue check. Use when the user asks "shape this,"
   "turn this into an issue," or a diagnosed fix needs a row. Produces a shaped
   issue — never a folder or a plan document. Teaches fog graduation (park,
-  then a decision child) and one-criterion sizing (one fresh context window,
-  verifiable alone). Not for quick capture (use idea), problem discovery that
-  should author a brief first (use pitch), or open-ended divergent thinking
-  (agent technique: explore / brainstorm — user entry routes to pitch).
+  then a decision child) and one-criterion sizing (verifiable alone, revertible
+  alone). Not for quick capture (use idea), problem discovery that should author
+  a brief first (use pitch), or open-ended divergent thinking (agent technique:
+  explore / brainstorm — user entry routes to pitch).
 ---
 
 # Shape
@@ -30,19 +30,19 @@ Prepare a bounded, reviewable issue.
 
 ## Critical Rules
 
-1. **Log invocation first** — `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
-2. **Produces an issue, never a folder** — the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
-3. **The fog register routes, you don't guess** — every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
-4. **Fog graduates instead of evaporating** — a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
-5. **Blindspot pass precedes grilling, offered not imposed** — run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
-6. **Grill one question at a time, with a recommendation** — using your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
-7. **Techniques return fog entries, not decisions** — blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
-8. **Decomposition is the tail** — a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
-9. **One sizing criterion** — a slice is right-sized when it fits one fresh context window and is verifiable alone. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
-10. **Surface misalignment, never silently adjust** — when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
-11. **Critique before finalizing** — run the Critique Gate as the last shaping step, before `loaf issue check`.
-12. **A diagnosed one-line fix is two commands** — `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
-13. **Log the outcome** — `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
+1. **Log invocation first** — Because shaping is a project-scoped event others may audit, `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
+2. **Produces an issue, never a folder** — Because bounded work lives in SQLite and ships through PRs, the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
+3. **The fog register routes, you don't guess** — Because unknowns have different resolution techniques, every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
+4. **Fog graduates instead of evaporating** — Because parked questions resurface as scope creep, a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
+5. **Blindspot pass precedes grilling, offered not imposed** — Because reconnaissance cost should match unfamiliarity, run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
+6. **Grill one question at a time, with a recommendation** — Because parallel questions hide trade-offs, use your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
+7. **Techniques return fog entries, not decisions** — Because the human adjudicates, blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
+8. **Decomposition is the tail** — Because premature splitting obscures the problem, a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
+9. **One sizing criterion** — Because unattended autonomy appreciates per-slice proof and bounded revert (while executor window-fit decays with better continuity), a slice is right-sized when it is verifiable alone and revertible alone. Window-fit ("fits one fresh context window") is a labeled **runtime heuristic** owned by implement — shape decomposes for verification; implement sub-decomposes for execution per executor via handoffs and scratchpad, and that runtime carving never appears in the issue tree. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
+10. **Surface misalignment, never silently adjust** — Because strategic drift hidden in a reshaped issue wastes implementer time, when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
+11. **Critique before finalizing** — Because agents won't interrogate their own scope without a gate, run the Critique Gate as the last shaping step, before `loaf issue check`.
+12. **A diagnosed one-line fix is two commands** — Because ceremony should match uncertainty, `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
+13. **Log the outcome** — Because shaped issues are audit events, `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
 
 ---
 
@@ -169,7 +169,7 @@ Then shape the child the same way (body, out-of-scope, its own criteria). Order 
 
 ### Step 6: Run the Critique Gate
 
-Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable in one fresh context window?
+Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable alone and revertible alone?
 
 ### Step 7: Validate
 

--- a/dist/skills/shape/references/critique-gate.md
+++ b/dist/skills/shape/references/critique-gate.md
@@ -4,7 +4,7 @@ The last shaping step, before `loaf issue check` and any review offer. An agent 
 
 Run through these before finalizing:
 
-- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable in one fresh context window?
+- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable alone and revertible alone?
 - **Does every new command, state, or lifecycle verb name its ceremony?** If a command or state can't name the ceremony that exercises it, cut it — don't build it now and hope a use appears.
 - **Is a second progress flag creeping into the body?** `readiness`, `phase`, `stage`, or anything else that reintroduces a declared progress flag. Status lives on the issue row (`loaf issue status`). Shaped, covered, and ready are derived by `loaf issue check`. `loaf issue bucket` is a label only and is never read as a constraint.
 - **Is the CLI/skill boundary drawn correctly?** Is the skill doing deterministic work that belongs in the CLI, or is the CLI claiming judgment that belongs in the skill?

--- a/dist/skills/shape/references/decomposition.md
+++ b/dist/skills/shape/references/decomposition.md
@@ -20,10 +20,11 @@ Same problem, another slice → another criterion on this issue, or a promoted c
 
 ## The sizing rule
 
-One test, replacing the old four-question checklist: **a slice is right-sized when it fits one fresh context window and is verifiable alone.**
+One test, replacing the old four-question checklist: **a slice is right-sized when it is verifiable alone and revertible alone.**
 
-- If an implementer cannot pick the issue up in a new conversation and finish it without reading a sibling, split.
-- If the done-check cannot run (or be reviewed) without another slice landing first, either split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Verifiable alone** — the done-check can run (or be reviewed) without another slice landing first. If not, split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Revertible alone** — the slice's landing can be reverted without undoing a sibling. If reverting would require coordinated rollback across slices, split or sequence with `blocks` edges.
+- **Window-fit is implement's runtime heuristic** — if an executor slice still exceeds one fresh context window, implement sub-decomposes for execution via handoffs and scratchpad; that carving never appears in the issue tree. Shape sizes for verification and revertibility, not executor memory.
 - If you are splitting just to have more rows, merge back.
 
 Per-slice verification stays with the slice. Never a separate "verify" child; keep tests with the code they test.

--- a/plugins/loaf/skills/implement/SKILL.md
+++ b/plugins/loaf/skills/implement/SKILL.md
@@ -47,6 +47,7 @@ You are the coordinator. Work units are issues.
 - **One agent, one worktree.** `loaf issue start <ref>` walks to the shippable root and starts or joins that root workspace (`issue/<root-alias>`). Only the root records `started_branch` / `started_worktree`; a descendant becomes `active` without its own worktree. Before dispatch, run `loaf issue list --started`. Never send two agents into the same worktree.
 - **Definition of done is the completion contract.** `loaf issue verify <ref>` runs V-tier criteria from the repository root and writes nothing. H-tier is reviewed by a human or this orchestrator. Completion is the work landing plus `loaf issue status <ref> done`. Do not flip checkboxes. Provenance is the delivering commits and the PR whose body is `loaf issue render <ref>`.
 - Shape prepares issues. If `loaf issue check <ref>` does not report the delivery issue shaped (or the decision issue ready), stop and send the work to shape. Do not mint a new issue from this skill.
+- **Window-fit is a runtime heuristic, not a tree edge.** Shape sizes slices for verification and revertibility alone. When an executor slice still exceeds one fresh context window, implement sub-decomposes for execution — via handoffs, scratchpad, and agent spawns — without minting child issues. That carving never appears in the issue tree.
 
 ### Orchestrator Can Do Directly
 - Log journal entries, read journal context, create council files

--- a/plugins/loaf/skills/shape/SKILL.md
+++ b/plugins/loaf/skills/shape/SKILL.md
@@ -6,10 +6,10 @@ description: >-
   DoD — validated by loaf issue check. Use when the user asks "shape this,"
   "turn this into an issue," or a diagnosed fix needs a row. Produces a shaped
   issue — never a folder or a plan document. Teaches fog graduation (park,
-  then a decision child) and one-criterion sizing (one fresh context window,
-  verifiable alone). Not for quick capture (use idea), problem discovery that
-  should author a brief first (use pitch), or open-ended divergent thinking
-  (agent technique: explore / brainstorm — user entry routes to pitch).
+  then a decision child) and one-criterion sizing (verifiable alone, revertible
+  alone). Not for quick capture (use idea), problem discovery that should author
+  a brief first (use pitch), or open-ended divergent thinking (agent technique:
+  explore / brainstorm — user entry routes to pitch).
 user-invocable: true
 argument-hint: '[messy input to shape into a Change]'
 version: 0.3.1
@@ -33,19 +33,19 @@ Prepare a bounded, reviewable issue.
 
 ## Critical Rules
 
-1. **Log invocation first** — `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
-2. **Produces an issue, never a folder** — the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
-3. **The fog register routes, you don't guess** — every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
-4. **Fog graduates instead of evaporating** — a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
-5. **Blindspot pass precedes grilling, offered not imposed** — run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
-6. **Grill one question at a time, with a recommendation** — using your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
-7. **Techniques return fog entries, not decisions** — blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
-8. **Decomposition is the tail** — a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
-9. **One sizing criterion** — a slice is right-sized when it fits one fresh context window and is verifiable alone. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
-10. **Surface misalignment, never silently adjust** — when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
-11. **Critique before finalizing** — run the Critique Gate as the last shaping step, before `loaf issue check`.
-12. **A diagnosed one-line fix is two commands** — `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
-13. **Log the outcome** — `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
+1. **Log invocation first** — Because shaping is a project-scoped event others may audit, `loaf journal log "skill(shape): shaping <topic> into LOAF-42"` before doing anything else. If no issue exists yet, log `skill(shape): shaping <topic>` and add the alias in the outcome entry.
+2. **Produces an issue, never a folder** — Because bounded work lives in SQLite and ships through PRs, the deliverable is the issue row: problem in the body, definition of done as `loaf issue dod` criteria, an explicit out-of-scope statement in the body, children via `loaf issue promote` when a criterion earns its own DoD. No plan document is committed. The PR body, if a PR is opened, is `loaf issue render` output.
+3. **The fog register routes, you don't guess** — Because unknowns have different resolution techniques, every named unknown carries a quadrant tag that dispatches it to exactly one technique (see Quick Reference). Technique-by-vibes is the failure mode this replaces.
+4. **Fog graduates instead of evaporating** — Because parked questions resurface as scope creep, a question not yet sharp enough is parked in the issue's `fog` field (`loaf issue new --fog`). When it sharpens it becomes a `--kind decision` child, which is ready when it poses a sharp question (a `?` in the title or body). No plan required.
+5. **Blindspot pass precedes grilling, offered not imposed** — Because reconnaissance cost should match unfamiliarity, run it when the territory is unfamiliar; skip it when the shaper is the domain expert. Never impose it as a mandatory step.
+6. **Grill one question at a time, with a recommendation** — Because parallel questions hide trade-offs, use your harness's structured question tool if it has one (otherwise one inline question per message — same semantics). Never a form to fill in one pass. Order by architectural impact: questions whose answer would change the architecture go first, cosmetic questions last.
+7. **Techniques return fog entries, not decisions** — Because the human adjudicates, blindspot passes, grilling, and reaction artifacts hand back named unknowns and evidence for the human to adjudicate. Reconnaissance, not orders.
+8. **Decomposition is the tail** — Because premature splitting obscures the problem, a parent gets children only when its DoD needs more than one coherent slice. A criterion becomes a child the moment it earns its own DoD, via `loaf issue promote`. Own those boundaries autonomously; ask only when two orderings carry genuinely different trade-offs.
+9. **One sizing criterion** — Because unattended autonomy appreciates per-slice proof and bounded revert (while executor window-fit decays with better continuity), a slice is right-sized when it is verifiable alone and revertible alone. Window-fit ("fits one fresh context window") is a labeled **runtime heuristic** owned by implement — shape decomposes for verification; implement sub-decomposes for execution per executor via handoffs and scratchpad, and that runtime carving never appears in the issue tree. Expand–contract is the named exception for wide mechanical refactors. See [references/decomposition.md](references/decomposition.md).
+10. **Surface misalignment, never silently adjust** — Because strategic drift hidden in a reshaped issue wastes implementer time, when the idea conflicts with strategic docs, prior issues, or the journal, tell the user and let them decide. Don't quietly reshape their idea.
+11. **Critique before finalizing** — Because agents won't interrogate their own scope without a gate, run the Critique Gate as the last shaping step, before `loaf issue check`.
+12. **A diagnosed one-line fix is two commands** — Because ceremony should match uncertainty, `loaf issue new` with a body that states the problem and `Out of scope: …`, then one `loaf issue dod add`. No problem-space ceremony. Confirm scope with the user before `loaf issue new` on anything larger.
+13. **Log the outcome** — Because shaped issues are audit events, `loaf journal log "decision(shape): LOAF-42 shaped — N children, N open fog entries"`.
 
 ---
 
@@ -172,7 +172,7 @@ Then shape the child the same way (body, out-of-scope, its own criteria). Order 
 
 ### Step 6: Run the Critique Gate
 
-Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable in one fresh context window?
+Before finalizing, challenge the draft — see [references/critique-gate.md](references/critique-gate.md). Is scope still bounded, does every new command or state name its ceremony, is a second progress flag creeping into the body, is the CLI/skill boundary drawn correctly, and could this be smaller and still be verifiable alone and revertible alone?
 
 ### Step 7: Validate
 

--- a/plugins/loaf/skills/shape/references/critique-gate.md
+++ b/plugins/loaf/skills/shape/references/critique-gate.md
@@ -4,7 +4,7 @@ The last shaping step, before `loaf issue check` and any review offer. An agent 
 
 Run through these before finalizing:
 
-- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable in one fresh context window?
+- **Is scope still bounded?** Has the draft crept beyond what the problem statement justifies? Could this issue be smaller and still be verifiable alone and revertible alone?
 - **Does every new command, state, or lifecycle verb name its ceremony?** If a command or state can't name the ceremony that exercises it, cut it — don't build it now and hope a use appears.
 - **Is a second progress flag creeping into the body?** `readiness`, `phase`, `stage`, or anything else that reintroduces a declared progress flag. Status lives on the issue row (`loaf issue status`). Shaped, covered, and ready are derived by `loaf issue check`. `loaf issue bucket` is a label only and is never read as a constraint.
 - **Is the CLI/skill boundary drawn correctly?** Is the skill doing deterministic work that belongs in the CLI, or is the CLI claiming judgment that belongs in the skill?

--- a/plugins/loaf/skills/shape/references/decomposition.md
+++ b/plugins/loaf/skills/shape/references/decomposition.md
@@ -20,10 +20,11 @@ Same problem, another slice → another criterion on this issue, or a promoted c
 
 ## The sizing rule
 
-One test, replacing the old four-question checklist: **a slice is right-sized when it fits one fresh context window and is verifiable alone.**
+One test, replacing the old four-question checklist: **a slice is right-sized when it is verifiable alone and revertible alone.**
 
-- If an implementer cannot pick the issue up in a new conversation and finish it without reading a sibling, split.
-- If the done-check cannot run (or be reviewed) without another slice landing first, either split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Verifiable alone** — the done-check can run (or be reviewed) without another slice landing first. If not, split and `loaf issue link <predecessor> blocks <successor>`, or merge — do not leave a criterion that is only true in combination.
+- **Revertible alone** — the slice's landing can be reverted without undoing a sibling. If reverting would require coordinated rollback across slices, split or sequence with `blocks` edges.
+- **Window-fit is implement's runtime heuristic** — if an executor slice still exceeds one fresh context window, implement sub-decomposes for execution via handoffs and scratchpad; that carving never appears in the issue tree. Shape sizes for verification and revertibility, not executor memory.
 - If you are splitting just to have more rows, merge back.
 
 Per-slice verification stays with the slice. Never a separate "verify" child; keep tests with the code they test.


### PR DESCRIPTION
# Re-index the sizing rule to verification

The shape skill's Critical Rule 9 sizes slices by executor memory ("fits one fresh context window"), a premise the substrate arc (LOAF-62) is explicitly eroding — wraps, handoffs, and the scratchpad make window boundaries survivable. The rule's two halves have opposite lifespans: window-fit decays with better executors and better continuity; verifiable-alone appreciates with autonomy (more unattended hours = more value in per-slice proof and bounded revert).

Change: rewrite Critical Rule 9 to "a slice is right-sized when it is verifiable alone and revertible alone", demoting window-fit to a labeled runtime heuristic owned by implement (shape decomposes for verification; the orchestrator sub-decomposes for execution per executor, coordinating via handoffs/scratchpad, and that runtime carving never appears in the issue tree). Update references/decomposition.md to match. Adopt the premise-naming convention: every Critical Rule states the fact it depends on.

Out of scope: any change to existing issue trees; implement-skill mechanics beyond acknowledging it owns the heuristic; measuring seam cost from journal evidence (a future, substrate-powered refinement).

## Definition of Done

- [ ] Critical Rule 9 states the verification-indexed rule with window-fit as a labeled runtime heuristic