### PR TITLE
feat: bootstrap cloud project environments for Cursor and Amp

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Amp Orb resume script (LOAF-78). Re-runs project-environment install on wake.
+# Attach pre-warm deferred until LOAF-67 attach ceremony ships.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+export PATH="$ROOT/bin:$PATH"
+export LOAF_PROJECT_ENV=1
+exec loaf install --to amp --yes

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Amp Orb setup script (LOAF-78). Runs once when a fresh orb is prepared.
+# Installs the Loaf CLI, then project-environment `loaf install --to amp`.
+# Project secret (LOAF-67, when attach ships): LOAF_CLIENT_TOKEN from
+# `loaf auth link --project` via amp secrets / project environment.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+if [[ ! -x "$ROOT/bin/loaf" ]]; then
+  npm ci
+  npm run build:go
+fi
+export PATH="$ROOT/bin:$PATH"
+export LOAF_PROJECT_ENV=1
+exec loaf install --to amp --yes

--- a/.agents/setup
+++ b/.agents/setup
@@ -6,7 +6,18 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
-if [[ ! -x "$ROOT/bin/loaf" ]]; then
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+case "$arch" in
+  x86_64) arch=x64 ;;
+  aarch64|arm64) arch=arm64 ;;
+esac
+NATIVE="$ROOT/bin/native/${os}-${arch}/loaf"
+
+# bin/loaf is only the Node launcher; require the native binary for this host
+# before skipping the build.
+if [[ ! -x "$ROOT/bin/loaf" || ! -x "$NATIVE" ]]; then
   npm ci
   npm run build:go
 fi

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "install": ".cursor/loaf-cloud-install.sh",
+  "start": ".cursor/loaf-cloud-start.sh"
+}

--- a/.cursor/loaf-cloud-install.sh
+++ b/.cursor/loaf-cloud-install.sh
@@ -1,12 +1,29 @@
 #!/usr/bin/env bash
 # Cursor Cloud Agent install script (LOAF-78).
-# Builds the Loaf CLI from this checkout. Project secrets (LOAF-67, when attach
-# ships): set LOAF_CLIENT_TOKEN from `loaf auth link --project` in the Cursor
-# Cloud project environment; optional LOAF_SYNC_URL for sync endpoint.
+# Builds the Loaf CLI for this host, then installs harness surfaces into the
+# project environment so hooks/skills exist before the agent starts.
+# Project secrets (LOAF-67, when attach ships): set LOAF_CLIENT_TOKEN from
+# `loaf auth link --project` in the Cursor Cloud project environment; optional
+# LOAF_SYNC_URL for sync endpoint.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
-if [[ ! -x "$ROOT/bin/loaf" ]]; then
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+case "$arch" in
+  x86_64) arch=x64 ;;
+  aarch64|arm64) arch=arm64 ;;
+esac
+NATIVE="$ROOT/bin/native/${os}-${arch}/loaf"
+
+# bin/loaf is only the Node launcher; require the native binary for this host
+# before skipping the build (cloud agents are typically linux-*, not darwin).
+if [[ ! -x "$ROOT/bin/loaf" || ! -x "$NATIVE" ]]; then
   npm ci
   npm run build:go
 fi
+
+export PATH="$ROOT/bin:$PATH"
+export LOAF_PROJECT_ENV=1
+loaf install --to cursor --yes

--- a/.cursor/loaf-cloud-install.sh
+++ b/.cursor/loaf-cloud-install.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Cursor Cloud Agent install script (LOAF-78).
+# Builds the Loaf CLI from this checkout. Project secrets (LOAF-67, when attach
+# ships): set LOAF_CLIENT_TOKEN from `loaf auth link --project` in the Cursor
+# Cloud project environment; optional LOAF_SYNC_URL for sync endpoint.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+if [[ ! -x "$ROOT/bin/loaf" ]]; then
+  npm ci
+  npm run build:go
+fi

--- a/.cursor/loaf-cloud-start.sh
+++ b/.cursor/loaf-cloud-start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Cursor Cloud Agent start script (LOAF-78).
+# Deploys harness surfaces via project-environment install. Attach pre-warm
+# (`loaf attach` or equivalent) is deferred until LOAF-67 attach ceremony ships.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+export PATH="$ROOT/bin:$PATH"
+export LOAF_PROJECT_ENV=1
+exec loaf install --to cursor --yes

--- a/.cursor/loaf-cloud-start.sh
+++ b/.cursor/loaf-cloud-start.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Cursor Cloud Agent start script (LOAF-78).
-# Deploys harness surfaces via project-environment install. Attach pre-warm
-# (`loaf attach` or equivalent) is deferred until LOAF-67 attach ceremony ships.
+# Harness install runs in the install/build phase (loaf-cloud-install.sh) so
+# hooks/skills exist before the agent works. Attach pre-warm (`loaf attach` or
+# equivalent) is deferred until LOAF-67 attach ceremony ships.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 export PATH="$ROOT/bin:$PATH"
-export LOAF_PROJECT_ENV=1
-exec loaf install --to cursor --yes
+# no-op until LOAF-67 attach pre-warm lands
+exit 0

--- a/.cursor/loaf-cloud-start.sh
+++ b/.cursor/loaf-cloud-start.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # Cursor Cloud Agent start script (LOAF-78).
 # Harness install runs in the install/build phase (loaf-cloud-install.sh) so
-# hooks/skills exist before the agent works. Attach pre-warm (`loaf attach` or
-# equivalent) is deferred until LOAF-67 attach ceremony ships.
+# hooks/skills exist before the agent works. Re-export LOAF_PROJECT_ENV so
+# session loaf upgrade/config/hooks keep the project-local layout — Cursor Cloud
+# does not carry install-time shell exports into agent sessions.
+# Attach pre-warm (`loaf attach` or equivalent) is deferred until LOAF-67.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 export PATH="$ROOT/bin:$PATH"
+export LOAF_PROJECT_ENV=1
 # no-op until LOAF-67 attach pre-warm lands
 exit 0

--- a/internal/cli/cloud_environment.go
+++ b/internal/cli/cloud_environment.go
@@ -2,7 +2,7 @@ package cli
 
 // LOAF_PROJECT_ENV routes harness install to project-local config dirs on
 // ephemeral cloud hosts. See cloud_environment_bootstrap.go for bootstrap scripts
-// and LOAF-67 credential secret names.
+// and LOAF-67 client-token env names.
 
 import (
 	"os"

--- a/internal/cli/cloud_environment.go
+++ b/internal/cli/cloud_environment.go
@@ -1,0 +1,52 @@
+package cli
+
+// LOAF_PROJECT_ENV routes harness install to project-local config dirs on
+// ephemeral cloud hosts. See cloud_environment_bootstrap.go for bootstrap scripts
+// and LOAF-67 credential secret names.
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/levifig/loaf/internal/project"
+)
+
+const projectEnvironmentEnv = "LOAF_PROJECT_ENV"
+
+func projectEnvironmentActive() bool {
+	return os.Getenv(projectEnvironmentEnv) == "1"
+}
+
+func projectEnvironmentConfigDirs(projectRoot string) map[string]string {
+	return map[string]string{
+		"opencode": filepath.Join(projectRoot, ".opencode"),
+		"cursor":   filepath.Join(projectRoot, ".cursor"),
+		"codex":    filepath.Join(projectRoot, ".codex"),
+		"amp":      filepath.Join(projectRoot, ".amp"),
+	}
+}
+
+func resolveInstallLayout(projectRoot string) (configDirs map[string]string, recordHome string) {
+	if projectEnvironmentActive() {
+		effectiveRoot := projectRoot
+		if effectiveRoot == "" {
+			if resolved, err := project.ResolveRoot("."); err == nil {
+				effectiveRoot = resolved.Path()
+			}
+		}
+		if effectiveRoot != "" {
+			return projectEnvironmentConfigDirs(effectiveRoot), effectiveRoot
+		}
+	}
+	return defaultInstallConfigDirs(), installHome()
+}
+
+func installLayoutConfigDirs(projectRoot string) map[string]string {
+	dirs, _ := resolveInstallLayout(projectRoot)
+	return dirs
+}
+
+func installLayoutHome(projectRoot string) string {
+	_, home := resolveInstallLayout(projectRoot)
+	return home
+}

--- a/internal/cli/cloud_environment.go
+++ b/internal/cli/cloud_environment.go
@@ -50,3 +50,25 @@ func installLayoutHome(projectRoot string) string {
 	_, home := resolveInstallLayout(projectRoot)
 	return home
 }
+
+// resolveInstallCodexHome picks the Codex home used for hooks, rules, and
+// markers. Under LOAF_PROJECT_ENV=1 it must match ConfigDir (project-local
+// .codex) so CODEX_HOME cannot split hooks from the install layout.
+func resolveInstallCodexHome(configDir string) string {
+	if projectEnvironmentActive() && configDir != "" {
+		return configDir
+	}
+	return os.Getenv("CODEX_HOME")
+}
+
+// effectiveCodexHome is the directory Codex hooks/rules/markers write to for
+// one install options value. Project-environment installs always use ConfigDir.
+func effectiveCodexHome(options targetInstallOptions) string {
+	if projectEnvironmentActive() && options.ConfigDir != "" {
+		return options.ConfigDir
+	}
+	if options.CodexHome != "" {
+		return options.CodexHome
+	}
+	return filepath.Join(installHomeDir(options), ".codex")
+}

--- a/internal/cli/cloud_environment_bootstrap.go
+++ b/internal/cli/cloud_environment_bootstrap.go
@@ -13,18 +13,18 @@ import (
 // Harness surfaces ride `loaf install` under LOAF_PROJECT_ENV=1 (project-local
 // .cursor/, .amp/, .agents/skills/), not user-level ~/.cursor or hooks.json.
 //
-// LOAF-67 attach credential (not wired until attach ceremony ships):
+// LOAF-67 attach client token (not wired until attach ceremony ships):
 //   - Mint locally: loaf auth link --project
-//   - Cursor Cloud Agent: add project environment secret LOAF_CLIENT_TOKEN
-//     (project-scoped client credential; never the operator master key)
-//   - Amp Orb: add project secret LOAF_CLIENT_TOKEN via amp secrets / dashboard
+//   - Cursor Cloud Agent: add project environment var LOAF_CLIENT_TOKEN
+//     (project-scoped client token; never the operator master key)
+//   - Amp Orb: add project env LOAF_CLIENT_TOKEN via amp project configuration
 //   - Optional sync endpoint (when configured): LOAF_SYNC_URL
 //
 // Attach pre-warm in the start script is intentionally deferred until LOAF-67
 // lands; the issue body treats start-script attach as optional pre-warm only.
 const (
-	// projectEnvironmentClientTokenEnv is the provisional per-project secret name
-	// for the LOAF-67 client credential in Cursor Cloud and Amp Orb environments.
+	// projectEnvironmentClientTokenEnv is the provisional per-project env var name
+	// for the LOAF-67 client token in Cursor Cloud and Amp Orb environments.
 	projectEnvironmentClientTokenEnv = "LOAF_CLIENT_TOKEN"
 	// projectEnvironmentSyncURLEnv is optional when a project sync endpoint is configured.
 	projectEnvironmentSyncURLEnv = "LOAF_SYNC_URL"

--- a/internal/cli/cloud_environment_bootstrap.go
+++ b/internal/cli/cloud_environment_bootstrap.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Cloud project-environment bootstrap for Cursor Cloud Agents and Amp Orbs.
+//
+// Harness surfaces ride `loaf install` under LOAF_PROJECT_ENV=1 (project-local
+// .cursor/, .amp/, .agents/skills/), not user-level ~/.cursor or hooks.json.
+//
+// LOAF-67 attach credential (not wired until attach ceremony ships):
+//   - Mint locally: loaf auth link --project
+//   - Cursor Cloud Agent: add project environment secret LOAF_CLIENT_TOKEN
+//     (project-scoped client credential; never the operator master key)
+//   - Amp Orb: add project secret LOAF_CLIENT_TOKEN via amp secrets / dashboard
+//   - Optional sync endpoint (when configured): LOAF_SYNC_URL
+//
+// Attach pre-warm in the start script is intentionally deferred until LOAF-67
+// lands; the issue body treats start-script attach as optional pre-warm only.
+const (
+	// projectEnvironmentClientTokenEnv is the provisional per-project secret name
+	// for the LOAF-67 client credential in Cursor Cloud and Amp Orb environments.
+	projectEnvironmentClientTokenEnv = "LOAF_CLIENT_TOKEN"
+	// projectEnvironmentSyncURLEnv is optional when a project sync endpoint is configured.
+	projectEnvironmentSyncURLEnv = "LOAF_SYNC_URL"
+)
+
+const (
+	cursorCloudEnvironmentFile = ".cursor/environment.json"
+	cursorCloudInstallScript   = ".cursor/loaf-cloud-install.sh"
+	cursorCloudStartScript     = ".cursor/loaf-cloud-start.sh"
+	ampOrbSetupScript          = ".agents/setup"
+	ampOrbResumeScript         = ".agents/resume"
+)
+
+type cursorCloudEnvironment struct {
+	Install string `json:"install"`
+	Start   string `json:"start"`
+}
+
+var requiredCloudBootstrapMarkers = map[string][]string{
+	cursorCloudInstallScript: {
+		"npm run build:go",
+		"bin/loaf",
+	},
+	cursorCloudStartScript: {
+		projectEnvironmentEnv + "=1",
+		"loaf install --to cursor",
+	},
+	ampOrbSetupScript: {
+		"npm run build:go",
+		projectEnvironmentEnv + "=1",
+		"loaf install --to amp",
+	},
+	ampOrbResumeScript: {
+		projectEnvironmentEnv + "=1",
+		"loaf install --to amp",
+	},
+}
+
+func loafRepositoryRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for dir := wd; ; dir = filepath.Dir(dir) {
+		if fileExistsForInstall(filepath.Join(dir, "go.mod")) &&
+			fileExistsForInstall(filepath.Join(dir, "package.json")) &&
+			dirExistsForInstall(filepath.Join(dir, "cmd", "loaf")) {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+	}
+	return "", fmt.Errorf("loaf repository root not found from %s", wd)
+}
+
+func stripShellComments(body string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func readCloudBootstrapFile(root, rel string) (string, error) {
+	body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func validateCloudBootstrapScript(root, rel string) error {
+	body, err := readCloudBootstrapFile(root, rel)
+	if err != nil {
+		return err
+	}
+	for _, marker := range requiredCloudBootstrapMarkers[rel] {
+		if !strings.Contains(body, marker) {
+			return fmt.Errorf("%s missing %q", rel, marker)
+		}
+	}
+	if rel == cursorCloudInstallScript || rel == ampOrbSetupScript {
+		executable := stripShellComments(body)
+		loafIdx := strings.Index(executable, "loaf ")
+		buildIdx := strings.Index(executable, "npm run build:go")
+		if buildIdx < 0 {
+			return fmt.Errorf("%s must install the Loaf CLI before the first loaf command", rel)
+		}
+		if loafIdx >= 0 && buildIdx > loafIdx {
+			return fmt.Errorf("%s runs loaf before CLI install", rel)
+		}
+	}
+	return nil
+}
+
+func validateCursorCloudEnvironment(root string) error {
+	raw, err := readCloudBootstrapFile(root, cursorCloudEnvironmentFile)
+	if err != nil {
+		return err
+	}
+	var env cursorCloudEnvironment
+	if err := json.Unmarshal([]byte(raw), &env); err != nil {
+		return fmt.Errorf("parse %s: %w", cursorCloudEnvironmentFile, err)
+	}
+	if env.Install != cursorCloudInstallScript {
+		return fmt.Errorf("%s install = %q, want %q", cursorCloudEnvironmentFile, env.Install, cursorCloudInstallScript)
+	}
+	if env.Start != cursorCloudStartScript {
+		return fmt.Errorf("%s start = %q, want %q", cursorCloudEnvironmentFile, env.Start, cursorCloudStartScript)
+	}
+	return nil
+}
+
+func validateCloudEnvironmentBootstrap(root string) error {
+	if err := validateCursorCloudEnvironment(root); err != nil {
+		return err
+	}
+	for _, rel := range []string{cursorCloudInstallScript, cursorCloudStartScript, ampOrbSetupScript, ampOrbResumeScript} {
+		if err := validateCloudBootstrapScript(root, rel); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cli/cloud_environment_bootstrap.go
+++ b/internal/cli/cloud_environment_bootstrap.go
@@ -20,8 +20,9 @@ import (
 //   - Amp Orb: add project env LOAF_CLIENT_TOKEN via amp project configuration
 //   - Optional sync endpoint (when configured): LOAF_SYNC_URL
 //
-// Attach pre-warm in the start script is intentionally deferred until LOAF-67
-// lands; the issue body treats start-script attach as optional pre-warm only.
+// Cursor Cloud harness install runs in the install/build script so hooks and
+// skills exist before the agent starts. Attach pre-warm in the start script is
+// intentionally deferred until LOAF-67 lands.
 const (
 	// projectEnvironmentClientTokenEnv is the provisional per-project env var name
 	// for the LOAF-67 client token in Cursor Cloud and Amp Orb environments.
@@ -46,14 +47,18 @@ type cursorCloudEnvironment struct {
 var requiredCloudBootstrapMarkers = map[string][]string{
 	cursorCloudInstallScript: {
 		"npm run build:go",
+		"bin/native/",
 		"bin/loaf",
-	},
-	cursorCloudStartScript: {
 		projectEnvironmentEnv + "=1",
 		"loaf install --to cursor",
 	},
+	cursorCloudStartScript: {
+		"LOAF-67",
+	},
 	ampOrbSetupScript: {
 		"npm run build:go",
+		"bin/native/",
+		"bin/loaf",
 		projectEnvironmentEnv + "=1",
 		"loaf install --to amp",
 	},

--- a/internal/cli/cloud_environment_bootstrap.go
+++ b/internal/cli/cloud_environment_bootstrap.go
@@ -13,11 +13,20 @@ import (
 // Harness surfaces ride `loaf install` under LOAF_PROJECT_ENV=1 (project-local
 // .cursor/, .amp/, .agents/skills/), not user-level ~/.cursor or hooks.json.
 //
+// Project-environment layout (LOAF_PROJECT_ENV):
+//   - Must be exported in every cloud session entry that runs loaf after
+//     bootstrap (Cursor start script; Amp setup/resume). Cursor Cloud does not
+//     carry install-time shell exports into agent sessions.
+//   - Optional durable project env var with the same name keeps layout without
+//     relying on start/resume scripts alone.
+//
 // LOAF-67 attach client token (not wired until attach ceremony ships):
 //   - Mint locally: loaf auth link --project
-//   - Cursor Cloud Agent: add project environment var LOAF_CLIENT_TOKEN
-//     (project-scoped client token; never the operator master key)
-//   - Amp Orb: add project env LOAF_CLIENT_TOKEN via amp project configuration
+//   - Cursor Cloud Agent: add project environment vars LOAF_CLIENT_TOKEN and
+//     preferably LOAF_PROJECT_ENV=1 (project-scoped client token; never the
+//     operator master key)
+//   - Amp Orb: add project env LOAF_CLIENT_TOKEN (and LOAF_PROJECT_ENV=1) via
+//     amp project configuration
 //   - Optional sync endpoint (when configured): LOAF_SYNC_URL
 //
 // Cursor Cloud harness install runs in the install/build script so hooks and
@@ -53,6 +62,7 @@ var requiredCloudBootstrapMarkers = map[string][]string{
 		"loaf install --to cursor",
 	},
 	cursorCloudStartScript: {
+		projectEnvironmentEnv + "=1",
 		"LOAF-67",
 	},
 	ampOrbSetupScript: {

--- a/internal/cli/cloud_environment_test.go
+++ b/internal/cli/cloud_environment_test.go
@@ -58,6 +58,9 @@ func TestCloudEnvironmentBootstrapInstallUsesProjectEnvironmentInstall(t *testin
 	if err != nil {
 		t.Fatalf("readCloudBootstrapFile(%q) error = %v", cursorCloudStartScript, err)
 	}
+	if !strings.Contains(start, projectEnvironmentEnv+"=1") {
+		t.Fatalf("%s missing %s=1 (Cursor sessions do not inherit install exports)", cursorCloudStartScript, projectEnvironmentEnv)
+	}
 	if strings.Contains(stripShellComments(start), "loaf install") {
 		t.Fatalf("%s must not run loaf install (belongs in install phase)", cursorCloudStartScript)
 	}
@@ -171,6 +174,27 @@ func TestIsLoafInstalledForTargetInstallUsesLayoutHome(t *testing.T) {
 func TestCloudEnvironmentBootstrapDocumentsClientTokenSecret(t *testing.T) {
 	if projectEnvironmentClientTokenEnv != "LOAF_CLIENT_TOKEN" {
 		t.Fatalf("client token env = %q", projectEnvironmentClientTokenEnv)
+	}
+	if projectEnvironmentEnv != "LOAF_PROJECT_ENV" {
+		t.Fatalf("project env = %q", projectEnvironmentEnv)
+	}
+	body, err := os.ReadFile("cloud_environment_bootstrap.go")
+	if err != nil {
+		// package-relative; tests run with package dir as cwd for source reads via loafRepositoryRoot
+		root, rootErr := loafRepositoryRoot()
+		if rootErr != nil {
+			t.Fatalf("loafRepositoryRoot() error = %v", rootErr)
+		}
+		body, err = os.ReadFile(filepath.Join(root, "internal", "cli", "cloud_environment_bootstrap.go"))
+	}
+	if err != nil {
+		t.Fatalf("read bootstrap docs error = %v", err)
+	}
+	docs := string(body)
+	for _, want := range []string{projectEnvironmentEnv, projectEnvironmentClientTokenEnv, projectEnvironmentSyncURLEnv} {
+		if !strings.Contains(docs, want) {
+			t.Fatalf("bootstrap docs missing %q", want)
+		}
 	}
 }
 

--- a/internal/cli/cloud_environment_test.go
+++ b/internal/cli/cloud_environment_test.go
@@ -29,15 +29,19 @@ func TestCloudEnvironmentBootstrapArtifactsInstallCLI(t *testing.T) {
 		if loafIdx >= 0 && buildIdx > loafIdx {
 			t.Fatalf("%s runs loaf before CLI install", rel)
 		}
+		if !strings.Contains(executable, "bin/native/") {
+			t.Fatalf("%s must require bin/native/<platform>/loaf before skipping build", rel)
+		}
 	}
 }
 
-func TestCloudEnvironmentBootstrapStartUsesProjectEnvironmentInstall(t *testing.T) {
+func TestCloudEnvironmentBootstrapInstallUsesProjectEnvironmentInstall(t *testing.T) {
 	root, err := loafRepositoryRoot()
 	if err != nil {
 		t.Fatalf("loafRepositoryRoot() error = %v", err)
 	}
-	for _, rel := range []string{cursorCloudStartScript, ampOrbSetupScript, ampOrbResumeScript} {
+	// Cursor: install/build phase; Amp: setup/resume.
+	for _, rel := range []string{cursorCloudInstallScript, ampOrbSetupScript, ampOrbResumeScript} {
 		body, err := readCloudBootstrapFile(root, rel)
 		if err != nil {
 			t.Fatalf("readCloudBootstrapFile(%q) error = %v", rel, err)
@@ -48,6 +52,13 @@ func TestCloudEnvironmentBootstrapStartUsesProjectEnvironmentInstall(t *testing.
 		if !strings.Contains(body, "loaf install --to ") {
 			t.Fatalf("%s missing project-environment loaf install", rel)
 		}
+	}
+	start, err := readCloudBootstrapFile(root, cursorCloudStartScript)
+	if err != nil {
+		t.Fatalf("readCloudBootstrapFile(%q) error = %v", cursorCloudStartScript, err)
+	}
+	if strings.Contains(stripShellComments(start), "loaf install") {
+		t.Fatalf("%s must not run loaf install (belongs in install phase)", cursorCloudStartScript)
 	}
 }
 
@@ -159,5 +170,70 @@ func TestIsLoafInstalledForTargetInstallUsesLayoutHome(t *testing.T) {
 func TestCloudEnvironmentBootstrapDocumentsClientTokenSecret(t *testing.T) {
 	if projectEnvironmentClientTokenEnv != "LOAF_CLIENT_TOKEN" {
 		t.Fatalf("client token env = %q", projectEnvironmentClientTokenEnv)
+	}
+}
+
+func TestCloudEnvironmentCodexUsesProjectLayoutIgnoringCodexHome(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	projectDir := filepath.Join(root, "project")
+	dist := filepath.Join(projectDir, "dist")
+	userCodex := filepath.Join(home, "custom-codex")
+	projectCodex := filepath.Join(projectDir, ".codex")
+	mkdirAll(t, userCodex)
+	mkdirAll(t, projectDir)
+	writeInstallFile(t, filepath.Join(projectDir, "AGENTS.md"), "# Project\n")
+	writeInstallFile(t, filepath.Join(projectDir, ".agents", "loaf.json"), `{"issue":{"prefix":"LOAF"}}`+"\n")
+	seedCanonicalSkillsFixture(t, projectDir, home, []string{"codex"}, "# Foundations\n")
+	installTestHookDistribution(t, projectDir, "codex")
+
+	t.Setenv("HOME", home)
+	t.Setenv("LOAF_DB", filepath.Join(t.TempDir(), "loaf.sqlite"))
+	t.Setenv("CODEX_HOME", userCodex)
+	t.Setenv(projectEnvironmentEnv, "1")
+
+	configDir := installLayoutConfigDirs(projectDir)["codex"]
+	options := targetInstallOptions{
+		Target:      "codex",
+		DistDir:     filepath.Join(dist, "codex"),
+		ConfigDir:   configDir,
+		Version:     "9.8.7-test.1",
+		HomeDir:     installLayoutHome(projectDir),
+		CodexHome:   resolveInstallCodexHome(configDir),
+		ProjectRoot: projectDir,
+		HookState:   installTestHookState(t),
+	}
+	if err := installTargetDistribution(options); err != nil {
+		t.Fatalf("installTargetDistribution() error = %v", err)
+	}
+
+	if fileExistsForInstall(filepath.Join(userCodex, loafInstallMarkerFile)) {
+		t.Fatalf("wrote Codex marker to CODEX_HOME %s under project env", userCodex)
+	}
+	if fileExistsForInstall(filepath.Join(userCodex, "hooks.json")) {
+		t.Fatalf("wrote Codex hooks to CODEX_HOME %s under project env", userCodex)
+	}
+	if !fileExistsForInstall(filepath.Join(projectCodex, loafInstallMarkerFile)) {
+		t.Fatalf("missing project-environment Codex marker at %s", projectCodex)
+	}
+	if !fileExistsForInstall(filepath.Join(projectCodex, "hooks.json")) {
+		t.Fatalf("missing project-environment Codex hooks at %s", projectCodex)
+	}
+	if got := effectiveCodexHome(options); got != projectCodex {
+		t.Fatalf("effectiveCodexHome = %q, want %q", got, projectCodex)
+	}
+}
+
+func TestCloudEnvironmentResolveInstallCodexHomeIgnoresEnv(t *testing.T) {
+	root := t.TempDir()
+	configDir := filepath.Join(root, "project", ".codex")
+	t.Setenv("CODEX_HOME", filepath.Join(root, "elsewhere"))
+	t.Setenv(projectEnvironmentEnv, "1")
+	if got := resolveInstallCodexHome(configDir); got != configDir {
+		t.Fatalf("resolveInstallCodexHome = %q, want %q", got, configDir)
+	}
+	os.Unsetenv(projectEnvironmentEnv)
+	if got := resolveInstallCodexHome(configDir); got != filepath.Join(root, "elsewhere") {
+		t.Fatalf("resolveInstallCodexHome without project env = %q, want elsewhere", got)
 	}
 }

--- a/internal/cli/cloud_environment_test.go
+++ b/internal/cli/cloud_environment_test.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCloudEnvironmentBootstrapArtifactsInstallCLI(t *testing.T) {
+	root, err := loafRepositoryRoot()
+	if err != nil {
+		t.Fatalf("loafRepositoryRoot() error = %v", err)
+	}
+	if err := validateCloudEnvironmentBootstrap(root); err != nil {
+		t.Fatalf("validateCloudEnvironmentBootstrap() error = %v", err)
+	}
+	for _, rel := range []string{cursorCloudInstallScript, ampOrbSetupScript} {
+		body, err := readCloudBootstrapFile(root, rel)
+		if err != nil {
+			t.Fatalf("readCloudBootstrapFile(%q) error = %v", rel, err)
+		}
+		executable := stripShellComments(body)
+		loafIdx := strings.Index(executable, "loaf ")
+		buildIdx := strings.Index(executable, "npm run build:go")
+		if buildIdx < 0 {
+			t.Fatalf("%s missing npm run build:go", rel)
+		}
+		if loafIdx >= 0 && buildIdx > loafIdx {
+			t.Fatalf("%s runs loaf before CLI install", rel)
+		}
+	}
+}
+
+func TestCloudEnvironmentBootstrapStartUsesProjectEnvironmentInstall(t *testing.T) {
+	root, err := loafRepositoryRoot()
+	if err != nil {
+		t.Fatalf("loafRepositoryRoot() error = %v", err)
+	}
+	for _, rel := range []string{cursorCloudStartScript, ampOrbSetupScript, ampOrbResumeScript} {
+		body, err := readCloudBootstrapFile(root, rel)
+		if err != nil {
+			t.Fatalf("readCloudBootstrapFile(%q) error = %v", rel, err)
+		}
+		if !strings.Contains(body, projectEnvironmentEnv+"=1") {
+			t.Fatalf("%s missing %s=1", rel, projectEnvironmentEnv)
+		}
+		if !strings.Contains(body, "loaf install --to ") {
+			t.Fatalf("%s missing project-environment loaf install", rel)
+		}
+	}
+}
+
+func TestInstallUsesProjectEnvironmentPathsNotUserHome(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	projectDir := filepath.Join(root, "project")
+	dist := filepath.Join(projectDir, "dist")
+	userCursor := filepath.Join(home, ".cursor")
+	projectCursor := filepath.Join(projectDir, ".cursor")
+	mkdirAll(t, userCursor)
+	mkdirAll(t, projectDir)
+	writeInstallFile(t, filepath.Join(projectDir, "AGENTS.md"), "# Project\n")
+	writeInstallFile(t, filepath.Join(projectDir, ".agents", "loaf.json"), `{"issue":{"prefix":"LOAF"}}`+"\n")
+	seedCanonicalSkillsFixture(t, projectDir, home, []string{"cursor"}, "# Foundations\n")
+	installTestHookDistribution(t, projectDir, "cursor")
+
+	t.Setenv("HOME", home)
+	t.Setenv("LOAF_DB", filepath.Join(t.TempDir(), "loaf.sqlite"))
+	t.Setenv(projectEnvironmentEnv, "1")
+
+	options := targetInstallOptions{
+		Target:      "cursor",
+		DistDir:     filepath.Join(dist, "cursor"),
+		ConfigDir:   installLayoutConfigDirs(projectDir)["cursor"],
+		Version:     "9.8.7-test.1",
+		HomeDir:     installLayoutHome(projectDir),
+		ProjectRoot: projectDir,
+		HookState:   installTestHookState(t),
+	}
+	if err := installTargetDistribution(options); err != nil {
+		t.Fatalf("installTargetDistribution() error = %v", err)
+	}
+
+	if fileExistsForInstall(filepath.Join(userCursor, loafInstallMarkerFile)) {
+		t.Fatalf("wrote harness surfaces to user-level %s", userCursor)
+	}
+	if !fileExistsForInstall(filepath.Join(projectCursor, loafInstallMarkerFile)) {
+		t.Fatalf("missing project-environment install marker at %s", projectCursor)
+	}
+	if !fileExistsForInstall(filepath.Join(projectCursor, "hooks.json")) {
+		t.Fatalf("missing project-environment hooks at %s", projectCursor)
+	}
+	skillsDest := filepath.Join(projectDir, ".agents", "skills", "foundations", "SKILL.md")
+	if !fileExistsForInstall(skillsDest) {
+		t.Fatalf("skills not installed to project environment: %s", skillsDest)
+	}
+	userSkills := filepath.Join(home, ".agents", "skills", "foundations", "SKILL.md")
+	if fileExistsForInstall(userSkills) {
+		t.Fatalf("skills incorrectly installed to user home %s", userSkills)
+	}
+}
+
+func TestResolveInstallLayoutFallsBackToUserHome(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	t.Setenv("HOME", home)
+	os.Unsetenv(projectEnvironmentEnv)
+
+	dirs, recordHome := resolveInstallLayout(root)
+	if recordHome != home {
+		t.Fatalf("recordHome = %q, want %q", recordHome, home)
+	}
+	if dirs["cursor"] != filepath.Join(home, ".cursor") {
+		t.Fatalf("cursor config = %q, want %q", dirs["cursor"], filepath.Join(home, ".cursor"))
+	}
+}
+
+func TestResolveInstallLayoutUsesProjectRootWhenActive(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	projectDir := filepath.Join(root, "project")
+	t.Setenv("HOME", home)
+	t.Setenv(projectEnvironmentEnv, "1")
+
+	dirs, recordHome := resolveInstallLayout(projectDir)
+	if recordHome != projectDir {
+		t.Fatalf("recordHome = %q, want %q", recordHome, projectDir)
+	}
+	if dirs["cursor"] != filepath.Join(projectDir, ".cursor") {
+		t.Fatalf("cursor config = %q, want %q", dirs["cursor"], filepath.Join(projectDir, ".cursor"))
+	}
+	if dirs["amp"] != filepath.Join(projectDir, ".amp") {
+		t.Fatalf("amp config = %q, want %q", dirs["amp"], filepath.Join(projectDir, ".amp"))
+	}
+}
+
+func TestIsLoafInstalledForTargetInstallUsesLayoutHome(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	projectDir := filepath.Join(root, "project")
+	recordDir := filepath.Join(projectDir, ".agents", "loaf", "install-targets")
+	mkdirAll(t, recordDir)
+	writeInstallFile(t, filepath.Join(recordDir, "cursor.json"), "{}"+"\n")
+
+	t.Setenv("HOME", home)
+	t.Setenv(projectEnvironmentEnv, "1")
+
+	if isLoafInstalledForTargetInstall("cursor", filepath.Join(home, ".cursor"), installLayoutHome(projectDir)) {
+		// record lives under project root, not user home
+	} else {
+		t.Fatal("expected install record under project layout home to count as installed")
+	}
+	if isLoafInstalledForTargetInstall("cursor", filepath.Join(home, ".cursor"), home) {
+		t.Fatal("user home must not satisfy project-environment install record")
+	}
+}
+
+func TestCloudEnvironmentBootstrapDocumentsClientTokenSecret(t *testing.T) {
+	if projectEnvironmentClientTokenEnv != "LOAF_CLIENT_TOKEN" {
+		t.Fatalf("client token env = %q", projectEnvironmentClientTokenEnv)
+	}
+}

--- a/internal/cli/cloud_environment_test.go
+++ b/internal/cli/cloud_environment_test.go
@@ -237,3 +237,33 @@ func TestCloudEnvironmentResolveInstallCodexHomeIgnoresEnv(t *testing.T) {
 		t.Fatalf("resolveInstallCodexHome without project env = %q, want elsewhere", got)
 	}
 }
+
+func TestCloudEnvironmentConfigTargetInstallOptionsUsesLayoutHome(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	projectDir := filepath.Join(root, "project")
+	mkdirAll(t, home)
+	mkdirAll(t, projectDir)
+	t.Setenv("HOME", home)
+	t.Setenv(projectEnvironmentEnv, "1")
+
+	opts := configTargetInstallOptions(projectDir, projectDir, detectedInstallTool{
+		key:       "cursor",
+		configDir: filepath.Join(projectDir, ".cursor"),
+	}, installTestHookState(t), false)
+	if opts.HomeDir != projectDir {
+		t.Fatalf("HomeDir = %q, want project layout home %q", opts.HomeDir, projectDir)
+	}
+	if opts.HomeDir == home {
+		t.Fatal("HomeDir must not be user installHome under LOAF_PROJECT_ENV=1")
+	}
+
+	os.Unsetenv(projectEnvironmentEnv)
+	opts = configTargetInstallOptions(projectDir, projectDir, detectedInstallTool{
+		key:       "cursor",
+		configDir: filepath.Join(home, ".cursor"),
+	}, installTestHookState(t), false)
+	if opts.HomeDir != home {
+		t.Fatalf("HomeDir without project env = %q, want %q", opts.HomeDir, home)
+	}
+}

--- a/internal/cli/cloud_environment_test.go
+++ b/internal/cli/cloud_environment_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -265,5 +266,67 @@ func TestCloudEnvironmentConfigTargetInstallOptionsUsesLayoutHome(t *testing.T) 
 	}, installTestHookState(t), false)
 	if opts.HomeDir != home {
 		t.Fatalf("HomeDir without project env = %q, want %q", opts.HomeDir, home)
+	}
+}
+
+func TestCloudEnvironmentConfigReadsInstallRecordFromLayoutHome(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	projectDir := filepath.Join(root, "project")
+	projectCursor := filepath.Join(projectDir, ".cursor")
+	mkdirAll(t, home)
+	mkdirAll(t, projectCursor)
+	t.Setenv("HOME", home)
+	t.Setenv(projectEnvironmentEnv, "1")
+
+	recordDir := filepath.Join(projectDir, ".agents", "loaf", "install-targets")
+	mkdirAll(t, recordDir)
+	body, err := json.MarshalIndent(installTargetRecord{
+		Version:   "9.8.7-test.1",
+		Target:    "cursor",
+		ConfigDir: projectCursor,
+		SkillsDir: filepath.Join(projectDir, ".agents", "skills"),
+	}, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent error = %v", err)
+	}
+	writeInstallFile(t, filepath.Join(recordDir, "cursor.json"), string(append(body, '\n')))
+
+	userRecordDir := filepath.Join(home, ".agents", "loaf", "install-targets")
+	mkdirAll(t, userRecordDir)
+	userBody, err := json.MarshalIndent(installTargetRecord{
+		Version:   "0.0.0-user",
+		Target:    "cursor",
+		ConfigDir: filepath.Join(home, ".cursor"),
+	}, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent(user) error = %v", err)
+	}
+	writeInstallFile(t, filepath.Join(userRecordDir, "cursor.json"), string(append(userBody, '\n')))
+
+	record, ok := readConfigInstallRecord(projectDir, "cursor")
+	if !ok {
+		t.Fatal("readConfigInstallRecord missed project-layout install record")
+	}
+	if record.Version != "9.8.7-test.1" {
+		t.Fatalf("Version = %q, want project-env record 9.8.7-test.1", record.Version)
+	}
+	if record.ConfigDir != projectCursor {
+		t.Fatalf("ConfigDir = %q, want %q", record.ConfigDir, projectCursor)
+	}
+
+	installed := installedConfigTargets(projectDir)
+	var found bool
+	for _, tool := range installed {
+		if tool.key != "cursor" {
+			continue
+		}
+		found = true
+		if tool.configDir != projectCursor {
+			t.Fatalf("installed cursor configDir = %q, want %q", tool.configDir, projectCursor)
+		}
+	}
+	if !found {
+		t.Fatal("installedConfigTargets missed project-env cursor")
 	}
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -192,7 +192,7 @@ func runConfigCheck(projectRoot string, loafRoot string, options configCheckOpti
 		result.Fixed = true
 	}
 
-	for _, target := range installedConfigTargets() {
+	for _, target := range installedConfigTargets(projectRoot) {
 		status := checkConfigTargetHooks(projectRoot, loafRoot, target, options.hookState)
 		if !status.healthy() && options.fix {
 			status = fixConfigTargetHooks(projectRoot, loafRoot, target, status, options.hookState)
@@ -464,10 +464,10 @@ func jsonNumber(value any) bool {
 	}
 }
 
-func installedConfigTargets() []detectedInstallTool {
-	tools := detectInstallTools()
+func installedConfigTargets(projectRoot string) []detectedInstallTool {
+	tools := detectInstallToolsForProject(projectRoot)
 	for i := range tools {
-		if record, ok := readConfigInstallRecord(tools[i].key); ok {
+		if record, ok := readConfigInstallRecord(projectRoot, tools[i].key); ok {
 			if record.ConfigDir != "" {
 				tools[i].configDir = record.ConfigDir
 			}
@@ -484,8 +484,8 @@ func installedConfigTargets() []detectedInstallTool {
 	return installed
 }
 
-func readConfigInstallRecord(target string) (installTargetRecord, bool) {
-	body, err := readRegularFile(installRecordPath(installHome(), target), projectFileReadLimit)
+func readConfigInstallRecord(projectRoot string, target string) (installTargetRecord, bool) {
+	body, err := readRegularFile(installRecordPath(installLayoutHome(projectRoot), target), projectFileReadLimit)
 	if err != nil {
 		return installTargetRecord{}, false
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -595,7 +595,7 @@ func configTargetInstallOptions(projectRoot string, loafRoot string, target dete
 		ConfigDir:   target.configDir,
 		Upgrade:     upgrade,
 		Version:     packageVersion(loafRoot),
-		HomeDir:     installHome(),
+		HomeDir:     installLayoutHome(projectRoot),
 		CodexHome:   resolveInstallCodexHome(target.configDir),
 		ProjectRoot: projectRoot,
 		HookState:   hookState,

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -596,7 +596,7 @@ func configTargetInstallOptions(projectRoot string, loafRoot string, target dete
 		Upgrade:     upgrade,
 		Version:     packageVersion(loafRoot),
 		HomeDir:     installHome(),
-		CodexHome:   os.Getenv("CODEX_HOME"),
+		CodexHome:   resolveInstallCodexHome(target.configDir),
 		ProjectRoot: projectRoot,
 		HookState:   hookState,
 	}

--- a/internal/cli/harness_drift.go
+++ b/internal/cli/harness_drift.go
@@ -45,7 +45,7 @@ type harnessDriftReading struct {
 // `.loaf-version` marker lives in, through the same table install writes the
 // marker with.
 func harnessDriftConfigDir(harness string) string {
-	return defaultInstallConfigDirs()[harness]
+	return installLayoutConfigDirs("")[harness]
 }
 
 func readHarnessVersionMarker(configDir string) string {

--- a/internal/cli/hook_reconcile.go
+++ b/internal/cli/hook_reconcile.go
@@ -204,10 +204,7 @@ func hookArtifactRoot(options targetInstallOptions) string {
 	if options.Target != "codex" {
 		return options.ConfigDir
 	}
-	if options.CodexHome != "" {
-		return options.CodexHome
-	}
-	return filepath.Join(installHomeDir(options), ".codex")
+	return effectiveCodexHome(options)
 }
 
 // targetReconcilesHookEntries reports whether this target's hooks file is

--- a/internal/cli/hooks.go
+++ b/internal/cli/hooks.go
@@ -292,7 +292,7 @@ func (r Runner) hooksTargetSurfaces(projectRoot string, hookState hookStateResol
 }
 
 func newHooksTargetSurface(loafRoot string, tools []detectedInstallTool, projectRoot string, hookState hookStateResolver, target string) hooksTargetSurface {
-	configDir := defaultInstallConfigDirs()[target]
+	configDir := installLayoutConfigDirs(projectRoot)[target]
 	if tool, ok := installToolsByKey(tools)[target]; ok && tool.configDir != "" {
 		configDir = tool.configDir
 	}
@@ -301,7 +301,7 @@ func newHooksTargetSurface(loafRoot string, tools []detectedInstallTool, project
 		DistDir:     filepath.Join(loafRoot, "dist", target),
 		ConfigDir:   configDir,
 		Version:     packageVersion(loafRoot),
-		HomeDir:     installHome(),
+		HomeDir:     installLayoutHome(projectRoot),
 		CodexHome:   os.Getenv("CODEX_HOME"),
 		ProjectRoot: projectRoot,
 		HookState:   hookState,

--- a/internal/cli/hooks.go
+++ b/internal/cli/hooks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -302,7 +301,7 @@ func newHooksTargetSurface(loafRoot string, tools []detectedInstallTool, project
 		ConfigDir:   configDir,
 		Version:     packageVersion(loafRoot),
 		HomeDir:     installLayoutHome(projectRoot),
-		CodexHome:   os.Getenv("CODEX_HOME"),
+		CodexHome:   resolveInstallCodexHome(configDir),
 		ProjectRoot: projectRoot,
 		HookState:   hookState,
 	}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -156,7 +156,7 @@ func (r Runner) runInstallWithOptions(options installOptions, out io.Writer, run
 			CodexBasicCommands: options.codexBasicCommands,
 			Version:            version,
 			HomeDir:            layoutHome,
-			CodexHome:          os.Getenv("CODEX_HOME"),
+			CodexHome:          resolveInstallCodexHome(configDir),
 			ProjectRoot:        projectRoot.Path(),
 			SkipSkillsSync:     true,
 			HookState:          hookState,

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -131,7 +131,7 @@ func (r Runner) runInstallWithOptions(options installOptions, out io.Writer, run
 
 	var installedTargets []string
 	var codexBasicCommandsErr error
-	defaults := defaultInstallConfigDirs()
+	defaults, layoutHome := resolveInstallLayout(projectRoot.Path())
 	toolByKey := installToolsByKey(tools)
 	hookState, releaseHookState := r.hookStateForApply(projectRoot.Path())
 	defer releaseHookState()
@@ -155,7 +155,7 @@ func (r Runner) runInstallWithOptions(options installOptions, out io.Writer, run
 			ConfigDir:          configDir,
 			CodexBasicCommands: options.codexBasicCommands,
 			Version:            version,
-			HomeDir:            installHome(),
+			HomeDir:            layoutHome,
 			CodexHome:          os.Getenv("CODEX_HOME"),
 			ProjectRoot:        projectRoot.Path(),
 			SkipSkillsSync:     true,
@@ -373,7 +373,7 @@ func (r Runner) selectedInstallTargets(options installOptions, tools []detectedI
 			return nil, fmt.Errorf("unknown install target %q (valid targets: %s, all)", options.target, strings.Join(installValidTargets, ", "))
 		}
 		if !containsInstallTool(tools, options.target) {
-			fmt.Fprintf(out, "  %s %s was not auto-detected; installing to %s\n", ansiYellow("⚡"), options.target, defaultInstallConfigDirs()[options.target])
+			fmt.Fprintf(out, "  %s %s was not auto-detected; installing to %s\n", ansiYellow("⚡"), options.target, installLayoutConfigDirs("")[options.target])
 		}
 		return []string{options.target}, nil
 	case options.upgrade:
@@ -650,39 +650,43 @@ func writeInstallFencedResults(out io.Writer, results map[string]fencedInstallRe
 }
 
 func detectInstallTools() []detectedInstallTool {
-	home := installHome()
-	defaults := defaultInstallConfigDirs()
+	return detectInstallToolsForProject("")
+}
+
+func detectInstallToolsForProject(projectRoot string) []detectedInstallTool {
+	home := installLayoutHome(projectRoot)
+	defaults := installLayoutConfigDirs(projectRoot)
 	var tools []detectedInstallTool
 	if dirExistsForInstall(defaults["opencode"]) || installRecordExists(home, "opencode") {
-		tools = append(tools, newDetectedInstallTool("opencode", defaults["opencode"], "config"))
+		tools = append(tools, newDetectedInstallTool("opencode", defaults["opencode"], "config", home))
 	}
 	cursorConfig := defaults["cursor"]
 	switch {
 	case installCommandExists("cursor"):
-		tools = append(tools, newDetectedInstallTool("cursor", cursorConfig, "cli"))
+		tools = append(tools, newDetectedInstallTool("cursor", cursorConfig, "cli", home))
 	case runtime.GOOS == "darwin" && (dirExistsForInstall("/Applications/Cursor.app") || dirExistsForInstall(filepath.Join(home, "Applications", "Cursor.app"))):
-		tools = append(tools, newDetectedInstallTool("cursor", cursorConfig, "app"))
+		tools = append(tools, newDetectedInstallTool("cursor", cursorConfig, "app", home))
 	case dirExistsForInstall(cursorConfig) || installRecordExists(home, "cursor"):
-		tools = append(tools, newDetectedInstallTool("cursor", cursorConfig, "config"))
+		tools = append(tools, newDetectedInstallTool("cursor", cursorConfig, "config", home))
 	}
 	codexConfig := defaults["codex"]
 	if installCommandExists("codex") || dirExistsForInstall(codexConfig) || dirExistsForInstall(filepath.Join(home, ".codex")) || installRecordExists(home, "codex") {
-		tools = append(tools, newDetectedInstallTool("codex", codexConfig, "config"))
+		tools = append(tools, newDetectedInstallTool("codex", codexConfig, "config", home))
 	}
 	ampConfig := defaults["amp"]
 	legacyAmpConfig := filepath.Join(home, ".amp")
 	if installCommandExists("amp") || dirExistsForInstall(ampConfig) || dirExistsForInstall(legacyAmpConfig) || installRecordExists(home, "amp") {
-		tools = append(tools, newDetectedInstallTool("amp", ampConfig, "config"))
+		tools = append(tools, newDetectedInstallTool("amp", ampConfig, "config", home))
 	}
 	return tools
 }
 
-func newDetectedInstallTool(key string, configDir string, detectedBy string) detectedInstallTool {
+func newDetectedInstallTool(key string, configDir string, detectedBy string, recordHome string) detectedInstallTool {
 	return detectedInstallTool{
 		key:        key,
 		name:       installDisplayName(key),
 		configDir:  configDir,
-		installed:  isLoafInstalledForTargetInstall(key, configDir),
+		installed:  isLoafInstalledForTargetInstall(key, configDir, recordHome),
 		detectedBy: detectedBy,
 	}
 }
@@ -717,12 +721,15 @@ func isLoafInstalledForInstall(configDir string) bool {
 	return false
 }
 
-func isLoafInstalledForTargetInstall(target string, configDir string) bool {
-	if isLoafInstalledForInstall(configDir) || installRecordExists(installHome(), target) {
+func isLoafInstalledForTargetInstall(target string, configDir string, recordHome string) bool {
+	if recordHome == "" {
+		recordHome = installHome()
+	}
+	if isLoafInstalledForInstall(configDir) || installRecordExists(recordHome, target) {
 		return true
 	}
 	if target == "amp" {
-		return isLoafInstalledForInstall(filepath.Join(installHome(), ".amp"))
+		return isLoafInstalledForInstall(filepath.Join(recordHome, ".amp"))
 	}
 	return false
 }

--- a/internal/cli/install_command_test.go
+++ b/internal/cli/install_command_test.go
@@ -119,7 +119,7 @@ func TestRunnerInstallRecordKeepsRelocatedTargetDetectable(t *testing.T) {
 	if err := os.Remove(filepath.Join(home, ".cursor", loafInstallMarkerFile)); err != nil {
 		t.Fatalf("Remove(marker) error = %v", err)
 	}
-	if !isLoafInstalledForTargetInstall("cursor", filepath.Join(home, ".cursor")) {
+	if !isLoafInstalledForTargetInstall("cursor", filepath.Join(home, ".cursor"), home) {
 		t.Fatal("cursor install not detected from shared install record")
 	}
 }

--- a/internal/cli/install_plan.go
+++ b/internal/cli/install_plan.go
@@ -160,7 +160,7 @@ func (r Runner) buildInstallDryRunPlan(options installOptions, loafRoot string, 
 	plan.Deprecations = deprecations
 
 	toolByKey := installToolsByKey(tools)
-	defaults := defaultInstallConfigDirs()
+	defaults, layoutHome := resolveInstallLayout(projectRoot)
 	// A plan reads hook enablement and never creates it: a dry run that brought
 	// a state database into existence would be a write, and the plan promises
 	// none.
@@ -193,7 +193,7 @@ func (r Runner) buildInstallDryRunPlan(options installOptions, loafRoot string, 
 			Upgrade:            options.upgrade,
 			CodexBasicCommands: options.codexBasicCommands,
 			Version:            version,
-			HomeDir:            installHome(),
+			HomeDir:            layoutHome,
 			CodexHome:          os.Getenv("CODEX_HOME"),
 			ProjectRoot:        projectRoot,
 			HookState:          hookState,

--- a/internal/cli/install_plan.go
+++ b/internal/cli/install_plan.go
@@ -194,7 +194,7 @@ func (r Runner) buildInstallDryRunPlan(options installOptions, loafRoot string, 
 			CodexBasicCommands: options.codexBasicCommands,
 			Version:            version,
 			HomeDir:            layoutHome,
-			CodexHome:          os.Getenv("CODEX_HOME"),
+			CodexHome:          resolveInstallCodexHome(configDir),
 			ProjectRoot:        projectRoot,
 			HookState:          hookState,
 		}
@@ -601,10 +601,7 @@ func planTargetAdapterArtifacts(options targetInstallOptions) ([]artifactPlanDec
 // needed it uses the same read-only trusted-executable resolution and template
 // rendering the apply path uses.
 func planCodexJournalRule(options targetInstallOptions) ([]artifactPlanDecision, error) {
-	codexHome := options.CodexHome
-	if codexHome == "" {
-		codexHome = filepath.Join(installHomeDir(options), ".codex")
-	}
+	codexHome := effectiveCodexHome(options)
 	rulesDir := filepath.Join(codexHome, "rules")
 	ruleDest := filepath.Join(rulesDir, codexJournalRuleRelativePath)
 	manifestPath := filepath.Join(rulesDir, codexJournalRuleManifest)

--- a/internal/cli/install_target.go
+++ b/internal/cli/install_target.go
@@ -399,11 +399,7 @@ func installCodexTarget(options targetInstallOptions) error {
 	if err != nil {
 		return err
 	}
-	homeDir := installHomeDir(options)
-	codexHome := options.CodexHome
-	if codexHome == "" {
-		codexHome = filepath.Join(homeDir, ".codex")
-	}
+	codexHome := effectiveCodexHome(options)
 	skillsDest := installSkillsDestination(options)
 	if !options.SkipSkillsSync {
 		if err := syncManagedSkillsDirIfExists(filepath.Join(options.DistDir, "skills"), skillsDest); err != nil {

--- a/internal/cli/install_target.go
+++ b/internal/cli/install_target.go
@@ -478,6 +478,9 @@ func installSkillsDestination(options targetInstallOptions) string {
 	if options.Target == "amp" && options.AmpSkillsDir != "" {
 		return options.AmpSkillsDir
 	}
+	if projectEnvironmentActive() && options.ProjectRoot != "" {
+		return filepath.Join(options.ProjectRoot, ".agents", "skills")
+	}
 	return filepath.Join(installHomeDir(options), ".agents", "skills")
 }
 

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -252,7 +251,7 @@ func (r Runner) upgradeInstalledTargets(out io.Writer, options upgradeOptions, t
 			Upgrade:        true,
 			Version:        version,
 			HomeDir:        layoutHome,
-			CodexHome:      os.Getenv("CODEX_HOME"),
+			CodexHome:      resolveInstallCodexHome(configDir),
 			ProjectRoot:    projectRoot,
 			SkipSkillsSync: true,
 			HookState:      hookState,

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -229,7 +229,7 @@ func (r Runner) upgradeInstalledTargets(out io.Writer, options upgradeOptions, t
 	}
 
 	var failed []string
-	defaults := defaultInstallConfigDirs()
+	defaults, layoutHome := resolveInstallLayout(projectRoot)
 	toolByKey := installToolsByKey(tools)
 	hookState, releaseHookState := r.hookStateForApply(projectRoot)
 	defer releaseHookState()
@@ -251,7 +251,7 @@ func (r Runner) upgradeInstalledTargets(out io.Writer, options upgradeOptions, t
 			ConfigDir:      configDir,
 			Upgrade:        true,
 			Version:        version,
-			HomeDir:        installHome(),
+			HomeDir:        layoutHome,
 			CodexHome:      os.Getenv("CODEX_HOME"),
 			ProjectRoot:    projectRoot,
 			SkipSkillsSync: true,


### PR DESCRIPTION
# Cloud environment bootstrap: install and harness surfaces on ephemeral hosts

The attach ceremony (LOAF-67) presumes the Loaf CLI exists on the machine — but cloud agents and microVMs start from a fresh clone with no Loaf installed. Something must install the CLI before first run, and the harness surfaces (skills, commands, hooks) need a distribution path on hosts where user-level config does not exist and only the project environment is honored (sessionStart unsupported on Cursor Cloud; user-level hooks.json ignored).

Primary path, locked (premise update 2026-08-25): both Cursor Agents and Amp Orbs expose per-project environments with install/start scripts and per-project secrets. The install script installs the Loaf CLI. The environment secrets carry the project-scoped client credential minted by `loaf auth link --project`. The start script may pre-warm attach. After install, skills/commands/hooks resolve from that environment's install — not from ~/.cursor, ~/.claude, or any user-level hooks.json.

Harness surfaces ride the install (bundled by `loaf install` in the start script), not the substrate and not a committed plugin tree. Repo-committed surfaces stay the existing project files (AGENTS.md, loaf.conf). Substrate-synced skills wait for a later layer.

Out of scope: the attach ceremony itself (LOAF-67); the sync server (LOAF-75); changing what surfaces exist per harness (build system owns that); install-on-demand as a first-run fallback inside a random shell; pre-baked images for Loaf-controlled microVMs (named future); syncing skills through the substrate. Rabbit holes: a Loaf-owned cloud image catalog. No-gos: requiring the operator to pre-install Loaf on a machine they do not have a login on.

## Definition of Done

- [ ] Cursor Agent and Amp Orb install/start scripts install the Loaf CLI before the first loaf command
- [ ] After the start script, skills/commands/hooks resolve from the project-environment install, not user-level config
- [ ] Walkthrough: project env secrets carry the LOAF-67 client credential; start may pre-warm attach
