### PR TITLE
feat(LOAF-64): normalize remote URLs for identity evidence

### DIFF
--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -163,3 +163,38 @@ func git(t *testing.T, dir string, args ...string) {
 		t.Fatalf("git %v failed: %v\n%s", args, err, out)
 	}
 }
+
+func TestNormalizeRemoteURLConvergesEquivalentRemotes(t *testing.T) {
+	pairs := [][2]string{
+		{"git@github.com:levifig/loaf.git", "https://github.com/levifig/loaf"},
+		{"ssh://git@github.com/levifig/loaf", "git@github.com:levifig/loaf.git"},
+		{"https://github.com:443/levifig/loaf.git/", "https://github.com/levifig/loaf"},
+	}
+	for _, pair := range pairs {
+		left, err := NormalizeRemoteURL(pair[0])
+		if err != nil {
+			t.Fatalf("NormalizeRemoteURL(%q) error = %v", pair[0], err)
+		}
+		right, err := NormalizeRemoteURL(pair[1])
+		if err != nil {
+			t.Fatalf("NormalizeRemoteURL(%q) error = %v", pair[1], err)
+		}
+		if left != right {
+			t.Fatalf("%q -> %q, %q -> %q; want equal keys", pair[0], left, pair[1], right)
+		}
+	}
+}
+
+func TestNormalizeRemoteURLDoesNotConvergeCrossHostMirrors(t *testing.T) {
+	left, err := NormalizeRemoteURL("git@github.com:levifig/loaf.git")
+	if err != nil {
+		t.Fatalf("NormalizeRemoteURL() error = %v", err)
+	}
+	right, err := NormalizeRemoteURL("git@gitlab.com:levifig/loaf.git")
+	if err != nil {
+		t.Fatalf("NormalizeRemoteURL() error = %v", err)
+	}
+	if left == right {
+		t.Fatalf("cross-host mirrors converged unexpectedly: %q", left)
+	}
+}

--- a/internal/project/remote_url.go
+++ b/internal/project/remote_url.go
@@ -1,0 +1,75 @@
+package project
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var scpLikeRemote = regexp.MustCompile(`^([^@/]+@)?([^:/]+):([^/].+)$`)
+
+// NormalizeRemoteURL converges ssh/https/port/.git variants of one remote to a
+// canonical comparison key. Cross-host mirror pairs do not converge unless
+// explicitly attached elsewhere.
+func NormalizeRemoteURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	host, path, err := parseRemoteHostPath(raw)
+	if err != nil {
+		return "", err
+	}
+	if host == "" {
+		return "", nil
+	}
+	path = trimGitSuffix(cleanRemotePath(path))
+	key := strings.ToLower(host) + path
+	return strings.TrimSuffix(key, "/"), nil
+}
+
+func parseRemoteHostPath(raw string) (host, path string, err error) {
+	if strings.Contains(raw, "://") {
+		parsed, err := url.Parse(raw)
+		if err != nil {
+			return "", "", err
+		}
+		host = parsed.Hostname()
+		port := parsed.Port()
+		if port != "" && port != "22" && port != "443" && port != "80" {
+			host = host + ":" + port
+		}
+		return host, parsed.Path, nil
+	}
+	trimmed := strings.TrimSpace(raw)
+	trimmed = strings.TrimPrefix(trimmed, "ssh://")
+	if strings.HasPrefix(trimmed, "git@") {
+		trimmed = trimmed[len("git@"):]
+	} else if match := scpLikeRemote.FindStringSubmatch(trimmed); len(match) == 4 {
+		return match[2], "/" + match[3], nil
+	}
+	parts := strings.SplitN(trimmed, ":", 2)
+	if len(parts) == 2 && !strings.Contains(parts[0], "/") {
+		return parts[0], "/" + parts[1], nil
+	}
+	host, path, ok := strings.Cut(strings.TrimPrefix(trimmed, "/"), "/")
+	if !ok {
+		return trimmed, "", nil
+	}
+	return host, "/" + path, nil
+}
+
+func cleanRemotePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return path
+}
+
+func trimGitSuffix(path string) string {
+	path = strings.TrimSuffix(path, "/"); return strings.TrimSuffix(path, ".git")
+}


### PR DESCRIPTION
## Summary
- Adds `NormalizeRemoteURL` in `internal/project` converging ssh/https/default-port/.git variants to a scheme-agnostic host/path key
- Cross-host mirror URLs remain distinct (explicit attach required later)
- First shippable slice toward LOAF-64 DoD criterion on URL normalization

## Test plan
- [x] `go test ./internal/project/... -run NormalizeRemote`
- [ ] CI green