### PR TITLE
feat(LOAF-81): classify project-scoped tables and prune fossil edges

### DIFF
--- a/docs/schema/0022_prune_fossil_relationship_edges.sql
+++ b/docs/schema/0022_prune_fossil_relationship_edges.sql
@@ -1,0 +1,6 @@
+-- Prune polymorphic relationship edges that name vocabulary-fossil entity kinds.
+-- Fossil rows and aliases stay in local-archive tables; only sync-facing edges
+-- that would cross the minimal core boundary are removed.
+DELETE FROM relationships
+WHERE from_entity_kind IN ('plan', 'spec', 'task', 'intent', 'brainstorm')
+   OR to_entity_kind IN ('plan', 'spec', 'task', 'intent', 'brainstorm');

--- a/internal/state/document_layer_migration_test.go
+++ b/internal/state/document_layer_migration_test.go
@@ -9,6 +9,21 @@ import (
 	"testing"
 )
 
+func documentLayerMigrationPre() ([]SchemaMigration, int) {
+	migrations := SchemaMigrations()
+	dropIdx := -1
+	for i, migration := range migrations {
+		if migration.Name == "drop_document_layer" {
+			dropIdx = i
+			break
+		}
+	}
+	if dropIdx < 0 {
+		panic("drop_document_layer migration missing")
+	}
+	return migrations[:dropIdx], dropIdx
+}
+
 func TestDocumentLayerMigrationExportsThenDropsTables(t *testing.T) {
 	ctx := context.Background()
 	root := projectRoot(t)
@@ -21,9 +36,9 @@ func TestDocumentLayerMigrationExportsThenDropsTables(t *testing.T) {
 	db.SetMaxOpenConns(1)
 
 	migrations := SchemaMigrations()
-	pre := migrations[:len(migrations)-1]
-	if pre[len(pre)-1].Version != 20 || migrations[len(migrations)-1].Version != 21 {
-		t.Fatalf("unexpected migration tail: last pre=%d final=%d", pre[len(pre)-1].Version, migrations[len(migrations)-1].Version)
+	pre, dropIdx := documentLayerMigrationPre()
+	if pre[len(pre)-1].Version != 20 || migrations[dropIdx].Version != 21 {
+		t.Fatalf("unexpected migration tail: last pre=%d drop=%d", pre[len(pre)-1].Version, migrations[dropIdx].Version)
 	}
 	if err := ApplyMigrations(ctx, db, pre); err != nil {
 		t.Fatalf("ApplyMigrations(pre-0021) error = %v", err)
@@ -80,7 +95,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		}
 	}
 
-	if err := ApplyMigrations(ctx, db, migrations); err != nil {
+	if err := ApplyMigrations(ctx, db, migrations[dropIdx:dropIdx+1]); err != nil {
 		t.Fatalf("ApplyMigrations(0021) error = %v", err)
 	}
 	if err := validateGoneTablesAbsent(ctx, db); err != nil {
@@ -114,7 +129,7 @@ func TestDocumentLayerMigrationRefusesMissingProjectPath(t *testing.T) {
 	db.SetMaxOpenConns(1)
 
 	migrations := SchemaMigrations()
-	pre := migrations[:len(migrations)-1]
+	pre, dropIdx := documentLayerMigrationPre()
 	if err := ApplyMigrations(ctx, db, pre); err != nil {
 		t.Fatalf("ApplyMigrations(pre-0021) error = %v", err)
 	}
@@ -132,7 +147,7 @@ VALUES (?, ?, 'audit', 'Orphan Report', 'draft', NULL, ?, ?)
 `, "report:orphan", projectID, now, now); err != nil {
 		t.Fatalf("insert report: %v", err)
 	}
-	err = ApplyMigrations(ctx, db, migrations)
+	err = ApplyMigrations(ctx, db, migrations[dropIdx:dropIdx+1])
 	if err == nil {
 		t.Fatal("ApplyMigrations(0021) error = nil, want missing-path refusal")
 	}
@@ -153,7 +168,7 @@ func TestDocumentLayerMigrationRefusesExistingDest(t *testing.T) {
 	db.SetMaxOpenConns(1)
 
 	migrations := SchemaMigrations()
-	pre := migrations[:len(migrations)-1]
+	pre, dropIdx := documentLayerMigrationPre()
 	if err := ApplyMigrations(ctx, db, pre); err != nil {
 		t.Fatalf("ApplyMigrations(pre-0021) error = %v", err)
 	}
@@ -190,7 +205,7 @@ VALUES (?, ?, 'report', ?, 'report', 'conflict-report', ?, ?)
 	if err := os.WriteFile(filepath.Join(dest, "conflict-report.md"), []byte("existing\n"), 0o600); err != nil {
 		t.Fatalf("seed existing file: %v", err)
 	}
-	err = ApplyMigrations(ctx, db, migrations)
+	err = ApplyMigrations(ctx, db, migrations[dropIdx:dropIdx+1])
 	if err == nil {
 		t.Fatal("ApplyMigrations(0021) error = nil, want existing-dest refusal")
 	}

--- a/internal/state/journal_first_migration_test.go
+++ b/internal/state/journal_first_migration_test.go
@@ -583,8 +583,8 @@ func TestBackupVerifiesMigratedJournalFirstDatabase(t *testing.T) {
 }
 
 func TestJournalFirstMigrationExcludedFromAutoApply(t *testing.T) {
-	if CurrentSchemaVersion() != 21 {
-		t.Fatalf("CurrentSchemaVersion() = %d, want 21 (migration 10 must not auto-apply on store open)", CurrentSchemaVersion())
+	if CurrentSchemaVersion() != 22 {
+		t.Fatalf("CurrentSchemaVersion() = %d, want 22 (migration 10 must not auto-apply on store open)", CurrentSchemaVersion())
 	}
 	for _, m := range SchemaMigrations() {
 		if m.Version == journalFirstMigrationVersion {

--- a/internal/state/migrations/0022_prune_fossil_relationship_edges.sql
+++ b/internal/state/migrations/0022_prune_fossil_relationship_edges.sql
@@ -1,0 +1,6 @@
+-- Prune polymorphic relationship edges that name vocabulary-fossil entity kinds.
+-- Fossil rows and aliases stay in local-archive tables; only sync-facing edges
+-- that would cross the minimal core boundary are removed.
+DELETE FROM relationships
+WHERE from_entity_kind IN ('plan', 'spec', 'task', 'intent', 'brainstorm')
+   OR to_entity_kind IN ('plan', 'spec', 'task', 'intent', 'brainstorm');

--- a/internal/state/project_identity.go
+++ b/internal/state/project_identity.go
@@ -643,9 +643,7 @@ WHERE project_id = ?
 }
 
 func projectScopedRekeyTables() []string {
-	tables := append([]string{"project_paths"}, projectScopedMergeTables...)
-	tables = append(tables, "facts", "fact_env_clocks")
-	return tables
+	return ProjectScopedLiveTables()
 }
 
 func newProjectID() (string, error) {

--- a/internal/state/schema.go
+++ b/internal/state/schema.go
@@ -70,6 +70,9 @@ var factsAndJournalEnvelopeSQL string
 //go:embed migrations/0021_drop_document_layer.sql
 var dropDocumentLayerSQL string
 
+//go:embed migrations/0022_prune_fossil_relationship_edges.sql
+var pruneFossilRelationshipEdgesSQL string
+
 const schemaMigrationsDDL = `CREATE TABLE IF NOT EXISTS schema_migrations (
   version INTEGER PRIMARY KEY NOT NULL,
   name TEXT NOT NULL,
@@ -187,6 +190,11 @@ func SchemaMigrations() []SchemaMigration {
 			Version: 21,
 			Name:    "drop_document_layer",
 			SQL:     normalizeMigrationSQL(dropDocumentLayerSQL),
+		},
+		{
+			Version: 22,
+			Name:    "prune_fossil_relationship_edges",
+			SQL:     normalizeMigrationSQL(pruneFossilRelationshipEdgesSQL),
 		},
 	}
 }

--- a/internal/state/schema_test.go
+++ b/internal/state/schema_test.go
@@ -106,11 +106,11 @@ var userScopedTables = map[string]bool{
 
 func TestSchemaMigrationsAreOrderedAndChecksummed(t *testing.T) {
 	migrations := SchemaMigrations()
-	if len(migrations) != 20 {
-		t.Fatalf("len(SchemaMigrations()) = %d, want 20", len(migrations))
+	if len(migrations) != 21 {
+		t.Fatalf("len(SchemaMigrations()) = %d, want 21", len(migrations))
 	}
 
-	wantVersions := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}
+	wantVersions := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22}
 	for i, migration := range migrations {
 		if migration.Version != wantVersions[i] {
 			t.Fatalf("migration[%d].Version = %d, want %d", i, migration.Version, wantVersions[i])
@@ -173,8 +173,11 @@ func TestSchemaMigrationsAreOrderedAndChecksummed(t *testing.T) {
 	if migrations[18].Name != "facts_and_journal_envelope" {
 		t.Fatalf("migration[18].Name = %q, want facts_and_journal_envelope", migrations[18].Name)
 	}
-	if migrations[19].Name != "drop_document_layer" {
+ 	if migrations[19].Name != "drop_document_layer" {
 		t.Fatalf("migration[19].Name = %q, want drop_document_layer", migrations[19].Name)
+	}
+	if migrations[20].Name != "prune_fossil_relationship_edges" {
+		t.Fatalf("migration[20].Name = %q, want prune_fossil_relationship_edges", migrations[20].Name)
 	}
 	for _, migration := range migrations {
 		if strings.TrimSpace(migration.SQL) == "" {
@@ -430,9 +433,13 @@ func TestSchemaDocumentationMirrorsExecutableMigration(t *testing.T) {
 	if normalizeMigrationSQL(sqlDoc) != normalizeMigrationSQL(factsAndJournalEnvelopeSQL) {
 		t.Fatal("docs/schema/0020_facts_and_journal_envelope.sql must match embedded migration 0020 exactly")
 	}
-	sqlDoc = readRepoFile(t, "docs", "schema", "0021_drop_document_layer.sql")
+ 	sqlDoc = readRepoFile(t, "docs", "schema", "0021_drop_document_layer.sql")
 	if sqlDoc != SchemaMigrations()[19].SQL {
 		t.Fatal("docs/schema/0021_drop_document_layer.sql must match embedded migration 0021 exactly")
+	}
+	sqlDoc = readRepoFile(t, "docs", "schema", "0022_prune_fossil_relationship_edges.sql")
+	if sqlDoc != SchemaMigrations()[20].SQL {
+		t.Fatal("docs/schema/0022_prune_fossil_relationship_edges.sql must match embedded migration 0022 exactly")
 	}
 
 	dbmlDoc := readRepoFile(t, "docs", "schema", "operational-state.dbml")

--- a/internal/state/storage_home_migration.go
+++ b/internal/state/storage_home_migration.go
@@ -23,41 +23,8 @@ const (
 	StorageHomeActionNoLegacyState   = "no-legacy-state"
 )
 
-var projectScopedMergeTables = []string{
-	"sources",
-	"specs",
-	"tasks",
-	"issues",
-	"issue_criteria",
-	"issue_criterion_claims",
-	"work_contracts",
-	"work_contract_criteria",
-	"work_contract_criterion_claims",
-	"work_contract_workspace",
-	"work_contract_mappings",
-	"work_contract_receipts",
-	"issue_identity",
-	"releases",
-	"release_members",
-	"ideas",
-	"sparks",
-	"brainstorms",
-	"sessions",
-	"facts",
-	"fact_env_clocks",
-	"journal_entries",
-	"events",
-	"relationships",
-	"tags",
-	"entity_tags",
-	"bundles",
-	"bundle_members",
-	"aliases",
-	"backend_mappings",
-	"hook_events",
-	"exports",
-	"session_state_snapshots",
-}
+// projectScopedMergeTables is the sync-class inventory used by storage-home merge.
+var projectScopedMergeTables = ProjectScopedSyncTables()
 
 // StorageHomeMigrationPlan describes the XDG_STATE_HOME to XDG_DATA_HOME move.
 type StorageHomeMigrationPlan struct {

--- a/internal/state/table_class.go
+++ b/internal/state/table_class.go
@@ -1,0 +1,188 @@
+package state
+
+import (
+	"fmt"
+	"sort"
+)
+
+// TableClass is the sync disposition for one project-scoped table. Every table
+// that carries project_id must declare exactly one class. Gone tables are
+// recorded so completeness tests stay closed when schema drops them.
+type TableClass string
+
+const (
+	TableClassSync         TableClass = "sync"
+	TableClassLocalArchive TableClass = "local-archive"
+	TableClassMachineLocal TableClass = "machine-local"
+	TableClassGone         TableClass = "gone"
+)
+
+// fossilEntityKinds are vocabulary fossils whose relationship edges are pruned
+// during migration and never participate in sync.
+var fossilEntityKinds = []string{
+	"plan",
+	"spec",
+	"task",
+	"intent",
+	"brainstorm",
+}
+
+// goneEntityKinds are deleted schema kinds whose polymorphic references were
+// removed by migrations 0018 and 0021.
+var goneEntityKinds = []string{
+	"finding",
+	"verdict",
+	"run",
+	"report",
+	"council",
+	"shaping_draft",
+}
+
+// projectScopedTableClasses is the closed inventory lock for LOAF-81. Keys are
+// every project-scoped table that exists or was intentionally removed.
+var projectScopedTableClasses = map[string]TableClass{
+	// Sync — minimal core (LOAF-62): identity evidence, refs/contracts, ledger,
+	// releases. FTS and machine-local projections are excluded.
+	"project_paths":                    TableClassSync,
+	"aliases":                          TableClassSync,
+	"sources":                          TableClassSync,
+	"ideas":                            TableClassSync,
+	"sparks":                           TableClassSync,
+	"journal_entries":                  TableClassSync,
+	"journal_origins":                  TableClassSync,
+	"journal_deferrals":                TableClassSync,
+	"handoffs":                         TableClassSync,
+	"facts":                            TableClassSync,
+	"fact_env_clocks":                  TableClassSync,
+	"events":                           TableClassSync,
+	"relationships":                    TableClassSync,
+	"tags":                             TableClassSync,
+	"entity_tags":                      TableClassSync,
+	"bundles":                          TableClassSync,
+	"bundle_members":                   TableClassSync,
+	"backend_mappings":                 TableClassSync,
+	"issues":                           TableClassSync,
+	"issue_criteria":                   TableClassSync,
+	"issue_criterion_claims":           TableClassSync,
+	"issue_identity":                   TableClassSync,
+	"work_contracts":                   TableClassSync,
+	"work_contract_criteria":           TableClassSync,
+	"work_contract_criterion_claims":   TableClassSync,
+	"work_contract_workspace":          TableClassSync,
+	"work_contract_mappings":           TableClassSync,
+	"work_contract_receipts":           TableClassSync,
+	"releases":                         TableClassSync,
+	"release_members":                  TableClassSync,
+
+	// Local archive — vocabulary fossils stay readable locally and never sync.
+	"specs":                        TableClassLocalArchive,
+	"tasks":                        TableClassLocalArchive,
+	"plans":                        TableClassLocalArchive,
+	"brainstorms":                  TableClassLocalArchive,
+	"intents":                      TableClassLocalArchive,
+	"intent_snapshots":             TableClassLocalArchive,
+	"intent_deferrals":             TableClassLocalArchive,
+	"intent_dispositions":          TableClassLocalArchive,
+	"intent_operations":            TableClassLocalArchive,
+	"explorations":                 TableClassLocalArchive,
+	"exploration_checkpoints":      TableClassLocalArchive,
+	"exploration_checkpoint_items": TableClassLocalArchive,
+
+	// Machine-local — hook trust, conversation handles, observations, session
+	// snapshots, and locally rebuilt FTS source tables never sync.
+	"sessions":                         TableClassMachineLocal,
+	"session_state_snapshots":          TableClassMachineLocal,
+	"hook_events":                      TableClassMachineLocal,
+	"exports":                          TableClassMachineLocal,
+	"artifact_bodies":                  TableClassMachineLocal,
+	"docs_index":                       TableClassMachineLocal,
+	"logical_conversations":            TableClassMachineLocal,
+	"conversation_handles":             TableClassMachineLocal,
+	"conversation_log_refs":            TableClassMachineLocal,
+	"exploration_conversations":        TableClassMachineLocal,
+	"journal_conversation_handles":     TableClassMachineLocal,
+	"source_availability_observations": TableClassMachineLocal,
+
+	// Gone — schema deleted; tests refuse reintroduction (LOAF-79/80).
+	"findings":       TableClassGone,
+	"verdicts":       TableClassGone,
+	"runs":           TableClassGone,
+	"reports":        TableClassGone,
+	"councils":       TableClassGone,
+	"shaping_drafts": TableClassGone,
+}
+
+// ProjectScopedTableClass returns the declared class for one project-scoped table.
+func ProjectScopedTableClass(table string) (TableClass, bool) {
+	class, ok := projectScopedTableClasses[table]
+	return class, ok
+}
+
+// ProjectScopedTableClasses returns a sorted copy of the inventory registry.
+func ProjectScopedTableClasses() map[string]TableClass {
+	out := make(map[string]TableClass, len(projectScopedTableClasses))
+	for table, class := range projectScopedTableClasses {
+		out[table] = class
+	}
+	return out
+}
+
+// ProjectScopedSyncTables returns project-scoped tables that participate in
+// storage-home merge and future sync transport.
+func ProjectScopedSyncTables() []string {
+	return tablesForClass(TableClassSync)
+}
+
+// FossilEntityKinds returns vocabulary fossil entity kinds whose relationship
+// edges are pruned and never synced.
+func FossilEntityKinds() []string {
+	return append([]string(nil), fossilEntityKinds...)
+}
+
+// GoneEntityKinds returns deleted entity kinds whose polymorphic references
+// must stay absent.
+func GoneEntityKinds() []string {
+	return append([]string(nil), goneEntityKinds...)
+}
+
+// ProjectScopedLiveTables returns every project-scoped table that still exists
+// in the live schema (sync, local-archive, and machine-local).
+func ProjectScopedLiveTables() []string {
+	var tables []string
+	for table, class := range projectScopedTableClasses {
+		if class == TableClassGone {
+			continue
+		}
+		tables = append(tables, table)
+	}
+	sort.Strings(tables)
+	return tables
+}
+
+// PrunableNeighborEntityKinds returns deleted entity kinds whose polymorphic
+// neighbor edges should be skipped during trace/link hydration.
+func PrunableNeighborEntityKinds() []string {
+	return append([]string(nil), goneEntityKinds...)
+}
+
+func tablesForClass(class TableClass) []string {
+	var tables []string
+	for table, candidate := range projectScopedTableClasses {
+		if candidate == class {
+			tables = append(tables, table)
+		}
+	}
+	sort.Strings(tables)
+	return tables
+}
+
+func validateProjectScopedTableInventory() error {
+	for table, class := range projectScopedTableClasses {
+		switch class {
+		case TableClassSync, TableClassLocalArchive, TableClassMachineLocal, TableClassGone:
+		default:
+			return fmt.Errorf("table %s has unknown class %q", table, class)
+		}
+	}
+	return nil
+}

--- a/internal/state/table_inventory_test.go
+++ b/internal/state/table_inventory_test.go
@@ -1,0 +1,222 @@
+package state
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestProjectScopedTableInventoryIsComplete(t *testing.T) {
+	if err := validateProjectScopedTableInventory(); err != nil {
+		t.Fatalf("validateProjectScopedTableInventory() error = %v", err)
+	}
+
+	columnsByTable := schemaColumnNames(t, effectiveSchemaSQL())
+	var projectScoped []string
+	for table, columns := range columnsByTable {
+		if userScopedTables[table] {
+			continue
+		}
+		hasProjectID := false
+		for _, column := range columns {
+			if column == "project_id" {
+				hasProjectID = true
+				break
+			}
+		}
+		if hasProjectID {
+			projectScoped = append(projectScoped, table)
+		}
+	}
+	sort.Strings(projectScoped)
+
+	var missing, extra []string
+	for _, table := range projectScoped {
+		if _, ok := projectScopedTableClasses[table]; !ok {
+			missing = append(missing, table)
+		}
+	}
+	for table := range projectScopedTableClasses {
+		if class := projectScopedTableClasses[table]; class == TableClassGone {
+			continue
+		}
+		found := false
+		for _, candidate := range projectScoped {
+			if candidate == table {
+				found = true
+				break
+			}
+		}
+		if !found {
+			extra = append(extra, table)
+		}
+	}
+	if len(missing) != 0 || len(extra) != 0 {
+		t.Fatalf("inventory mismatch:\n missing: %v\n extra: %v", missing, extra)
+	}
+}
+
+func TestProjectScopedMergeTablesMatchSyncInventory(t *testing.T) {
+	want := ProjectScopedSyncTables()
+	got := append([]string(nil), projectScopedMergeTables...)
+	sort.Strings(got)
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("projectScopedMergeTables:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestNonSyncTablesNeverAppearInMergeRegistry(t *testing.T) {
+	mergeSet := make(map[string]struct{}, len(projectScopedMergeTables))
+	for _, table := range projectScopedMergeTables {
+		mergeSet[table] = struct{}{}
+	}
+	for table, class := range projectScopedTableClasses {
+		if class == TableClassSync {
+			continue
+		}
+		if _, ok := mergeSet[table]; ok {
+			t.Fatalf("table %s is class %q but appears in projectScopedMergeTables", table, class)
+		}
+	}
+}
+
+func TestMigration0022DeletesFossilKindRelationships(t *testing.T) {
+	ctx := context.Background()
+	root := projectRoot(t)
+	databasePath := filepath.Join(t.TempDir(), "state.sqlite")
+	store, err := OpenStore(databasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+
+	migrations := SchemaMigrations()
+	pruneIdx := -1
+	for i, migration := range migrations {
+		if migration.Name == "prune_fossil_relationship_edges" {
+			pruneIdx = i
+			break
+		}
+	}
+	if pruneIdx < 0 {
+		t.Fatal("prune_fossil_relationship_edges migration missing")
+	}
+	if err := ApplyMigrations(ctx, store.db, migrations[:pruneIdx]); err != nil {
+		t.Fatalf("ApplyMigrations(pre-0022) error = %v", err)
+	}
+	if err := store.UpsertProject(ctx, root); err != nil {
+		t.Fatalf("UpsertProject() error = %v", err)
+	}
+	projectID := projectIDForTest(t, store, root)
+	now := "2026-08-26T00:00:00Z"
+
+	mustExec(t, store, `
+INSERT INTO sparks (id, project_id, status, text, created_at, updated_at)
+VALUES ('spark-fossil-trace', ?, 'captured', 'Alive spark', ?, ?)
+`, projectID, now, now)
+	mustExec(t, store, `
+INSERT INTO specs (id, project_id, title, status, created_at, updated_at)
+VALUES ('spec-fossil', ?, 'Fossil spec', 'draft', ?, ?)
+`, projectID, now, now)
+	mustExec(t, store, `
+INSERT INTO aliases (id, project_id, entity_kind, entity_id, namespace, alias, created_at, updated_at)
+VALUES
+  ('alias-spark-fossil-trace', ?, 'spark', 'spark-fossil-trace', 'spark', 'SPARK-FOSSIL-TRACE', ?, ?),
+  ('alias-spec', ?, 'spec', 'spec-fossil', 'spec', 'SPEC-FOSSIL', ?, ?)
+`, projectID, now, now, projectID, now, now)
+	mustExec(t, store, `
+INSERT INTO relationships (id, project_id, from_entity_kind, from_entity_id, to_entity_kind, to_entity_id, relationship_type, reason, origin, created_at, updated_at)
+VALUES
+  ('rel-spark-spec', ?, 'spark', 'spark-fossil-trace', 'spec', 'spec-fossil', 'produced', 'fossil', 'command', ?, ?),
+  ('rel-keep', ?, 'spark', 'spark-fossil-trace', 'spark', 'spark-fossil-trace', 'self', 'keep', 'manual', ?, ?)
+`, projectID, now, now, projectID, now, now)
+
+	if err := ApplyMigrations(ctx, store.db, migrations[pruneIdx:pruneIdx+1]); err != nil {
+		t.Fatalf("ApplyMigrations(0022) error = %v", err)
+	}
+
+ 	var fossilRelationships, fossilAliases, keptRelationships int
+	if err := store.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM relationships
+WHERE from_entity_kind IN ('plan', 'spec', 'task', 'intent', 'brainstorm')
+   OR to_entity_kind IN ('plan', 'spec', 'task', 'intent', 'brainstorm')
+`).Scan(&fossilRelationships); err != nil {
+		t.Fatalf("count fossil relationships: %v", err)
+	}
+	if err := store.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM aliases WHERE entity_kind IN ('plan', 'spec', 'task', 'intent', 'brainstorm')
+`).Scan(&fossilAliases); err != nil {
+		t.Fatalf("count fossil aliases: %v", err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM relationships WHERE id = 'rel-keep'`).Scan(&keptRelationships); err != nil {
+		t.Fatalf("count kept relationships: %v", err)
+	}
+	if fossilRelationships != 0 {
+		t.Fatalf("fossil relationships=%d, want 0 after migration 0022", fossilRelationships)
+	}
+	if fossilAliases != 1 {
+		t.Fatalf("fossil aliases=%d, want 1 preserved (relationship prune only)", fossilAliases)
+	}
+	if keptRelationships != 1 {
+		t.Fatalf("kept relationships = %d, want 1", keptRelationships)
+	}
+}
+
+func TestTraceAndLinkListHydrateLocalArchiveNeighbors(t *testing.T) {
+	ctx := context.Background()
+	root := projectRoot(t)
+	stateHome := t.TempDir()
+	status, err := Initialize(ctx, root, PathResolver{StateHome: stateHome})
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	store, err := OpenStore(status.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+
+	projectID := projectIDForTest(t, store, root)
+	now := "2026-08-26T00:00:00Z"
+	mustExec(t, store, `
+INSERT INTO sparks (id, project_id, status, text, created_at, updated_at)
+VALUES ('spark-fossil-trace', ?, 'captured', 'Alive spark', ?, ?)
+`, projectID, now, now)
+	mustExec(t, store, `
+INSERT INTO specs (id, project_id, title, status, created_at, updated_at)
+VALUES ('spec-fossil', ?, 'Fossil spec', 'draft', ?, ?)
+`, projectID, now, now)
+	mustExec(t, store, `
+INSERT INTO aliases (id, project_id, entity_kind, entity_id, namespace, alias, created_at, updated_at)
+VALUES
+  ('alias-spark-fossil-trace', ?, 'spark', 'spark-fossil-trace', 'spark', 'SPARK-FOSSIL-TRACE', ?, ?),
+  ('alias-spec', ?, 'spec', 'spec-fossil', 'spec', 'SPEC-FOSSIL', ?, ?)
+`, projectID, now, now, projectID, now, now)
+	mustExec(t, store, `
+INSERT INTO relationships (id, project_id, from_entity_kind, from_entity_id, to_entity_kind, to_entity_id, relationship_type, reason, origin, created_at, updated_at)
+VALUES
+  ('rel-fossil', ?, 'spark', 'spark-fossil-trace', 'spec', 'spec-fossil', 'produced', 'fossil neighbor', 'command', ?, ?),
+  ('rel-alive', ?, 'spark', 'spark-fossil-trace', 'spark', 'spark-fossil-trace', 'self', 'alive neighbor', 'manual', ?, ?)
+`, projectID, now, now, projectID, now, now)
+
+	trace, err := store.Trace(ctx, root, "SPARK-FOSSIL-TRACE")
+	if err != nil {
+		t.Fatalf("Trace() error = %v", err)
+	}
+	if !hasStateTraceRelationship(trace.Relationships, "outbound", "produced", "spec", "SPEC-FOSSIL") {
+		t.Fatalf("trace relationships = %#v, want local-archive spec neighbor hydrated", trace.Relationships)
+	}
+	if !hasStateTraceRelationship(trace.Relationships, "outbound", "self", "spark", "SPARK-FOSSIL-TRACE") {
+		t.Fatalf("trace relationships = %#v, want alive spark self edge retained", trace.Relationships)
+	}
+
+	list, err := store.ListLinks(ctx, root, "SPARK-FOSSIL-TRACE")
+	if err != nil {
+		t.Fatalf("ListLinks() error = %v", err)
+	}
+	if !hasStateTraceRelationship(list.Relationships, "outbound", "produced", "spec", "SPEC-FOSSIL") {
+		t.Fatalf("list relationships = %#v, want local-archive spec neighbor hydrated", list.Relationships)
+	}
+}

--- a/internal/state/trace.go
+++ b/internal/state/trace.go
@@ -350,6 +350,9 @@ func (s *Store) queryTraceRelationships(ctx context.Context, projectID string, d
 
 	var relationships []TraceRelationship
 	for _, relationship := range raw {
+		if isPrunableNeighborEntityKind(relationship.otherKind) {
+			continue
+		}
 		other, err := s.entityDetails(ctx, projectID, relationship.otherKind, relationship.otherID)
 		if err != nil {
 			// Skip gone/unknown neighbor kinds (e.g. finding/verdict/run fossils)
@@ -370,6 +373,19 @@ func (s *Store) queryTraceRelationships(ctx context.Context, projectID string, d
 		})
 	}
 	return relationships, nil
+}
+
+var prunableNeighborEntityKinds = func() map[string]struct{} {
+	out := make(map[string]struct{}, len(PrunableNeighborEntityKinds()))
+	for _, kind := range PrunableNeighborEntityKinds() {
+		out[kind] = struct{}{}
+	}
+	return out
+}()
+
+func isPrunableNeighborEntityKind(kind string) bool {
+	_, ok := prunableNeighborEntityKinds[kind]
+	return ok
 }
 
 func isUnsupportedTraceEntityKind(err error) bool {

--- a/internal/state/trace_test.go
+++ b/internal/state/trace_test.go
@@ -130,7 +130,6 @@ status: accepted
 	assertTraceRelationship(t, ideaTrace.Relationships, "inbound", "promoted_to", "spark", "SPARK-sqlite-state")
 	assertTraceRelationship(t, ideaTrace.Relationships, "outbound", "resolved_by", "spec", "SPEC-001")
 	assertTraceRelationship(t, ideaTrace.Relationships, "outbound", "resolved_by", "task", "TASK-001")
-	assertTraceRelationship(t, ideaTrace.Relationships, "outbound", "exported_as", "report", "export")
 
 	assertFileContent(t, filepath.Join(root.Path(), ".agents", "ideas", "20260528-sqlite-state.md"), ideaBody)
 	assertFileContent(t, filepath.Join(root.Path(), ".agents", "sessions", "20260528-lineage.md"), sessionBody)
@@ -209,7 +208,6 @@ status: complete
 		t.Fatalf("Trace(20260528-runtime) error = %v", err)
 	}
 	assertTraceRelationship(t, ideaTrace.Relationships, "inbound", "promoted_to", "brainstorm", "20260528-brainstorm-runtime")
-	assertTraceRelationship(t, ideaTrace.Relationships, "outbound", "promoted_to", "shaping_draft", "20260528-runtime-draft")
 
 	shapingTrace, err := store.Trace(context.Background(), root, "20260528-runtime-draft")
 	if err != nil {
@@ -226,7 +224,6 @@ status: complete
 	if err != nil {
 		t.Fatalf("Trace(SPEC-002) error = %v", err)
 	}
-	assertTraceRelationship(t, specTrace.Relationships, "inbound", "promoted_to", "shaping_draft", "20260528-runtime-draft")
 	assertTraceRelationship(t, specTrace.Relationships, "inbound", "implements", "task", "TASK-002")
 
 	assertFileContent(t, filepath.Join(root.Path(), ".agents", "drafts", "20260528-brainstorm-runtime.md"), brainstormBody)


### PR DESCRIPTION
# Classify every table; prune fossil relationship edges

After unused schema is gone and documents are files, every remaining project-scoped table must declare exactly one class: sync (minimal core), local-archive (fossils: plans, specs, tasks, intents, brainstorms), machine-local (hook trust, conversation handles, observations, session snapshots), or gone. Fossils and machine-local never sync. Relationship edges that point at fossils are pruned.

The completeness test is the lock — the same class as the merge-table registry test. Run after LOAF-79 and LOAF-80 so the inventory describes the post-cleanup schema.

Out of scope: choosing the minimal core (LOAF-62 already did); deleting fossil rows; the fact model (LOAF-63). No-gos: shipping an unclassified table into sync.

## Definition of Done

- [ ] Every project-scoped table is classified sync, local-archive, machine-local, or gone; fossils and machine-local never sync; fossil-target relationship edges are pruned