### PR TITLE
fix: run issue verify in the invoking worktree

### DIFF
--- a/internal/cli/issue_verify.go
+++ b/internal/cli/issue_verify.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/levifig/loaf/internal/project"
 	"github.com/levifig/loaf/internal/state"
 )
 
@@ -46,7 +47,12 @@ func (r Runner) runIssueVerify(args []string, out io.Writer, runtime state.Runti
 		return err
 	}
 
-	rootPath := projectRoot.Path()
+	commandRoot, err := project.ResolveRepositoryRoot(runtime.RootPath())
+	if err != nil {
+		return err
+	}
+	commandPath := commandRoot.Path()
+
 	result := issueVerifyResult{
 		ContractVersion:    shown.ContractVersion,
 		DatabaseScope:      shown.DatabaseScope,
@@ -63,7 +69,7 @@ func (r Runner) runIssueVerify(args []string, out io.Writer, runtime state.Runti
 		if criterion.Tier != state.IssueCriterionTierV || strings.TrimSpace(criterion.Command) == "" {
 			continue
 		}
-		exitCode, output, runErr := runChangeCriterionCommand(rootPath, criterion.Command)
+		exitCode, output, runErr := runChangeCriterionCommand(commandPath, criterion.Command)
 		expectation := parseChangeExpectation(criterion.Expect)
 		checks := evaluateChangeExpectation(expectation, exitCode, output)
 		ok := runErr == nil && changeExpectChecksPass(checks)
@@ -110,6 +116,6 @@ func (r Runner) runIssueVerify(args []string, out io.Writer, runtime state.Runti
 
 func writeIssueVerifyHelp(out io.Writer) {
 	writeUsageHelp(out, "loaf issue verify <ref> [--json]",
-		"Run the issue's V-tier criteria (command + expect) from the repository root. Honors exit N and contains `text`. Writes nothing; exits non-zero on any failure.",
+		"Run the issue's V-tier criteria (command + expect) from the invoking worktree repository root. Honors exit N and contains `text`. Writes nothing; exits non-zero on any failure.",
 		"--json       Output per-criterion results as JSON")
 }

--- a/internal/cli/issue_worktree_test.go
+++ b/internal/cli/issue_worktree_test.go
@@ -66,6 +66,41 @@ func gitOutputCLI(t *testing.T, dir string, args ...string) string {
 	return strings.TrimSpace(string(out))
 }
 
+func TestRunnerIssueVerifyRunsInInvokingWorktree(t *testing.T) {
+	repo, stateHome := issueGitFixture(t)
+	if _, err := runIssue(t, repo, stateHome, "new", "Verify worktree"); err != nil {
+		t.Fatalf("issue new error = %v", err)
+	}
+	marker := "worktree-only-marker.txt"
+	command := "test -f " + marker
+	if _, err := runIssue(t, repo, stateHome, "dod", "add", "LOAF-1", "marker exists in invoking worktree",
+		"--command", command, "--expect", "exit 0"); err != nil {
+		t.Fatalf("dod add error = %v", err)
+	}
+
+	startedOut, err := runIssue(t, repo, stateHome, "start", "LOAF-1", "--json")
+	if err != nil {
+		t.Fatalf("issue start error = %v", err)
+	}
+	started := decodeIssueStart(t, startedOut)
+	if err := os.WriteFile(filepath.Join(started.Worktree, marker), []byte("present\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(marker) error = %v", err)
+	}
+
+	out, err := runIssue(t, started.Worktree, stateHome, "verify", "LOAF-1")
+	if err != nil {
+		t.Fatalf("verify from worktree error = %v\n%s", err, out)
+	}
+	if !strings.Contains(out, command) {
+		t.Fatalf("verify output = %q, want command %q", out, command)
+	}
+
+	failOut, err := runIssue(t, repo, stateHome, "verify", "LOAF-1")
+	if err == nil {
+		t.Fatalf("verify from main checkout should fail when marker exists only in worktree\n%s", failOut)
+	}
+}
+
 func TestRunnerIssueStartChildJoinsRootWorkspace(t *testing.T) {
 	repo, stateHome := issueGitFixture(t)
 	if _, err := runIssue(t, repo, stateHome, "new", "Parent"); err != nil {
@@ -314,7 +349,6 @@ func TestRunnerIssueStopChildNamesRootWhenRootNotStarted(t *testing.T) {
 		t.Fatalf("stop child error = %v, want root-directed refusal", err)
 	}
 }
-
 
 func TestRunnerIssueListStartedShowsLiveAndStale(t *testing.T) {
 	repo, stateHome := issueGitFixture(t)

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -66,6 +66,21 @@ func (r Root) Path() string {
 	return r.path
 }
 
+// ResolveRepositoryRoot returns the Git worktree root for command execution
+// at the given start path. Linked worktrees resolve to their own checkout; unlike ResolveRoot,
+// this does not normalize to the main worktree.
+func ResolveRepositoryRoot(start string) (Root, error) {
+	workingDir, err := ResolveWorkingDirectory(start)
+	if err != nil {
+		return Root{}, err
+	}
+
+	if gitRoot, ok := gitOutput(workingDir.Path(), "rev-parse", "--show-toplevel"); ok {
+		return Root{path: realpathOrSelf(gitRoot)}, nil
+	}
+	return Root{path: workingDir.Path()}, nil
+}
+
 func resolveGitRoot(start string) (string, bool) {
 	gitDir, ok := gitOutput(start, "rev-parse", "--path-format=absolute", "--git-dir")
 	if !ok {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -45,6 +45,28 @@ func TestResolveRootUsesGitTopLevelFromSubdirectory(t *testing.T) {
 	}
 }
 
+func TestResolveRepositoryRootUsesLinkedWorktreeCheckout(t *testing.T) {
+	requireGit(t)
+	main := initGitRepo(t)
+	linked := addLinkedWorktree(t, main, "command-root")
+
+	fromMain, err := ResolveRepositoryRoot(main)
+	if err != nil {
+		t.Fatalf("ResolveRepositoryRoot(main) error = %v", err)
+	}
+	fromLinked, err := ResolveRepositoryRoot(linked)
+	if err != nil {
+		t.Fatalf("ResolveRepositoryRoot(linked) error = %v", err)
+	}
+
+	if fromMain.Path() != main {
+		t.Fatalf("main Path() = %q, want %q", fromMain.Path(), main)
+	}
+	if fromLinked.Path() != linked {
+		t.Fatalf("linked Path() = %q, want linked checkout %q", fromLinked.Path(), linked)
+	}
+}
+
 func TestResolveRootUsesMainWorktreeForLinkedWorktree(t *testing.T) {
 	requireGit(t)
 	main := initGitRepo(t)


### PR DESCRIPTION
# Verify runs in the invoking worktree

loaf issue verify executes V-tier commands in project.ResolveRoot (the canonical main checkout), not the invoking worktree — internal/cli/issue_verify.go uses the canonical path as cmd.Dir while state.Runtime already carries WorkingDirectory. The official loop is self-inconsistent: issue start creates a linked worktree, implement says verify there, verify runs against main, so unmerged feature code cannot pass its own criteria. Fix: read issue metadata from canonical project state; execute commands from the invoking worktree's repository root. This is the two-roots constraint (project-state root ≠ command-execution root) that also binds LOAF-62.

Out of scope: the substrate arc (LOAF-62); any change to project identity resolution for state.

## Definition of Done

- [ ] A V-tier criterion command executes in the invoking linked worktree's repo root and passes against unmerged feature code