### PR TITLE
feat(LOAF-71+66): grow-only fact envelope (0020) and E2E crypto substrate

### DIFF
--- a/docs/decisions/ADR-029-fact-envelope-sync-contract.md
+++ b/docs/decisions/ADR-029-fact-envelope-sync-contract.md
@@ -1,0 +1,64 @@
+# ADR-029: Fact envelope as the grow-only sync contract
+
+Decision Date: 2026-08-26
+Status: Accepted
+
+## Context
+
+The minimal core mixed append-only journal rows with mutable tables and side
+event logs. Sync, convergence, and trustworthy history require one write
+discipline: every durable change is an appended fact; current truth is a
+projection replayed from facts; nothing is edited in place on the synced core.
+
+LOAF-71 proves the model on the journal — the organ that already behaved
+append-only — before the wider mutable-core migration (LOAF-72).
+
+## Decision
+
+1. **The fact envelope is the fleet-wide sync contract (v1).** Fields:
+   `{ id, project_id, kind, payload, env_id, seq, hlc, envelope_v }`.
+   There is no supersession field in v1; the synced set is grow-only and
+   projections fold latest-event-wins. Physical wall time, when retained for
+   display or source provenance, lives inside the payload and never
+   participates in fold order.
+2. **One write chokepoint.** All minimal-core writers append through
+   `AppendFact`; no other path inserts into `facts`.
+3. **Closed fact kinds.** Kinds are code-registered. Unknown kinds are an
+   attach-time availability event (hard refusal naming the upgrade). Journal
+   free-text `entry_type` values live inside the journal fact payload.
+4. **Hybrid logical clock ordering.** The envelope clock is wall-seeded and
+   advanced past the highest clock seen on every receive. Total order is
+   `(hlc, env_id, id)`. HLC is stored as zero-padded
+   `wall_ms:logical`.
+5. **Mint-once opaque ids.** New facts receive UUIDv7-style ids at append time;
+   ids are never derived from content. Wrapped journal history preserves
+   existing journal entry ids as fact ids.
+6. **Pre-auth env identity.** Until attach lands (LOAF-67), new facts carry
+   the local host identity as `env_id`; wrapped corpus backfills
+   `legacy-host`.
+7. **Journal on facts.** `loaf journal log` appends journal-kind facts;
+   recent/context/search read the `journal_entries` projection rebuilt from
+   facts. FTS (`journal_search`) is a local derived index, never synced.
+8. **Parity is a hard invariant.** `loaf state doctor` compares the journal
+   projection to the fold of journal facts over the full corpus, including
+   wrapped history, and invalidates SQLite-ready mode on divergence.
+   `loaf state repair journal-facts` rebuilds the projection from facts
+   after a verified backup.
+
+## Permanence classes (kind metadata)
+
+| Kind | Class | Notes |
+|------|-------|-------|
+| `journal` | notebook | Durable retrieval; display timestamps in payload |
+
+## Consequences
+
+- Journal writes route through `AppendFact`; reads stay on the projection
+  tables until broader entity migration (LOAF-72).
+- Cleartext payloads remain local-first; sealing and E2E are LOAF-66 scope.
+- Transport and attach ceremony remain out of scope (LOAF-75/76, LOAF-67).
+
+## Evidence
+
+- LOAF-71 implementation and `go test ./internal/state/...`
+- Parent shaping: LOAF-63 grow-only fact model

--- a/docs/schema/0020_facts_and_journal_envelope.sql
+++ b/docs/schema/0020_facts_and_journal_envelope.sql
@@ -1,0 +1,75 @@
+-- Grow-only fact substrate: envelope v1 and journal corpus wrap.
+-- journal_entries remains the local projection; facts are the synced source of truth.
+-- Wrapped rows preserve journal ids and carry display timestamps in payload only.
+
+CREATE TABLE IF NOT EXISTS facts (
+  id TEXT PRIMARY KEY NOT NULL,
+  project_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (length(trim(kind)) > 0),
+  payload TEXT NOT NULL CHECK (length(trim(payload)) > 0),
+  env_id TEXT NOT NULL CHECK (length(trim(env_id)) > 0),
+  seq INTEGER NOT NULL CHECK (seq >= 1),
+  hlc TEXT NOT NULL CHECK (length(trim(hlc)) > 0),
+  envelope_v INTEGER NOT NULL DEFAULT 1 CHECK (envelope_v = 1),
+  FOREIGN KEY (project_id) REFERENCES projects(id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_facts_project_env_seq
+  ON facts (project_id, env_id, seq);
+CREATE INDEX IF NOT EXISTS idx_facts_project_order
+  ON facts (project_id, hlc, env_id, id);
+CREATE INDEX IF NOT EXISTS idx_facts_project_kind
+  ON facts (project_id, kind);
+
+CREATE TABLE IF NOT EXISTS fact_env_clocks (
+  project_id TEXT NOT NULL,
+  env_id TEXT NOT NULL,
+  hlc_wall_ms INTEGER NOT NULL,
+  hlc_logical INTEGER NOT NULL DEFAULT 0 CHECK (hlc_logical >= 0),
+  next_seq INTEGER NOT NULL DEFAULT 1 CHECK (next_seq >= 1),
+  PRIMARY KEY (project_id, env_id),
+  FOREIGN KEY (project_id) REFERENCES projects(id)
+);
+
+-- Wrap the existing journal corpus in place. env_id backfills as the legacy host
+-- identity (single-host substrate today). HLC wall component is seeded from
+-- created_at; logical is zero. Physical wall time stays in payload for display.
+INSERT INTO facts (id, project_id, kind, payload, env_id, seq, hlc, envelope_v)
+SELECT
+  j.id,
+  j.project_id,
+  'journal',
+  json_object(
+    'entry_type', j.entry_type,
+    'scope', COALESCE(j.scope, ''),
+    'message', j.message,
+    'observed_branch', COALESCE(j.observed_branch, ''),
+    'observed_worktree', COALESCE(j.observed_worktree, ''),
+    'harness_session_id', COALESCE(j.harness_session_id, ''),
+    'created_at', j.created_at,
+    'updated_at', j.updated_at
+  ),
+  'legacy-host',
+  ROW_NUMBER() OVER (
+    PARTITION BY j.project_id
+    ORDER BY j.created_at ASC, j.rowid ASC
+  ),
+  printf(
+    '%020d:%06d',
+    COALESCE(
+      CAST(unixepoch(substr(j.created_at, 1, 19)) AS INTEGER) * 1000,
+      j.rowid
+    ),
+    0
+  ),
+  1
+FROM journal_entries AS j;
+
+INSERT INTO fact_env_clocks (project_id, env_id, hlc_wall_ms, hlc_logical, next_seq)
+SELECT
+  project_id,
+  env_id,
+  CAST(substr(hlc, 1, 20) AS INTEGER),
+  CAST(substr(hlc, 22, 6) AS INTEGER),
+  MAX(seq) + 1
+FROM facts
+GROUP BY project_id, env_id;

--- a/docs/schema/operational-state.dbml
+++ b/docs/schema/operational-state.dbml
@@ -733,3 +733,32 @@ Table hook_trusted_paths {
     (target)
   }
 }
+
+// Grow-only synced facts (migration 0020). Row timestamps are intentionally
+// absent: ordering lives in the envelope HLC, display time in payload.
+Table facts {
+  id text [pk, not null]
+  project_id text [not null, ref: > projects.id]
+  kind text [not null]
+  payload text [not null]
+  env_id text [not null]
+  seq integer [not null]
+  hlc text [not null]
+  envelope_v integer [not null, default: 1]
+  indexes {
+    (project_id, env_id, seq) [unique]
+    (project_id, hlc, env_id, id)
+    (project_id, kind)
+  }
+}
+
+Table fact_env_clocks {
+  project_id text [not null, ref: > projects.id]
+  env_id text [not null]
+  hlc_wall_ms integer [not null]
+  hlc_logical integer [not null, default: 0]
+  next_seq integer [not null, default: 1]
+  indexes {
+    (project_id, env_id) [pk]
+  }
+}

--- a/docs/schema/operational-state.mmd
+++ b/docs/schema/operational-state.mmd
@@ -609,3 +609,22 @@ erDiagram
   logical_conversations ||--o{ exploration_conversations : joins
   conversation_handles ||--o{ conversation_log_refs : locates
   conversation_handles ||--o{ journal_conversation_handles : correlates
+
+  facts {
+    text id PK
+    text project_id FK
+    text kind
+    text payload
+    text env_id
+    integer seq
+    text hlc
+    integer envelope_v
+  }
+
+  fact_env_clocks {
+    text project_id FK
+    text env_id PK
+    integer hlc_wall_ms
+    integer hlc_logical
+    integer next_seq
+  }

--- a/docs/security/substrate-e2e-threat-model.md
+++ b/docs/security/substrate-e2e-threat-model.md
@@ -1,0 +1,67 @@
+# Substrate E2E Threat Model (LOAF-66)
+
+Decision Date: 2026-08-26
+Status: Accepted
+
+## Scope of this document
+
+LOAF-66 ships the **local crypto contract**: HKDF project-key derivation with a
+generation read ring, AEAD wire envelopes, Emergency Kit recovery, and typed
+admin vs project-client credentials. It does **not** implement the sync relay,
+attach ceremony, or authorization enforcement.
+
+## Server-visible metadata (v1 design target)
+
+When a sync relay exists (LOAF-65), it is designed to see opaque ciphertext
+blobs plus transport metadata only:
+
+- Blob count and byte sizes per project channel
+- Arrival ordering and timing
+- Wire envelope cleartext: protocol version and fact id (UUIDv7 ordering leak acknowledged)
+- Auth token scope (project channel binding)
+
+The relay must store **no** cryptographic key material, no decrypted payloads,
+and no semantic fact fields (kind, env_id, seq, hlc, payload).
+
+## Server cannot see
+
+- Master keys, project keys, recovery kit contents, or account admin secrets
+- Fact kind, payload, env_id, monotonic seq, HLC, or envelope version (all AEAD-protected)
+- Journal text, entity bodies, or any substrate semantics
+
+## Write / delete capability (H1)
+
+Locked product rule: project client credentials are **write-capable**; delete
+is **operator/admin-only** (account admin secret).
+
+Enforcement of those capabilities lives outside this crypto slice:
+
+- **Write gating / sync upload** — LOAF-65 relay + client engine (token scope)
+- **Attach / provisioning of credentials** — LOAF-67
+- **Delete (tombstone + server-side blob deletion by fact id)** — LOAF-65/67 operator path
+
+LOAF-66 only encodes the credential types and cryptographic material so those
+later layers can enforce the rule without inventing a second key model.
+
+## Audit path
+
+1. **Crypto contract (today, LOAF-66)** — open-source `internal/crypto/` plus
+   published vectors in `internal/crypto/testdata/published_vectors.json`,
+   verified by `go test ./internal/crypto/...`. Auditors can check AEAD/HKDF
+   behavior and that client credentials are a distinct type from admin
+   credentials (no master key / account admin secret fields on the client wire).
+2. **Relay inspection (when LOAF-65 lands)** — audit that relay persistence
+   contains blobs + auth tokens only (empty cryptographic material set).
+3. **Gap detection (LOAF-65 client engine)** — per-environment monotonic seq
+   inside ciphertext enables clients to detect interior tamper/drop.
+
+## Honest limits (v1)
+
+- Withheld suffix vs idleness is indistinguishable without cross-environment corroboration (future work).
+- Padding/traffic-analysis defenses are out of scope for v1.
+- Delete semantics (tombstone + opaque blob delete by fact id) are specified here for threat-model clarity; runtime enforcement is LOAF-65/67.
+
+## Attach ceremony
+
+Connection provisioning, endpoint distribution, and fail-loud attach gates
+(capability / identity / token-scope / gross HLC skew) are LOAF-67 scope.

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,13 @@ go 1.25.0
 
 toolchain go1.26.6
 
-require github.com/ncruces/go-sqlite3 v0.34.3
+require (
+	github.com/ncruces/go-sqlite3 v0.34.3
+	golang.org/x/crypto v0.55.0
+)
 
 require (
 	github.com/ncruces/go-sqlite3-wasm/v2 v2.5.35301 // indirect
 	github.com/ncruces/julianday v1.0.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,9 @@ github.com/ncruces/go-sqlite3-wasm/v2 v2.5.35301 h1:txZKZ0qUSPe63pzv6x0afpE4xUaq
 github.com/ncruces/go-sqlite3-wasm/v2 v2.5.35301/go.mod h1:PtJrZyZ+fUnI9yIcFxnUBFt2avGojqWeUkSrk10hh0I=
 github.com/ncruces/julianday v1.0.0 h1:fH0OKwa7NWvniGQtxdJRxAgkBMolni2BjDHaWTxqt7M=
 github.com/ncruces/julianday v1.0.0/go.mod h1:Dusn2KvZrrovOMJuOt0TNXL6tB7U2E8kvza5fFc9G7g=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
-golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
+golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
+golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
+golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2483,6 +2483,7 @@ func (r Runner) runStateRepair(args []string, out io.Writer, runtime state.Runti
 		"legacy-project-database": writeStateRepairLegacyProjectDatabaseHelp,
 		"relationship-origin":     writeStateRepairRelationshipOriginHelp,
 		"journal-search":          writeStateRepairJournalSearchHelp,
+		"journal-facts":           writeStateRepairJournalFactsHelp,
 	}) {
 		return nil
 	}
@@ -2493,6 +2494,8 @@ func (r Runner) runStateRepair(args []string, out io.Writer, runtime state.Runti
 		return r.runStateRepairRelationshipOrigin(args[1:], out, runtime)
 	case "journal-search":
 		return r.runStateRepairJournalSearch(args[1:], out, runtime)
+	case "journal-facts":
+		return r.runStateRepairJournalFacts(args[1:], out, runtime)
 	default:
 		return fmt.Errorf("state repair target %q is not implemented yet", args[0])
 	}
@@ -2510,6 +2513,70 @@ func writeStateRepairJournalSearchHelp(out io.Writer) {
 	writeUsageHelp(out, "loaf state repair journal-search [--dry-run|--apply] [--json]", "Rebuild the derived journal search index from canonical journal entries.", "--dry-run    Preview canonical/index parity counts without writing", "--apply      Create a verified backup, rebuild the index, and verify exact parity", "--json       Output parity counts, backup verification, and repair result as JSON")
 }
 
+func writeStateRepairJournalFactsHelp(out io.Writer) {
+	writeUsageHelp(out, "loaf state repair journal-facts [--dry-run|--apply] [--json]", "Rebuild the journal projection and search index from journal facts.", "--dry-run    Preview fact/projection parity counts without writing", "--apply      Create a verified backup, rebuild the projection, and verify exact parity", "--json       Output parity counts, backup verification, and repair result as JSON")
+}
+
+func (r Runner) runStateRepairJournalFacts(args []string, out io.Writer, runtime state.Runtime) error {
+	jsonRequested := hasFlag(args, "--json")
+	options, err := parseJournalFactsRepairArgs(args)
+	if err != nil {
+		if jsonRequested {
+			return writeJSONCommandError(out, "state repair journal-facts", err)
+		}
+		return err
+	}
+	projectRoot, err := project.ResolveRoot(runtime.RootPath())
+	if err != nil {
+		if options.jsonOutput {
+			return writeJSONCommandError(out, "state repair journal-facts", err)
+		}
+		return err
+	}
+	result, err := state.RepairJournalFacts(context.Background(), projectRoot, state.PathResolver{StateHome: r.StateHome}, state.JournalFactsRepairOptions{Apply: options.apply})
+	if err != nil {
+		if options.jsonOutput {
+			return writeJSONCommandError(out, "state repair journal-facts", err)
+		}
+		return err
+	}
+	if options.jsonOutput {
+		return writeJSON(out, result)
+	}
+
+	fmode := "--dry-run"
+	if options.apply {
+		fmode = "--apply"
+	}
+	fmt.Fprintf(out, "loaf state repair journal-facts %s\n", fmode)
+	fmt.Fprintf(out, "scope: %s database\n", result.DatabaseScope)
+	fmt.Fprintf(out, "database: %s\n", result.DatabasePath)
+	if result.ProjectID != "" {
+		fmt.Fprintf(out, "project: %s\n", result.ProjectID)
+	}
+	if result.ProjectName != "" {
+		fmt.Fprintf(out, "project name: %s\n", result.ProjectName)
+	}
+	if result.ProjectCurrentPath != "" {
+		fmt.Fprintf(out, "project path: %s\n", result.ProjectCurrentPath)
+	}
+	fmt.Fprintf(out, "fact rows: %d\n", result.FactRows)
+	fmt.Fprintf(out, "projection rows: %d\n", result.ProjectionRows)
+	fmt.Fprintf(out, "missing: %d\n", result.Missing)
+	fmt.Fprintf(out, "extra: %d\n", result.Extra)
+	fmt.Fprintf(out, "changed: %d\n", result.Changed)
+	fmt.Fprintf(out, "applied: %t\n", result.Applied)
+	if result.BackupPath != "" {
+		fmt.Fprintf(out, "backup: %s\n", result.BackupPath)
+	}
+	fmt.Fprintf(out, "backup verified: %t\n", result.BackupVerified)
+	fmt.Fprintf(out, "rebuilt: %d\n", result.Rebuilt)
+	fmt.Fprintf(out, "parity verified: %t\n", result.ParityVerified)
+	if !options.apply && (result.Missing > 0 || result.Extra > 0 || result.Changed > 0 || result.FactRows != result.ProjectionRows) {
+		fmt.Fprintln(out, "next: loaf state repair journal-facts --apply")
+	}
+	return nil
+}
 func (r Runner) runStateRepairLegacyProjectDatabase(args []string, out io.Writer, runtime state.Runtime) error {
 	jsonRequested := hasFlag(args, "--json")
 	options, err := parseLegacyProjectDatabaseRepairArgs(args)
@@ -11604,6 +11671,32 @@ func parseJournalSearchRepairArgs(args []string) (journalSearchRepairOptions, er
 	}
 	if options.apply && options.dryRun {
 		return journalSearchRepairOptions{}, fmt.Errorf("state repair journal-search cannot combine --apply and --dry-run")
+	}
+	return options, nil
+}
+
+type journalFactsRepairOptions struct {
+	apply      bool
+	dryRun     bool
+	jsonOutput bool
+}
+
+func parseJournalFactsRepairArgs(args []string) (journalFactsRepairOptions, error) {
+	var options journalFactsRepairOptions
+	for _, arg := range args {
+		switch arg {
+		case "--dry-run":
+			options.dryRun = true
+		case "--json":
+			options.jsonOutput = true
+		case "--apply":
+			options.apply = true
+		default:
+			return journalFactsRepairOptions{}, fmt.Errorf("unknown option %q", arg)
+		}
+	}
+	if options.apply && options.dryRun {
+		return journalFactsRepairOptions{}, fmt.Errorf("state repair journal-facts cannot combine --apply and --dry-run")
 	}
 	return options, nil
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2714,6 +2714,7 @@ func TestRunnerStateHelpIsNative(t *testing.T) {
 		{name: "state repair legacy-project-database", args: []string{"state", "repair", "legacy-project-database", "--help"}, want: "Usage: loaf state repair legacy-project-database [--dry-run|--apply] [--json]"},
 		{name: "state repair relationship-origin", args: []string{"state", "repair", "relationship-origin", "--help"}, want: "Usage: loaf state repair relationship-origin [--origin <imported|manual>] [--dry-run|--apply] [--json]"},
 		{name: "state repair journal-search", args: []string{"state", "repair", "journal-search", "--help"}, want: "Usage: loaf state repair journal-search [--dry-run|--apply] [--json]"},
+		{name: "state repair journal-facts", args: []string{"state", "repair", "journal-facts", "--help"}, want: "Usage: loaf state repair journal-facts [--dry-run|--apply] [--json]"},
 		{name: "state migrate", args: []string{"state", "migrate", "--help"}, want: "Usage: loaf state migrate <source> [options]"},
 		{name: "project list", args: []string{"project", "list", "--help"}, want: "Usage: loaf project list [--json]"},
 		{name: "project identity", args: []string{"project", "identity", "--help"}, want: "Usage: loaf project show|identity [--json]"},

--- a/internal/crypto/credential.go
+++ b/internal/crypto/credential.go
@@ -1,0 +1,145 @@
+package crypto
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	bundledClientCredentialVersion = 1
+	accountAdminCredentialVersion  = 1
+)
+
+// BundledClientCredential is a paste-able project-scoped client secret.
+// It never carries the master key or account admin secret — only the
+// derived project key for one project channel.
+type BundledClientCredential struct {
+	Kind            string `json:"kind"`
+	Endpoint        string `json:"endpoint"`
+	ConnectionToken string `json:"connection_token"`
+	ProjectID       string `json:"project_id"`
+	KeyGeneration   int    `json:"key_generation"`
+	ProjectKey      []byte `json:"project_key"`
+}
+
+// AccountAdminCredential is the trusted-machine admin credential.
+// It is a distinct type from BundledClientCredential and cannot be
+// encoded or decoded through the client credential wire format.
+type AccountAdminCredential struct {
+	Kind                string    `json:"kind"`
+	Endpoint            string    `json:"endpoint"`
+	AccountAccessKey    string    `json:"account_access_key"`
+	AccountAccessSecret string    `json:"account_access_secret"`
+	MasterKey           MasterKey `json:"master_key"`
+}
+
+const (
+	credentialKindClient = "project_client"
+	credentialKindAdmin  = "account_admin"
+)
+
+// EncodeBundledClientCredential renders a project client credential as one string.
+func EncodeBundledClientCredential(c BundledClientCredential) (string, error) {
+	if strings.TrimSpace(c.Endpoint) == "" {
+		return "", fmt.Errorf("encode bundled credential: endpoint is empty")
+	}
+	if strings.TrimSpace(c.ConnectionToken) == "" {
+		return "", fmt.Errorf("encode bundled credential: connection token is empty")
+	}
+	if strings.TrimSpace(c.ProjectID) == "" {
+		return "", fmt.Errorf("encode bundled credential: project id is empty")
+	}
+	if len(c.ProjectKey) != projectKeySize {
+		return "", fmt.Errorf("encode bundled credential: project key must be %d bytes", projectKeySize)
+	}
+	c.Kind = credentialKindClient
+	payload, err := json.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("encode bundled credential: %w", err)
+	}
+	return fmt.Sprintf("loafclient%d://%s", bundledClientCredentialVersion, base64.RawURLEncoding.EncodeToString(payload)), nil
+}
+
+// DecodeBundledClientCredential parses a project client credential string.
+// Structurally refuses admin wire formats and admin-only JSON fields.
+func DecodeBundledClientCredential(raw string) (BundledClientCredential, error) {
+	raw = strings.TrimSpace(raw)
+	prefix := fmt.Sprintf("loafclient%d://", bundledClientCredentialVersion)
+	if strings.HasPrefix(raw, fmt.Sprintf("loafadmin%d://", accountAdminCredentialVersion)) {
+		return BundledClientCredential{}, fmt.Errorf("decode bundled credential: account admin credential is not a project client credential")
+	}
+	if !strings.HasPrefix(raw, prefix) {
+		return BundledClientCredential{}, fmt.Errorf("decode bundled credential: unsupported prefix")
+	}
+	body, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(raw, prefix))
+	if err != nil {
+		return BundledClientCredential{}, fmt.Errorf("decode bundled credential: %w", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return BundledClientCredential{}, fmt.Errorf("decode bundled credential: %w", err)
+	}
+	for _, forbidden := range []string{"master_key", "account_access_key", "account_access_secret"} {
+		if _, ok := fields[forbidden]; ok {
+			return BundledClientCredential{}, fmt.Errorf("decode bundled credential: admin field %q is not allowed on project client credentials", forbidden)
+		}
+	}
+	var c BundledClientCredential
+	if err := json.Unmarshal(body, &c); err != nil {
+		return BundledClientCredential{}, fmt.Errorf("decode bundled credential: %w", err)
+	}
+	if c.Kind != "" && c.Kind != credentialKindClient {
+		return BundledClientCredential{}, fmt.Errorf("decode bundled credential: unexpected kind %q", c.Kind)
+	}
+	if len(c.ProjectKey) != projectKeySize {
+		return BundledClientCredential{}, fmt.Errorf("decode bundled credential: project key must be %d bytes", projectKeySize)
+	}
+	c.Kind = credentialKindClient
+	return c, nil
+}
+
+// EncodeAccountAdminCredential renders an admin credential as a distinct wire string.
+func EncodeAccountAdminCredential(c AccountAdminCredential) (string, error) {
+	if strings.TrimSpace(c.Endpoint) == "" {
+		return "", fmt.Errorf("encode admin credential: endpoint is empty")
+	}
+	if strings.TrimSpace(c.AccountAccessKey) == "" {
+		return "", fmt.Errorf("encode admin credential: account access key is empty")
+	}
+	if strings.TrimSpace(c.AccountAccessSecret) == "" {
+		return "", fmt.Errorf("encode admin credential: account access secret is empty")
+	}
+	c.Kind = credentialKindAdmin
+	payload, err := json.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("encode admin credential: %w", err)
+	}
+	return fmt.Sprintf("loafadmin%d://%s", accountAdminCredentialVersion, base64.RawURLEncoding.EncodeToString(payload)), nil
+}
+
+// DecodeAccountAdminCredential parses an account admin credential string.
+func DecodeAccountAdminCredential(raw string) (AccountAdminCredential, error) {
+	raw = strings.TrimSpace(raw)
+	prefix := fmt.Sprintf("loafadmin%d://", accountAdminCredentialVersion)
+	if strings.HasPrefix(raw, fmt.Sprintf("loafclient%d://", bundledClientCredentialVersion)) {
+		return AccountAdminCredential{}, fmt.Errorf("decode admin credential: project client credential is not an account admin credential")
+	}
+	if !strings.HasPrefix(raw, prefix) {
+		return AccountAdminCredential{}, fmt.Errorf("decode admin credential: unsupported prefix")
+	}
+	body, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(raw, prefix))
+	if err != nil {
+		return AccountAdminCredential{}, fmt.Errorf("decode admin credential: %w", err)
+	}
+	var c AccountAdminCredential
+	if err := json.Unmarshal(body, &c); err != nil {
+		return AccountAdminCredential{}, fmt.Errorf("decode admin credential: %w", err)
+	}
+	if c.Kind != "" && c.Kind != credentialKindAdmin {
+		return AccountAdminCredential{}, fmt.Errorf("decode admin credential: unexpected kind %q", c.Kind)
+	}
+	c.Kind = credentialKindAdmin
+	return c, nil
+}

--- a/internal/crypto/credential_test.go
+++ b/internal/crypto/credential_test.go
@@ -1,0 +1,160 @@
+package crypto
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBundledClientCredentialRoundTrip(t *testing.T) {
+	master, err := GenerateMasterKey()
+	if err != nil {
+		t.Fatalf("GenerateMasterKey() error = %v", err)
+	}
+	projectID := "proj_client_cred_00000001"
+	ring := NewProjectKeyRing(master, projectID)
+	projectKey, err := ring.WriteKey()
+	if err != nil {
+		t.Fatalf("WriteKey() error = %v", err)
+	}
+	cred := BundledClientCredential{
+		Endpoint:        "https://sync.example.test/v1",
+		ConnectionToken: "project-token-scope",
+		ProjectID:       projectID,
+		KeyGeneration:   ring.WriteGeneration,
+		ProjectKey:      projectKey[:],
+	}
+	encoded, err := EncodeBundledClientCredential(cred)
+	if err != nil {
+		t.Fatalf("EncodeBundledClientCredential() error = %v", err)
+	}
+	if !strings.HasPrefix(encoded, "loafclient1://") {
+		t.Fatalf("client prefix = %q, want loafclient1://", encoded)
+	}
+	decoded, err := DecodeBundledClientCredential(encoded)
+	if err != nil {
+		t.Fatalf("DecodeBundledClientCredential() error = %v", err)
+	}
+	if decoded.Endpoint != cred.Endpoint || decoded.ConnectionToken != cred.ConnectionToken || decoded.ProjectID != cred.ProjectID {
+		t.Fatalf("decoded credential = %#v, want %#v", decoded, cred)
+	}
+	if decoded.Kind != credentialKindClient {
+		t.Fatalf("decoded kind = %q, want %q", decoded.Kind, credentialKindClient)
+	}
+}
+
+func TestClientCredentialStructurallyExcludesAdminFields(t *testing.T) {
+	master, err := GenerateMasterKey()
+	if err != nil {
+		t.Fatalf("GenerateMasterKey() error = %v", err)
+	}
+	ring := NewProjectKeyRing(master, "proj_struct_00000001")
+	projectKey, err := ring.WriteKey()
+	if err != nil {
+		t.Fatalf("WriteKey() error = %v", err)
+	}
+	encoded, err := EncodeBundledClientCredential(BundledClientCredential{
+		Endpoint:        "https://sync.example.test/v1",
+		ConnectionToken: "project-token-scope",
+		ProjectID:       ring.ProjectID,
+		KeyGeneration:   0,
+		ProjectKey:      projectKey[:],
+	})
+	if err != nil {
+		t.Fatalf("EncodeBundledClientCredential() error = %v", err)
+	}
+	body, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(encoded, "loafclient1://"))
+	if err != nil {
+		t.Fatalf("DecodeString() error = %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	for _, forbidden := range []string{"master_key", "account_access_key", "account_access_secret"} {
+		if _, ok := fields[forbidden]; ok {
+			t.Fatalf("client credential unexpectedly contains admin field %q", forbidden)
+		}
+	}
+	if _, ok := fields["project_key"]; !ok {
+		t.Fatal("client credential missing project_key")
+	}
+}
+
+func TestDecodeClientRejectsAdminWireAndAdminFields(t *testing.T) {
+	master, err := GenerateMasterKey()
+	if err != nil {
+		t.Fatalf("GenerateMasterKey() error = %v", err)
+	}
+	adminEncoded, err := EncodeAccountAdminCredential(AccountAdminCredential{
+		Endpoint:            "https://sync.example.test/v1",
+		AccountAccessKey:    "ak_live",
+		AccountAccessSecret: "sk_live",
+		MasterKey:           master,
+	})
+	if err != nil {
+		t.Fatalf("EncodeAccountAdminCredential() error = %v", err)
+	}
+	if _, err := DecodeBundledClientCredential(adminEncoded); err == nil {
+		t.Fatal("DecodeBundledClientCredential(admin) error = nil, want refusal")
+	}
+
+	// Even if someone re-prefixes an admin JSON body as a client wire string,
+	// structural field checks must refuse.
+	adminJSON, err := json.Marshal(map[string]any{
+		"kind":                  credentialKindClient,
+		"endpoint":              "https://sync.example.test/v1",
+		"connection_token":      "token",
+		"project_id":            "proj_x",
+		"key_generation":        0,
+		"project_key":           make([]byte, projectKeySize),
+		"account_access_secret": "sk_live",
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	fake := "loafclient1://" + base64.RawURLEncoding.EncodeToString(adminJSON)
+	if _, err := DecodeBundledClientCredential(fake); err == nil {
+		t.Fatal("DecodeBundledClientCredential(admin fields) error = nil, want refusal")
+	}
+}
+
+func TestAccountAdminCredentialRoundTripAndSeparation(t *testing.T) {
+	master, err := GenerateMasterKey()
+	if err != nil {
+		t.Fatalf("GenerateMasterKey() error = %v", err)
+	}
+	admin := AccountAdminCredential{
+		Endpoint:            "https://sync.example.test/v1",
+		AccountAccessKey:    "ak_live",
+		AccountAccessSecret: "sk_live",
+		MasterKey:           master,
+	}
+	encoded, err := EncodeAccountAdminCredential(admin)
+	if err != nil {
+		t.Fatalf("EncodeAccountAdminCredential() error = %v", err)
+	}
+	if !strings.HasPrefix(encoded, "loafadmin1://") {
+		t.Fatalf("admin prefix = %q, want loafadmin1://", encoded)
+	}
+	decoded, err := DecodeAccountAdminCredential(encoded)
+	if err != nil {
+		t.Fatalf("DecodeAccountAdminCredential() error = %v", err)
+	}
+	if decoded.MasterKey != master || decoded.AccountAccessSecret != admin.AccountAccessSecret {
+		t.Fatalf("decoded admin = %#v", decoded)
+	}
+	clientEncoded, err := EncodeBundledClientCredential(BundledClientCredential{
+		Endpoint:        admin.Endpoint,
+		ConnectionToken: "project-token",
+		ProjectID:       "proj_x",
+		ProjectKey:      make([]byte, projectKeySize),
+	})
+	if err != nil {
+		t.Fatalf("EncodeBundledClientCredential() error = %v", err)
+	}
+	if _, err := DecodeAccountAdminCredential(clientEncoded); err == nil {
+		t.Fatal("DecodeAccountAdminCredential(client) error = nil, want refusal")
+	}
+}

--- a/internal/crypto/emergency_kit.go
+++ b/internal/crypto/emergency_kit.go
@@ -1,0 +1,76 @@
+package crypto
+
+import (
+	"crypto/sha256"
+	"encoding/base32"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const (
+	recoveryCodeWords  = 16
+	recoveryKitVersion = 1
+)
+
+var recoveryWordEncoder = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// EmergencyKitSetup mints a master key and a one-time printable recovery code.
+func EmergencyKitSetup() (MasterKey, string, error) {
+	master, err := GenerateMasterKey()
+	if err != nil {
+		return MasterKey{}, "", err
+	}
+	code, err := EncodeEmergencyKit(master)
+	if err != nil {
+		return MasterKey{}, "", err
+	}
+	return master, code, nil
+}
+
+// EncodeEmergencyKit renders a master key as a grouped recovery code shown once at setup.
+func EncodeEmergencyKit(master MasterKey) (string, error) {
+	payload := append([]byte{recoveryKitVersion}, master[:]...)
+	encoded := recoveryWordEncoder.EncodeToString(payload)
+	chunk := (len(encoded) + recoveryCodeWords - 1) / recoveryCodeWords
+	words := make([]string, recoveryCodeWords)
+	for i := 0; i < recoveryCodeWords; i++ {
+		start := i * chunk
+		end := start + chunk
+		if start >= len(encoded) {
+			words[i] = ""
+			continue
+		}
+		if end > len(encoded) {
+			end = len(encoded)
+		}
+		words[i] = encoded[start:end]
+	}
+	return strings.Join(words, "-"), nil
+}
+
+// RecoverMasterKeyFromEmergencyKit restores the master key from the printable code alone.
+func RecoverMasterKeyFromEmergencyKit(code string) (MasterKey, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(code))
+	normalized = strings.ReplaceAll(normalized, " ", "")
+	words := strings.Split(normalized, "-")
+	if len(words) != recoveryCodeWords {
+		return MasterKey{}, fmt.Errorf("recover master key: expected %d words, got %d", recoveryCodeWords, len(words))
+	}
+	encoded := strings.Join(words, "")
+	raw, err := recoveryWordEncoder.DecodeString(encoded)
+	if err != nil {
+		return MasterKey{}, fmt.Errorf("recover master key: decode recovery code: %w", err)
+	}
+	if len(raw) != 1+masterKeySize || raw[0] != recoveryKitVersion {
+		return MasterKey{}, fmt.Errorf("recover master key: invalid recovery kit payload")
+	}
+	return MasterKeyFromBytes(raw[1:])
+}
+
+// MasterKeyFingerprint returns a stable SHA-256 hex digest for diagnostics.
+// It never returns the raw master key material.
+func MasterKeyFingerprint(master MasterKey) string {
+	sum := sha256.Sum256(master[:])
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/crypto/emergency_kit_test.go
+++ b/internal/crypto/emergency_kit_test.go
@@ -1,0 +1,80 @@
+package crypto
+
+import (
+	"testing"
+)
+
+func TestEmergencyKitSetupAndRecovery(t *testing.T) {
+	master, code, err := EmergencyKitSetup()
+	if err != nil {
+		t.Fatalf("EmergencyKitSetup() error = %v", err)
+	}
+	if code == "" {
+		t.Fatal("recovery code is empty")
+	}
+	recovered, err := RecoverMasterKeyFromEmergencyKit(code)
+	if err != nil {
+		t.Fatalf("RecoverMasterKeyFromEmergencyKit() error = %v", err)
+	}
+	if recovered != master {
+		t.Fatalf("recovered master mismatch")
+	}
+}
+
+func TestEmergencyKitDecryptsExistingSubstrate(t *testing.T) {
+	master, code, err := EmergencyKitSetup()
+	if err != nil {
+		t.Fatalf("EmergencyKitSetup() error = %v", err)
+	}
+	ring := NewProjectKeyRing(master, "proj_kit_test_00000001")
+	writeKey, err := ring.WriteKey()
+	if err != nil {
+		t.Fatalf("WriteKey() error = %v", err)
+	}
+	plain := FactPlaintext{Kind: "journal", Payload: "existing-substrate", EnvID: "env-a", Seq: 1, HLC: "1:0", EnvelopeV: 1, KeyGen: 0}
+	envelope, err := EncryptFactEnvelope(writeKey, "fact-kit-1", plain)
+	if err != nil {
+		t.Fatalf("EncryptFactEnvelope() error = %v", err)
+	}
+	recoveredMaster, err := RecoverMasterKeyFromEmergencyKit(code)
+	if err != nil {
+		t.Fatalf("RecoverMasterKeyFromEmergencyKit() error = %v", err)
+	}
+	recoveredRing := NewProjectKeyRing(recoveredMaster, ring.ProjectID)
+	readKeys, err := recoveredRing.ReadKeys()
+	if err != nil {
+		t.Fatalf("ReadKeys() error = %v", err)
+	}
+	got, err := DecryptFactEnvelope(readKeys, envelope)
+	if err != nil {
+		t.Fatalf("DecryptFactEnvelope() error = %v", err)
+	}
+	if got.Payload != plain.Payload {
+		t.Fatalf("payload = %q, want %q", got.Payload, plain.Payload)
+	}
+}
+
+func TestMasterKeyFingerprintIsDigestNotRawKey(t *testing.T) {
+	master, err := MasterKeyFromBytes(make([]byte, masterKeySize))
+	if err != nil {
+		t.Fatalf("MasterKeyFromBytes() error = %v", err)
+	}
+	for i := range master {
+		master[i] = byte(i + 3)
+	}
+	fp := MasterKeyFingerprint(master)
+	if fp == master.Hex() {
+		t.Fatal("MasterKeyFingerprint() must not equal raw master hex")
+	}
+	if len(fp) != 64 {
+		t.Fatalf("fingerprint length = %d, want 64 hex chars", len(fp))
+	}
+	if again := MasterKeyFingerprint(master); again != fp {
+		t.Fatalf("fingerprint unstable: %q vs %q", fp, again)
+	}
+	other := master
+	other[0] ^= 0xff
+	if MasterKeyFingerprint(other) == fp {
+		t.Fatal("distinct keys must not share fingerprint")
+	}
+}

--- a/internal/crypto/envelope.go
+++ b/internal/crypto/envelope.go
@@ -1,0 +1,110 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+const wireEnvelopeVersion = 1
+
+// FactPlaintext is the semantic body encrypted inside the E2E envelope.
+type FactPlaintext struct {
+	Kind      string `json:"kind"`
+	Payload   string `json:"payload"`
+	EnvID     string `json:"env_id"`
+	Seq       int64  `json:"seq"`
+	HLC       string `json:"hlc"`
+	EnvelopeV int    `json:"envelope_v"`
+	KeyGen    int    `json:"key_gen"`
+}
+
+// WireEnvelope is the on-wire E2E fact envelope. Cleartext carries only version
+// and the fact id idempotency key; everything semantic rides in Ciphertext.
+type WireEnvelope struct {
+	Version    int    `json:"version"`
+	FactID     string `json:"fact_id"`
+	Nonce      []byte `json:"nonce"`
+	Ciphertext []byte `json:"ciphertext"`
+}
+
+func encryptFactEnvelopeWithNonce(projectKey [projectKeySize]byte, factID string, plaintext FactPlaintext, nonce []byte) (WireEnvelope, error) {
+	factID = strings.TrimSpace(factID)
+	if factID == "" {
+		return WireEnvelope{}, fmt.Errorf("encrypt fact envelope: fact id is empty")
+	}
+	if len(nonce) != chacha20poly1305.NonceSizeX {
+		return WireEnvelope{}, fmt.Errorf("encrypt fact envelope: nonce must be %d bytes", chacha20poly1305.NonceSizeX)
+	}
+	if strings.TrimSpace(plaintext.Kind) == "" {
+		return WireEnvelope{}, fmt.Errorf("encrypt fact envelope: kind is empty")
+	}
+	if strings.TrimSpace(plaintext.Payload) == "" {
+		return WireEnvelope{}, fmt.Errorf("encrypt fact envelope: payload is empty")
+	}
+	body, err := json.Marshal(plaintext)
+	if err != nil {
+		return WireEnvelope{}, fmt.Errorf("marshal fact plaintext: %w", err)
+	}
+	aead, err := chacha20poly1305.NewX(projectKey[:])
+	if err != nil {
+		return WireEnvelope{}, fmt.Errorf("init xchacha20-poly1305: %w", err)
+	}
+	aad := []byte(fmt.Sprintf("loaf-e2e-v%d/%s", wireEnvelopeVersion, factID))
+	ciphertext := aead.Seal(nil, nonce, body, aad)
+	return WireEnvelope{
+		Version:    wireEnvelopeVersion,
+		FactID:     factID,
+		Nonce:      nonce,
+		Ciphertext: ciphertext,
+	}, nil
+}
+
+// EncryptFactEnvelope seals a fact plaintext with the project key for keyGen.
+func EncryptFactEnvelope(projectKey [projectKeySize]byte, factID string, plaintext FactPlaintext) (WireEnvelope, error) {
+	nonce := make([]byte, chacha20poly1305.NonceSizeX)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return WireEnvelope{}, fmt.Errorf("generate envelope nonce: %w", err)
+	}
+	return encryptFactEnvelopeWithNonce(projectKey, factID, plaintext, nonce)
+}
+
+// DecryptFactEnvelope opens a wire envelope using a generation ring.
+func DecryptFactEnvelope(readKeys [][projectKeySize]byte, envelope WireEnvelope) (FactPlaintext, error) {
+	if envelope.Version != wireEnvelopeVersion {
+		return FactPlaintext{}, fmt.Errorf("decrypt fact envelope: unsupported wire version %d", envelope.Version)
+	}
+	factID := strings.TrimSpace(envelope.FactID)
+	if factID == "" {
+		return FactPlaintext{}, fmt.Errorf("decrypt fact envelope: fact id is empty")
+	}
+	if len(envelope.Nonce) != chacha20poly1305.NonceSizeX {
+		return FactPlaintext{}, fmt.Errorf("decrypt fact envelope: nonce must be %d bytes", chacha20poly1305.NonceSizeX)
+	}
+	aad := []byte(fmt.Sprintf("loaf-e2e-v%d/%s", wireEnvelopeVersion, factID))
+	var lastErr error
+	for _, key := range readKeys {
+		aead, err := chacha20poly1305.NewX(key[:])
+		if err != nil {
+			return FactPlaintext{}, fmt.Errorf("init xchacha20-poly1305: %w", err)
+		}
+		body, err := aead.Open(nil, envelope.Nonce, envelope.Ciphertext, aad)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		var plaintext FactPlaintext
+		if err := json.Unmarshal(body, &plaintext); err != nil {
+			return FactPlaintext{}, fmt.Errorf("unmarshal fact plaintext: %w", err)
+		}
+		return plaintext, nil
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no read keys provided")
+	}
+	return FactPlaintext{}, fmt.Errorf("decrypt fact envelope: %w", lastErr)
+}

--- a/internal/crypto/keys.go
+++ b/internal/crypto/keys.go
@@ -1,0 +1,110 @@
+package crypto
+
+import (
+	"crypto/hkdf"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+const (
+	masterKeySize   = 32
+	projectKeySize  = 32
+	projectKeyLabel = "loaf-substrate-v1/project-key"
+)
+
+// MasterKey is a full-entropy operator secret used only on trusted machines.
+type MasterKey [masterKeySize]byte
+
+// GenerateMasterKey mints a fresh master key.
+func GenerateMasterKey() (MasterKey, error) {
+	var key MasterKey
+	if _, err := io.ReadFull(rand.Reader, key[:]); err != nil {
+		return MasterKey{}, fmt.Errorf("generate master key: %w", err)
+	}
+	return key, nil
+}
+
+// MasterKeyFromBytes copies raw key material.
+func MasterKeyFromBytes(raw []byte) (MasterKey, error) {
+	if len(raw) != masterKeySize {
+		return MasterKey{}, fmt.Errorf("master key must be %d bytes, got %d", masterKeySize, len(raw))
+	}
+	var key MasterKey
+	copy(key[:], raw)
+	return key, nil
+}
+
+// Bytes returns a copy of the raw master key bytes.
+func (k MasterKey) Bytes() []byte {
+	out := make([]byte, masterKeySize)
+	copy(out, k[:])
+	return out
+}
+
+// Hex returns lowercase hex encoding of the master key.
+func (k MasterKey) Hex() string {
+	return hex.EncodeToString(k[:])
+}
+
+// ProjectKeyRing derives per-project keys from a master key and tracks generations.
+type ProjectKeyRing struct {
+	Master          MasterKey
+	ProjectID       string
+	WriteGeneration int
+}
+
+// NewProjectKeyRing starts a ring at generation zero.
+func NewProjectKeyRing(master MasterKey, projectID string) ProjectKeyRing {
+	return ProjectKeyRing{
+		Master:          master,
+		ProjectID:       strings.TrimSpace(projectID),
+		WriteGeneration: 0,
+	}
+}
+
+// DeriveProjectKey returns the AEAD key for a specific generation.
+func DeriveProjectKey(master MasterKey, projectID string, generation int) ([projectKeySize]byte, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return [projectKeySize]byte{}, fmt.Errorf("derive project key: project id is empty")
+	}
+	if generation < 0 {
+		return [projectKeySize]byte{}, fmt.Errorf("derive project key: generation %d is invalid", generation)
+	}
+	info := projectKeyLabel + "/" + projectID + "/gen/" + strconv.Itoa(generation)
+	raw, err := hkdf.Key(sha256.New, master[:], nil, info, projectKeySize)
+	if err != nil {
+		return [projectKeySize]byte{}, fmt.Errorf("derive project key: %w", err)
+	}
+	var key [projectKeySize]byte
+	copy(key[:], raw)
+	return key, nil
+}
+
+// WriteKey returns the current write-generation project key.
+func (r ProjectKeyRing) WriteKey() ([projectKeySize]byte, error) {
+	return DeriveProjectKey(r.Master, r.ProjectID, r.WriteGeneration)
+}
+
+// ReadKeys returns keys for every generation from zero through the write generation.
+func (r ProjectKeyRing) ReadKeys() ([][projectKeySize]byte, error) {
+	keys := make([][projectKeySize]byte, 0, r.WriteGeneration+1)
+	for gen := 0; gen <= r.WriteGeneration; gen++ {
+		key, err := DeriveProjectKey(r.Master, r.ProjectID, gen)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+// Rotate bumps the write generation while preserving read access to prior keys.
+func (r *ProjectKeyRing) Rotate() {
+	r.WriteGeneration++
+}

--- a/internal/crypto/keys_test.go
+++ b/internal/crypto/keys_test.go
@@ -1,0 +1,63 @@
+package crypto
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestDeriveProjectKeyGenerationRing(t *testing.T) {
+	master, err := MasterKeyFromBytes(make([]byte, masterKeySize))
+	if err != nil {
+		t.Fatalf("MasterKeyFromBytes() error = %v", err)
+	}
+	for i := range master {
+		master[i] = byte(i + 1)
+	}
+	projectID := "proj_ring_test_00000001"
+	gen0, err := DeriveProjectKey(master, projectID, 0)
+	if err != nil {
+		t.Fatalf("DeriveProjectKey(gen0) error = %v", err)
+	}
+	gen1, err := DeriveProjectKey(master, projectID, 1)
+	if err != nil {
+		t.Fatalf("DeriveProjectKey(gen1) error = %v", err)
+	}
+	if gen0 == gen1 {
+		t.Fatal("generation 0 and 1 keys must differ")
+	}
+	ring := NewProjectKeyRing(master, projectID)
+	ring.Rotate()
+	readKeys, err := ring.ReadKeys()
+	if err != nil {
+		t.Fatalf("ReadKeys() error = %v", err)
+	}
+	if len(readKeys) != 2 {
+		t.Fatalf("ReadKeys() len = %d, want 2", len(readKeys))
+	}
+	if readKeys[0] != gen0 || readKeys[1] != gen1 {
+		t.Fatalf("read ring keys mismatch gen0=%x gen1=%x", readKeys[0], readKeys[1])
+	}
+}
+
+func TestPublishedProjectKeyVector(t *testing.T) {
+	const want = "535cd60458a448749c8f88aba609a2853f9995d3a59e773ae49df4808f21bb4e"
+	raw, err := hex.DecodeString("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
+	if err != nil {
+		t.Fatalf("DecodeString() error = %v", err)
+	}
+	master, err := MasterKeyFromBytes(raw)
+	if err != nil {
+		t.Fatalf("MasterKeyFromBytes() error = %v", err)
+	}
+	key, err := DeriveProjectKey(master, "proj_test_vectors_00000001", 0)
+	if err != nil {
+		t.Fatalf("DeriveProjectKey() error = %v", err)
+	}
+	got := hex.EncodeToString(key[:])
+	if len(got) != 64 {
+		t.Fatalf("project key hex length = %d, want 64", len(got))
+	}
+	if got != want {
+		t.Fatalf("project key = %s, want %s", got, want)
+	}
+}

--- a/internal/crypto/testdata/published_vectors.json
+++ b/internal/crypto/testdata/published_vectors.json
@@ -1,0 +1,18 @@
+{
+  "ciphertext_hex": "b6aec3b60911ebb0cc4e324f1c14ba226356a89c2e60423de542005d22d7c9512a6d2bf62de9839a00f72fd5bc43896b7040ff424fc684c1604453f3e7e64582ee29c42cfc8cfa094eed22ee4989a5da5b511c59477ada0230d07c35c648a9847d9f2eaa38f9b2c00d4756edeaded17360b114fff22ec879e5506d3ba244bbb61c78afba6834bb50b167ce252baf15231a0424d43b2d783dfae5856bc01b0df4d0dbd2f9fa91cd30b964ffa0a6e3b96398125513a80f7860a45048b1258a94dcc0",
+  "fact_id": "0198c0a1-0000-7000-8000-000000000001",
+  "generation": 0,
+  "master_key_hex": "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+  "nonce_hex": "0102030405060708090a0b0c0d0e0f101112131415161718",
+  "plaintext": {
+    "kind": "journal",
+    "payload": "{\"entry_type\":\"decision\",\"message\":\"vector\"}",
+    "env_id": "legacy-host",
+    "seq": 1,
+    "hlc": "00000000000000000000:000000",
+    "envelope_v": 1,
+    "key_gen": 0
+  },
+  "project_id": "proj_test_vectors_00000001",
+  "project_key_hex": "535cd60458a448749c8f88aba609a2853f9995d3a59e773ae49df4808f21bb4e"
+}

--- a/internal/crypto/vectors_test.go
+++ b/internal/crypto/vectors_test.go
@@ -1,0 +1,131 @@
+package crypto
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+type publishedVectorFile struct {
+	MasterKeyHex  string        `json:"master_key_hex"`
+	ProjectID     string        `json:"project_id"`
+	Generation    int           `json:"generation"`
+	FactID        string        `json:"fact_id"`
+	Plaintext     FactPlaintext `json:"plaintext"`
+	NonceHex      string        `json:"nonce_hex"`
+	ProjectKeyHex string        `json:"project_key_hex"`
+	CiphertextHex string        `json:"ciphertext_hex"`
+}
+
+func loadPublishedVectors(t *testing.T) publishedVectorFile {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	path := filepath.Join(filepath.Dir(file), "testdata", "published_vectors.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	var vectors publishedVectorFile
+	if err := json.Unmarshal(raw, &vectors); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	return vectors
+}
+
+func TestPublishedEnvelopeVectorsRoundTrip(t *testing.T) {
+	vectors := loadPublishedVectors(t)
+	masterRaw, err := hex.DecodeString(vectors.MasterKeyHex)
+	if err != nil {
+		t.Fatalf("DecodeString(master) error = %v", err)
+	}
+	master, err := MasterKeyFromBytes(masterRaw)
+	if err != nil {
+		t.Fatalf("MasterKeyFromBytes() error = %v", err)
+	}
+	projectKey, err := DeriveProjectKey(master, vectors.ProjectID, vectors.Generation)
+	if err != nil {
+		t.Fatalf("DeriveProjectKey() error = %v", err)
+	}
+	if vectors.ProjectKeyHex != "" {
+		want, err := hex.DecodeString(vectors.ProjectKeyHex)
+		if err != nil {
+			t.Fatalf("DecodeString(project key) error = %v", err)
+		}
+		if string(projectKey[:]) != string(want) {
+			t.Fatalf("project key = %x, want %x", projectKey, want)
+		}
+	}
+	nonce, err := hex.DecodeString(vectors.NonceHex)
+	if err != nil {
+		t.Fatalf("DecodeString(nonce) error = %v", err)
+	}
+	envelope, err := encryptFactEnvelopeWithNonce(projectKey, vectors.FactID, vectors.Plaintext, nonce)
+	if err != nil {
+		t.Fatalf("encryptFactEnvelopeWithNonce() error = %v", err)
+	}
+	if vectors.CiphertextHex != "" {
+		want, err := hex.DecodeString(vectors.CiphertextHex)
+		if err != nil {
+			t.Fatalf("DecodeString(ciphertext) error = %v", err)
+		}
+		if string(envelope.Ciphertext) != string(want) {
+			t.Fatalf("ciphertext = %x, want %x", envelope.Ciphertext, want)
+		}
+	}
+	ring := NewProjectKeyRing(master, vectors.ProjectID)
+	readKeys, err := ring.ReadKeys()
+	if err != nil {
+		t.Fatalf("ReadKeys() error = %v", err)
+	}
+	got, err := DecryptFactEnvelope(readKeys, envelope)
+	if err != nil {
+		t.Fatalf("DecryptFactEnvelope() error = %v", err)
+	}
+	if got != vectors.Plaintext {
+		t.Fatalf("plaintext = %#v, want %#v", got, vectors.Plaintext)
+	}
+}
+
+func TestEnvelopeRoundTripAcrossRotatedGeneration(t *testing.T) {
+	master, err := GenerateMasterKey()
+	if err != nil {
+		t.Fatalf("GenerateMasterKey() error = %v", err)
+	}
+	ring := NewProjectKeyRing(master, "proj_rotate_test_00000001")
+	writeKey, err := ring.WriteKey()
+	if err != nil {
+		t.Fatalf("WriteKey() error = %v", err)
+	}
+	plain := FactPlaintext{Kind: "journal", Payload: "{}", EnvID: "env-a", Seq: 1, HLC: "1:0", EnvelopeV: 1, KeyGen: 0}
+	envelope, err := EncryptFactEnvelope(writeKey, "fact-rotate-1", plain)
+	if err != nil {
+		t.Fatalf("EncryptFactEnvelope() error = %v", err)
+	}
+	ring.Rotate()
+	newWrite, err := ring.WriteKey()
+	if err != nil {
+		t.Fatalf("WriteKey() after rotate error = %v", err)
+	}
+	plain.KeyGen = 1
+	plain.Seq = 2
+	envelope2, err := EncryptFactEnvelope(newWrite, "fact-rotate-2", plain)
+	if err != nil {
+		t.Fatalf("EncryptFactEnvelope(gen1) error = %v", err)
+	}
+	readKeys, err := ring.ReadKeys()
+	if err != nil {
+		t.Fatalf("ReadKeys() error = %v", err)
+	}
+	if _, err := DecryptFactEnvelope(readKeys, envelope); err != nil {
+		t.Fatalf("decrypt gen0 envelope error = %v", err)
+	}
+	if _, err := DecryptFactEnvelope(readKeys, envelope2); err != nil {
+		t.Fatalf("decrypt gen1 envelope error = %v", err)
+	}
+}

--- a/internal/state/alias_orphan_migration_proof_test.go
+++ b/internal/state/alias_orphan_migration_proof_test.go
@@ -435,6 +435,9 @@ func TestAliasOrphanRepointsSparkProvenanceAtTheTwin(t *testing.T) {
 INSERT INTO journal_entries (id, project_id, entry_type, scope, message, created_at, updated_at)
 VALUES (?, ?, 'spark', 'scope', 'defer this thought', ?, ?)
 `, "journal:deferral0000000001", projectID, "2026-06-13T10:00:00Z", "2026-06-13T10:00:00Z")
+	store := openTestStore(t, root, stateHome)
+	mustBackfillJournalFactForTest(t, store, projectID, "journal:deferral0000000001")
+	store.Close()
 	mustExecOpen(t, stateHome, root, `
 INSERT INTO journal_deferrals (project_id, operation_key, journal_entry_id, spark_id, stored_digest, created_at)
 VALUES (?, 'op-defer-1', ?, ?, ?, ?)

--- a/internal/state/fact.go
+++ b/internal/state/fact.go
@@ -1,0 +1,202 @@
+package state
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	FactKindJournal = "journal"
+
+	legacyFactEnvID = "legacy-host"
+)
+
+var registeredFactKinds = map[string]string{
+	FactKindJournal: "notebook",
+}
+
+// FactEnvelope is the v1 grow-only sync contract. There is no supersession field.
+type FactEnvelope struct {
+	ID         string `json:"id"`
+	ProjectID  string `json:"project_id"`
+	Kind       string `json:"kind"`
+	Payload    string `json:"payload"`
+	EnvID      string `json:"env_id"`
+	Seq        int64  `json:"seq"`
+	HLC        string `json:"hlc"`
+	EnvelopeV  int    `json:"envelope_v"`
+	Permanence string `json:"permanence_class,omitempty"`
+}
+
+// AppendFactInput describes one grow-only append through the single write chokepoint.
+type AppendFactInput struct {
+	ProjectID string
+	Kind      string
+	Payload   string
+	EnvID     string
+	ID        string
+	Now       time.Time
+}
+
+// AppendFact appends one fact to the grow-only store.
+func AppendFact(ctx context.Context, store *Store, input AppendFactInput) (FactEnvelope, error) {
+	if store == nil || store.db == nil {
+		return FactEnvelope{}, fmt.Errorf("append fact: store is nil")
+	}
+	tx, err := store.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return FactEnvelope{}, fmt.Errorf("begin fact transaction: %w", err)
+	}
+	defer tx.Rollback()
+	envelope, err := appendFactTx(ctx, tx, input)
+	if err != nil {
+		return FactEnvelope{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return FactEnvelope{}, fmt.Errorf("commit fact transaction: %w", err)
+	}
+	return envelope, nil
+}
+
+func appendFactTx(ctx context.Context, tx *sql.Tx, input AppendFactInput) (FactEnvelope, error) {
+	permanence, err := validateFactKind(input.Kind)
+	if err != nil {
+		return FactEnvelope{}, err
+	}
+	payload := strings.TrimSpace(input.Payload)
+	if payload == "" {
+		return FactEnvelope{}, fmt.Errorf("append fact: payload cannot be empty")
+	}
+	envID := strings.TrimSpace(input.EnvID)
+	if envID == "" {
+		envID = localFactEnvID()
+	}
+	now := input.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	id := strings.TrimSpace(input.ID)
+	if id == "" {
+		id, err = mintFactID(now)
+		if err != nil {
+			return FactEnvelope{}, err
+		}
+	}
+	var existing int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM facts WHERE id = ?`, id).Scan(&existing); err != nil {
+		return FactEnvelope{}, fmt.Errorf("inspect fact id %q: %w", id, err)
+	}
+	if existing > 0 {
+		return FactEnvelope{}, fmt.Errorf("append fact: id %q already exists", id)
+	}
+
+	hlc, seq, err := nextFactClockTx(ctx, tx, input.ProjectID, envID, now)
+	if err != nil {
+		return FactEnvelope{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO facts (id, project_id, kind, payload, env_id, seq, hlc, envelope_v)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+`, id, input.ProjectID, input.Kind, payload, envID, seq, hlc.String(), factEnvelopeVersion); err != nil {
+		return FactEnvelope{}, fmt.Errorf("insert fact %q: %w", id, err)
+	}
+	return FactEnvelope{
+		ID:         id,
+		ProjectID:  input.ProjectID,
+		Kind:       input.Kind,
+		Payload:    payload,
+		EnvID:      envID,
+		Seq:        seq,
+		HLC:        hlc.String(),
+		EnvelopeV:  factEnvelopeVersion,
+		Permanence: permanence,
+	}, nil
+}
+
+func validateFactKind(kind string) (string, error) {
+	kind = strings.TrimSpace(kind)
+	permanence, ok := registeredFactKinds[kind]
+	if !ok {
+		return "", fmt.Errorf("append fact: unknown kind %q", kind)
+	}
+	return permanence, nil
+}
+
+func localFactEnvID() string {
+	host, err := os.Hostname()
+	if err != nil || strings.TrimSpace(host) == "" {
+		return "local-host"
+	}
+	return strings.TrimSpace(host)
+}
+
+func nextFactClockTx(ctx context.Context, tx *sql.Tx, projectID, envID string, now time.Time) (HLC, int64, error) {
+	nowMS := now.UTC().UnixMilli()
+	var wallMS, logical, nextSeq int64
+	err := tx.QueryRowContext(ctx, `
+SELECT hlc_wall_ms, hlc_logical, next_seq
+FROM fact_env_clocks
+WHERE project_id = ? AND env_id = ?
+`, projectID, envID).Scan(&wallMS, &logical, &nextSeq)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		hlc := advanceHLC(HLC{}, nowMS, HLC{})
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO fact_env_clocks (project_id, env_id, hlc_wall_ms, hlc_logical, next_seq)
+VALUES (?, ?, ?, ?, ?)
+`, projectID, envID, hlc.WallMS, hlc.Logical, int64(2)); err != nil {
+			return HLC{}, 0, fmt.Errorf("seed fact env clock: %w", err)
+		}
+		return hlc, 1, nil
+	case err != nil:
+		return HLC{}, 0, fmt.Errorf("read fact env clock: %w", err)
+	default:
+		current := HLC{WallMS: wallMS, Logical: logical}
+		hlc := advanceHLC(current, nowMS, current)
+		if _, err := tx.ExecContext(ctx, `
+UPDATE fact_env_clocks
+SET hlc_wall_ms = ?, hlc_logical = ?, next_seq = ?
+WHERE project_id = ? AND env_id = ?
+`, hlc.WallMS, hlc.Logical, nextSeq+1, projectID, envID); err != nil {
+			return HLC{}, 0, fmt.Errorf("advance fact env clock: %w", err)
+		}
+		return hlc, nextSeq, nil
+	}
+}
+
+func observeFactHLCTx(ctx context.Context, tx *sql.Tx, projectID string, seen HLC) error {
+	rows, err := tx.QueryContext(ctx, `
+SELECT env_id, hlc_wall_ms, hlc_logical, next_seq
+FROM fact_env_clocks
+WHERE project_id = ?
+`, projectID)
+	if err != nil {
+		return fmt.Errorf("list fact env clocks: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var envID string
+		var wallMS, logical, nextSeq int64
+		if err := rows.Scan(&envID, &wallMS, &logical, &nextSeq); err != nil {
+			return fmt.Errorf("scan fact env clock: %w", err)
+		}
+		current := HLC{WallMS: wallMS, Logical: logical}
+		if compareHLC(seen, current) <= 0 {
+			continue
+		}
+		advanced := advanceHLC(current, seen.WallMS, seen)
+		if _, err := tx.ExecContext(ctx, `
+UPDATE fact_env_clocks
+SET hlc_wall_ms = ?, hlc_logical = ?
+WHERE project_id = ? AND env_id = ?
+`, advanced.WallMS, advanced.Logical, projectID, envID); err != nil {
+			return fmt.Errorf("observe fact hlc for env %q: %w", envID, err)
+		}
+	}
+	return rows.Err()
+}

--- a/internal/state/fact_hlc.go
+++ b/internal/state/fact_hlc.go
@@ -1,0 +1,75 @@
+package state
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const factEnvelopeVersion = 1
+
+// HLC is the hybrid logical clock carried on every fact envelope.
+type HLC struct {
+	WallMS  int64
+	Logical int64
+}
+
+func (h HLC) String() string {
+	return fmt.Sprintf("%020d:%06d", h.WallMS, h.Logical)
+}
+
+func parseHLC(value string) (HLC, error) {
+	parts := strings.Split(value, ":")
+	if len(parts) != 2 {
+		return HLC{}, fmt.Errorf("invalid hlc %q", value)
+	}
+	wallMS, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return HLC{}, fmt.Errorf("parse hlc wall component: %w", err)
+	}
+	logical, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return HLC{}, fmt.Errorf("parse hlc logical component: %w", err)
+	}
+	return HLC{WallMS: wallMS, Logical: logical}, nil
+}
+
+func compareHLC(left, right HLC) int {
+	if left.WallMS != right.WallMS {
+		if left.WallMS < right.WallMS {
+			return -1
+		}
+		return 1
+	}
+	if left.Logical != right.Logical {
+		if left.Logical < right.Logical {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+func compareFactOrder(hlcLeft HLC, envLeft, idLeft string, hlcRight HLC, envRight, idRight string) int {
+	if cmp := compareHLC(hlcLeft, hlcRight); cmp != 0 {
+		return cmp
+	}
+	if cmp := strings.Compare(envLeft, envRight); cmp != 0 {
+		return cmp
+	}
+	return strings.Compare(idLeft, idRight)
+}
+
+func advanceHLC(clock HLC, nowMS int64, seen HLC) HLC {
+	next := HLC{WallMS: nowMS, Logical: 0}
+	if compareHLC(clock, next) > 0 {
+		next = clock
+	}
+	if compareHLC(seen, next) > 0 {
+		next = seen
+	}
+	if next.WallMS == clock.WallMS && next.Logical == clock.Logical {
+		next.Logical++
+	}
+	return next
+}

--- a/internal/state/fact_id.go
+++ b/internal/state/fact_id.go
@@ -1,0 +1,30 @@
+package state
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+func mintFactID(now time.Time) (string, error) {
+	var raw [16]byte
+	ms := uint64(now.UTC().UnixMilli())
+	raw[0] = byte(ms >> 40)
+	raw[1] = byte(ms >> 32)
+	raw[2] = byte(ms >> 24)
+	raw[3] = byte(ms >> 16)
+	raw[4] = byte(ms >> 8)
+	raw[5] = byte(ms)
+	if _, err := rand.Read(raw[6:]); err != nil {
+		return "", fmt.Errorf("mint fact id: %w", err)
+	}
+	raw[6] = (raw[6] & 0x0f) | 0x70
+	raw[8] = (raw[8] & 0x3f) | 0x80
+	return formatUUID(raw), nil
+}
+
+func formatUUID(raw [16]byte) string {
+	hexed := hex.EncodeToString(raw[:])
+	return hexed[0:8] + "-" + hexed[8:12] + "-" + hexed[12:16] + "-" + hexed[16:20] + "-" + hexed[20:32]
+}

--- a/internal/state/fact_test.go
+++ b/internal/state/fact_test.go
@@ -1,0 +1,96 @@
+package state
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAppendFactGrowOnlyAndEnvelopeV1(t *testing.T) {
+	ctx := context.Background()
+	root := projectRoot(t)
+	resolver := PathResolver{StateHome: t.TempDir()}
+	status, err := Initialize(ctx, root, resolver)
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	store, err := OpenStore(status.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+
+	projectID, err := store.projectID(ctx, root)
+	if err != nil {
+		t.Fatalf("projectID() error = %v", err)
+	}
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	first, err := AppendFact(ctx, store, AppendFactInput{
+		ProjectID: projectID,
+		Kind:      FactKindJournal,
+		Payload:   `{"entry_type":"discover","message":"first"}`,
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("AppendFact() first error = %v", err)
+	}
+	if first.EnvelopeV != 1 {
+		t.Fatalf("EnvelopeV = %d, want 1", first.EnvelopeV)
+	}
+	if first.Permanence != "notebook" {
+		t.Fatalf("Permanence = %q, want notebook", first.Permanence)
+	}
+	if strings.TrimSpace(first.ID) == "" {
+		t.Fatal("id is empty")
+	}
+	second, err := AppendFact(ctx, store, AppendFactInput{
+		ProjectID: projectID,
+		Kind:      FactKindJournal,
+		Payload:   `{"entry_type":"discover","message":"second"}`,
+		Now:       now.Add(time.Millisecond),
+	})
+	if err != nil {
+		t.Fatalf("AppendFact() second error = %v", err)
+	}
+	if compareFactOrder(parseHLCMust(t, first.HLC), first.EnvID, first.ID, parseHLCMust(t, second.HLC), second.EnvID, second.ID) >= 0 {
+		t.Fatalf("order = (%s,%s,%s) before (%s,%s,%s)", first.HLC, first.EnvID, first.ID, second.HLC, second.EnvID, second.ID)
+	}
+	if _, err := AppendFact(ctx, store, AppendFactInput{
+		ProjectID: projectID,
+		Kind:      FactKindJournal,
+		Payload:   `{"entry_type":"discover","message":"duplicate"}`,
+		ID:        first.ID,
+		Now:       now,
+	}); err == nil {
+		t.Fatal("AppendFact() duplicate id error = nil, want failure")
+	}
+	if _, err := AppendFact(ctx, store, AppendFactInput{
+		ProjectID: projectID,
+		Kind:      "unknown-kind",
+		Payload:   `{}`,
+		Now:       now,
+	}); err == nil {
+		t.Fatal("AppendFact() unknown kind error = nil, want failure")
+	}
+}
+
+func TestHLCOrderingUsesEnvAndIDTiebreak(t *testing.T) {
+	left := HLC{WallMS: 100, Logical: 0}
+	right := HLC{WallMS: 100, Logical: 0}
+	if compareFactOrder(left, "a-host", "fact-a", right, "b-host", "fact-b") >= 0 {
+		t.Fatal("env_id tiebreak failed")
+	}
+	if compareFactOrder(left, "same-host", "fact-a", right, "same-host", "fact-b") >= 0 {
+		t.Fatal("id tiebreak failed")
+	}
+}
+
+func parseHLCMust(t *testing.T, value string) HLC {
+	t.Helper()
+	parsed, err := parseHLC(value)
+	if err != nil {
+		t.Fatalf("parseHLC(%q) error = %v", value, err)
+	}
+	return parsed
+}

--- a/internal/state/intake_test.go
+++ b/internal/state/intake_test.go
@@ -89,6 +89,7 @@ VALUES ('journal:legacy-intake', ?, 'decision', 'defer/x', 'Intent: legacy body'
 INSERT INTO journal_search (rowid, journal_entry_id, project_id, session_id, entry_type, scope, message)
 SELECT rowid, id, project_id, '', 'decision', 'defer/x', 'Intent: legacy body' FROM journal_entries WHERE id = 'journal:legacy-intake'
 `)
+	mustBackfillJournalFactForTest(t, store, projectID, "journal:legacy-intake")
 	mustExecSchemaSQL(t, store, `
 INSERT INTO sparks (id, project_id, scope, status, text, created_at, updated_at)
 VALUES ('spark:legacy-intake', ?, 'defer/x', 'open', 'Intent: legacy body' || char(10) || 'Decision: journal:legacy-intake', '2026-07-01T00:00:00Z', '2026-07-01T00:00:00Z')

--- a/internal/state/intent_conversion_test.go
+++ b/internal/state/intent_conversion_test.go
@@ -24,6 +24,7 @@ VALUES (?, ?, 'decision', 'defer/legacy', ?, ?, ?)
 INSERT INTO journal_search (rowid, journal_entry_id, project_id, session_id, entry_type, scope, message)
 SELECT rowid, id, project_id, '', 'decision', 'defer/legacy', message FROM journal_entries WHERE id = ?
 `, decisionID)
+	mustBackfillJournalFactForTest(t, store, projectID, decisionID)
 	mustExecSchemaSQL(t, store, `
 INSERT INTO sparks (id, project_id, scope, status, text, created_at, updated_at)
 VALUES (?, ?, 'defer/legacy', 'open', ?, ?, ?)

--- a/internal/state/journal.go
+++ b/internal/state/journal.go
@@ -127,7 +127,10 @@ func (s *Store) logJournalWithHooks(ctx context.Context, root project.Root, opti
 	if err != nil {
 		return JournalLogResult{}, err
 	}
-	id := stableMigrationID("journal", projectID, now, entryType, scope, message)
+	id, err := mintFactID(time.Now().UTC())
+	if err != nil {
+		return JournalLogResult{}, err
+	}
 	// SQLite maps serializable transactions to BEGIN IMMEDIATE. Taking the write
 	// lock before inspecting the latest exact key outcome makes validation and
 	// insertion one atomic operation across independent stores and processes.
@@ -148,24 +151,25 @@ func (s *Store) logJournalWithHooks(ctx context.Context, root project.Root, opti
 			return JournalLogResult{}, err
 		}
 	}
-	_, err = tx.ExecContext(ctx, `
-INSERT INTO journal_entries (
-  id,
-  project_id,
-  entry_type,
-  scope,
-  message,
-  observed_branch,
-  observed_worktree,
-  harness_session_id,
-  spec_id,
-  task_id,
-  created_at,
-  updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)
-`, id, projectID, entryType, emptyToNil(scope), message, emptyToNil(options.ObservedBranch), emptyToNil(options.ObservedWorktree), emptyToNil(options.HarnessSessionID), now, now)
+	journalPayload := JournalFactPayload{
+		EntryType:        entryType,
+		Scope:            scope,
+		Message:          message,
+		ObservedBranch:   options.ObservedBranch,
+		ObservedWorktree: options.ObservedWorktree,
+		HarnessSessionID: options.HarnessSessionID,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, now)
 	if err != nil {
-		return JournalLogResult{}, fmt.Errorf("insert journal entry: %w", err)
+		return JournalLogResult{}, fmt.Errorf("parse journal timestamp: %w", err)
+	}
+	if _, err := appendJournalFactTx(ctx, tx, projectID, id, journalPayload, createdAt); err != nil {
+		return JournalLogResult{}, err
+	}
+	if err := insertJournalProjectionTx(ctx, tx, projectID, id, journalPayload); err != nil {
+		return JournalLogResult{}, err
 	}
 	if err := runJournalLogHook(hooks, func(h *journalLogHooks) func(*sql.Tx) error { return h.afterCanonical }, tx); err != nil {
 		return JournalLogResult{}, err
@@ -301,9 +305,14 @@ func parseJournalEntry(entry string) (string, string, string, error) {
 	return matches[1], strings.TrimSpace(matches[2]), strings.TrimSpace(matches[3]), nil
 }
 
-func insertJournalSearchTx(ctx context.Context, tx *sql.Tx, projectID string, journalEntryID string, harnessSessionID string, entryType string, scope string, message string) error {
+type journalWriteExecer interface {
+	queryContext
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func insertJournalSearchTx(ctx context.Context, execer journalWriteExecer, projectID string, journalEntryID string, harnessSessionID string, entryType string, scope string, message string) error {
 	var rowID int64
-	if err := tx.QueryRowContext(ctx, `
+	if err := execer.QueryRowContext(ctx, `
 SELECT rowid FROM journal_entries
 WHERE project_id = ? AND id = ?
 `, projectID, journalEntryID).Scan(&rowID); err != nil {
@@ -312,7 +321,7 @@ WHERE project_id = ? AND id = ?
 	// The FTS correlation column is harness_session_id on the current schema and
 	// session_id on the pre-migration schema. Match the live table so the write
 	// works on both shapes.
-	correlationColumn, err := journalSearchCorrelationColumn(ctx, tx)
+	correlationColumn, err := journalSearchCorrelationColumn(ctx, execer)
 	if err != nil {
 		return err
 	}
@@ -320,7 +329,7 @@ WHERE project_id = ? AND id = ?
 INSERT INTO journal_search(rowid, project_id, journal_entry_id, %s, entry_type, scope, message)
 VALUES (?, ?, ?, ?, ?, ?, ?)
 `, correlationColumn)
-	if _, err := tx.ExecContext(ctx, query, rowID, projectID, journalEntryID, firstNonEmpty(harnessSessionID, ""), entryType, firstNonEmpty(scope, ""), message); err != nil {
+	if _, err := execer.ExecContext(ctx, query, rowID, projectID, journalEntryID, firstNonEmpty(harnessSessionID, ""), entryType, firstNonEmpty(scope, ""), message); err != nil {
 		return fmt.Errorf("insert journal search row %s: %w", journalEntryID, err)
 	}
 	return nil

--- a/internal/state/journal_context_test.go
+++ b/internal/state/journal_context_test.go
@@ -684,6 +684,7 @@ INSERT INTO journal_entries (
 `, decisionID, projectID, scope, "Intent: "+intentText, emptyToNil(branch), createdAt, createdAt); err != nil {
 		t.Fatalf("seed legacy decision: %v", err)
 	}
+	mustBackfillJournalFactForTest(t, store, projectID, decisionID)
 	if _, err := store.db.ExecContext(ctx, `
 INSERT INTO sparks (id, project_id, scope, status, text, source_id, created_at, updated_at)
 VALUES (?, ?, ?, 'open', ?, NULL, ?, ?)

--- a/internal/state/journal_defer.go
+++ b/internal/state/journal_defer.go
@@ -187,13 +187,7 @@ WHERE project_id = ? AND operation_key = ?
 	decisionMessage := packet + "\nSpark: " + sparkID
 	sparkText := packet + "\nDecision: " + decisionID
 
-	if _, err := tx.ExecContext(ctx, `
-INSERT INTO journal_entries (
-  id, project_id, entry_type, scope, message,
-  observed_branch, observed_worktree, harness_session_id,
-  spec_id, task_id, created_at, updated_at
-) VALUES (?, ?, 'decision', ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?)
-`, decisionID, projectID, scope, decisionMessage, now, now); err != nil {
+	if err := appendJournalDecisionFactAndProjectionTx(ctx, tx, projectID, decisionID, scope, decisionMessage, nowTime); err != nil {
 		return JournalDeferResult{}, &JournalDeferTransactionError{Stage: "decision", Err: err}
 	}
 	if err := runJournalDeferHook(hooks, "after decision", func(h *journalDeferHooks) func(*sql.Tx) error { return h.afterDecision }, tx); err != nil {
@@ -398,17 +392,12 @@ WHERE project_id = ? AND operation_key = ?
 	sparkID := stableMigrationID("journal-defer-spark", projectID, normalized.OperationID)
 	alias := "SPARK-DEFER-" + operationDigest[:journalDeferScopePrefixLen]
 	scope := "defer/" + operationDigest[:journalDeferScopePrefixLen]
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+	nowTime := time.Now().UTC()
+	now := nowTime.Format(time.RFC3339Nano)
 	decisionMessage := storedPacket + "\nSpark: " + sparkID
 	sparkText := storedPacket + "\nDecision: " + decisionID
 
-	if _, err := tx.ExecContext(ctx, `
-INSERT INTO journal_entries (
-  id, project_id, entry_type, scope, message,
-  observed_branch, observed_worktree, harness_session_id,
-  spec_id, task_id, created_at, updated_at
-) VALUES (?, ?, 'decision', ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?)
-`, decisionID, projectID, scope, decisionMessage, now, now); err != nil {
+	if err := appendJournalDecisionFactAndProjectionTx(ctx, tx, projectID, decisionID, scope, decisionMessage, nowTime); err != nil {
 		return JournalDeferResult{}, &JournalDeferTransactionError{Stage: "decision", Err: err}
 	}
 	if err := runJournalDeferHook(hooks, "after decision", func(h *journalDeferHooks) func(*sql.Tx) error { return h.afterDecision }, tx); err != nil {

--- a/internal/state/journal_duplicate_migration.go
+++ b/internal/state/journal_duplicate_migration.go
@@ -749,6 +749,9 @@ SELECT * FROM artifact_bodies WHERE project_id = ? AND entity_kind = ? AND entit
 		return err
 	}
 
+	if err := captureAndDeleteJournalDuplicateTx(ctx, tx, "facts", `WHERE id = ?`, []any{entryID}, manifest, order); err != nil {
+		return err
+	}
 	if err := captureAndDeleteJournalDuplicateTx(ctx, tx, "journal_entries", `WHERE project_id = ? AND id = ?`, []any{projectID, entryID}, manifest, order); err != nil {
 		return err
 	}

--- a/internal/state/journal_duplicate_migration_test.go
+++ b/internal/state/journal_duplicate_migration_test.go
@@ -504,6 +504,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?)
 	if err := tx.Commit(); err != nil {
 		t.Fatalf("commit journal_search for %s: %v", id, err)
 	}
+	mustBackfillJournalFactForTest(t, store, projectID, id)
 }
 
 func seedJournalDuplicateOrigin(t *testing.T, stateHome string, root project.Root, projectID, entryID, createdAt string) {

--- a/internal/state/journal_fact.go
+++ b/internal/state/journal_fact.go
@@ -11,6 +11,8 @@ import (
 )
 
 // JournalFactPayload is the journal-kind fact body. Display timestamps live here.
+// EntryID, when set, is the stable journal_entries projection id. Empty means the
+// fact id itself is the projection id (wrapped corpus and first write).
 type JournalFactPayload struct {
 	EntryType        string `json:"entry_type"`
 	Scope            string `json:"scope,omitempty"`
@@ -20,9 +22,10 @@ type JournalFactPayload struct {
 	HarnessSessionID string `json:"harness_session_id,omitempty"`
 	CreatedAt        string `json:"created_at"`
 	UpdatedAt        string `json:"updated_at"`
+	EntryID          string `json:"entry_id,omitempty"`
 }
 
-// JournalFactParity describes parity between journal facts and the projection.
+// JournalFactParity describes parity between folded journal facts and the projection.
 type JournalFactParity struct {
 	FactRows       int  `json:"fact_rows"`
 	ProjectionRows int  `json:"projection_rows"`
@@ -35,6 +38,11 @@ type JournalFactParity struct {
 const JournalFactParityDivergenceCode = "journal-fact-parity-diverged"
 
 const JournalFactParityRepairCommand = "loaf state repair journal-facts --dry-run --json"
+
+type foldedJournalFact struct {
+	projectID string
+	payload   JournalFactPayload
+}
 
 func encodeJournalFactPayload(payload JournalFactPayload) (string, error) {
 	raw, err := json.Marshal(payload)
@@ -52,7 +60,18 @@ func decodeJournalFactPayload(raw string) (JournalFactPayload, error) {
 	return payload, nil
 }
 
+func journalEntryIDFromFact(factID string, payload JournalFactPayload) string {
+	if id := strings.TrimSpace(payload.EntryID); id != "" {
+		return id
+	}
+	return factID
+}
+
 func appendJournalFactTx(ctx context.Context, tx *sql.Tx, projectID string, id string, payload JournalFactPayload, now time.Time) (FactEnvelope, error) {
+	return appendJournalFactWithEnvTx(ctx, tx, projectID, id, payload, now, "")
+}
+
+func appendJournalFactWithEnvTx(ctx context.Context, tx *sql.Tx, projectID string, id string, payload JournalFactPayload, now time.Time, envID string) (FactEnvelope, error) {
 	encoded, err := encodeJournalFactPayload(payload)
 	if err != nil {
 		return FactEnvelope{}, err
@@ -61,6 +80,7 @@ func appendJournalFactTx(ctx context.Context, tx *sql.Tx, projectID string, id s
 		ProjectID: projectID,
 		Kind:      FactKindJournal,
 		Payload:   encoded,
+		EnvID:     envID,
 		ID:        id,
 		Now:       now,
 	})
@@ -82,12 +102,49 @@ INSERT INTO journal_entries (
 	return nil
 }
 
-func journalFactExistsTx(ctx context.Context, tx *sql.Tx, id string) (bool, error) {
-	var count int
-	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM facts WHERE id = ?`, id).Scan(&count); err != nil {
-		return false, fmt.Errorf("inspect journal fact id %q: %w", id, err)
+func foldJournalFacts(ctx context.Context, queryer queryContext, projectID string) (map[string]foldedJournalFact, error) {
+	query := `
+SELECT f.id, f.project_id, f.payload
+FROM facts AS f
+WHERE f.kind = ?
+`
+	args := []any{FactKindJournal}
+	if strings.TrimSpace(projectID) != "" {
+		query += ` AND f.project_id = ?`
+		args = append(args, projectID)
 	}
-	return count > 0, nil
+	query += ` ORDER BY f.project_id, f.hlc, f.env_id, f.id`
+	rows, err := queryer.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list journal facts for fold: %w", err)
+	}
+	defer rows.Close()
+	folded := map[string]foldedJournalFact{}
+	for rows.Next() {
+		var id, projID, payloadRaw string
+		if err := rows.Scan(&id, &projID, &payloadRaw); err != nil {
+			return nil, fmt.Errorf("scan journal fact for fold: %w", err)
+		}
+		payload, err := decodeJournalFactPayload(payloadRaw)
+		if err != nil {
+			return nil, err
+		}
+		entryID := journalEntryIDFromFact(id, payload)
+		folded[entryID] = foldedJournalFact{projectID: projID, payload: payload}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate journal facts for fold: %w", err)
+	}
+	return folded, nil
+}
+
+func journalFactExistsForEntryTx(ctx context.Context, tx *sql.Tx, projectID, entryID string) (bool, error) {
+	folded, err := foldJournalFacts(ctx, tx, projectID)
+	if err != nil {
+		return false, err
+	}
+	_, ok := folded[entryID]
+	return ok, nil
 }
 
 func appendJournalDecisionFactAndProjectionTx(ctx context.Context, tx *sql.Tx, projectID, decisionID, scope, decisionMessage string, nowTime time.Time) error {
@@ -105,7 +162,7 @@ func appendJournalDecisionFactAndProjectionTx(ctx context.Context, tx *sql.Tx, p
 	return insertJournalProjectionTx(ctx, tx, projectID, decisionID, payload)
 }
 
-func upsertJournalProjectionTx(ctx context.Context, execer journalWriteExecer, projectID, id string, payload JournalFactPayload) error {
+func upsertJournalProjectionTx(ctx context.Context, execer journalWriteExecer, projectID string, id string, payload JournalFactPayload) error {
 	_, err := execer.ExecContext(ctx, `
 INSERT INTO journal_entries (
   id, project_id, entry_type, scope, message,
@@ -139,14 +196,19 @@ func journalFactPayloadContentEqual(a, b JournalFactPayload) bool {
 		a.CreatedAt == b.CreatedAt
 }
 
-func replaceJournalFactForImportTx(ctx context.Context, tx *sql.Tx, projectID, id string, payload JournalFactPayload, nowTime time.Time) error {
-	if _, err := tx.ExecContext(ctx, `DELETE FROM facts WHERE id = ?`, id); err != nil {
-		return fmt.Errorf("replace journal fact %q: %w", id, err)
-	}
-	if _, err := appendJournalFactTx(ctx, tx, projectID, id, payload, nowTime); err != nil {
+// appendJournalFactRevisionForImportTx appends a grow-only revision fact for an
+// existing journal entry and updates the stable projection pointer. It never
+// deletes facts rows.
+func appendJournalFactRevisionForImportTx(ctx context.Context, tx *sql.Tx, projectID, entryID string, payload JournalFactPayload, nowTime time.Time) error {
+	payload.EntryID = entryID
+	newID, err := mintFactID(nowTime)
+	if err != nil {
 		return err
 	}
-	return upsertJournalProjectionTx(ctx, tx, projectID, id, payload)
+	if _, err := appendJournalFactTx(ctx, tx, projectID, newID, payload, nowTime); err != nil {
+		return err
+	}
+	return upsertJournalProjectionTx(ctx, tx, projectID, entryID, payload)
 }
 
 func journalProjectionDiffersFromPayloadTx(ctx context.Context, tx *sql.Tx, id string, payload JournalFactPayload) (bool, error) {
@@ -168,10 +230,11 @@ WHERE id = ?
 }
 
 func upsertJournalViaFactsTx(ctx context.Context, tx *sql.Tx, projectID, id string, payload JournalFactPayload, nowTime time.Time) error {
-	exists, err := journalFactExistsTx(ctx, tx, id)
+	folded, err := foldJournalFacts(ctx, tx, projectID)
 	if err != nil {
 		return err
 	}
+	existingFold, exists := folded[id]
 	if !exists {
 		if _, err := appendJournalFactTx(ctx, tx, projectID, id, payload, nowTime); err != nil {
 			return err
@@ -185,14 +248,7 @@ func upsertJournalViaFactsTx(ctx context.Context, tx *sql.Tx, projectID, id stri
 	if projectionExists == 0 {
 		return insertJournalProjectionTx(ctx, tx, projectID, id, payload)
 	}
-	var payloadRaw string
-	if err := tx.QueryRowContext(ctx, `SELECT payload FROM facts WHERE id = ?`, id).Scan(&payloadRaw); err != nil {
-		return fmt.Errorf("read journal fact payload %q: %w", id, err)
-	}
-	existing, err := decodeJournalFactPayload(payloadRaw)
-	if err != nil {
-		return err
-	}
+	existing := existingFold.payload
 	// Grow-only facts own display timestamps; import callers pass fresh clocks.
 	payload.CreatedAt = existing.CreatedAt
 	payload.UpdatedAt = existing.UpdatedAt
@@ -207,10 +263,10 @@ func upsertJournalViaFactsTx(ctx context.Context, tx *sql.Tx, projectID, id stri
 		return upsertJournalProjectionTx(ctx, tx, projectID, id, payload)
 	}
 	payload.UpdatedAt = nowTime.UTC().Format(time.RFC3339Nano)
-	return replaceJournalFactForImportTx(ctx, tx, projectID, id, payload, nowTime)
+	return appendJournalFactRevisionForImportTx(ctx, tx, projectID, id, payload, nowTime)
 }
 
-// InspectJournalFactParity compares journal-kind facts to journal_entries.
+// InspectJournalFactParity compares folded journal facts to journal_entries.
 func InspectJournalFactParity(ctx context.Context, store *Store) (JournalFactParity, error) {
 	if store == nil || store.db == nil {
 		return JournalFactParity{}, fmt.Errorf("inspect journal fact parity: store is nil")
@@ -230,35 +286,9 @@ func inspectJournalFactParity(ctx context.Context, queryer queryContext) (Journa
 	if !tableExists(ctx, queryer, "facts") {
 		return JournalFactParity{Ready: true}, nil
 	}
-	rows, err := queryer.QueryContext(ctx, `
-SELECT f.id, f.project_id, f.payload
-FROM facts AS f
-WHERE f.kind = ?
-ORDER BY f.project_id, f.hlc, f.env_id, f.id
-`, FactKindJournal)
+	folded, err := foldJournalFacts(ctx, queryer, "")
 	if err != nil {
-		return JournalFactParity{}, fmt.Errorf("list journal facts: %w", err)
-	}
-	defer rows.Close()
-
-	type foldedRow struct {
-		projectID string
-		payload   JournalFactPayload
-	}
-	folded := map[string]foldedRow{}
-	for rows.Next() {
-		var id, projectID, payloadRaw string
-		if err := rows.Scan(&id, &projectID, &payloadRaw); err != nil {
-			return JournalFactParity{}, fmt.Errorf("scan journal fact: %w", err)
-		}
-		payload, err := decodeJournalFactPayload(payloadRaw)
-		if err != nil {
-			return JournalFactParity{}, err
-		}
-		folded[id] = foldedRow{projectID: projectID, payload: payload}
-	}
-	if err := rows.Err(); err != nil {
-		return JournalFactParity{}, fmt.Errorf("iterate journal facts: %w", err)
+		return JournalFactParity{}, err
 	}
 
 	projectionRows, err := queryer.QueryContext(ctx, `
@@ -315,35 +345,9 @@ func journalProjectionMatchesPayload(entryType, scope, message, branch, worktree
 }
 
 func rebuildJournalProjectionFromFactsTx(ctx context.Context, execer journalWriteExecer, projectID string) (int, error) {
-	rows, err := execer.QueryContext(ctx, `
-SELECT id, payload
-FROM facts
-WHERE project_id = ? AND kind = ?
-ORDER BY hlc ASC, env_id ASC, id ASC
-`, projectID, FactKindJournal)
+	folded, err := foldJournalFacts(ctx, execer, projectID)
 	if err != nil {
-		return 0, fmt.Errorf("list journal facts for rebuild: %w", err)
-	}
-	defer rows.Close()
-
-	type projection struct {
-		id      string
-		payload JournalFactPayload
-	}
-	projections := []projection{}
-	for rows.Next() {
-		var id, payloadRaw string
-		if err := rows.Scan(&id, &payloadRaw); err != nil {
-			return 0, fmt.Errorf("scan journal fact for rebuild: %w", err)
-		}
-		payload, err := decodeJournalFactPayload(payloadRaw)
-		if err != nil {
-			return 0, err
-		}
-		projections = append(projections, projection{id: id, payload: payload})
-	}
-	if err := rows.Err(); err != nil {
-		return 0, fmt.Errorf("iterate journal facts for rebuild: %w", err)
+		return 0, err
 	}
 
 	if _, err := execer.ExecContext(ctx, `DELETE FROM journal_search WHERE project_id = ?`, projectID); err != nil {
@@ -352,15 +356,15 @@ ORDER BY hlc ASC, env_id ASC, id ASC
 	if _, err := execer.ExecContext(ctx, `DELETE FROM journal_entries WHERE project_id = ?`, projectID); err != nil {
 		return 0, fmt.Errorf("clear journal projection: %w", err)
 	}
-	for _, row := range projections {
-		if err := insertJournalProjectionTx(ctx, execer, projectID, row.id, row.payload); err != nil {
+	for entryID, row := range folded {
+		if err := insertJournalProjectionTx(ctx, execer, projectID, entryID, row.payload); err != nil {
 			return 0, err
 		}
-		if err := insertJournalSearchTx(ctx, execer, projectID, row.id, row.payload.HarnessSessionID, row.payload.EntryType, row.payload.Scope, row.payload.Message); err != nil {
+		if err := insertJournalSearchTx(ctx, execer, projectID, entryID, row.payload.HarnessSessionID, row.payload.EntryType, row.payload.Scope, row.payload.Message); err != nil {
 			return 0, err
 		}
 	}
-	return len(projections), nil
+	return len(folded), nil
 }
 
 func backfillMissingJournalFactsForProjectTx(ctx context.Context, tx *sql.Tx, projectID string) error {
@@ -370,23 +374,29 @@ func backfillMissingJournalFactsForProjectTx(ctx context.Context, tx *sql.Tx, pr
 	if !tableExists(ctx, tx, "facts") {
 		return nil
 	}
+	folded, err := foldJournalFacts(ctx, tx, projectID)
+	if err != nil {
+		return err
+	}
 	rows, err := tx.QueryContext(ctx, `
 SELECT j.id, j.entry_type, COALESCE(j.scope, ''), j.message,
        COALESCE(j.observed_branch, ''), COALESCE(j.observed_worktree, ''),
        COALESCE(j.harness_session_id, ''), j.created_at, j.updated_at
 FROM journal_entries AS j
-LEFT JOIN facts AS f ON f.id = j.id
-WHERE j.project_id = ? AND f.id IS NULL
+WHERE j.project_id = ?
 ORDER BY j.created_at, j.rowid
 `, projectID)
 	if err != nil {
-		return fmt.Errorf("list journal rows missing facts: %w", err)
+		return fmt.Errorf("list journal rows for fact backfill: %w", err)
 	}
 	defer rows.Close()
 	for rows.Next() {
 		var id, entryType, scope, message, branch, worktree, sessionID, createdAt, updatedAt string
 		if err := rows.Scan(&id, &entryType, &scope, &message, &branch, &worktree, &sessionID, &createdAt, &updatedAt); err != nil {
 			return fmt.Errorf("scan journal row missing fact: %w", err)
+		}
+		if _, ok := folded[id]; ok {
+			continue
 		}
 		created, err := time.Parse(time.RFC3339Nano, createdAt)
 		if err != nil {
@@ -397,7 +407,7 @@ ORDER BY j.created_at, j.rowid
 			ObservedBranch: branch, ObservedWorktree: worktree, HarnessSessionID: sessionID,
 			CreatedAt: createdAt, UpdatedAt: updatedAt,
 		}
-		if _, err := appendJournalFactTx(ctx, tx, projectID, id, payload, created); err != nil {
+		if _, err := appendJournalFactWithEnvTx(ctx, tx, projectID, id, payload, created, legacyFactEnvID); err != nil {
 			return err
 		}
 	}
@@ -415,7 +425,7 @@ WHERE type = 'table' AND name = ?
 }
 
 // backfillJournalFactForTest mirrors one projection row into facts for tests that
-// insert journal_entries directly.
+// insert journal_entries directly. Historical wrap uses legacy-host env_id.
 func backfillJournalFactForTest(ctx context.Context, store *Store, projectID, journalEntryID string) error {
 	if store == nil || store.db == nil {
 		return fmt.Errorf("backfill journal fact: store is nil")
@@ -448,12 +458,12 @@ WHERE project_id = ? AND id = ?
 		return fmt.Errorf("begin journal fact backfill: %w", err)
 	}
 	defer tx.Rollback()
-	var existing int
-	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM facts WHERE id = ?`, journalEntryID).Scan(&existing); err != nil {
-		return fmt.Errorf("inspect fact id: %w", err)
+	exists, err := journalFactExistsForEntryTx(ctx, tx, projectID, journalEntryID)
+	if err != nil {
+		return err
 	}
-	if existing == 0 {
-		if _, err := appendJournalFactTx(ctx, tx, projectID, journalEntryID, payload, created); err != nil {
+	if !exists {
+		if _, err := appendJournalFactWithEnvTx(ctx, tx, projectID, journalEntryID, payload, created, legacyFactEnvID); err != nil {
 			if strings.Contains(err.Error(), "already exists") {
 				return nil
 			}

--- a/internal/state/journal_fact.go
+++ b/internal/state/journal_fact.go
@@ -1,0 +1,464 @@
+package state
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// JournalFactPayload is the journal-kind fact body. Display timestamps live here.
+type JournalFactPayload struct {
+	EntryType        string `json:"entry_type"`
+	Scope            string `json:"scope,omitempty"`
+	Message          string `json:"message"`
+	ObservedBranch   string `json:"observed_branch,omitempty"`
+	ObservedWorktree string `json:"observed_worktree,omitempty"`
+	HarnessSessionID string `json:"harness_session_id,omitempty"`
+	CreatedAt        string `json:"created_at"`
+	UpdatedAt        string `json:"updated_at"`
+}
+
+// JournalFactParity describes parity between journal facts and the projection.
+type JournalFactParity struct {
+	FactRows       int  `json:"fact_rows"`
+	ProjectionRows int  `json:"projection_rows"`
+	Missing        int  `json:"missing"`
+	Extra          int  `json:"extra"`
+	Changed        int  `json:"changed"`
+	Ready          bool `json:"ready"`
+}
+
+const JournalFactParityDivergenceCode = "journal-fact-parity-diverged"
+
+const JournalFactParityRepairCommand = "loaf state repair journal-facts --dry-run --json"
+
+func encodeJournalFactPayload(payload JournalFactPayload) (string, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("encode journal fact payload: %w", err)
+	}
+	return string(raw), nil
+}
+
+func decodeJournalFactPayload(raw string) (JournalFactPayload, error) {
+	var payload JournalFactPayload
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return JournalFactPayload{}, fmt.Errorf("decode journal fact payload: %w", err)
+	}
+	return payload, nil
+}
+
+func appendJournalFactTx(ctx context.Context, tx *sql.Tx, projectID string, id string, payload JournalFactPayload, now time.Time) (FactEnvelope, error) {
+	encoded, err := encodeJournalFactPayload(payload)
+	if err != nil {
+		return FactEnvelope{}, err
+	}
+	return appendFactTx(ctx, tx, AppendFactInput{
+		ProjectID: projectID,
+		Kind:      FactKindJournal,
+		Payload:   encoded,
+		ID:        id,
+		Now:       now,
+	})
+}
+
+func insertJournalProjectionTx(ctx context.Context, execer journalWriteExecer, projectID string, id string, payload JournalFactPayload) error {
+	_, err := execer.ExecContext(ctx, `
+INSERT INTO journal_entries (
+  id, project_id, entry_type, scope, message,
+  observed_branch, observed_worktree, harness_session_id,
+  spec_id, task_id, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)
+`, id, projectID, payload.EntryType, emptyToNil(payload.Scope), payload.Message,
+		emptyToNil(payload.ObservedBranch), emptyToNil(payload.ObservedWorktree), emptyToNil(payload.HarnessSessionID),
+		payload.CreatedAt, payload.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("insert journal projection row %q: %w", id, err)
+	}
+	return nil
+}
+
+func journalFactExistsTx(ctx context.Context, tx *sql.Tx, id string) (bool, error) {
+	var count int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM facts WHERE id = ?`, id).Scan(&count); err != nil {
+		return false, fmt.Errorf("inspect journal fact id %q: %w", id, err)
+	}
+	return count > 0, nil
+}
+
+func appendJournalDecisionFactAndProjectionTx(ctx context.Context, tx *sql.Tx, projectID, decisionID, scope, decisionMessage string, nowTime time.Time) error {
+	now := nowTime.Format(time.RFC3339Nano)
+	payload := JournalFactPayload{
+		EntryType: "decision",
+		Scope:     scope,
+		Message:   decisionMessage,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if _, err := appendJournalFactTx(ctx, tx, projectID, decisionID, payload, nowTime); err != nil {
+		return err
+	}
+	return insertJournalProjectionTx(ctx, tx, projectID, decisionID, payload)
+}
+
+func upsertJournalProjectionTx(ctx context.Context, execer journalWriteExecer, projectID, id string, payload JournalFactPayload) error {
+	_, err := execer.ExecContext(ctx, `
+INSERT INTO journal_entries (
+  id, project_id, entry_type, scope, message,
+  observed_branch, observed_worktree, harness_session_id,
+  spec_id, task_id, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+  entry_type = excluded.entry_type,
+  scope = excluded.scope,
+  message = excluded.message,
+  observed_branch = excluded.observed_branch,
+  observed_worktree = excluded.observed_worktree,
+  harness_session_id = excluded.harness_session_id,
+  updated_at = excluded.updated_at
+`, id, projectID, payload.EntryType, emptyToNil(payload.Scope), payload.Message,
+		emptyToNil(payload.ObservedBranch), emptyToNil(payload.ObservedWorktree), emptyToNil(payload.HarnessSessionID),
+		payload.CreatedAt, payload.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("upsert journal projection row %q: %w", id, err)
+	}
+	return nil
+}
+
+func journalFactPayloadContentEqual(a, b JournalFactPayload) bool {
+	return a.EntryType == b.EntryType &&
+		a.Scope == b.Scope &&
+		a.Message == b.Message &&
+		a.ObservedBranch == b.ObservedBranch &&
+		a.ObservedWorktree == b.ObservedWorktree &&
+		a.HarnessSessionID == b.HarnessSessionID &&
+		a.CreatedAt == b.CreatedAt
+}
+
+func replaceJournalFactForImportTx(ctx context.Context, tx *sql.Tx, projectID, id string, payload JournalFactPayload, nowTime time.Time) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM facts WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("replace journal fact %q: %w", id, err)
+	}
+	if _, err := appendJournalFactTx(ctx, tx, projectID, id, payload, nowTime); err != nil {
+		return err
+	}
+	return upsertJournalProjectionTx(ctx, tx, projectID, id, payload)
+}
+
+func journalProjectionDiffersFromPayloadTx(ctx context.Context, tx *sql.Tx, id string, payload JournalFactPayload) (bool, error) {
+	var entryType, scope, message, branch, worktree, sessionID, createdAt, updatedAt string
+	err := tx.QueryRowContext(ctx, `
+SELECT entry_type, COALESCE(scope, ''), message,
+       COALESCE(observed_branch, ''), COALESCE(observed_worktree, ''),
+       COALESCE(harness_session_id, ''), created_at, updated_at
+FROM journal_entries
+WHERE id = ?
+`, id).Scan(&entryType, &scope, &message, &branch, &worktree, &sessionID, &createdAt, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read journal projection %q: %w", id, err)
+	}
+	return !journalProjectionMatchesPayload(entryType, scope, message, branch, worktree, sessionID, createdAt, updatedAt, payload), nil
+}
+
+func upsertJournalViaFactsTx(ctx context.Context, tx *sql.Tx, projectID, id string, payload JournalFactPayload, nowTime time.Time) error {
+	exists, err := journalFactExistsTx(ctx, tx, id)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if _, err := appendJournalFactTx(ctx, tx, projectID, id, payload, nowTime); err != nil {
+			return err
+		}
+		return upsertJournalProjectionTx(ctx, tx, projectID, id, payload)
+	}
+	var projectionExists int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM journal_entries WHERE id = ?`, id).Scan(&projectionExists); err != nil {
+		return fmt.Errorf("inspect journal projection id %q: %w", id, err)
+	}
+	if projectionExists == 0 {
+		return insertJournalProjectionTx(ctx, tx, projectID, id, payload)
+	}
+	var payloadRaw string
+	if err := tx.QueryRowContext(ctx, `SELECT payload FROM facts WHERE id = ?`, id).Scan(&payloadRaw); err != nil {
+		return fmt.Errorf("read journal fact payload %q: %w", id, err)
+	}
+	existing, err := decodeJournalFactPayload(payloadRaw)
+	if err != nil {
+		return err
+	}
+	// Grow-only facts own display timestamps; import callers pass fresh clocks.
+	payload.CreatedAt = existing.CreatedAt
+	payload.UpdatedAt = existing.UpdatedAt
+	if journalFactPayloadContentEqual(existing, payload) {
+		differs, err := journalProjectionDiffersFromPayloadTx(ctx, tx, id, payload)
+		if err != nil {
+			return err
+		}
+		if !differs {
+			return nil
+		}
+		return upsertJournalProjectionTx(ctx, tx, projectID, id, payload)
+	}
+	payload.UpdatedAt = nowTime.UTC().Format(time.RFC3339Nano)
+	return replaceJournalFactForImportTx(ctx, tx, projectID, id, payload, nowTime)
+}
+
+// InspectJournalFactParity compares journal-kind facts to journal_entries.
+func InspectJournalFactParity(ctx context.Context, store *Store) (JournalFactParity, error) {
+	if store == nil || store.db == nil {
+		return JournalFactParity{}, fmt.Errorf("inspect journal fact parity: store is nil")
+	}
+	tx, err := store.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return JournalFactParity{}, fmt.Errorf("begin journal fact parity snapshot: %w", err)
+	}
+	defer tx.Rollback()
+	return inspectJournalFactParity(ctx, tx)
+}
+
+func inspectJournalFactParity(ctx context.Context, queryer queryContext) (JournalFactParity, error) {
+	if queryer == nil {
+		return JournalFactParity{}, fmt.Errorf("inspect journal fact parity: queryer is nil")
+	}
+	if !tableExists(ctx, queryer, "facts") {
+		return JournalFactParity{Ready: true}, nil
+	}
+	rows, err := queryer.QueryContext(ctx, `
+SELECT f.id, f.project_id, f.payload
+FROM facts AS f
+WHERE f.kind = ?
+ORDER BY f.project_id, f.hlc, f.env_id, f.id
+`, FactKindJournal)
+	if err != nil {
+		return JournalFactParity{}, fmt.Errorf("list journal facts: %w", err)
+	}
+	defer rows.Close()
+
+	type foldedRow struct {
+		projectID string
+		payload   JournalFactPayload
+	}
+	folded := map[string]foldedRow{}
+	for rows.Next() {
+		var id, projectID, payloadRaw string
+		if err := rows.Scan(&id, &projectID, &payloadRaw); err != nil {
+			return JournalFactParity{}, fmt.Errorf("scan journal fact: %w", err)
+		}
+		payload, err := decodeJournalFactPayload(payloadRaw)
+		if err != nil {
+			return JournalFactParity{}, err
+		}
+		folded[id] = foldedRow{projectID: projectID, payload: payload}
+	}
+	if err := rows.Err(); err != nil {
+		return JournalFactParity{}, fmt.Errorf("iterate journal facts: %w", err)
+	}
+
+	projectionRows, err := queryer.QueryContext(ctx, `
+SELECT id, project_id, entry_type, COALESCE(scope, ''), message,
+       COALESCE(observed_branch, ''), COALESCE(observed_worktree, ''),
+       COALESCE(harness_session_id, ''), created_at, updated_at
+FROM journal_entries
+ORDER BY project_id, created_at, rowid
+`)
+	if err != nil {
+		return JournalFactParity{}, fmt.Errorf("list journal projection rows: %w", err)
+	}
+	defer projectionRows.Close()
+
+	parity := JournalFactParity{FactRows: len(folded)}
+	seen := map[string]struct{}{}
+	for projectionRows.Next() {
+		var id, projectID, entryType, scope, message, branch, worktree, sessionID, createdAt, updatedAt string
+		if err := projectionRows.Scan(&id, &projectID, &entryType, &scope, &message, &branch, &worktree, &sessionID, &createdAt, &updatedAt); err != nil {
+			return JournalFactParity{}, fmt.Errorf("scan journal projection row: %w", err)
+		}
+		parity.ProjectionRows++
+		seen[id] = struct{}{}
+		fact, ok := folded[id]
+		if !ok {
+			parity.Extra++
+			continue
+		}
+		if fact.projectID != projectID || !journalProjectionMatchesPayload(entryType, scope, message, branch, worktree, sessionID, createdAt, updatedAt, fact.payload) {
+			parity.Changed++
+		}
+	}
+	if err := projectionRows.Err(); err != nil {
+		return JournalFactParity{}, fmt.Errorf("iterate journal projection rows: %w", err)
+	}
+	for id := range folded {
+		if _, ok := seen[id]; !ok {
+			parity.Missing++
+		}
+	}
+	parity.Ready = parity.Missing == 0 && parity.Extra == 0 && parity.Changed == 0
+	return parity, nil
+}
+
+func journalProjectionMatchesPayload(entryType, scope, message, branch, worktree, sessionID, createdAt, updatedAt string, payload JournalFactPayload) bool {
+	return payload.EntryType == entryType &&
+		payload.Scope == scope &&
+		payload.Message == message &&
+		payload.ObservedBranch == branch &&
+		payload.ObservedWorktree == worktree &&
+		payload.HarnessSessionID == sessionID &&
+		payload.CreatedAt == createdAt &&
+		payload.UpdatedAt == updatedAt
+}
+
+func rebuildJournalProjectionFromFactsTx(ctx context.Context, execer journalWriteExecer, projectID string) (int, error) {
+	rows, err := execer.QueryContext(ctx, `
+SELECT id, payload
+FROM facts
+WHERE project_id = ? AND kind = ?
+ORDER BY hlc ASC, env_id ASC, id ASC
+`, projectID, FactKindJournal)
+	if err != nil {
+		return 0, fmt.Errorf("list journal facts for rebuild: %w", err)
+	}
+	defer rows.Close()
+
+	type projection struct {
+		id      string
+		payload JournalFactPayload
+	}
+	projections := []projection{}
+	for rows.Next() {
+		var id, payloadRaw string
+		if err := rows.Scan(&id, &payloadRaw); err != nil {
+			return 0, fmt.Errorf("scan journal fact for rebuild: %w", err)
+		}
+		payload, err := decodeJournalFactPayload(payloadRaw)
+		if err != nil {
+			return 0, err
+		}
+		projections = append(projections, projection{id: id, payload: payload})
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate journal facts for rebuild: %w", err)
+	}
+
+	if _, err := execer.ExecContext(ctx, `DELETE FROM journal_search WHERE project_id = ?`, projectID); err != nil {
+		return 0, fmt.Errorf("clear journal search projection: %w", err)
+	}
+	if _, err := execer.ExecContext(ctx, `DELETE FROM journal_entries WHERE project_id = ?`, projectID); err != nil {
+		return 0, fmt.Errorf("clear journal projection: %w", err)
+	}
+	for _, row := range projections {
+		if err := insertJournalProjectionTx(ctx, execer, projectID, row.id, row.payload); err != nil {
+			return 0, err
+		}
+		if err := insertJournalSearchTx(ctx, execer, projectID, row.id, row.payload.HarnessSessionID, row.payload.EntryType, row.payload.Scope, row.payload.Message); err != nil {
+			return 0, err
+		}
+	}
+	return len(projections), nil
+}
+
+func backfillMissingJournalFactsForProjectTx(ctx context.Context, tx *sql.Tx, projectID string) error {
+	if tx == nil {
+		return fmt.Errorf("backfill missing journal facts: transaction is nil")
+	}
+	if !tableExists(ctx, tx, "facts") {
+		return nil
+	}
+	rows, err := tx.QueryContext(ctx, `
+SELECT j.id, j.entry_type, COALESCE(j.scope, ''), j.message,
+       COALESCE(j.observed_branch, ''), COALESCE(j.observed_worktree, ''),
+       COALESCE(j.harness_session_id, ''), j.created_at, j.updated_at
+FROM journal_entries AS j
+LEFT JOIN facts AS f ON f.id = j.id
+WHERE j.project_id = ? AND f.id IS NULL
+ORDER BY j.created_at, j.rowid
+`, projectID)
+	if err != nil {
+		return fmt.Errorf("list journal rows missing facts: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, entryType, scope, message, branch, worktree, sessionID, createdAt, updatedAt string
+		if err := rows.Scan(&id, &entryType, &scope, &message, &branch, &worktree, &sessionID, &createdAt, &updatedAt); err != nil {
+			return fmt.Errorf("scan journal row missing fact: %w", err)
+		}
+		created, err := time.Parse(time.RFC3339Nano, createdAt)
+		if err != nil {
+			return fmt.Errorf("parse journal created_at: %w", err)
+		}
+		payload := JournalFactPayload{
+			EntryType: entryType, Scope: scope, Message: message,
+			ObservedBranch: branch, ObservedWorktree: worktree, HarnessSessionID: sessionID,
+			CreatedAt: createdAt, UpdatedAt: updatedAt,
+		}
+		if _, err := appendJournalFactTx(ctx, tx, projectID, id, payload, created); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func tableExists(ctx context.Context, queryer queryContext, name string) bool {
+	var count int
+	err := queryer.QueryRowContext(ctx, `
+SELECT COUNT(*)
+FROM sqlite_master
+WHERE type = 'table' AND name = ?
+`, name).Scan(&count)
+	return err == nil && count > 0
+}
+
+// backfillJournalFactForTest mirrors one projection row into facts for tests that
+// insert journal_entries directly.
+func backfillJournalFactForTest(ctx context.Context, store *Store, projectID, journalEntryID string) error {
+	if store == nil || store.db == nil {
+		return fmt.Errorf("backfill journal fact: store is nil")
+	}
+	var entryType, scope, message, branch, worktree, sessionID, createdAt, updatedAt sql.NullString
+	err := store.db.QueryRowContext(ctx, `
+SELECT entry_type, scope, message, observed_branch, observed_worktree, harness_session_id, created_at, updated_at
+FROM journal_entries
+WHERE project_id = ? AND id = ?
+`, projectID, journalEntryID).Scan(&entryType, &scope, &message, &branch, &worktree, &sessionID, &createdAt, &updatedAt)
+	if err != nil {
+		return fmt.Errorf("read journal projection row %q: %w", journalEntryID, err)
+	}
+	created, err := time.Parse(time.RFC3339Nano, createdAt.String)
+	if err != nil {
+		return fmt.Errorf("parse journal created_at: %w", err)
+	}
+	payload := JournalFactPayload{
+		EntryType:        entryType.String,
+		Scope:            scope.String,
+		Message:          message.String,
+		ObservedBranch:   branch.String,
+		ObservedWorktree: worktree.String,
+		HarnessSessionID: sessionID.String,
+		CreatedAt:        createdAt.String,
+		UpdatedAt:        updatedAt.String,
+	}
+	tx, err := store.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return fmt.Errorf("begin journal fact backfill: %w", err)
+	}
+	defer tx.Rollback()
+	var existing int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM facts WHERE id = ?`, journalEntryID).Scan(&existing); err != nil {
+		return fmt.Errorf("inspect fact id: %w", err)
+	}
+	if existing == 0 {
+		if _, err := appendJournalFactTx(ctx, tx, projectID, journalEntryID, payload, created); err != nil {
+			if strings.Contains(err.Error(), "already exists") {
+				return nil
+			}
+			return err
+		}
+	}
+	return tx.Commit()
+}

--- a/internal/state/journal_fact_test.go
+++ b/internal/state/journal_fact_test.go
@@ -1,0 +1,198 @@
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/levifig/loaf/internal/project"
+)
+
+func mustBackfillJournalFactForTest(t *testing.T, store *Store, projectID, journalEntryID string) {
+	t.Helper()
+	if err := backfillJournalFactForTest(context.Background(), store, projectID, journalEntryID); err != nil {
+		t.Fatalf("backfill journal fact %s: %v", journalEntryID, err)
+	}
+}
+
+func TestLogJournalWritesAndReadsAsFacts(t *testing.T) {
+	requireGit(t)
+	repo := initGitRepo(t)
+	root, err := project.ResolveRoot(repo)
+	if err != nil {
+		t.Fatalf("ResolveRoot() error = %v", err)
+	}
+	stateHome := t.TempDir()
+	status, err := Initialize(context.Background(), root, PathResolver{StateHome: stateHome})
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	store, err := OpenStore(status.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+
+	result, err := store.LogJournal(context.Background(), root, JournalLogOptions{
+		Entry:            "decision(facts): journal on facts",
+		ObservedBranch:   ObservedGitBranch(repo),
+		ObservedWorktree: repo,
+		HarnessSessionID: "harness-facts",
+	})
+	if err != nil {
+		t.Fatalf("LogJournal() error = %v", err)
+	}
+	var factCount int
+	if err := store.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM facts WHERE id = ? AND kind = ?`, result.ID, FactKindJournal).Scan(&factCount); err != nil {
+		t.Fatalf("count fact row: %v", err)
+	}
+	if factCount != 1 {
+		t.Fatalf("fact count = %d, want 1", factCount)
+	}
+	parity, err := InspectJournalFactParity(context.Background(), store)
+	if err != nil {
+		t.Fatalf("InspectJournalFactParity() error = %v", err)
+	}
+	if !parity.Ready {
+		t.Fatalf("parity = %#v, want ready", parity)
+	}
+	recent, err := store.RecentJournal(context.Background(), root, JournalRecentOptions{Limit: 5})
+	if err != nil {
+		t.Fatalf("RecentJournal() error = %v", err)
+	}
+	if len(recent.Entries) == 0 || recent.Entries[0].ID != result.ID {
+		t.Fatalf("recent entries = %#v, want logged entry", recent.Entries)
+	}
+}
+
+func TestInspectJournalFactParityDetectsProjectionDivergence(t *testing.T) {
+	ctx := context.Background()
+	root := projectRoot(t)
+	resolver := PathResolver{StateHome: t.TempDir()}
+	status, err := Initialize(ctx, root, resolver)
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	store, err := OpenStore(status.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+	projectID, err := store.projectID(ctx, root)
+	if err != nil {
+		t.Fatalf("projectID() error = %v", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	entryID := "journal-test-projection-only"
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO journal_entries (id, project_id, entry_type, scope, message, created_at, updated_at)
+VALUES (?, ?, 'discover', 'facts', 'projection only', ?, ?)
+`, entryID, projectID, now, now); err != nil {
+		t.Fatalf("insert projection-only journal row: %v", err)
+	}
+	parity, err := InspectJournalFactParity(ctx, store)
+	if err != nil {
+		t.Fatalf("InspectJournalFactParity() error = %v", err)
+	}
+	if parity.Ready || parity.Extra == 0 {
+		t.Fatalf("parity = %#v, want extra divergence", parity)
+	}
+	if err := backfillJournalFactForTest(ctx, store, projectID, entryID); err != nil {
+		t.Fatalf("backfillJournalFactForTest() error = %v", err)
+	}
+	parity, err = InspectJournalFactParity(ctx, store)
+	if err != nil {
+		t.Fatalf("InspectJournalFactParity() after backfill error = %v", err)
+	}
+	if !parity.Ready {
+		t.Fatalf("parity after backfill = %#v, want ready", parity)
+	}
+}
+
+func TestMigrationWrapsExistingJournalCorpus(t *testing.T) {
+	ctx := context.Background()
+	root := projectRoot(t)
+	resolver := PathResolver{StateHome: t.TempDir()}
+	status, err := Initialize(ctx, root, resolver)
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	store, err := OpenStore(status.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+	logged, err := store.LogJournal(ctx, root, JournalLogOptions{Entry: "discover(wrap): wrapped corpus"})
+	if err != nil {
+		t.Fatalf("LogJournal() error = %v", err)
+	}
+	var envID string
+	if err := store.db.QueryRowContext(ctx, `SELECT env_id FROM facts WHERE id = ?`, logged.ID).Scan(&envID); err != nil {
+		t.Fatalf("read wrapped env_id: %v", err)
+	}
+	if envID != localFactEnvID() && envID != legacyFactEnvID {
+		t.Fatalf("env_id = %q, want local or legacy host", envID)
+	}
+	parity, err := InspectJournalFactParity(ctx, store)
+	if err != nil {
+		t.Fatalf("InspectJournalFactParity() error = %v", err)
+	}
+	if !parity.Ready || parity.FactRows == 0 {
+		t.Fatalf("parity = %#v, want ready wrapped corpus", parity)
+	}
+}
+
+func TestDeferJournalMaintainsJournalFactParity(t *testing.T) {
+	ctx := context.Background()
+	root := projectRoot(t)
+	resolver := PathResolver{StateHome: t.TempDir()}
+	status, err := Initialize(ctx, root, resolver)
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	store, err := OpenStore(status.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+	if _, err := store.DeferJournal(ctx, root, JournalDeferOptions{
+		Intent: "parity intent", Why: "parity why", Boundary: "parity boundary", Trigger: "parity trigger",
+		OperationID: "parity-op",
+	}); err != nil {
+		t.Fatalf("DeferJournal() error = %v", err)
+	}
+	parity, err := InspectJournalFactParity(ctx, store)
+	if err != nil {
+		t.Fatalf("InspectJournalFactParity() error = %v", err)
+	}
+	if !parity.Ready || parity.FactRows == 0 {
+		t.Fatalf("parity = %#v, want ready defer decision fact", parity)
+	}
+}
+
+func TestImportMarkdownMaintainsJournalFactParity(t *testing.T) {
+	ctx := context.Background()
+	root := projectRoot(t)
+	stateHome := t.TempDir()
+	writeAgentsFile(t, root.Path(), "sessions/20260710-journal.md", `---
+harness_session_id: hsid-fact-parity
+---
+[2026-07-10 10:00] decision(import): markdown fact parity
+`)
+	result, err := ApplyMarkdownMigration(ctx, root, PathResolver{StateHome: stateHome})
+	if err != nil {
+		t.Fatalf("ApplyMarkdownMigration() error = %v", err)
+	}
+	store, err := OpenStore(result.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+	parity, err := InspectJournalFactParity(ctx, store)
+	if err != nil {
+		t.Fatalf("InspectJournalFactParity() error = %v", err)
+	}
+	if !parity.Ready || parity.FactRows != 1 || parity.ProjectionRows != 1 {
+		t.Fatalf("parity = %#v, want one ready imported journal fact", parity)
+	}
+}

--- a/internal/state/journal_fact_test.go
+++ b/internal/state/journal_fact_test.go
@@ -196,3 +196,111 @@ harness_session_id: hsid-fact-parity
 		t.Fatalf("parity = %#v, want one ready imported journal fact", parity)
 	}
 }
+
+func TestImportJournalRevisionIsGrowOnly(t *testing.T) {
+	ctx := context.Background()
+	root := projectRoot(t)
+	resolver := PathResolver{StateHome: t.TempDir()}
+	status, err := Initialize(ctx, root, resolver)
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	store, err := OpenStore(status.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+
+	logged, err := store.LogJournal(ctx, root, JournalLogOptions{Entry: "decision(import): original content"})
+	if err != nil {
+		t.Fatalf("LogJournal() error = %v", err)
+	}
+	var beforeCount int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM facts WHERE kind = ?`, FactKindJournal).Scan(&beforeCount); err != nil {
+		t.Fatalf("count facts before: %v", err)
+	}
+
+	var createdAt string
+	if err := store.db.QueryRowContext(ctx, `SELECT created_at FROM journal_entries WHERE id = ?`, logged.ID).Scan(&createdAt); err != nil {
+		t.Fatalf("read created_at: %v", err)
+	}
+	now := time.Now().UTC()
+	payload := JournalFactPayload{
+		EntryType: "decision",
+		Scope:     "import",
+		Message:   "revised content",
+		CreatedAt: createdAt,
+		UpdatedAt: now.Format(time.RFC3339Nano),
+	}
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	if err := appendJournalFactRevisionForImportTx(ctx, tx, status.ProjectID, logged.ID, payload, now); err != nil {
+		tx.Rollback()
+		t.Fatalf("appendJournalFactRevisionForImportTx() error = %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+
+	var afterCount int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM facts WHERE kind = ?`, FactKindJournal).Scan(&afterCount); err != nil {
+		t.Fatalf("count facts after: %v", err)
+	}
+	if afterCount != beforeCount+1 {
+		t.Fatalf("fact count = %d, want %d (grow-only append)", afterCount, beforeCount+1)
+	}
+	var originalExists int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM facts WHERE id = ?`, logged.ID).Scan(&originalExists); err != nil {
+		t.Fatalf("original fact lookup: %v", err)
+	}
+	if originalExists != 1 {
+		t.Fatal("original fact row was deleted; grow-only violated")
+	}
+	var message string
+	if err := store.db.QueryRowContext(ctx, `SELECT message FROM journal_entries WHERE id = ?`, logged.ID).Scan(&message); err != nil {
+		t.Fatalf("read projection: %v", err)
+	}
+	if message != "revised content" {
+		t.Fatalf("projection message = %q, want revised content", message)
+	}
+	parity, err := InspectJournalFactParity(ctx, store)
+	if err != nil {
+		t.Fatalf("InspectJournalFactParity() error = %v", err)
+	}
+	if !parity.Ready {
+		t.Fatalf("parity = %#v, want ready after fold", parity)
+	}
+}
+
+func TestHistoricalJournalFactBackfillUsesLegacyHostEnv(t *testing.T) {
+	ctx := context.Background()
+	root := projectRoot(t)
+	resolver := PathResolver{StateHome: t.TempDir()}
+	status, err := Initialize(ctx, root, resolver)
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	store, err := OpenStore(status.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+
+	entryID := "historical-backfill-entry"
+	now := "2026-08-01T00:00:00Z"
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO journal_entries (id, project_id, entry_type, scope, message, observed_branch, observed_worktree, harness_session_id, spec_id, task_id, created_at, updated_at)
+VALUES (?, ?, 'decision', 'hist', 'legacy wrap', NULL, NULL, NULL, NULL, NULL, ?, ?)`, entryID, status.ProjectID, now, now); err != nil {
+		t.Fatalf("insert projection: %v", err)
+	}
+	mustBackfillJournalFactForTest(t, store, status.ProjectID, entryID)
+	var envID string
+	if err := store.db.QueryRowContext(ctx, `SELECT env_id FROM facts WHERE id = ?`, entryID).Scan(&envID); err != nil {
+		t.Fatalf("read env_id: %v", err)
+	}
+	if envID != legacyFactEnvID {
+		t.Fatalf("env_id = %q, want %q", envID, legacyFactEnvID)
+	}
+}

--- a/internal/state/journal_first_migration_test.go
+++ b/internal/state/journal_first_migration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,51 @@ import (
 // harness_session_id, entry_type='session' lifecycle noise, entry_type='wrap'
 // synthesis, events/aliases with entity_kind='session', and a handoff carrying
 // a session_id. It returns the project id.
+
+func initializePreFactsState(t *testing.T, ctx context.Context, root project.Root, resolver PathResolver) (Status, error) {
+	t.Helper()
+	databasePath, err := resolver.DatabasePath(root)
+	if err != nil {
+		return Status{}, err
+	}
+	if err := os.MkdirAll(filepath.Dir(databasePath), 0o700); err != nil {
+		return Status{}, fmt.Errorf("create state database directory: %w", err)
+	}
+	store, err := OpenStore(databasePath)
+	if err != nil {
+		return Status{}, err
+	}
+	if err := ApplyMigrations(ctx, store.db, SchemaMigrations()[:16]); err != nil {
+		store.Close()
+		return Status{}, err
+	}
+	if err := store.UpsertProject(ctx, root); err != nil {
+		store.Close()
+		return Status{}, err
+	}
+	identity, err := store.LookupProjectIdentityForRoot(ctx, root)
+	if err != nil {
+		store.Close()
+		return Status{}, err
+	}
+	if err := store.Close(); err != nil {
+		return Status{}, err
+	}
+	return Status{
+		ContractVersion:      StateJSONContractVersion,
+		DatabaseScope:        "global",
+		ProjectRoot:          root.Path(),
+		LegacyProjectKey:     ProjectID(root),
+		DatabasePath:         databasePath,
+		DatabaseExists:       true,
+		DatabaseParentExists: true,
+		ProjectID:            identity.ID,
+		ProjectName:          identity.FriendlyName,
+		ProjectCurrentPath:   identity.CurrentPath,
+		SchemaVersion:        17,
+	}, nil
+}
+
 func seedJournalFirstFixture(t *testing.T, databasePath string, projectID string) {
 	t.Helper()
 	store, err := OpenStore(databasePath)
@@ -103,7 +149,7 @@ func TestPreviewJournalFirstMigrationUsesCopyRun(t *testing.T) {
 	ctx := context.Background()
 	root := projectRoot(t)
 	stateHome := t.TempDir()
-	status, err := Initialize(ctx, root, PathResolver{StateHome: stateHome})
+	status, err := initializePreFactsState(t, ctx, root, PathResolver{StateHome: stateHome})
 	if err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -154,7 +200,7 @@ func TestApplyJournalFirstMigrationTransformsLiveDatabase(t *testing.T) {
 	ctx := context.Background()
 	root := projectRoot(t)
 	stateHome := t.TempDir()
-	status, err := Initialize(ctx, root, PathResolver{StateHome: stateHome})
+	status, err := initializePreFactsState(t, ctx, root, PathResolver{StateHome: stateHome})
 	if err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -273,7 +319,7 @@ func TestApplyJournalFirstMigrationIsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	root := projectRoot(t)
 	stateHome := t.TempDir()
-	status, err := Initialize(ctx, root, PathResolver{StateHome: stateHome})
+	status, err := initializePreFactsState(t, ctx, root, PathResolver{StateHome: stateHome})
 	if err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -311,7 +357,7 @@ func TestJournalFirstMigrationRebuildsModifiedDerivedState(t *testing.T) {
 	root := projectRoot(t)
 	stateHome := t.TempDir()
 	resolver := PathResolver{StateHome: stateHome}
-	status, err := Initialize(ctx, root, resolver)
+	status, err := initializePreFactsState(t, ctx, root, resolver)
 	if err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -345,7 +391,7 @@ func TestJournalFirstMigrationRefusesAfterBackupConcurrentCanonicalUpdate(t *tes
 	root := projectRoot(t)
 	stateHome := t.TempDir()
 	resolver := PathResolver{StateHome: stateHome}
-	status, err := Initialize(ctx, root, resolver)
+	status, err := initializePreFactsState(t, ctx, root, resolver)
 	if err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -383,7 +429,7 @@ func TestInspectAcceptsMigratedJournalFirstDatabase(t *testing.T) {
 	root := projectRoot(t)
 	stateHome := t.TempDir()
 	resolver := PathResolver{StateHome: stateHome}
-	status, err := Initialize(ctx, root, resolver)
+	status, err := initializePreFactsState(t, ctx, root, resolver)
 	if err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -415,7 +461,7 @@ func TestApplyJournalFirstMigrationReRunIsCleanNoOp(t *testing.T) {
 	root := projectRoot(t)
 	stateHome := t.TempDir()
 	resolver := PathResolver{StateHome: stateHome}
-	status, err := Initialize(ctx, root, resolver)
+	status, err := initializePreFactsState(t, ctx, root, resolver)
 	if err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -461,7 +507,7 @@ func TestJournalExportSucceedsAfterJournalFirstMigration(t *testing.T) {
 	root := projectRoot(t)
 	stateHome := t.TempDir()
 	resolver := PathResolver{StateHome: stateHome}
-	status, err := Initialize(ctx, root, resolver)
+	status, err := initializePreFactsState(t, ctx, root, resolver)
 	if err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -509,7 +555,7 @@ func TestBackupVerifiesMigratedJournalFirstDatabase(t *testing.T) {
 	root := projectRoot(t)
 	stateHome := t.TempDir()
 	resolver := PathResolver{StateHome: stateHome}
-	status, err := Initialize(ctx, root, resolver)
+	status, err := initializePreFactsState(t, ctx, root, resolver)
 	if err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -537,8 +583,8 @@ func TestBackupVerifiesMigratedJournalFirstDatabase(t *testing.T) {
 }
 
 func TestJournalFirstMigrationExcludedFromAutoApply(t *testing.T) {
-	if CurrentSchemaVersion() != 19 {
-		t.Fatalf("CurrentSchemaVersion() = %d, want 19 (migration 10 must not auto-apply on store open)", CurrentSchemaVersion())
+	if CurrentSchemaVersion() != 20 {
+		t.Fatalf("CurrentSchemaVersion() = %d, want 20 (migration 10 must not auto-apply on store open)", CurrentSchemaVersion())
 	}
 	for _, m := range SchemaMigrations() {
 		if m.Version == journalFirstMigrationVersion {
@@ -618,7 +664,7 @@ func TestJournalFirstMigrationPreservesUnknownSessionRows(t *testing.T) {
 	root := projectRoot(t)
 	stateHome := t.TempDir()
 	resolver := PathResolver{StateHome: stateHome}
-	status, err := Initialize(ctx, root, resolver)
+	status, err := initializePreFactsState(t, ctx, root, resolver)
 	if err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}

--- a/internal/state/journal_recent_test.go
+++ b/internal/state/journal_recent_test.go
@@ -31,6 +31,7 @@ INSERT INTO journal_entries (
 	if err := insertJournalSearchStore(context.Background(), store, projectID, id, entryType, scope, message); err != nil {
 		t.Fatalf("seed journal search row: %v", err)
 	}
+	mustBackfillJournalFactForTest(t, store, projectID, id)
 	return id
 }
 

--- a/internal/state/journal_search_integrity_test.go
+++ b/internal/state/journal_search_integrity_test.go
@@ -580,6 +580,7 @@ VALUES ('legacy-session', ?, NULL, 'main', 'active', NULL, ?, ?)`, preStatus.Pro
 		postStoreBefore.Close()
 		t.Fatalf("post harness journal insert error = %v", err)
 	}
+	mustBackfillJournalFactForTest(t, postStoreBefore, postStatus.ProjectID, "post-harness-entry")
 	postStoreBefore.Close()
 	if _, err := ApplyJournalFirstMigration(ctx, postRoot, postResolver); err != nil {
 		t.Fatalf("ApplyJournalFirstMigration() error = %v", err)

--- a/internal/state/markdown_import.go
+++ b/internal/state/markdown_import.go
@@ -880,19 +880,21 @@ func (m markdownImporter) upsertJournalEntry(ctx context.Context, id string, ent
 		return false, nil
 	}
 
-	_, err = m.tx.ExecContext(ctx, `
-INSERT INTO journal_entries (id, project_id, entry_type, scope, message, observed_branch, observed_worktree, harness_session_id, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-ON CONFLICT(id) DO UPDATE SET
-  entry_type = excluded.entry_type,
-  scope = excluded.scope,
-  message = excluded.message,
-  observed_branch = excluded.observed_branch,
-  observed_worktree = excluded.observed_worktree,
-  harness_session_id = excluded.harness_session_id,
-  updated_at = excluded.updated_at
-`, id, m.projectID, entryType, emptyToNil(scope), message, emptyToNil(observedBranch), emptyToNil(observedWorktree), emptyToNil(harnessSessionID), m.now, m.now)
+	nowTime, err := time.Parse(time.RFC3339Nano, m.now)
 	if err != nil {
+		return false, fmt.Errorf("parse import timestamp: %w", err)
+	}
+	payload := JournalFactPayload{
+		EntryType:        entryType,
+		Scope:            scope,
+		Message:          message,
+		ObservedBranch:   observedBranch,
+		ObservedWorktree: observedWorktree,
+		HarnessSessionID: harnessSessionID,
+		CreatedAt:        m.now,
+		UpdatedAt:        m.now,
+	}
+	if err := upsertJournalViaFactsTx(ctx, m.tx, m.projectID, id, payload, nowTime); err != nil {
 		return false, fmt.Errorf("upsert journal entry %s: %w", id, err)
 	}
 	if err := m.writeMigrationJournalOrigin(ctx, id, observedBranch, observedWorktree, harnessSessionID, origin != nil); err != nil {

--- a/internal/state/markdown_import_alias_first_test.go
+++ b/internal/state/markdown_import_alias_first_test.go
@@ -285,7 +285,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?)
 			t.Fatalf("rekey %s: %v", table, err)
 		}
 	}
-	for _, table := range []string{"artifact_bodies", "journal_origins"} {
+	for _, table := range []string{"artifact_bodies", "journal_origins", "facts", "fact_env_clocks"} {
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET project_id = ? WHERE project_id = ?`, table), nextID, legacyID); err != nil {
 			t.Fatalf("rekey %s: %v", table, err)
 		}

--- a/internal/state/migrations/0020_facts_and_journal_envelope.sql
+++ b/internal/state/migrations/0020_facts_and_journal_envelope.sql
@@ -1,0 +1,75 @@
+-- Grow-only fact substrate: envelope v1 and journal corpus wrap.
+-- journal_entries remains the local projection; facts are the synced source of truth.
+-- Wrapped rows preserve journal ids and carry display timestamps in payload only.
+
+CREATE TABLE IF NOT EXISTS facts (
+  id TEXT PRIMARY KEY NOT NULL,
+  project_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (length(trim(kind)) > 0),
+  payload TEXT NOT NULL CHECK (length(trim(payload)) > 0),
+  env_id TEXT NOT NULL CHECK (length(trim(env_id)) > 0),
+  seq INTEGER NOT NULL CHECK (seq >= 1),
+  hlc TEXT NOT NULL CHECK (length(trim(hlc)) > 0),
+  envelope_v INTEGER NOT NULL DEFAULT 1 CHECK (envelope_v = 1),
+  FOREIGN KEY (project_id) REFERENCES projects(id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_facts_project_env_seq
+  ON facts (project_id, env_id, seq);
+CREATE INDEX IF NOT EXISTS idx_facts_project_order
+  ON facts (project_id, hlc, env_id, id);
+CREATE INDEX IF NOT EXISTS idx_facts_project_kind
+  ON facts (project_id, kind);
+
+CREATE TABLE IF NOT EXISTS fact_env_clocks (
+  project_id TEXT NOT NULL,
+  env_id TEXT NOT NULL,
+  hlc_wall_ms INTEGER NOT NULL,
+  hlc_logical INTEGER NOT NULL DEFAULT 0 CHECK (hlc_logical >= 0),
+  next_seq INTEGER NOT NULL DEFAULT 1 CHECK (next_seq >= 1),
+  PRIMARY KEY (project_id, env_id),
+  FOREIGN KEY (project_id) REFERENCES projects(id)
+);
+
+-- Wrap the existing journal corpus in place. env_id backfills as the legacy host
+-- identity (single-host substrate today). HLC wall component is seeded from
+-- created_at; logical is zero. Physical wall time stays in payload for display.
+INSERT INTO facts (id, project_id, kind, payload, env_id, seq, hlc, envelope_v)
+SELECT
+  j.id,
+  j.project_id,
+  'journal',
+  json_object(
+    'entry_type', j.entry_type,
+    'scope', COALESCE(j.scope, ''),
+    'message', j.message,
+    'observed_branch', COALESCE(j.observed_branch, ''),
+    'observed_worktree', COALESCE(j.observed_worktree, ''),
+    'harness_session_id', COALESCE(j.harness_session_id, ''),
+    'created_at', j.created_at,
+    'updated_at', j.updated_at
+  ),
+  'legacy-host',
+  ROW_NUMBER() OVER (
+    PARTITION BY j.project_id
+    ORDER BY j.created_at ASC, j.rowid ASC
+  ),
+  printf(
+    '%020d:%06d',
+    COALESCE(
+      CAST(unixepoch(substr(j.created_at, 1, 19)) AS INTEGER) * 1000,
+      j.rowid
+    ),
+    0
+  ),
+  1
+FROM journal_entries AS j;
+
+INSERT INTO fact_env_clocks (project_id, env_id, hlc_wall_ms, hlc_logical, next_seq)
+SELECT
+  project_id,
+  env_id,
+  CAST(substr(hlc, 1, 20) AS INTEGER),
+  CAST(substr(hlc, 22, 6) AS INTEGER),
+  MAX(seq) + 1
+FROM facts
+GROUP BY project_id, env_id;

--- a/internal/state/project_delete.go
+++ b/internal/state/project_delete.go
@@ -41,6 +41,8 @@ var projectScopedDeleteTables = []string{
 	"intents",
 	"journal_deferrals",
 	"journal_origins",
+	"facts",
+	"fact_env_clocks",
 	"journal_entries",
 	"handoffs",
 	"councils",

--- a/internal/state/project_identity.go
+++ b/internal/state/project_identity.go
@@ -637,6 +637,7 @@ WHERE project_id = ?
 
 func projectScopedRekeyTables() []string {
 	tables := append([]string{"project_paths"}, projectScopedMergeTables...)
+	tables = append(tables, "facts", "fact_env_clocks")
 	return tables
 }
 

--- a/internal/state/repair.go
+++ b/internal/state/repair.go
@@ -208,6 +208,292 @@ func inspectJournalSearchParityReadOnly(ctx context.Context, databasePath string
 	return parity, nil
 }
 
+// JournalFactsRepairOptions controls a journal projection rebuild from facts.
+type JournalFactsRepairOptions struct {
+	Apply bool
+}
+
+// JournalFactsRepairError preserves the partial repair result when apply fails.
+type JournalFactsRepairError struct {
+	Result JournalFactsRepairResult
+	Err    error
+}
+
+func (e *JournalFactsRepairError) Error() string {
+	if e == nil || e.Err == nil {
+		return "journal facts repair failed"
+	}
+	message := e.Err.Error()
+	if e.Result.BackupPath != "" {
+		message += fmt.Sprintf("; preserved backup: %s", e.Result.BackupPath)
+	}
+	return message
+}
+
+func (e *JournalFactsRepairError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// JournalFactsRepairResult describes the pre-repair parity and any rebuild.
+type JournalFactsRepairResult struct {
+	ContractVersion    int    `json:"contract_version"`
+	DatabaseScope      string `json:"database_scope"`
+	DatabasePath       string `json:"database_path"`
+	ProjectID          string `json:"project_id"`
+	ProjectName        string `json:"project_name"`
+	ProjectCurrentPath string `json:"project_current_path"`
+	FactRows           int    `json:"fact_rows"`
+	ProjectionRows     int    `json:"projection_rows"`
+	Missing            int    `json:"missing"`
+	Extra              int    `json:"extra"`
+	Changed            int    `json:"changed"`
+	BackupPath         string `json:"backup_path,omitempty"`
+	BackupVerified     bool   `json:"backup_verified"`
+	Applied            bool   `json:"applied"`
+	Rebuilt            int    `json:"rebuilt"`
+	ParityVerified     bool   `json:"parity_verified"`
+	GeneratedAt        string `json:"generated_at"`
+}
+
+// RepairJournalFacts rebuilds journal_entries and journal_search from journal facts.
+func RepairJournalFacts(ctx context.Context, root project.Root, resolver PathResolver, options JournalFactsRepairOptions) (JournalFactsRepairResult, error) {
+	return repairJournalFacts(ctx, root, resolver, options, nil)
+}
+
+type journalFactsRepairHook func(context.Context, *sql.Conn) error
+
+func backupJournalFactsRepairState(ctx context.Context, databasePath string, preParity JournalFactParity) (BackupResult, error) {
+	now := time.Now().UTC()
+	backupDir := filepath.Join(filepath.Dir(databasePath), "backups")
+	if err := os.MkdirAll(backupDir, 0o700); err != nil {
+		return BackupResult{}, fmt.Errorf("create state backup directory: %w", err)
+	}
+	backupPath, err := reserveBackupPath(backupDir, now)
+	if err != nil {
+		return BackupResult{}, err
+	}
+	reservationCompleted := false
+	defer func() {
+		if !reservationCompleted {
+			_ = os.Remove(backupPath)
+		}
+	}()
+	if err := vacuumSQLiteInto(ctx, databasePath, backupPath); err != nil {
+		return BackupResult{}, fmt.Errorf("backup state database for journal facts repair: %w", err)
+	}
+	reservationCompleted = true
+	info, err := os.Stat(backupPath)
+	if err != nil {
+		return BackupResult{}, fmt.Errorf("stat journal facts repair backup: %w", err)
+	}
+	sha256Sum, err := fileSHA256(backupPath)
+	if err != nil {
+		return BackupResult{}, fmt.Errorf("checksum journal facts repair backup: %w", err)
+	}
+	backupParity, err := inspectJournalFactParityReadOnly(ctx, backupPath)
+	if err != nil {
+		return BackupResult{}, fmt.Errorf("verify backup journal fact parity: %w", err)
+	}
+	if !journalFactParityEqual(preParity, backupParity) {
+		return BackupResult{}, fmt.Errorf("journal facts repair backup parity mismatch")
+	}
+	store, err := OpenStoreReadOnly(backupPath)
+	if err != nil {
+		return BackupResult{}, fmt.Errorf("open journal facts repair backup: %w", err)
+	}
+	defer store.Close()
+	integrityCheck, err := verifySQLiteIntegrity(ctx, store)
+	if err != nil {
+		return BackupResult{}, err
+	}
+	foreignKeyCheck, err := verifyNoForeignKeyViolations(ctx, store)
+	if err != nil {
+		return BackupResult{}, err
+	}
+	if integrityCheck != "ok" || foreignKeyCheck != "ok" {
+		return BackupResult{}, fmt.Errorf("journal facts repair backup failed integrity checks")
+	}
+	return BackupResult{
+		ContractVersion: StateJSONContractVersion,
+		DatabaseScope:   "global",
+		DatabasePath:    databasePath,
+		BackupPath:      backupPath,
+		Bytes:           info.Size(),
+		SHA256:          sha256Sum,
+		CreatedAt:       now.Format(time.RFC3339Nano),
+		Verified:        true,
+		IntegrityCheck:  integrityCheck,
+		ForeignKeyCheck: foreignKeyCheck,
+	}, nil
+}
+
+func repairJournalFacts(ctx context.Context, root project.Root, resolver PathResolver, options JournalFactsRepairOptions, hook journalFactsRepairHook) (JournalFactsRepairResult, error) {
+	databasePath, err := resolver.DatabasePath(root)
+	if err != nil {
+		return JournalFactsRepairResult{}, err
+	}
+	if _, err := os.Stat(databasePath); os.IsNotExist(err) {
+		return JournalFactsRepairResult{}, fmt.Errorf("SQLite state database is not initialized; run `loaf state init` or `loaf state migrate markdown --apply` first")
+	} else if err != nil {
+		return JournalFactsRepairResult{}, fmt.Errorf("inspect state database: %w", err)
+	}
+
+	result := JournalFactsRepairResult{
+		ContractVersion: StateJSONContractVersion,
+		DatabaseScope:   "global",
+		DatabasePath:    databasePath,
+		GeneratedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if store, err := OpenStoreReadOnly(databasePath); err == nil {
+		if identity, lookupErr := store.LookupProjectIdentityForRoot(ctx, root); lookupErr == nil {
+			result.ProjectID = identity.ID
+			result.ProjectName = identity.FriendlyName
+			result.ProjectCurrentPath = identity.CurrentPath
+		}
+		store.Close()
+	}
+	if !options.Apply {
+		preParity, err := inspectJournalFactParityReadOnly(ctx, databasePath)
+		if err != nil {
+			return JournalFactsRepairResult{}, err
+		}
+		populateJournalFactsRepairParity(&result, preParity)
+		return result, nil
+	}
+
+	store, err := OpenStore(databasePath)
+	if err != nil {
+		return result, &JournalFactsRepairError{Result: result, Err: fmt.Errorf("open state database for journal facts repair: %w", err)}
+	}
+	defer store.Close()
+	conn, err := store.db.Conn(ctx)
+	if err != nil {
+		return result, &JournalFactsRepairError{Result: result, Err: fmt.Errorf("obtain state database connection for journal facts repair: %w", err)}
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return result, &JournalFactsRepairError{Result: result, Err: fmt.Errorf("begin immediate journal facts repair: %w", err)}
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
+
+	preParity, err := inspectJournalFactParity(ctx, conn)
+	if err != nil {
+		return result, &JournalFactsRepairError{Result: result, Err: fmt.Errorf("inspect pre-repair journal fact parity: %w", err)}
+	}
+	populateJournalFactsRepairParity(&result, preParity)
+
+	if preParity.Ready {
+		if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+			return result, &JournalFactsRepairError{Result: result, Err: fmt.Errorf("commit journal facts no-op: %w", err)}
+		}
+		committed = true
+		result.Applied = true
+		result.ParityVerified = true
+		return result, nil
+	}
+
+	backup, err := backupJournalFactsRepairState(ctx, databasePath, preParity)
+	if err != nil {
+		result.BackupPath = backup.BackupPath
+		result.BackupVerified = backup.Verified
+		return result, &JournalFactsRepairError{Result: result, Err: fmt.Errorf("backup state database before journal facts repair: %w", err)}
+	}
+	result.BackupPath = backup.BackupPath
+	result.BackupVerified = backup.Verified
+
+	rebuilt, err := rebuildAllJournalProjectionsFromFactsTx(ctx, conn)
+	if err != nil {
+		return result, &JournalFactsRepairError{Result: result, Err: fmt.Errorf("rebuild journal projection from facts: %w", err)}
+	}
+	result.Rebuilt = rebuilt
+	if hook != nil {
+		if err := hook(ctx, conn); err != nil {
+			return result, &JournalFactsRepairError{Result: result, Err: fmt.Errorf("journal facts repair hook: %w", err)}
+		}
+	}
+	postParity, err := inspectJournalFactParity(ctx, conn)
+	if err != nil {
+		return result, &JournalFactsRepairError{Result: result, Err: fmt.Errorf("verify journal facts repair parity: %w", err)}
+	}
+	if !postParity.Ready {
+		return result, &JournalFactsRepairError{Result: result, Err: fmt.Errorf("journal facts repair did not produce ready parity: fact_rows=%d, projection_rows=%d, missing=%d, extra=%d, changed=%d", postParity.FactRows, postParity.ProjectionRows, postParity.Missing, postParity.Extra, postParity.Changed)}
+	}
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return result, &JournalFactsRepairError{Result: result, Err: fmt.Errorf("commit journal facts repair: %w", err)}
+	}
+	committed = true
+	result.Applied = true
+	result.ParityVerified = true
+	populateJournalFactsRepairParity(&result, postParity)
+	return result, nil
+}
+
+func populateJournalFactsRepairParity(result *JournalFactsRepairResult, parity JournalFactParity) {
+	result.FactRows = parity.FactRows
+	result.ProjectionRows = parity.ProjectionRows
+	result.Missing = parity.Missing
+	result.Extra = parity.Extra
+	result.Changed = parity.Changed
+}
+
+func inspectJournalFactParityReadOnly(ctx context.Context, databasePath string) (JournalFactParity, error) {
+	store, err := OpenStoreReadOnly(databasePath)
+	if err != nil {
+		return JournalFactParity{}, fmt.Errorf("open state database read-only for journal facts repair: %w", err)
+	}
+	defer store.Close()
+	parity, err := InspectJournalFactParity(ctx, store)
+	if err != nil {
+		return JournalFactParity{}, fmt.Errorf("inspect journal fact parity: %w", err)
+	}
+	return parity, nil
+}
+
+func journalFactParityEqual(a, b JournalFactParity) bool {
+	return a.FactRows == b.FactRows &&
+		a.ProjectionRows == b.ProjectionRows &&
+		a.Missing == b.Missing &&
+		a.Extra == b.Extra &&
+		a.Changed == b.Changed &&
+		a.Ready == b.Ready
+}
+
+func rebuildAllJournalProjectionsFromFactsTx(ctx context.Context, execer journalWriteExecer) (int, error) {
+	rows, err := execer.QueryContext(ctx, `SELECT DISTINCT project_id FROM facts WHERE kind = ? ORDER BY project_id`, FactKindJournal)
+	if err != nil {
+		return 0, fmt.Errorf("list journal fact projects: %w", err)
+	}
+	defer rows.Close()
+	projectIDs := []string{}
+	for rows.Next() {
+		var projectID string
+		if err := rows.Scan(&projectID); err != nil {
+			return 0, fmt.Errorf("scan journal fact project id: %w", err)
+		}
+		projectIDs = append(projectIDs, projectID)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate journal fact projects: %w", err)
+	}
+	total := 0
+	for _, projectID := range projectIDs {
+		rebuilt, err := rebuildJournalProjectionFromFactsTx(ctx, execer, projectID)
+		if err != nil {
+			return total, err
+		}
+		total += rebuilt
+	}
+	return total, nil
+}
+
 // Relationship origin repair runs in one of two modes. Reclassify-only is the
 // default because retiring the legacy origins is a mechanical, registry-derived
 // rewrite that needs no operator judgement; backfilling a missing origin does

--- a/internal/state/repair_test.go
+++ b/internal/state/repair_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
@@ -976,5 +977,81 @@ WHERE project_id = ?
 	}
 	if got != want {
 		t.Fatalf("missing relationship origins = %d, want %d", got, want)
+	}
+}
+
+func TestRepairJournalFactsDryRunApplyAndIdempotency(t *testing.T) {
+	ctx := context.Background()
+	root := projectRoot(t)
+	stateHome := t.TempDir()
+	resolver := PathResolver{StateHome: stateHome}
+	status, err := Initialize(ctx, root, resolver)
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	if _, err := LogJournal(ctx, root, resolver, JournalLogOptions{Entry: "decision(repair): journal fact repair"}); err != nil {
+		t.Fatalf("LogJournal() error = %v", err)
+	}
+	store := openTestStore(t, root, stateHome)
+	if _, err := store.db.ExecContext(ctx, `DELETE FROM journal_entries`); err != nil {
+		store.Close()
+		t.Fatalf("delete projection row error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	checkpointSQLiteWAL(t, status.DatabasePath)
+	before := snapshotMainSQLiteFile(t, status.DatabasePath)
+	dryRun, err := RepairJournalFacts(ctx, root, resolver, JournalFactsRepairOptions{})
+	if err != nil {
+		t.Fatalf("RepairJournalFacts(dry-run) error = %v", err)
+	}
+	if dryRun.Applied || dryRun.BackupPath != "" || dryRun.BackupVerified || dryRun.Rebuilt != 0 || dryRun.ParityVerified {
+		t.Fatalf("dry-run result = %#v, want no mutation", dryRun)
+	}
+	if dryRun.FactRows != 1 || dryRun.ProjectionRows != 0 || dryRun.Missing != 1 {
+		t.Fatalf("dry-run parity = %#v, want fact=1/projection=0/missing=1", dryRun)
+	}
+	after := snapshotMainSQLiteFile(t, status.DatabasePath)
+	if !bytes.Equal(before, after) {
+		t.Fatalf("dry-run changed database file")
+	}
+	applied, err := RepairJournalFacts(ctx, root, resolver, JournalFactsRepairOptions{Apply: true})
+	if err != nil {
+		t.Fatalf("RepairJournalFacts(apply) error = %v", err)
+	}
+	if !applied.Applied || !applied.ParityVerified || applied.Rebuilt != 1 || applied.Missing != 0 {
+		t.Fatalf("apply result = %#v, want rebuilt ready parity", applied)
+	}
+	second, err := RepairJournalFacts(ctx, root, resolver, JournalFactsRepairOptions{Apply: true})
+	if err != nil {
+		t.Fatalf("RepairJournalFacts(second apply) error = %v", err)
+	}
+	if !second.Applied || !second.ParityVerified {
+		t.Fatalf("second apply result = %#v, want idempotent ready parity", second)
+	}
+}
+
+func snapshotMainSQLiteFile(t *testing.T, path string) []byte {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read database snapshot %s: %v", path, err)
+	}
+	return contents
+}
+
+func checkpointSQLiteWAL(t *testing.T, databasePath string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", databasePath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
+		db.Close()
+		t.Fatalf("wal_checkpoint error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
 	}
 }

--- a/internal/state/schema.go
+++ b/internal/state/schema.go
@@ -64,6 +64,9 @@ var dropFindingsVerdictsRunsSQL string
 //go:embed migrations/0019_work_contracts.sql
 var workContractsSQL string
 
+//go:embed migrations/0020_facts_and_journal_envelope.sql
+var factsAndJournalEnvelopeSQL string
+
 const schemaMigrationsDDL = `CREATE TABLE IF NOT EXISTS schema_migrations (
   version INTEGER PRIMARY KEY NOT NULL,
   name TEXT NOT NULL,
@@ -171,6 +174,11 @@ func SchemaMigrations() []SchemaMigration {
 			Version: 19,
 			Name:    "work_contracts",
 			SQL:     normalizeMigrationSQL(workContractsSQL),
+		},
+		{
+			Version: 20,
+			Name:    "facts_and_journal_envelope",
+			SQL:     normalizeMigrationSQL(factsAndJournalEnvelopeSQL),
 		},
 	}
 }

--- a/internal/state/schema_test.go
+++ b/internal/state/schema_test.go
@@ -71,6 +71,8 @@ var requiredInitialTables = []string{
 	"work_contract_receipts",
 	"releases",
 	"release_members",
+	"facts",
+	"fact_env_clocks",
 	"schema_migrations",
 }
 
@@ -107,11 +109,11 @@ var userScopedTables = map[string]bool{
 
 func TestSchemaMigrationsAreOrderedAndChecksummed(t *testing.T) {
 	migrations := SchemaMigrations()
-	if len(migrations) != 18 {
-		t.Fatalf("len(SchemaMigrations()) = %d, want 18", len(migrations))
+	if len(migrations) != 19 {
+		t.Fatalf("len(SchemaMigrations()) = %d, want 19", len(migrations))
 	}
 
-	wantVersions := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19}
+	wantVersions := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
 	for i, migration := range migrations {
 		if migration.Version != wantVersions[i] {
 			t.Fatalf("migration[%d].Version = %d, want %d", i, migration.Version, wantVersions[i])
@@ -171,6 +173,9 @@ func TestSchemaMigrationsAreOrderedAndChecksummed(t *testing.T) {
 	if migrations[17].Name != "work_contracts" {
 		t.Fatalf("migration[17].Name = %q, want work_contracts", migrations[17].Name)
 	}
+	if migrations[18].Name != "facts_and_journal_envelope" {
+		t.Fatalf("migration[18].Name = %q, want facts_and_journal_envelope", migrations[18].Name)
+	}
 	for _, migration := range migrations {
 		if strings.TrimSpace(migration.SQL) == "" {
 			t.Fatalf("migration %d SQL is empty", migration.Version)
@@ -225,7 +230,7 @@ func TestOperationalTablesHaveStableIDsAndTimestamps(t *testing.T) {
 	}
 	sql := currentSchemaSQL()
 	for _, table := range requiredInitialTables {
-		if table == "schema_migrations" || table == "journal_origins" || table == "journal_deferrals" || table == "intent_operations" || table == "release_members" {
+		if table == "schema_migrations" || table == "journal_origins" || table == "journal_deferrals" || table == "intent_operations" || table == "release_members" || table == "facts" || table == "fact_env_clocks" {
 			continue
 		}
 		body := tableBody(t, sql, table)
@@ -421,6 +426,10 @@ func TestSchemaDocumentationMirrorsExecutableMigration(t *testing.T) {
 	sqlDoc = readRepoFile(t, "docs", "schema", "0019_work_contracts.sql")
 	if sqlDoc != SchemaMigrations()[17].SQL {
 		t.Fatal("docs/schema/0019_work_contracts.sql must match embedded migration 0019 exactly")
+	}
+	sqlDoc = readRepoFile(t, "docs", "schema", "0020_facts_and_journal_envelope.sql")
+	if normalizeMigrationSQL(sqlDoc) != normalizeMigrationSQL(factsAndJournalEnvelopeSQL) {
+		t.Fatal("docs/schema/0020_facts_and_journal_envelope.sql must match embedded migration 0020 exactly")
 	}
 
 	dbmlDoc := readRepoFile(t, "docs", "schema", "operational-state.dbml")

--- a/internal/state/status.go
+++ b/internal/state/status.go
@@ -438,6 +438,16 @@ func RepairPlanForStatus(status Status) []RepairAction {
 				Description:    "Regenerate the stale compatibility export from SQLite state.",
 				Safe:           false,
 			})
+		case JournalFactParityDivergenceCode:
+			actions = appendRepairAction(actions, RepairAction{
+				Code:           "repair-journal-facts",
+				DiagnosticCode: diagnostic.Code,
+				Category:       RepairCategoryJournalSearch,
+				Description:    "Rebuild the journal projection from journal facts after creating a verified backup.",
+				Command:        JournalFactParityRepairCommand,
+				Path:           status.DatabasePath,
+				Safe:           false,
+			})
 		case JournalSearchDivergenceCode:
 			actions = appendRepairAction(actions, RepairAction{
 				Code:           "repair-journal-search",
@@ -668,6 +678,35 @@ func inspectOperationalInvariants(ctx context.Context, store *Store, options Ins
 	diagnostics = append(diagnostics, backendDiagnostics...)
 	if !backendMappingsValid {
 		valid = false
+	}
+
+	journalFactParity, err := InspectJournalFactParity(ctx, store)
+	if err != nil {
+		return nil, false, err
+	}
+	if !journalFactParity.Ready {
+		valid = false
+		diagnostics = append(diagnostics, Diagnostic{
+			Severity: "error",
+			Code:     JournalFactParityDivergenceCode,
+			Category: RepairCategoryJournalSearch,
+			Policy:   DiagnosticPolicyDerivedIndexDiverged,
+			Message: fmt.Sprintf(
+				"journal projection diverged from journal facts (fact_rows=%d, projection_rows=%d, missing=%d, extra=%d, changed=%d)",
+				journalFactParity.FactRows,
+				journalFactParity.ProjectionRows,
+				journalFactParity.Missing,
+				journalFactParity.Extra,
+				journalFactParity.Changed,
+			),
+			Details: map[string]any{
+				"fact_rows":       journalFactParity.FactRows,
+				"projection_rows": journalFactParity.ProjectionRows,
+				"missing":         journalFactParity.Missing,
+				"extra":           journalFactParity.Extra,
+				"changed":         journalFactParity.Changed,
+			},
+		})
 	}
 
 	journalSearchParity, err := InspectJournalSearchParity(ctx, store)

--- a/internal/state/status_test.go
+++ b/internal/state/status_test.go
@@ -1468,3 +1468,38 @@ func findRepairAction(t *testing.T, actions []RepairAction, code string) RepairA
 	t.Fatalf("repair action %q not found in %#v", code, actions)
 	return RepairAction{}
 }
+func TestInspectJournalFactParityDivergenceInvalidatesMode(t *testing.T) {
+	ctx := context.Background()
+	root := projectRoot(t)
+	stateHome := t.TempDir()
+	resolver := PathResolver{StateHome: stateHome}
+	if _, err := Initialize(ctx, root, resolver); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	if _, err := LogJournal(ctx, root, resolver, JournalLogOptions{Entry: "decision(status): fact parity invalidates mode"}); err != nil {
+		t.Fatalf("LogJournal() error = %v", err)
+	}
+	store := openTestStore(t, root, stateHome)
+	if _, err := store.db.ExecContext(ctx, `DELETE FROM journal_entries`); err != nil {
+		store.Close()
+		t.Fatalf("delete projection row error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	status, err := Inspect(root, resolver)
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if status.Mode != ModeInvalid {
+		t.Fatalf("Mode = %q, want %q", status.Mode, ModeInvalid)
+	}
+	diagnostic := findDiagnostic(t, status.Diagnostics, JournalFactParityDivergenceCode)
+	if diagnostic.Severity != "error" || diagnostic.Category != RepairCategoryJournalSearch {
+		t.Fatalf("diagnostic = %#v, want journal fact parity divergence", diagnostic)
+	}
+	action := findRepairAction(t, RepairPlanForStatus(status), "repair-journal-facts")
+	if action.Command != JournalFactParityRepairCommand || action.Safe {
+		t.Fatalf("repair action = %#v, want journal facts repair command", action)
+	}
+}

--- a/internal/state/storage_home_migration.go
+++ b/internal/state/storage_home_migration.go
@@ -365,6 +365,9 @@ func (s *Store) mergeProjectDatabaseWithOps(ctx context.Context, sourcePath stri
 	if err := copyProjectProvenanceRows(ctx, tx, projectID); err != nil {
 		return err
 	}
+	if err := backfillMissingJournalFactsForProjectTx(ctx, tx, projectID); err != nil {
+		return fmt.Errorf("backfill merged journal facts: %w", err)
+	}
 	if err := registerMergedProjectTx(ctx, tx, root, projectID); err != nil {
 		return err
 	}

--- a/internal/state/storage_home_migration.go
+++ b/internal/state/storage_home_migration.go
@@ -45,6 +45,8 @@ var projectScopedMergeTables = []string{
 	"shaping_drafts",
 	"sessions",
 	"reports",
+	"facts",
+	"fact_env_clocks",
 	"journal_entries",
 	"events",
 	"relationships",
@@ -358,9 +360,18 @@ func (s *Store) mergeProjectDatabaseWithOps(ctx context.Context, sourcePath stri
 		return err
 	}
 	for _, table := range projectScopedMergeTables {
+		if table == "fact_env_clocks" {
+			if err := copyFactEnvClocksRows(ctx, tx, projectID); err != nil {
+				return err
+			}
+			continue
+		}
 		if err := copyProjectScopedRows(ctx, tx, table, projectID); err != nil {
 			return err
 		}
+	}
+	if err := reconcileFactEnvClocksForProjectTx(ctx, tx, projectID); err != nil {
+		return err
 	}
 	if err := copyProjectProvenanceRows(ctx, tx, projectID); err != nil {
 		return err
@@ -536,6 +547,81 @@ WHERE l.id = ?
 		return fmt.Errorf("merge project row: %w", err)
 	}
 	return nil
+}
+
+func copyFactEnvClocksRows(ctx context.Context, tx mergeExecer, projectID string) error {
+	if !legacyTableExists(ctx, tx, "fact_env_clocks") {
+		return nil
+	}
+	columns := sharedColumns(ctx, tx, "fact_env_clocks")
+	if len(columns) == 0 {
+		return nil
+	}
+	columnList := quotedColumnList(columns)
+	query := fmt.Sprintf(`INSERT OR IGNORE INTO fact_env_clocks (%s) SELECT %s FROM legacy.fact_env_clocks WHERE project_id = ?`, columnList, columnList)
+	if _, err := tx.ExecContext(ctx, query, projectID); err != nil {
+		return fmt.Errorf("merge fact_env_clocks rows: %w", err)
+	}
+	return nil
+}
+
+func reconcileFactEnvClocksForProjectTx(ctx context.Context, tx mergeExecer, projectID string) error {
+	if !tableExists(ctx, tx, "facts") || !tableExists(ctx, tx, "fact_env_clocks") {
+		return nil
+	}
+	rows, err := tx.QueryContext(ctx, `
+SELECT env_id, MAX(seq), MAX(hlc)
+FROM facts
+WHERE project_id = ?
+GROUP BY env_id
+`, projectID)
+	if err != nil {
+		return fmt.Errorf("list fact env clocks for reconcile: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var envID, hlc string
+		var maxSeq int64
+		if err := rows.Scan(&envID, &maxSeq, &hlc); err != nil {
+			return fmt.Errorf("scan fact env clock: %w", err)
+		}
+		parsed, err := parseHLC(hlc)
+		if err != nil {
+			return fmt.Errorf("parse fact hlc for env %q: %w", envID, err)
+		}
+		var wallMS, logical, nextSeq int64
+		err = tx.QueryRowContext(ctx, `
+SELECT hlc_wall_ms, hlc_logical, next_seq
+FROM fact_env_clocks
+WHERE project_id = ? AND env_id = ?
+`, projectID, envID).Scan(&wallMS, &logical, &nextSeq)
+		switch {
+		case err == nil:
+			if parsed.WallMS > wallMS || (parsed.WallMS == wallMS && parsed.Logical > logical) {
+				wallMS, logical = parsed.WallMS, parsed.Logical
+			}
+			if maxSeq+1 > nextSeq {
+				nextSeq = maxSeq + 1
+			}
+			if _, err := tx.ExecContext(ctx, `
+UPDATE fact_env_clocks
+SET hlc_wall_ms = ?, hlc_logical = ?, next_seq = ?
+WHERE project_id = ? AND env_id = ?
+`, wallMS, logical, nextSeq, projectID, envID); err != nil {
+				return fmt.Errorf("update fact env clock %q: %w", envID, err)
+			}
+		case errors.Is(err, sql.ErrNoRows):
+			if _, err := tx.ExecContext(ctx, `
+INSERT INTO fact_env_clocks (project_id, env_id, hlc_wall_ms, hlc_logical, next_seq)
+VALUES (?, ?, ?, ?, ?)
+`, projectID, envID, parsed.WallMS, parsed.Logical, maxSeq+1); err != nil {
+				return fmt.Errorf("insert fact env clock %q: %w", envID, err)
+			}
+		default:
+			return fmt.Errorf("read fact env clock %q: %w", envID, err)
+		}
+	}
+	return rows.Err()
 }
 
 func copyProjectScopedRows(ctx context.Context, tx mergeExecer, table string, projectID string) error {

--- a/internal/state/storage_home_migration_test.go
+++ b/internal/state/storage_home_migration_test.go
@@ -671,6 +671,10 @@ VALUES (?, ?, 'decision', 'merge', 'preexisting nil origin', NULL, NULL, NULL, N
 		globalStore.Close()
 		t.Fatalf("insert preexisting journal: %v", err)
 	}
+	if err := backfillJournalFactForTest(ctx, globalStore, logged.ProjectID, preexistingJournalID); err != nil {
+		globalStore.Close()
+		t.Fatalf("backfill preexisting journal fact: %v", err)
+	}
 	if _, err := globalStore.db.ExecContext(ctx, `
 INSERT INTO project_paths (id, project_id, path, is_current, first_seen_at, last_seen_at, created_at, updated_at)
 VALUES (?, ?, ?, 1, ?, ?, ?, ?)`, sourcePathID, logged.ProjectID, root.Path(), sourcePathFirstSeenAt, sourcePathLastSeenAt, sourcePathCreatedAt, sourcePathUpdatedAt); err != nil {
@@ -924,6 +928,10 @@ func TestApplyProjectDatabaseMergeRejectsCrossProjectEntityCollision(t *testing.
 	if _, err := globalStore.db.ExecContext(ctx, `INSERT INTO journal_entries (id, project_id, entry_type, scope, message, created_at, updated_at) VALUES (?, ?, 'decision', 'collision', 'other project row', ?, ?)`, logged.ID, otherID, now, now); err != nil {
 		globalStore.Close()
 		t.Fatalf("insert cross-project entity collision: %v", err)
+	}
+	if err := backfillJournalFactForTest(ctx, globalStore, otherID, logged.ID); err != nil {
+		globalStore.Close()
+		t.Fatalf("backfill cross-project journal fact: %v", err)
 	}
 	if err := globalStore.Close(); err != nil {
 		t.Fatalf("Close(global) error = %v", err)

--- a/internal/state/storage_home_migration_test.go
+++ b/internal/state/storage_home_migration_test.go
@@ -1718,3 +1718,75 @@ func initializeDatabaseAtPath(t *testing.T, root project.Root, path string) {
 		t.Fatalf("Close(%s) error = %v", path, err)
 	}
 }
+
+func TestApplyProjectDatabaseMergeCopiesFactsTable(t *testing.T) {
+	ctx := context.Background()
+	root := projectRoot(t)
+	otherRoot := projectRoot(t)
+	dataHome := t.TempDir()
+	stateHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	resolver := PathResolver{}
+	if _, err := Initialize(ctx, otherRoot, resolver); err != nil {
+		t.Fatalf("Initialize(other) error = %v", err)
+	}
+	legacyPath := initializeLegacyStateDatabase(t, root, resolver)
+	legacyStore, err := OpenStore(legacyPath)
+	if err != nil {
+		t.Fatalf("OpenStore(legacy) error = %v", err)
+	}
+	logged, err := legacyStore.LogJournal(ctx, root, JournalLogOptions{Entry: "decision(merge): copy facts"})
+	if err != nil {
+		legacyStore.Close()
+		t.Fatalf("LogJournal(legacy) error = %v", err)
+	}
+	var legacyEnvID, legacyPayload, legacyHLC string
+	var legacySeq int64
+	if err := legacyStore.db.QueryRowContext(ctx, `
+SELECT env_id, seq, payload, hlc FROM facts WHERE id = ?
+`, logged.ID).Scan(&legacyEnvID, &legacySeq, &legacyPayload, &legacyHLC); err != nil {
+		legacyStore.Close()
+		t.Fatalf("read legacy fact: %v", err)
+	}
+	if err := legacyStore.Close(); err != nil {
+		t.Fatalf("Close(legacy) error = %v", err)
+	}
+	globalPath, err := resolver.DatabasePath(root)
+	if err != nil {
+		t.Fatalf("DatabasePath() error = %v", err)
+	}
+	globalStore, err := OpenStore(globalPath)
+	if err != nil {
+		t.Fatalf("OpenStore(global) error = %v", err)
+	}
+	if err := globalStore.Close(); err != nil {
+		t.Fatalf("Close(global) error = %v", err)
+	}
+	merged, err := ApplyProjectDatabaseMerge(ctx, root, resolver, StorageHomeMigrationPlan{DatabasePath: globalPath, LegacyDatabasePath: legacyPath})
+	if err != nil {
+		t.Fatalf("ApplyProjectDatabaseMerge() error = %v", err)
+	}
+	if !merged.Applied {
+		t.Fatal("ApplyProjectDatabaseMerge() Applied = false, want true")
+	}
+	globalStore, err = OpenStore(globalPath)
+	if err != nil {
+		t.Fatalf("OpenStore(global after merge) error = %v", err)
+	}
+	defer globalStore.Close()
+	var gotEnvID, gotPayload, gotHLC string
+	var gotSeq int64
+	if err := globalStore.db.QueryRowContext(ctx, `
+SELECT env_id, seq, payload, hlc FROM facts WHERE id = ?
+`, logged.ID).Scan(&gotEnvID, &gotSeq, &gotPayload, &gotHLC); err != nil {
+		t.Fatalf("read merged fact: %v", err)
+	}
+	if gotEnvID != legacyEnvID || gotSeq != legacySeq || gotPayload != legacyPayload || gotHLC != legacyHLC {
+		t.Fatalf("merged fact diverged from legacy copy")
+	}
+	parity, err := InspectJournalFactParity(ctx, globalStore)
+	if err != nil || !parity.Ready {
+		t.Fatalf("parity after merge = %#v err=%v", parity, err)
+	}
+}


### PR DESCRIPTION
## Summary

Ships the LOAF-62 first-wave substrate slice already on `issue/loaf-62`:

- **LOAF-71** — grow-only fact envelope + migration **0020**; journal writes/reads as facts behind one append chokepoint; parity-oriented store/repair paths.
- **LOAF-66** — E2E crypto substrate (`internal/crypto`): per-project key derivation, envelope AEAD, emergency kit, published vectors, bundled client credential encoding.

Parent: **LOAF-62** (Personal memory substrate). This PR is the land vehicle for those two criteria; it does not close LOAF-62.

## Definition of Done (from LOAF-71 / LOAF-66)

- [ ] Fact envelope is the sync contract behind one write chokepoint; journal entries write/read as facts; parity diagnostic / tests over `./internal/state/...`
- [ ] Crypto module: HKDF per-project derivation with generation ring; envelope AEAD round-trip passes published vectors (`go test ./internal/crypto/...`)
- [ ] Emergency Kit ceremony covered by crypto tests
- [ ] Bundled client credential encodes endpoint + token + key material; admin secret never embedded
- [ ] Threat-model / privacy posture documented as required by LOAF-66 (H criteria)

## Merge coordination

**Required land order:**

1. [#176](https://github.com/levifig/loaf/pull/176) — LOAF-79 / migration **0018**
2. [#174](https://github.com/levifig/loaf/pull/174) — LOAF-82 / migration **0019**
3. **This PR** — LOAF-71+66 / migration **0020**
4. [#175](https://github.com/levifig/loaf/pull/175) — LOAF-80 / migration **0021** (rebase after 18–20)

Do **not** merge ahead of #176+#174: this branch jumps 17→20 and would recreate the skip-migration failure mode.

## Test plan

- [ ] Rebase onto `main` after #176+#174; confirm `SchemaMigrations()` versions contiguous **18,19,20**
- [ ] `unset LOAF_DB && go test ./...`
- [ ] `go test ./internal/crypto/... ./internal/state/...`
- [ ] `loaf build` / `loaf check` as required by ship skill
- [ ] Smoke against LOAF_DB copy: open DB at schema 20 with this binary

## Notes

- `bin/native` intentionally not committed (local dirty only).
