### PR TITLE
feat(LOAF-67): auth setup/link and fail-loud attach gate

### DIFF
--- a/docs/reports/2026-06-10-native-go-cutover-test-map.md
+++ b/docs/reports/2026-06-10-native-go-cutover-test-map.md
@@ -65,6 +65,7 @@ This audit is generated from the Go-native dispatch in `internal/cli/cli.go`, wi
 | `setup` | Native Go | Go dispatcher only | One-step bootstrap is native: target directory creation, native project init, package build invocation, and native install orchestration. The TypeScript command registration has been removed. |
 | `spark` | Native Go | Go dispatcher only | SQLite-only knowledge-object lifecycle. |
 | `spec` | Native Go | Go dispatcher only | Top-level help and unknown-subcommand handling are native; SQLite-backed list/show/archive are native; markdown-only `spec list`, `spec show`, and `spec archive` are native. The TypeScript command registration and obsolete TS implementation have been removed. |
+| `auth` | Native Go | Go dispatcher only | Substrate attach ceremony: admin setup/link/list/revoke and fail-loud gate for unattached environments. |
 | `sync` | Native Go | Go dispatcher only | Client sync engine: enqueue local facts, E2E-sealed push, cursor pull, journal projection refresh, and loud env-seq gap detection via bundled project credentials. |
 | `state` | Native Go | Go dispatcher only | Native operational-state control plane. |
 | `tag` | Native Go | Go dispatcher only | SQLite-backed tag operations. |

--- a/internal/auth/admin.go
+++ b/internal/auth/admin.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/levifig/loaf/internal/crypto"
+	"github.com/levifig/loaf/internal/syncserver"
+)
+
+// AdminContext holds decoded admin authority and an open sync server store.
+type AdminContext struct {
+	Wire       crypto.AccountAdminCredential
+	ServerDB   string
+	Server     *syncserver.Store
+}
+
+// OpenAdminContext loads the local admin wire and opens the configured sync server DB.
+func OpenAdminContext(ctx context.Context, store Store, serverDBOverride string) (AdminContext, func(), error) {
+	wireRaw, err := store.LoadAdminWire()
+	if err != nil {
+		return AdminContext{}, nil, err
+	}
+	wire, err := crypto.DecodeAccountAdminCredential(wireRaw)
+	if err != nil {
+		return AdminContext{}, nil, fmt.Errorf("decode admin wire: %w", err)
+	}
+	local, err := store.LoadLocalConfig()
+	if err != nil {
+		return AdminContext{}, nil, err
+	}
+	serverDB := strings.TrimSpace(serverDBOverride)
+	if serverDB == "" {
+		serverDB = strings.TrimSpace(local.ServerDB)
+	}
+	if serverDB == "" {
+		return AdminContext{}, nil, fmt.Errorf("sync server database path is required (--server-db or prior setup)")
+	}
+	server, err := syncserver.OpenStore(serverDB)
+	if err != nil {
+		return AdminContext{}, nil, err
+	}
+	cleanup := func() { _ = server.Close() }
+	if err := server.AuthenticateAdmin(ctx, wire.AccountAccessKey, wire.AccountAccessSecret); err != nil {
+		cleanup()
+		return AdminContext{}, nil, fmt.Errorf("admin authentication failed: %w", err)
+	}
+	return AdminContext{Wire: wire, ServerDB: serverDB, Server: server}, cleanup, nil
+}
+
+// AdminEndpoint returns the configured sync endpoint from stored admin wire.
+func AdminEndpoint(store Store) (string, error) {
+	wireRaw, err := store.LoadAdminWire()
+	if err != nil {
+		return "", err
+	}
+	wire, err := crypto.DecodeAccountAdminCredential(wireRaw)
+	if err != nil {
+		return "", fmt.Errorf("decode admin wire: %w", err)
+	}
+	return strings.TrimSpace(wire.Endpoint), nil
+}
+

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,93 @@
+package auth_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/levifig/loaf/internal/auth"
+	"github.com/levifig/loaf/internal/crypto"
+	"github.com/levifig/loaf/internal/syncserver"
+)
+
+func TestSetupLinkListRevokeRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	stateHome := t.TempDir()
+	serverDB := filepath.Join(t.TempDir(), "sync.sqlite")
+	projectID := "proj_test_auth_roundtrip"
+
+	setup, err := auth.Setup(ctx, auth.NewStore(stateHome), auth.SetupInput{
+		Endpoint: "http://127.0.0.1:8080",
+		ServerDB: serverDB,
+	})
+	if err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+	if setup.EmergencyKit == "" {
+		t.Fatal("Setup() emergency kit is empty")
+	}
+
+	link, err := auth.Link(ctx, auth.NewStore(stateHome), auth.LinkInput{
+		Name:      "ci-runner",
+		ProjectID: projectID,
+	})
+	if err != nil {
+		t.Fatalf("Link() error = %v", err)
+	}
+	if !strings.HasPrefix(link.ClientWire, "loafclient1://") {
+		t.Fatalf("client wire = %q, want loafclient1 prefix", link.ClientWire)
+	}
+	bundle, err := crypto.DecodeBundledClientCredential(link.ClientWire)
+	if err != nil {
+		t.Fatalf("DecodeBundledClientCredential() error = %v", err)
+	}
+	if bundle.ProjectID != projectID {
+		t.Fatalf("project id = %q, want %q", bundle.ProjectID, projectID)
+	}
+
+	rows, err := auth.ListConnections(ctx, auth.NewStore(stateHome), "")
+	if err != nil {
+		t.Fatalf("ListConnections() error = %v", err)
+	}
+	if len(rows) != 1 || rows[0].Name != "ci-runner" {
+		t.Fatalf("rows = %#v, want one ci-runner token", rows)
+	}
+
+	if err := auth.RevokeConnection(ctx, auth.NewStore(stateHome), "ci-runner", ""); err != nil {
+		t.Fatalf("RevokeConnection() error = %v", err)
+	}
+	server, err := syncserver.OpenStore(serverDB)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer server.Close()
+	if err := server.AuthenticateConnectionToken(ctx, link.ConnectionTokenID, strings.SplitN(bundle.ConnectionToken, ":", 2)[1], projectID); err == nil {
+		t.Fatal("revoked token still authenticates")
+	}
+}
+
+func TestCommandRequiresAttach(t *testing.T) {
+	t.Parallel()
+	if !auth.CommandRequiresAttach([]string{"journal", "recent"}) {
+		t.Fatal("journal should require attach")
+	}
+	if auth.CommandRequiresAttach([]string{"auth", "setup"}) {
+		t.Fatal("auth should be exempt")
+	}
+	if auth.CommandRequiresAttach([]string{"state", "path"}) {
+		t.Fatal("state path should be exempt")
+	}
+}
+
+
+
+func TestEnforcementInactiveUntilSetup(t *testing.T) {
+	t.Parallel()
+	store := auth.NewStore(t.TempDir())
+	active, err := store.EnforcementActive()
+	if err != nil || active {
+		t.Fatalf("EnforcementActive() = (%v, %v), want (false, nil) before setup", active, err)
+	}
+}

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -1,0 +1,8 @@
+package auth
+
+import "errors"
+
+var (
+	// ErrAdminNotConfigured means no admin wire is stored locally.
+	ErrAdminNotConfigured = errors.New("admin is not configured; run loaf auth setup first")
+)

--- a/internal/auth/gate.go
+++ b/internal/auth/gate.go
@@ -1,0 +1,44 @@
+package auth
+
+import "strings"
+
+var exemptTopLevelCommands = map[string]bool{
+	"auth":    true,
+	"build":   true,
+	"install": true,
+	"upgrade": true,
+	"init":    true,
+	"setup":   true,
+	"config":  true,
+	"hooks":   true,
+	"migrate": true,
+	"serve":   true,
+	"check":   true,
+	"version": true,
+	"release": true,
+}
+
+var exemptStateSubcommands = map[string]bool{
+	"init":    true,
+	"migrate": true,
+	"path":    true,
+	"status":  true,
+}
+
+// CommandRequiresAttach reports whether args name a substrate-touching command.
+func CommandRequiresAttach(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	top := strings.TrimSpace(args[0])
+	if top == "" || exemptTopLevelCommands[top] {
+		return false
+	}
+	if top == "state" && len(args) > 1 {
+		sub := strings.TrimSpace(args[1])
+		if exemptStateSubcommands[sub] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/auth/link.go
+++ b/internal/auth/link.go
@@ -1,0 +1,74 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/levifig/loaf/internal/crypto"
+)
+
+// LinkInput mints a named connection token and bundled client wire.
+type LinkInput struct {
+	Name      string
+	ProjectID string
+	ServerDB  string
+}
+
+// LinkResult is the minted client bundle and connection metadata.
+type LinkResult struct {
+	Name              string `json:"name"`
+	ProjectID         string `json:"project_id"`
+	ConnectionTokenID string `json:"connection_token_id"`
+	ClientWire        string `json:"client_wire"`
+}
+
+// Link mints a project-scoped connection token and emits the one-string bundled client wire.
+func Link(ctx context.Context, store Store, in LinkInput) (LinkResult, error) {
+	name := strings.TrimSpace(in.Name)
+	projectID := strings.TrimSpace(in.ProjectID)
+	if name == "" {
+		return LinkResult{}, fmt.Errorf("auth link: connection name is required")
+	}
+	if projectID == "" {
+		return LinkResult{}, fmt.Errorf("auth link: project id is required")
+	}
+	adminCtx, cleanup, err := OpenAdminContext(ctx, store, in.ServerDB)
+	if err != nil {
+		return LinkResult{}, err
+	}
+	defer cleanup()
+
+	token, tokenSecret, err := adminCtx.Server.MintConnectionToken(
+		ctx,
+		adminCtx.Wire.AccountAccessKey,
+		adminCtx.Wire.AccountAccessSecret,
+		name,
+		projectID,
+	)
+	if err != nil {
+		return LinkResult{}, fmt.Errorf("mint connection token: %w", err)
+	}
+	ring := crypto.NewProjectKeyRing(adminCtx.Wire.MasterKey, projectID)
+	projectKey, err := ring.WriteKey()
+	if err != nil {
+		return LinkResult{}, fmt.Errorf("derive project key: %w", err)
+	}
+	bundle := crypto.BundledClientCredential{
+		Endpoint:        adminCtx.Wire.Endpoint,
+		ConnectionToken: token.TokenID + ":" + tokenSecret,
+		ProjectID:       projectID,
+		KeyGeneration:   ring.WriteGeneration,
+		ProjectKey:      projectKey[:],
+	}
+	clientWire, err := crypto.EncodeBundledClientCredential(bundle)
+	if err != nil {
+		return LinkResult{}, fmt.Errorf("encode client wire: %w", err)
+	}
+	return LinkResult{
+		Name:              name,
+		ProjectID:         projectID,
+		ConnectionTokenID: token.TokenID,
+		ClientWire:        clientWire,
+	}, nil
+}

--- a/internal/auth/list.go
+++ b/internal/auth/list.go
@@ -1,0 +1,49 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/levifig/loaf/internal/syncserver"
+)
+
+// ConnectionSummary is a listed connection token row.
+type ConnectionSummary struct {
+	Name       string     `json:"name"`
+	ProjectID  string     `json:"project_id"`
+	TokenID    string     `json:"token_id"`
+	CreatedAt  time.Time  `json:"created_at"`
+	LastSeenAt *time.Time `json:"last_seen_at,omitempty"`
+	RevokedAt  *time.Time `json:"revoked_at,omitempty"`
+}
+
+// ListConnections returns named connection tokens for the configured admin account.
+func ListConnections(ctx context.Context, store Store, serverDB string) ([]ConnectionSummary, error) {
+	adminCtx, cleanup, err := OpenAdminContext(ctx, store, serverDB)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	tokens, err := adminCtx.Server.ListConnectionTokens(ctx, adminCtx.Wire.AccountAccessKey, adminCtx.Wire.AccountAccessSecret)
+	if err != nil {
+		return nil, fmt.Errorf("list connection tokens: %w", err)
+	}
+	out := make([]ConnectionSummary, 0, len(tokens))
+	for _, token := range tokens {
+		out = append(out, summarizeConnection(token))
+	}
+	return out, nil
+}
+
+func summarizeConnection(token syncserver.ConnectionToken) ConnectionSummary {
+	return ConnectionSummary{
+		Name:       token.Name,
+		ProjectID:  token.ProjectID,
+		TokenID:    token.TokenID,
+		CreatedAt:  token.CreatedAt,
+		LastSeenAt: token.LastSeenAt,
+		RevokedAt:  token.RevokedAt,
+	}
+}

--- a/internal/auth/refusal.go
+++ b/internal/auth/refusal.go
@@ -1,0 +1,63 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const UnattachedCode = "environment-unattached"
+
+// RefusalError is a machine-readable attach refusal.
+type RefusalError struct {
+	Code       string `json:"code"`
+	Cause      string `json:"cause"`
+	Remedy     string `json:"remedy"`
+	Command    string `json:"command,omitempty"`
+	Suggestion string `json:"suggestion,omitempty"`
+}
+
+func (e *RefusalError) Error() string {
+	if e == nil {
+		return "environment is unattached"
+	}
+	msg := strings.TrimSpace(e.Cause)
+	if msg == "" {
+		msg = "this environment is not attached to the substrate"
+	}
+	if remedy := strings.TrimSpace(e.Remedy); remedy != "" {
+		msg += "\n" + remedy
+	}
+	return msg
+}
+
+// JSON returns the refusal as compact JSON for --json callers.
+func (e *RefusalError) JSON() ([]byte, error) {
+	if e == nil {
+		e = &RefusalError{
+			Code:   UnattachedCode,
+			Cause:  "this environment is not attached to the substrate",
+			Remedy: "run loaf auth setup, then loaf auth link, then attach before substrate commands",
+		}
+	}
+	if e.Code == "" {
+		e.Code = UnattachedCode
+	}
+	return json.Marshal(e)
+}
+
+// NewUnattachedRefusal builds the default substrate-touching refusal.
+func NewUnattachedRefusal(command string) *RefusalError {
+	cmd := strings.TrimSpace(command)
+	suggestion := "loaf auth setup --endpoint <url> --server-db <path>"
+	if cmd != "" {
+		suggestion = fmt.Sprintf("attach this environment before `%s`; start with %s", cmd, suggestion)
+	}
+	return &RefusalError{
+		Code:       UnattachedCode,
+		Cause:      "this environment is not attached to the substrate",
+		Remedy:     "complete attach with loaf auth setup and loaf auth link, or paste a client bundle from an admin machine",
+		Command:    cmd,
+		Suggestion: suggestion,
+	}
+}

--- a/internal/auth/revoke.go
+++ b/internal/auth/revoke.go
@@ -1,0 +1,29 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// RevokeConnection revokes a named connection token. Effective at the client's next server contact.
+func RevokeConnection(ctx context.Context, store Store, name, serverDB string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("auth revoke: connection name is required")
+	}
+	adminCtx, cleanup, err := OpenAdminContext(ctx, store, serverDB)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	revoked, err := adminCtx.Server.RevokeConnectionToken(ctx, adminCtx.Wire.AccountAccessKey, adminCtx.Wire.AccountAccessSecret, name)
+	if err != nil {
+		return fmt.Errorf("revoke connection token: %w", err)
+	}
+	if !revoked {
+		return fmt.Errorf("auth revoke: connection %q not found", name)
+	}
+	return nil
+}

--- a/internal/auth/setup.go
+++ b/internal/auth/setup.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/levifig/loaf/internal/crypto"
+	"github.com/levifig/loaf/internal/syncserver"
+)
+
+// SetupInput configures first-time admin account provisioning.
+type SetupInput struct {
+	Endpoint string
+	ServerDB string
+}
+
+// SetupResult summarizes a successful setup.
+type SetupResult struct {
+	Endpoint         string `json:"endpoint"`
+	AccountAccessKey string `json:"account_access_key"`
+	EmergencyKit     string `json:"emergency_kit"`
+	MasterFingerprint string `json:"master_fingerprint"`
+	ServerDB         string `json:"server_db"`
+}
+
+// Setup creates a zero-PII sync account, mints a master key, stores admin wire locally, and returns the one-time Emergency Kit.
+func Setup(ctx context.Context, store Store, in SetupInput) (SetupResult, error) {
+	endpoint := strings.TrimRight(strings.TrimSpace(in.Endpoint), "/")
+	serverDB := strings.TrimSpace(in.ServerDB)
+	if endpoint == "" {
+		return SetupResult{}, fmt.Errorf("auth setup: endpoint is required")
+	}
+	if serverDB == "" {
+		return SetupResult{}, fmt.Errorf("auth setup: server database path is required")
+	}
+	server, err := syncserver.OpenStore(serverDB)
+	if err != nil {
+		return SetupResult{}, err
+	}
+	defer server.Close()
+
+	account, accessSecret, err := server.CreateAccountWithKey(ctx, "")
+	if err != nil {
+		return SetupResult{}, fmt.Errorf("create sync account: %w", err)
+	}
+	master, kit, err := crypto.EmergencyKitSetup()
+	if err != nil {
+		return SetupResult{}, fmt.Errorf("mint emergency kit: %w", err)
+	}
+	admin := crypto.AccountAdminCredential{
+		Endpoint:            endpoint,
+		AccountAccessKey:    account.AccessKeyID,
+		AccountAccessSecret: accessSecret,
+		MasterKey:           master,
+	}
+	wire, err := crypto.EncodeAccountAdminCredential(admin)
+	if err != nil {
+		return SetupResult{}, fmt.Errorf("encode admin wire: %w", err)
+	}
+	if err := store.SaveAdminWire(wire); err != nil {
+		return SetupResult{}, err
+	}
+	if err := store.SaveLocalConfig(LocalConfig{ServerDB: serverDB}); err != nil {
+		return SetupResult{}, err
+	}
+	return SetupResult{
+		Endpoint:          endpoint,
+		AccountAccessKey:  account.AccessKeyID,
+		EmergencyKit:      kit,
+		MasterFingerprint: crypto.MasterKeyFingerprint(master),
+		ServerDB:          serverDB,
+	}, nil
+}
+
+// MarkAttached records successful attach for this environment.
+func MarkAttached(store Store, endpoint, connectionName string) error {
+	return store.SaveAttachState(AttachState{
+		Attached:       true,
+		Endpoint:       strings.TrimSpace(endpoint),
+		ConnectionName: strings.TrimSpace(connectionName),
+		AttachedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+	})
+}

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -1,0 +1,182 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	attachStateFileName = "attach.json"
+	adminWireFileName   = "admin.wire"
+	localConfigFileName = "local.json"
+)
+
+// AttachState records whether this machine environment completed attach.
+type AttachState struct {
+	Attached       bool   `json:"attached"`
+	Endpoint       string `json:"endpoint,omitempty"`
+	ConnectionName string `json:"connection_name,omitempty"`
+	AttachedAt     string `json:"attached_at,omitempty"`
+}
+
+// LocalConfig holds non-wire local auth configuration (self-host paths).
+type LocalConfig struct {
+	ServerDB string `json:"server_db"`
+}
+
+// Store persists machine-local auth state under the Loaf state home.
+type Store struct {
+	Dir string
+}
+
+// NewStore returns the auth store rooted at stateHome/auth.
+func NewStore(authDir string) Store {
+	return Store{Dir: filepath.Clean(strings.TrimSpace(authDir))}
+}
+
+func (s Store) ensureDir() error {
+	if strings.TrimSpace(s.Dir) == "" {
+		return errors.New("auth store directory is unset")
+	}
+	return os.MkdirAll(s.Dir, 0o700)
+}
+
+func (s Store) attachStatePath() string {
+	return filepath.Join(s.Dir, attachStateFileName)
+}
+
+func (s Store) adminWirePath() string {
+	return filepath.Join(s.Dir, adminWireFileName)
+}
+
+func (s Store) localConfigPath() string {
+	return filepath.Join(s.Dir, localConfigFileName)
+}
+
+// LoadAttachState reads persisted attach state. Missing file means unattached.
+func (s Store) LoadAttachState() (AttachState, error) {
+	raw, err := os.ReadFile(s.attachStatePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return AttachState{}, nil
+		}
+		return AttachState{}, fmt.Errorf("read attach state: %w", err)
+	}
+	var state AttachState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return AttachState{}, fmt.Errorf("decode attach state: %w", err)
+	}
+	return state, nil
+}
+
+// SaveAttachState writes attach state atomically.
+func (s Store) SaveAttachState(state AttachState) error {
+	if err := s.ensureDir(); err != nil {
+		return err
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("encode attach state: %w", err)
+	}
+	tmp := s.attachStatePath() + ".tmp"
+	if err := os.WriteFile(tmp, raw, 0o600); err != nil {
+		return fmt.Errorf("write attach state: %w", err)
+	}
+	if err := os.Rename(tmp, s.attachStatePath()); err != nil {
+		return fmt.Errorf("commit attach state: %w", err)
+	}
+	return nil
+}
+
+// IsAttached reports whether the environment completed attach.
+func (s Store) IsAttached() (bool, error) {
+	state, err := s.LoadAttachState()
+	if err != nil {
+		return false, err
+	}
+	return state.Attached, nil
+}
+
+// LoadAdminWire returns the encoded admin wire string when present.
+func (s Store) LoadAdminWire() (string, error) {
+	raw, err := os.ReadFile(s.adminWirePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", ErrAdminNotConfigured
+		}
+		return "", fmt.Errorf("read admin wire: %w", err)
+	}
+	wire := strings.TrimSpace(string(raw))
+	if wire == "" {
+		return "", ErrAdminNotConfigured
+	}
+	return wire, nil
+}
+
+// SaveAdminWire stores the encoded admin wire string.
+func (s Store) SaveAdminWire(wire string) error {
+	wire = strings.TrimSpace(wire)
+	if wire == "" {
+		return errors.New("admin wire is empty")
+	}
+	if err := s.ensureDir(); err != nil {
+		return err
+	}
+	tmp := s.adminWirePath() + ".tmp"
+	if err := os.WriteFile(tmp, []byte(wire+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write admin wire: %w", err)
+	}
+	return os.Rename(tmp, s.adminWirePath())
+}
+
+// LoadLocalConfig reads self-host sync server DB path configuration.
+func (s Store) LoadLocalConfig() (LocalConfig, error) {
+	raw, err := os.ReadFile(s.localConfigPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return LocalConfig{}, nil
+		}
+		return LocalConfig{}, fmt.Errorf("read local auth config: %w", err)
+	}
+	var cfg LocalConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return LocalConfig{}, fmt.Errorf("decode local auth config: %w", err)
+	}
+	return cfg, nil
+}
+
+// SaveLocalConfig writes self-host sync server DB path configuration.
+func (s Store) SaveLocalConfig(cfg LocalConfig) error {
+	if err := s.ensureDir(); err != nil {
+		return err
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("encode local auth config: %w", err)
+	}
+	tmp := s.localConfigPath() + ".tmp"
+	if err := os.WriteFile(tmp, raw, 0o600); err != nil {
+		return fmt.Errorf("write local auth config: %w", err)
+	}
+	return os.Rename(tmp, s.localConfigPath())
+}
+// EnforcementActive reports whether attach refusal should gate substrate commands.
+// Gate engages once auth setup created admin wire or attach state exists on this machine.
+func (s Store) EnforcementActive() (bool, error) {
+	if _, err := os.Stat(s.adminWirePath()); err == nil {
+		return true, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	if _, err := os.Stat(s.attachStatePath()); err == nil {
+		return true, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	return false, nil
+}
+

--- a/internal/cli/attach_gate.go
+++ b/internal/cli/attach_gate.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/levifig/loaf/internal/auth"
+	"github.com/levifig/loaf/internal/state"
+)
+
+func (r Runner) authStore() (auth.Store, error) {
+	dir, err := state.PathResolver{StateHome: r.StateHome}.AuthDir()
+	if err != nil {
+		return auth.Store{}, err
+	}
+	return auth.NewStore(dir), nil
+}
+
+func (r Runner) enforceAttachGate(args []string, errOut io.Writer) error {
+	if argsRequestHelp(args) || !auth.CommandRequiresAttach(args) {
+		return nil
+	}
+	store, err := r.authStore()
+	if err != nil {
+		return err
+	}
+	active, err := store.EnforcementActive()
+	if err != nil {
+		return err
+	}
+	if !active {
+		return nil
+	}
+	attached, err := store.IsAttached()
+	if err != nil {
+		return err
+	}
+	if attached {
+		return nil
+	}
+	refusal := auth.NewUnattachedRefusal(strings.Join(args, " "))
+	if hasFlag(args, "--json") {
+		payload, err := refusal.JSON()
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(errOut, string(payload))
+	} else {
+		fmt.Fprintln(errOut, refusal.Error())
+		if suggestion := strings.TrimSpace(refusal.Suggestion); suggestion != "" {
+			fmt.Fprintln(errOut, suggestion)
+		}
+	}
+	return ExitError{Code: 1}
+}
+
+func argsRequestHelp(args []string) bool {
+	for _, arg := range args {
+		switch arg {
+		case "--help", "-h", "help":
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -1,0 +1,323 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/levifig/loaf/internal/auth"
+	"github.com/levifig/loaf/internal/project"
+	"github.com/levifig/loaf/internal/state"
+)
+
+type authCommonOptions struct {
+	serverDB   string
+	jsonOutput bool
+}
+
+func (r Runner) runAuth(args []string, out io.Writer, runtime state.Runtime) error {
+	if len(args) == 0 || isHelpArg(args) {
+		writeAuthHelp(out)
+		return nil
+	}
+	switch args[0] {
+	case "setup":
+		return r.runAuthSetup(args[1:], out)
+	case "link":
+		return r.runAuthLink(args[1:], out, runtime)
+	case "list":
+		return r.runAuthList(args[1:], out)
+	case "revoke":
+		return r.runAuthRevoke(args[1:], out)
+	case "attach":
+		return r.runAuthAttach(args[1:], out)
+	default:
+		return fmt.Errorf("auth: unknown subcommand %q", args[0])
+	}
+}
+
+func writeAuthHelp(out io.Writer) {
+	writeUsageHelp(out, "loaf auth <setup|link|list|revoke|attach>", "Manage substrate accounts, connection tokens, and attach state.",
+		"setup   Create a zero-PII account, mint master + Emergency Kit, store admin wire",
+		"link    Mint a named connection token and emit the bundled client wire",
+		"list    List named connection tokens with last-seen timestamps",
+		"revoke  Revoke a named connection token (effective at next client contact)",
+		"attach  Mark this environment attached after successful client provisioning")
+}
+
+func parseAuthCommonArgs(args []string) (authCommonOptions, []string, error) {
+	opts := authCommonOptions{}
+	rest := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--server-db":
+			if i+1 >= len(args) {
+				return authCommonOptions{}, nil, fmt.Errorf("auth --server-db requires a value")
+			}
+			i++
+			opts.serverDB = strings.TrimSpace(args[i])
+		case "--json":
+			opts.jsonOutput = true
+		default:
+			rest = append(rest, args[i])
+		}
+	}
+	return opts, rest, nil
+}
+
+func (r Runner) runAuthSetup(args []string, out io.Writer) error {
+	if len(args) == 1 && isHelpArg(args) {
+		writeUsageHelp(out, "loaf auth setup --endpoint <url> --server-db <path> [--json]", "Create account against a self-hosted sync server and store admin wire locally.")
+		return nil
+	}
+	endpoint := ""
+	serverDB := ""
+	jsonOutput := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--endpoint":
+			if i+1 >= len(args) {
+				return fmt.Errorf("auth setup --endpoint requires a value")
+			}
+			i++
+			endpoint = strings.TrimSpace(args[i])
+		case "--server-db":
+			if i+1 >= len(args) {
+				return fmt.Errorf("auth setup --server-db requires a value")
+			}
+			i++
+			serverDB = strings.TrimSpace(args[i])
+		case "--json":
+			jsonOutput = true
+		default:
+			return fmt.Errorf("auth setup: unknown option %q", args[i])
+		}
+	}
+	store, err := r.authStore()
+	if err != nil {
+		return err
+	}
+	result, err := auth.Setup(context.Background(), store, auth.SetupInput{
+		Endpoint: endpoint,
+		ServerDB: serverDB,
+	})
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+	fmt.Fprintf(out, "auth setup ok\n")
+	fmt.Fprintf(out, "endpoint: %s\n", result.Endpoint)
+	fmt.Fprintf(out, "account access key: %s\n", result.AccountAccessKey)
+	fmt.Fprintf(out, "master fingerprint: %s\n", result.MasterFingerprint)
+	fmt.Fprintf(out, "server db: %s\n", result.ServerDB)
+	fmt.Fprintln(out, "emergency kit (store offline; shown once):")
+	fmt.Fprintln(out, result.EmergencyKit)
+	return nil
+}
+
+func (r Runner) runAuthLink(args []string, out io.Writer, runtime state.Runtime) error {
+	if len(args) == 1 && isHelpArg(args) {
+		writeUsageHelp(out, "loaf auth link <name> [--project <id>] [--server-db <path>] [--json]", "Mint a named connection token and print the bundled client wire.")
+		return nil
+	}
+	opts, rest, err := parseAuthCommonArgs(args)
+	if err != nil {
+		return err
+	}
+	projectID := ""
+	name := ""
+	for i := 0; i < len(rest); i++ {
+		switch rest[i] {
+		case "--project":
+			if i+1 >= len(rest) {
+				return fmt.Errorf("auth link --project requires a value")
+			}
+			i++
+			projectID = strings.TrimSpace(rest[i])
+		default:
+			if name != "" {
+				return fmt.Errorf("auth link: unexpected argument %q", rest[i])
+			}
+			name = strings.TrimSpace(rest[i])
+		}
+	}
+	if name == "" {
+		return fmt.Errorf("auth link requires a connection name")
+	}
+	if projectID == "" {
+		projectID, err = r.resolveAuthProjectID(runtime)
+		if err != nil {
+			return err
+		}
+	}
+	store, err := r.authStore()
+	if err != nil {
+		return err
+	}
+	result, err := auth.Link(context.Background(), store, auth.LinkInput{
+		Name:      name,
+		ProjectID: projectID,
+		ServerDB:  opts.serverDB,
+	})
+	if err != nil {
+		return err
+	}
+	if opts.jsonOutput {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+	fmt.Fprintf(out, "auth link ok: name=%s project=%s token=%s\n", result.Name, result.ProjectID, result.ConnectionTokenID)
+	fmt.Fprintln(out, result.ClientWire)
+	return nil
+}
+
+func (r Runner) runAuthList(args []string, out io.Writer) error {
+	if len(args) == 1 && isHelpArg(args) {
+		writeUsageHelp(out, "loaf auth list [--server-db <path>] [--json]", "List named connection tokens.")
+		return nil
+	}
+	opts, rest, err := parseAuthCommonArgs(args)
+	if err != nil {
+		return err
+	}
+	if len(rest) > 0 {
+		return fmt.Errorf("auth list: unexpected argument %q", rest[0])
+	}
+	store, err := r.authStore()
+	if err != nil {
+		return err
+	}
+	rows, err := auth.ListConnections(context.Background(), store, opts.serverDB)
+	if err != nil {
+		return err
+	}
+	if opts.jsonOutput {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(rows)
+	}
+	if len(rows) == 0 {
+		fmt.Fprintln(out, "no connection tokens")
+		return nil
+	}
+	for _, row := range rows {
+		lastSeen := "-"
+		if row.LastSeenAt != nil {
+			lastSeen = row.LastSeenAt.UTC().Format("2006-01-02 15:04")
+		}
+		revoked := ""
+		if row.RevokedAt != nil {
+			revoked = " revoked"
+		}
+		fmt.Fprintf(out, "%s project=%s token=%s last_seen=%s%s\n", row.Name, row.ProjectID, row.TokenID, lastSeen, revoked)
+	}
+	return nil
+}
+
+func (r Runner) runAuthRevoke(args []string, out io.Writer) error {
+	if len(args) == 1 && isHelpArg(args) {
+		writeUsageHelp(out, "loaf auth revoke <name> [--server-db <path>]", "Revoke a named connection token.")
+		return nil
+	}
+	opts, rest, err := parseAuthCommonArgs(args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
+		return fmt.Errorf("auth revoke requires exactly one connection name")
+	}
+	store, err := r.authStore()
+	if err != nil {
+		return err
+	}
+	if err := auth.RevokeConnection(context.Background(), store, rest[0], opts.serverDB); err != nil {
+		return err
+	}
+	if opts.jsonOutput {
+		return json.NewEncoder(out).Encode(map[string]string{"status": "revoked", "name": rest[0]})
+	}
+	fmt.Fprintf(out, "revoked connection %q\n", rest[0])
+	return nil
+}
+
+func (r Runner) runAuthAttach(args []string, out io.Writer) error {
+	if len(args) == 1 && isHelpArg(args) {
+		writeUsageHelp(out, "loaf auth attach --name <connection> [--endpoint <url>]", "Record successful attach for this environment.")
+		return nil
+	}
+	name := ""
+	endpoint := ""
+	jsonOutput := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--name":
+			if i+1 >= len(args) {
+				return fmt.Errorf("auth attach --name requires a value")
+			}
+			i++
+			name = strings.TrimSpace(args[i])
+		case "--endpoint":
+			if i+1 >= len(args) {
+				return fmt.Errorf("auth attach --endpoint requires a value")
+			}
+			i++
+			endpoint = strings.TrimSpace(args[i])
+		case "--json":
+			jsonOutput = true
+		default:
+			return fmt.Errorf("auth attach: unknown option %q", args[i])
+		}
+	}
+	if name == "" {
+		return fmt.Errorf("auth attach requires --name")
+	}
+	store, err := r.authStore()
+	if err != nil {
+		return err
+	}
+	if endpoint == "" {
+		var err error
+		endpoint, err = auth.AdminEndpoint(store)
+		if err != nil {
+			return err
+		}
+	}
+	if err := auth.MarkAttached(store, endpoint, name); err != nil {
+		return err
+	}
+	if jsonOutput {
+		state, _ := store.LoadAttachState()
+		return json.NewEncoder(out).Encode(state)
+	}
+	fmt.Fprintf(out, "attached as %q via %s\n", name, endpoint)
+	return nil
+}
+
+func (r Runner) resolveAuthProjectID(runtime state.Runtime) (string, error) {
+	root, err := project.ResolveRoot(runtime.RootPath())
+	if err != nil {
+		return "", err
+	}
+	resolver := state.PathResolver{StateHome: r.StateHome}
+	databasePath, err := resolver.DatabasePath(root)
+	if err != nil {
+		return "", err
+	}
+	store, err := state.OpenStore(databasePath)
+	if err != nil {
+		return "", err
+	}
+	defer store.Close()
+	identity, err := store.LookupProjectIdentityForRoot(context.Background(), root)
+	if err != nil {
+		return "", fmt.Errorf("resolve project for auth link: %w", err)
+	}
+	return identity.ID, nil
+}

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/levifig/loaf/internal/auth"
+	"github.com/levifig/loaf/internal/state"
+)
+
+func testAuthStateHome(t *testing.T) string {
+	t.Helper()
+	stateHome := t.TempDir()
+	authDir, err := state.PathResolver{StateHome: stateHome}.AuthDir()
+	if err != nil {
+		t.Fatalf("AuthDir() error = %v", err)
+	}
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatalf("mkdir auth dir: %v", err)
+	}
+	return stateHome
+}
+
+func TestAttachGateRefusesJournalWhenConfiguredButUnattached(t *testing.T) {
+	t.Parallel()
+	stateHome := testAuthStateHome(t)
+	authDir, err := state.PathResolver{StateHome: stateHome}.AuthDir()
+	if err != nil {
+		t.Fatalf("AuthDir() error = %v", err)
+	}
+	ctx := context.Background()
+	serverDB := filepath.Join(t.TempDir(), "sync.sqlite")
+	if _, err := auth.Setup(ctx, auth.NewStore(authDir), auth.SetupInput{
+		Endpoint: "http://127.0.0.1:8080",
+		ServerDB: serverDB,
+	}); err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+	var stderr bytes.Buffer
+	err = Runner{
+		Stderr:     &stderr,
+		WorkingDir: t.TempDir(),
+		StateHome:  stateHome,
+	}.Run([]string{"journal", "recent"})
+	if err == nil {
+		t.Fatal("Run() error = nil, want attach refusal")
+	}
+	var exit ExitError
+	if !errorsAsExit(err, &exit) || exit.Code != 1 {
+		t.Fatalf("Run() error = %v, want ExitError code 1", err)
+	}
+	if !strings.Contains(stderr.String(), "not attached") {
+		t.Fatalf("stderr = %q, want unattached refusal", stderr.String())
+	}
+}
+
+func TestAttachGateAllowsJournalBeforeAuthSetup(t *testing.T) {
+	t.Parallel()
+	stateHome := testAuthStateHome(t)
+	var stderr bytes.Buffer
+	err := Runner{
+		Stderr:     &stderr,
+		WorkingDir: t.TempDir(),
+		StateHome:  stateHome,
+	}.Run([]string{"state", "path"})
+	if err != nil {
+		t.Fatalf("Run(state path) error = %v", err)
+	}
+}
+
+func TestAttachGateAllowsAuthSetupWhenUnattached(t *testing.T) {
+	t.Parallel()
+	var stderr bytes.Buffer
+	err := Runner{
+		Stderr:     &stderr,
+		WorkingDir: t.TempDir(),
+		StateHome:  t.TempDir(),
+	}.Run([]string{"auth", "setup", "--help"})
+	if err != nil {
+		t.Fatalf("Run(auth setup --help) error = %v", err)
+	}
+}
+
+func errorsAsExit(err error, target *ExitError) bool {
+	if err == nil {
+		return false
+	}
+	if e, ok := err.(ExitError); ok {
+		*target = e
+		return true
+	}
+	return false
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -215,6 +215,10 @@ func (r Runner) Run(args []string) error {
 		return nil
 	}
 
+	if gateErr := r.enforceAttachGate(args, errOut); gateErr != nil {
+		return gateErr
+	}
+
 	var dispatchErr error
 	switch args[0] {
 	case "--help", "-h", "help":
@@ -292,6 +296,8 @@ func (r Runner) Run(args []string) error {
 		dispatchErr = r.runJournal(args[1:], out, runtime)
 	case "scratchpad":
 		dispatchErr = r.runScratchpad(args[1:], out, runtime)
+	case "auth":
+		dispatchErr = r.runAuth(args[1:], out, runtime)
 	case "serve":
 		dispatchErr = r.runServe(args[1:], out)
 	case "sync":
@@ -367,6 +373,7 @@ func writeRootHelp(out io.Writer) {
 	fmt.Fprintln(out, "  render        Maintain durable markdown renders")
 	fmt.Fprintln(out, "  journal       Record and read the project journal")
 	fmt.Fprintln(out, "  scratchpad    Ephemeral agent coordination channel")
+	fmt.Fprintln(out, "  auth          Manage substrate attach and connection tokens")
 	fmt.Fprintln(out, "  serve         Run the self-hostable sync relay")
 	fmt.Fprintln(out, "  sync          Push and pull facts through the sync relay")
 	fmt.Fprintln(out, "  intent        Show tracked Intent (writes frozen; use issue)")

--- a/internal/state/path.go
+++ b/internal/state/path.go
@@ -120,6 +120,16 @@ func (r PathResolver) dataHome() (string, error) {
 	return filepath.Join(home, ".local", "share"), nil
 }
 
+
+// AuthDir returns the machine-local auth state directory beside the global database.
+func (r PathResolver) AuthDir() (string, error) {
+	dataHome, err := r.dataHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dataHome, "loaf", "auth"), nil
+}
+
 func (r PathResolver) legacyStateHome() (string, error) {
 	if value := os.Getenv("XDG_STATE_HOME"); value != "" {
 		if stateHome, ok := cleanAbsoluteXDGHome(value); ok {


### PR DESCRIPTION
## Summary
- Adds `internal/auth/` with `loaf auth setup|link|list|revoke|attach` for zero-PII admin provisioning and bundled client wire minting against the LOAF-75 sync server DB.
- Substrate-touching commands fail loud once auth is configured on the machine but the environment is not attached; bootstrap/tooling commands (`auth`, `serve`, `state init/migrate/path/status`, etc.) stay exempt.
- Auth state lives under XDG data home at `loaf/auth/` beside the global SQLite database.

## Test plan
- [x] `go test ./internal/auth/... -count=1`
- [x] `go test ./internal/cli/... -count=1`
- [ ] Full unattended attach sequence (criterion 3) — follow-up slice
- [ ] Cursor Cloud / Amp / CI walkthrough docs (criterion 5) — follow-up slice