### PR TITLE
feat(LOAF-83): render-out internal issues to branch authority refs

### DIFF
--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -74,6 +74,7 @@ func (r Runner) runIssue(args []string, out io.Writer, runtime state.Runtime) er
 		"bucket":    writeIssueBucketHelp,
 		"link":      writeIssueLinkHelp,
 		"render":    writeIssueRenderHelp,
+		"render-out": writeIssueRenderOutHelp,
 		"identity":  writeIssueIdentityHelp,
 		"export":    writeIssueExportHelp,
 		"pull":      writeIssuePullHelp,
@@ -128,6 +129,8 @@ func (r Runner) runIssue(args []string, out io.Writer, runtime state.Runtime) er
 		return r.runIssueLink(args[1:], out, runtime)
 	case "render":
 		return r.runIssueRender(args[1:], out, runtime)
+	case "render-out":
+		return r.runIssueRenderOut(args[1:], out, runtime)
 	case "identity":
 		return r.runIssueIdentity(args[1:], out, runtime)
 	case "export":
@@ -163,6 +166,7 @@ func writeIssueHelp(out io.Writer) {
 		{Name: "bucket", Summary: "Set an advisory Now/Next/Later label"},
 		{Name: "link", Summary: "Create or remove an issue relationship"},
 		{Name: "render", Summary: "Emit a paste-ready PR body"},
+		{Name: "render-out", Summary: "Render an internal issue row onto a durable authority ref"},
 		{Name: "identity", Summary: "Show, define, or align the local issue prefix"},
 		{Name: "export", Summary: "Export issues, identity, criteria, claims, and relationships as JSON"},
 		{Name: "pull", Summary: "Adopt an existing Linear issue"},

--- a/internal/cli/issue_render_out.go
+++ b/internal/cli/issue_render_out.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/levifig/loaf/internal/project"
 	"github.com/levifig/loaf/internal/state"
 )
 

--- a/internal/cli/issue_render_out.go
+++ b/internal/cli/issue_render_out.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/levifig/loaf/internal/project"
+	"github.com/levifig/loaf/internal/state"
+)
+
+type issueRenderOutOptions struct {
+	ref          string
+	branch       string
+	manualExport string
+	retire       bool
+	dryRun       bool
+	jsonOutput   bool
+}
+
+func writeIssueRenderOutHelp(out io.Writer) {
+	writeUsageHelp(out, "loaf issue render-out <ref> [--branch <name>] [--export <path>] [--retire] [--dry-run] [--json]",
+		"Render an internal issue row onto a durable authority ref without retiring unless --retire and a receipt was written.",
+		"--branch   Trackerless branch ref key (default: issue started branch or issue/loaf-<n>)",
+		"--export   Manual-export artifact path for trackerless projects",
+		"--retire   Archive the internal row after recording the export receipt",
+		"--dry-run  Preview the target authority ref and contract body",
+		"--json     Output JSON")
+}
+
+func (r Runner) runIssueRenderOut(args []string, out io.Writer, runtime state.Runtime) error {
+	options, err := parseIssueRenderOutArgs(args)
+	if err != nil {
+		return err
+	}
+	projectRoot, err := r.requireIssueSQLiteState("issue render-out", runtime)
+	if err != nil {
+		return err
+	}
+	result, err := state.RenderOutIssue(context.Background(), projectRoot, state.PathResolver{StateHome: r.StateHome}, state.IssueRenderOutOptions{
+		Ref:          options.ref,
+		Branch:       options.branch,
+		ManualExport: options.manualExport,
+		Retire:       options.retire,
+		DryRun:       options.dryRun,
+	})
+	if err != nil {
+		return err
+	}
+	if options.jsonOutput {
+		return writeJSON(out, result)
+	}
+	fmt.Fprintf(out, "%s %s\n", result.Action, result.AuthorityRef.String())
+	if result.Retired {
+		fmt.Fprintf(out, "retired %s\n", firstNonEmpty(result.Issue.Alias, result.Issue.ID))
+	}
+	return nil
+}
+
+func parseIssueRenderOutArgs(args []string) (issueRenderOutOptions, error) {
+	options := issueRenderOutOptions{}
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--json":
+			options.jsonOutput = true
+		case "--branch":
+			value, err := consumeFlagValue(args, &i, "--branch")
+			if err != nil {
+				return issueRenderOutOptions{}, err
+			}
+			options.branch = value
+		case "--export":
+			value, err := consumeFlagValue(args, &i, "--export")
+			if err != nil {
+				return issueRenderOutOptions{}, err
+			}
+			options.manualExport = value
+		case "--retire":
+			options.retire = true
+		case "--dry-run":
+			options.dryRun = true
+		default:
+			positional = append(positional, args[i])
+		}
+	}
+	if len(positional) != 1 {
+		return issueRenderOutOptions{}, fmt.Errorf("issue render-out requires exactly one issue ref")
+	}
+	options.ref = strings.TrimSpace(positional[0])
+	return options, nil
+}

--- a/internal/state/issue_render_out.go
+++ b/internal/state/issue_render_out.go
@@ -1,0 +1,309 @@
+package state
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/levifig/loaf/internal/project"
+)
+
+const (
+	RenderOutReceiptKind       = "render-out"
+	RenderOutMappingIssueID    = "internal_issue_id"
+	RenderOutMappingIssueAlias = "internal_issue_alias"
+	RenderOutMappingExportPath = "manual_export_path"
+)
+
+// IssueRenderOutOptions controls render-out of one internal issue row.
+type IssueRenderOutOptions struct {
+	Ref          string
+	Branch       string
+	ManualExport string
+	Retire       bool
+	DryRun       bool
+}
+
+// IssueRenderOutResult is the durable authority surface created from an issue row.
+type IssueRenderOutResult struct {
+	ContractVersion    int          `json:"contract_version"`
+	DatabaseScope      string       `json:"database_scope"`
+	DatabasePath       string       `json:"database_path,omitempty"`
+	ProjectID          string       `json:"project_id,omitempty"`
+	ProjectName        string       `json:"project_name,omitempty"`
+	ProjectCurrentPath string       `json:"project_current_path,omitempty"`
+	Issue              Issue        `json:"issue"`
+	AuthorityRef       AuthorityRef `json:"authority_ref"`
+	Contract           WorkContract `json:"contract"`
+	ReceiptKind        string       `json:"receipt_kind"`
+	Retired            bool         `json:"retired"`
+	Action             string       `json:"action"`
+}
+
+// RenderOutIssue publishes an internal issue row to a durable authority ref.
+func RenderOutIssue(ctx context.Context, root project.Root, resolver PathResolver, options IssueRenderOutOptions) (IssueRenderOutResult, error) {
+	store, err := openProjectStoreMutateExisting(ctx, root, resolver)
+	if err != nil {
+		return IssueRenderOutResult{}, err
+	}
+	defer store.Close()
+	return store.RenderOutIssue(ctx, root, options)
+}
+
+func (s *Store) RenderOutIssue(ctx context.Context, root project.Root, options IssueRenderOutOptions) (IssueRenderOutResult, error) {
+	ref := strings.TrimSpace(options.Ref)
+	if ref == "" {
+		return IssueRenderOutResult{}, fmt.Errorf("render-out requires an issue ref")
+	}
+	projectID, err := s.projectID(ctx, root)
+	if err != nil {
+		return IssueRenderOutResult{}, err
+	}
+	identity, err := s.projectIdentity(ctx, projectID)
+	if err != nil {
+		return IssueRenderOutResult{}, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return IssueRenderOutResult{}, fmt.Errorf("begin issue render-out: %w", err)
+	}
+	defer tx.Rollback()
+
+	issueID, issueAlias, err := resolveIssueRefTx(ctx, tx, projectID, ref)
+	if err != nil {
+		return IssueRenderOutResult{}, err
+	}
+	issue, err := loadIssueTx(ctx, tx, projectID, issueID)
+	if err != nil {
+		return IssueRenderOutResult{}, err
+	}
+	if issue.ArchivedAt != "" {
+		return IssueRenderOutResult{}, fmt.Errorf("issue %s is already archived", firstNonEmpty(issueAlias, issue.ID))
+	}
+	if issue.Kind == IssueKindDecision {
+		return IssueRenderOutResult{}, fmt.Errorf("decision-kind issues re-home via ledger facts (LOAF-84), not render-out")
+	}
+
+	issueIdentity, err := loadIssueIdentityTx(ctx, tx, projectID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return IssueRenderOutResult{}, err
+	}
+	if err == nil && issueIdentity.Authority == IssueAuthorityLinear {
+		bound, bindErr := lookupLinearIssueIdentifierTx(ctx, tx, projectID, issueID)
+		if bindErr != nil {
+			return IssueRenderOutResult{}, bindErr
+		}
+		if bound == "" {
+			return IssueRenderOutResult{}, fmt.Errorf("linear-configured project: publish issue to Linear first (loaf issue push %s), then render-out", firstNonEmpty(issueAlias, ref))
+		}
+		authorityRef := AuthorityRef{Provider: AuthorityProviderLinear, Key: bound}
+		return s.renderOutToExistingAuthority(ctx, tx, identity, issue, issueAlias, authorityRef, options)
+	}
+
+	if strings.TrimSpace(options.ManualExport) != "" {
+		exportPath := strings.TrimSpace(options.ManualExport)
+		authorityRef := AuthorityRef{Provider: AuthorityProviderBranch, Key: exportPath}
+		return s.renderOutToExistingAuthority(ctx, tx, identity, issue, issueAlias, authorityRef, options)
+	}
+
+	branch := strings.TrimSpace(options.Branch)
+	if branch == "" {
+		branch = strings.TrimSpace(issue.StartedBranch)
+	}
+	if branch == "" && issueAlias != "" {
+		suffix := strings.TrimPrefix(strings.ToUpper(issueAlias), "LOAF-")
+		branch = "issue/loaf-" + strings.ToLower(suffix)
+	}
+	if branch == "" {
+		return IssueRenderOutResult{}, fmt.Errorf("render-out requires --branch, a started branch on the issue, or a LOAF alias")
+	}
+	authorityRef := AuthorityRef{Provider: AuthorityProviderBranch, Key: branch}
+	return s.renderOutToExistingAuthority(ctx, tx, identity, issue, issueAlias, authorityRef, options)
+}
+
+func (s *Store) renderOutToExistingAuthority(ctx context.Context, tx *sql.Tx, identity ProjectIdentity, issue Issue, issueAlias string, authorityRef AuthorityRef, options IssueRenderOutOptions) (IssueRenderOutResult, error) {
+	projectID := identity.ID
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	criteria := issueCriteriaToInputs(issue.Criteria)
+
+	result := IssueRenderOutResult{
+		ContractVersion:    StateJSONContractVersion,
+		DatabaseScope:      identity.DatabaseScope,
+		DatabasePath:       identity.DatabasePath,
+		ProjectID:          identity.ID,
+		ProjectName:        identity.FriendlyName,
+		ProjectCurrentPath: identity.CurrentPath,
+		Issue:              issue,
+		AuthorityRef:       authorityRef,
+		ReceiptKind:        RenderOutReceiptKind,
+		Action:             "applied",
+	}
+	if options.DryRun {
+		result.Action = "dry-run"
+		result.Contract = WorkContract{
+			AuthorityRef: authorityRef,
+			Kind:         issue.Kind,
+			Title:        issue.Title,
+			Body:         issue.Body,
+			Fog:          issue.Fog,
+			Status:       issue.Status,
+			Criteria:     criteriaToWorkContract(criteria),
+		}
+		return result, nil
+	}
+
+	var contract WorkContract
+	existing, err := loadWorkContractByRefTx(ctx, tx, projectID, authorityRef)
+	switch {
+	case err == nil:
+		contract = existing
+		if _, err := tx.ExecContext(ctx, `
+UPDATE work_contracts
+SET title = ?, body = ?, fog = ?, status = ?, updated_at = ?
+WHERE project_id = ? AND id = ?
+`, issue.Title, issue.Body, emptyToNil(strings.TrimSpace(issue.Fog)), issue.Status, now, projectID, contract.ID); err != nil {
+			return IssueRenderOutResult{}, fmt.Errorf("refresh rendered work contract: %w", err)
+		}
+		if err := replaceWorkContractCriteriaTx(ctx, tx, projectID, contract.ID, criteria, now); err != nil {
+			return IssueRenderOutResult{}, err
+		}
+		contract, err = loadWorkContractTx(ctx, tx, projectID, contract.ID)
+		if err != nil {
+			return IssueRenderOutResult{}, err
+		}
+	case strings.Contains(err.Error(), "not found"):
+		contract, err = createWorkContractTx(ctx, tx, projectID, WorkContractCreateOptions{
+			AuthorityRef: authorityRef,
+			Title:        issue.Title,
+			Body:         issue.Body,
+			Fog:          issue.Fog,
+			Kind:         issue.Kind,
+			Criteria:     criteria,
+		}, now)
+		if err != nil {
+			return IssueRenderOutResult{}, err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE work_contracts SET status = ?, updated_at = ? WHERE project_id = ? AND id = ?`, issue.Status, now, projectID, contract.ID); err != nil {
+			return IssueRenderOutResult{}, fmt.Errorf("set rendered contract status: %w", err)
+		}
+		contract, err = loadWorkContractTx(ctx, tx, projectID, contract.ID)
+		if err != nil {
+			return IssueRenderOutResult{}, err
+		}
+	default:
+		return IssueRenderOutResult{}, err
+	}
+
+	receiptID, err := newOpaqueStateID("wcr")
+	if err != nil {
+		return IssueRenderOutResult{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO work_contract_receipts (id, project_id, provider, provider_ref, receipt_kind, receipt_value, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(project_id, provider, provider_ref, receipt_kind) DO UPDATE SET
+  receipt_value = excluded.receipt_value,
+  updated_at = excluded.updated_at
+`, receiptID, projectID, authorityRef.Provider, authorityRef.Key, RenderOutReceiptKind, issue.ID, now, now); err != nil {
+		return IssueRenderOutResult{}, fmt.Errorf("record render-out receipt: %w", err)
+	}
+	if err := upsertWorkContractMappingTx(ctx, tx, projectID, authorityRef, RenderOutMappingIssueID, issue.ID, now); err != nil {
+		return IssueRenderOutResult{}, err
+	}
+	if issueAlias != "" {
+		if err := upsertWorkContractMappingTx(ctx, tx, projectID, authorityRef, RenderOutMappingIssueAlias, issueAlias, now); err != nil {
+			return IssueRenderOutResult{}, err
+		}
+	}
+	if strings.TrimSpace(options.ManualExport) != "" {
+		if err := upsertWorkContractMappingTx(ctx, tx, projectID, authorityRef, RenderOutMappingExportPath, strings.TrimSpace(options.ManualExport), now); err != nil {
+			return IssueRenderOutResult{}, err
+		}
+	}
+
+	if options.Retire {
+		archivedAt := issue.ArchivedAt
+		if archivedAt == "" {
+			archivedAt = now
+		}
+		if _, err := tx.ExecContext(ctx, `
+UPDATE issues SET status = ?, archived_at = ?, updated_at = ? WHERE project_id = ? AND id = ?
+`, IssueStatusCancelled, archivedAt, now, projectID, issue.ID); err != nil {
+			return IssueRenderOutResult{}, fmt.Errorf("retire rendered issue: %w", err)
+		}
+		if issue.Status != IssueStatusCancelled {
+			if _, err := insertIssueStatusEventTx(ctx, tx, projectID, issue.ID, issue.Status, IssueStatusCancelled, "rendered to "+authorityRef.String(), now); err != nil {
+				return IssueRenderOutResult{}, err
+			}
+		}
+		result.Retired = true
+		issue.Status = IssueStatusCancelled
+		issue.ArchivedAt = archivedAt
+		result.Issue = issue
+	}
+
+	if err := tx.Commit(); err != nil {
+		return IssueRenderOutResult{}, fmt.Errorf("commit issue render-out: %w", err)
+	}
+	result.Contract = contract
+	return result, nil
+}
+
+func upsertWorkContractMappingTx(ctx context.Context, tx *sql.Tx, projectID string, ref AuthorityRef, kind, value, now string) error {
+	mappingID, err := newOpaqueStateID("wcm")
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `
+INSERT INTO work_contract_mappings (id, project_id, provider, provider_ref, mapping_kind, mapping_value, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(project_id, provider, provider_ref, mapping_kind) DO UPDATE SET
+  mapping_value = excluded.mapping_value,
+  updated_at = excluded.updated_at
+`, mappingID, projectID, ref.Provider, ref.Key, kind, value, now, now)
+	return err
+}
+
+func lookupLinearIssueIdentifierTx(ctx context.Context, tx *sql.Tx, projectID, issueID string) (string, error) {
+	var identifier string
+	err := tx.QueryRowContext(ctx, `
+SELECT external_id FROM backend_mappings
+WHERE project_id = ? AND backend = 'linear' AND entity_kind = 'issue' AND entity_id = ?
+`, projectID, issueID).Scan(&identifier)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return identifier, err
+}
+
+func issueCriteriaToInputs(criteria []IssueCriterion) []IssueCriterionInput {
+	inputs := make([]IssueCriterionInput, 0, len(criteria))
+	for _, criterion := range criteria {
+		inputs = append(inputs, IssueCriterionInput{
+			Text:     criterion.Text,
+			Command:  criterion.Command,
+			Expect:   criterion.Expect,
+			Tier:     criterion.Tier,
+			Position: criterion.Position,
+		})
+	}
+	return inputs
+}
+
+func criteriaToWorkContract(inputs []IssueCriterionInput) []WorkContractCriterion {
+	out := make([]WorkContractCriterion, 0, len(inputs))
+	for i, input := range inputs {
+		out = append(out, WorkContractCriterion{
+			Position: i + 1,
+			Text:     input.Text,
+			Command:  input.Command,
+			Expect:   input.Expect,
+			Tier:     input.Tier,
+		})
+	}
+	return out
+}

--- a/internal/state/issue_render_out_test.go
+++ b/internal/state/issue_render_out_test.go
@@ -1,0 +1,96 @@
+package state_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/levifig/loaf/internal/project"
+	"github.com/levifig/loaf/internal/state"
+)
+
+func TestRenderOutIssueCreatesBranchContractWithReceipt(t *testing.T) {
+	ctx := context.Background()
+	root, resolver := renderOutFixture(t)
+
+	created, err := state.CreateIssue(ctx, root, resolver, state.IssueCreateOptions{
+		Title: "Trackerless export",
+		Body:  "Problem body.\n\nOut of scope: nothing.",
+		Kind:  state.IssueKindDelivery,
+		Criteria: []state.IssueCriterionInput{{
+			Text: "First criterion holds",
+			Tier: state.IssueCriterionTierH,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+
+	result, err := state.RenderOutIssue(ctx, root, resolver, state.IssueRenderOutOptions{
+		Ref:    created.Alias,
+		Branch: "issue/loaf-test-export",
+	})
+	if err != nil {
+		t.Fatalf("RenderOutIssue() error = %v", err)
+	}
+	if result.AuthorityRef.String() != "branch:issue/loaf-test-export" {
+		t.Fatalf("authority ref = %q", result.AuthorityRef.String())
+	}
+	if result.Contract.Title != created.Title {
+		t.Fatalf("contract title = %q, want %q", result.Contract.Title, created.Title)
+	}
+
+	shown, err := state.ShowWorkContract(ctx, root, resolver, result.AuthorityRef.String())
+	if err != nil {
+		t.Fatalf("ShowWorkContract() error = %v", err)
+	}
+	if len(shown.Contract.Receipts) == 0 {
+		t.Fatal("expected render-out receipt on contract")
+	}
+	found := false
+	for _, receipt := range shown.Contract.Receipts {
+		if receipt.Kind == state.RenderOutReceiptKind && receipt.Value == created.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("receipts = %#v, want render-out receipt for %s", shown.Contract.Receipts, created.ID)
+	}
+}
+
+func TestRenderOutIssueRefusesDecisionKind(t *testing.T) {
+	ctx := context.Background()
+	root, resolver := renderOutFixture(t)
+	created, err := state.CreateIssue(ctx, root, resolver, state.IssueCreateOptions{
+		Title: "Decision row",
+		Body:  "Should this happen?",
+		Kind:  state.IssueKindDecision,
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+	if _, err := state.RenderOutIssue(ctx, root, resolver, state.IssueRenderOutOptions{Ref: created.Alias}); err == nil {
+		t.Fatal("RenderOutIssue() error = nil, want refusal for decision kind")
+	}
+}
+
+func renderOutFixture(t *testing.T) (project.Root, state.PathResolver) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	stateHome := t.TempDir()
+	t.Setenv("LOAF_DB", filepath.Join(stateHome, "loaf.sqlite"))
+	root, err := project.ResolveRoot(dir)
+	if err != nil {
+		t.Fatalf("ResolveRoot() error = %v", err)
+	}
+	resolver := state.PathResolver{StateHome: stateHome}
+	ctx := context.Background()
+	if _, err := state.Initialize(ctx, root, resolver); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	return root, resolver
+}


### PR DESCRIPTION
## Summary
- Adds `loaf issue render-out` to publish trackerless internal issue rows onto `branch:` work contracts
- Records render-out export receipts and internal-issue mappings before optional `--retire`
- Refuses decision-kind rows (LOAF-84) and Linear rows without an existing Linear bind

## Test plan
- [x] `go test ./internal/state/ -run RenderOut -count=1`
- [ ] Manual dry-run against copied production DB before batch render-out