### PR TITLE
docs(LOAF-67): cloud and CI attach walkthrough (slice 3)

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Amp Orb resume script (LOAF-78). Re-runs project-environment install on wake.
-# Attach pre-warm deferred until LOAF-67 attach ceremony ships.
+# Optional attach pre-warm: export LOAF_CLIENT_TOKEN in project secrets, then
+# run `loaf attach` after resume (see docs/knowledge/cloud-attach-walkthrough.md).
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"

--- a/.cursor/loaf-cloud-start.sh
+++ b/.cursor/loaf-cloud-start.sh
@@ -4,11 +4,11 @@
 # hooks/skills exist before the agent works. Re-export LOAF_PROJECT_ENV so
 # session loaf upgrade/config/hooks keep the project-local layout — Cursor Cloud
 # does not carry install-time shell exports into agent sessions.
-# Attach pre-warm (`loaf attach` or equivalent) is deferred until LOAF-67.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 export PATH="$ROOT/bin:$PATH"
 export LOAF_PROJECT_ENV=1
-# no-op until LOAF-67 attach pre-warm lands
-exit 0
+if [[ -n "${LOAF_CLIENT_TOKEN:-}" ]]; then
+  loaf attach
+fi

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -12,5 +12,6 @@ Loaf's domain knowledge — what agents need to understand about this project.
 | [skill-architecture.md](skill-architecture.md) | skills, agent-skills-standard, sidecars | `content/skills/**/*.md`, `content/skills/**/*.yaml`, `config/hooks.yaml` |
 | [task-system.md](task-system.md) | tasks, specs, changes, journal | `docs/changes/**/*.md`, `.agents/specs/**/*.md`, SQLite task state, `internal/cli/cli.go` |
 | [work-model.md](work-model.md) | changes, cohorts, receipts, pipeline | `docs/changes/**/*`, `internal/cli/change_*.go`, pitch/shape/implement/triage skills |
+| [cloud-attach-walkthrough.md](cloud-attach-walkthrough.md) | cloud attach, CI secrets, Cursor Cloud, Amp Orbs | `.cursor/loaf-cloud-*.sh`, `.agents/{setup,resume}`, `internal/auth/`, LOAF-67/78 |
 
 See [../decisions/](../decisions/) for architecture decision records.

--- a/docs/knowledge/cloud-attach-walkthrough.md
+++ b/docs/knowledge/cloud-attach-walkthrough.md
@@ -1,0 +1,272 @@
+# Cloud and CI Attach Walkthrough
+
+## Contents
+
+- Overview
+- Prerequisites
+- Environment variables
+- Cursor Cloud Agents
+- Amp Orbs
+- CI (GitHub Actions)
+- Failure modes
+- Verification
+
+Ephemeral hosts — Cursor Cloud Agents, Amp Orbs, and CI runners — start from a fresh clone with no Loaf installed and no substrate attach state. This walkthrough covers the operator path from minting a project-scoped client credential through unattended attach on each surface. It satisfies the LOAF-67 H-tier connection documentation and the LOAF-78 walkthrough criterion for project-environment secrets and attach pre-warm.
+
+## Overview
+
+Three layers stack on cloud hosts:
+
+1. **Bootstrap (LOAF-78)** — install scripts build the Loaf CLI and run `loaf install --to <harness>` under `LOAF_PROJECT_ENV=1` so skills, commands, and hooks resolve from the project checkout (`.cursor/`, `.amp/`, `.agents/skills/`), not user-level config.
+2. **Secrets (LOAF-67)** — per-project environment secrets carry the bundled client credential minted by `loaf auth link`. Never paste the operator master key or account admin secret into cloud or CI secrets.
+3. **Attach (LOAF-67)** — the start script (or an explicit CI step) runs `loaf attach`, which reads `.agents/loaf.conf`, `LOAF_CLIENT_TOKEN`, and optionally `LOAF_SYNC_URL`, then completes the unattended ceremony: HTTPS health → auth → pull → decrypt probe → capability check → HLC skew check → identity match.
+
+When attach enforcement is active and the environment is unattached, every substrate-touching `loaf` command exits nonzero with a machine-readable refusal. SessionStart journal context hooks fail closed the same way. Exempt commands: `--version`, help, and the auth/attach/install surface needed to become attached.
+
+## Prerequisites
+
+Complete these steps once on a trusted operator machine before configuring cloud or CI environments.
+
+### 1. Run a sync relay
+
+Self-host the sync server (`loaf serve`) or use your deployed relay. The endpoint must be HTTPS in production (TLS-terminated reverse proxy is fine).
+
+```bash
+loaf serve --listen :8443 --db /path/to/sync.sqlite
+```
+
+### 2. Create the substrate account
+
+```bash
+loaf auth setup --endpoint https://sync.example.com --server-db /path/to/sync.sqlite
+```
+
+Store the Emergency Kit offline. The admin wire stays on the operator machine only.
+
+### 3. Mint a project-scoped client credential
+
+From the project checkout (`.agents/loaf.conf` must exist with `project_id`):
+
+```bash
+loaf auth link cursor:myproject --project "$(jq -r .project_id .agents/loaf.conf)"
+```
+
+Copy the one-line bundled client wire printed after `auth link ok`. This string is the value for `LOAF_CLIENT_TOKEN` in cloud and CI secrets.
+
+Connection names are arbitrary but should encode harness and project for audit (`cursor:loaf`, `amp:loaf`, `ci:loaf`).
+
+## Environment variables
+
+| Variable | Required | Surface | Purpose |
+|----------|----------|---------|---------|
+| `LOAF_CLIENT_TOKEN` | Yes (cloud/CI attach) | All | Bundled client credential from `loaf auth link` |
+| `LOAF_PROJECT_ENV` | Yes (cloud harness install) | Cursor Cloud, Amp | Routes `loaf install` to project-local `.cursor/`, `.amp/`, `.agents/skills/` |
+| `LOAF_SYNC_URL` | No | All | Override sync endpoint embedded in the bundled credential |
+| `LOAF_CONNECTION_NAME` | No | All | Connection name recorded in attach state (defaults to token id) |
+
+Bootstrap scripts in this repository export `LOAF_PROJECT_ENV=1`. Cursor Cloud does not carry install-time shell exports into agent sessions, so the start script re-exports it. Prefer also setting `LOAF_PROJECT_ENV=1` as a durable project environment variable in the harness UI when available.
+
+## Cursor Cloud Agents
+
+This repository ships Cursor Cloud bootstrap artifacts:
+
+| File | Role |
+|------|------|
+| `.cursor/environment.json` | Points install/start scripts |
+| `.cursor/loaf-cloud-install.sh` | Builds CLI, runs `loaf install --to cursor` |
+| `.cursor/loaf-cloud-start.sh` | Re-exports `LOAF_PROJECT_ENV`, pre-warms attach when token present |
+
+### Operator setup
+
+1. Open the Cursor Cloud project settings for this repository.
+2. Add **project environment variables** (secrets):
+   - `LOAF_CLIENT_TOKEN` — the bundled wire from `loaf auth link`
+   - `LOAF_PROJECT_ENV` — `1` (recommended as a durable var, not only via start script)
+   - `LOAF_SYNC_URL` — optional override if the relay URL differs from the credential
+3. Confirm `.cursor/environment.json` references the install and start scripts (committed in-repo).
+
+### What happens on each agent session
+
+**Install/build phase** (`.cursor/loaf-cloud-install.sh`):
+
+```bash
+npm ci && npm run build:go   # when native binary missing for host
+export PATH="$ROOT/bin:$PATH"
+export LOAF_PROJECT_ENV=1
+loaf install --to cursor --yes
+```
+
+**Start phase** (`.cursor/loaf-cloud-start.sh`):
+
+```bash
+export PATH="$ROOT/bin:$PATH"
+export LOAF_PROJECT_ENV=1
+if [[ -n "${LOAF_CLIENT_TOKEN:-}" ]]; then
+  loaf attach
+fi
+```
+
+After attach succeeds, substrate commands (`loaf journal log`, `loaf issue …`, etc.) proceed normally. If `LOAF_CLIENT_TOKEN` is missing or attach fails, substrate commands refuse loudly and SessionStart context emission fails closed.
+
+### Manual verification on a cloud agent
+
+```bash
+loaf attach --json          # should exit 0 when secrets are correct
+loaf journal recent         # should succeed after attach
+loaf journal context --from-hook  # SessionStart path; fails closed when unattached
+```
+
+## Amp Orbs
+
+Amp uses `.agents/setup` (fresh orb) and `.agents/resume` (wake) instead of Cursor's environment.json.
+
+| File | Role |
+|------|------|
+| `.agents/setup` | Builds CLI, runs `loaf install --to amp` |
+| `.agents/resume` | Re-runs project-environment install on wake |
+
+### Operator setup
+
+1. In Amp project configuration, add **project secrets / environment variables**:
+   - `LOAF_CLIENT_TOKEN` — bundled wire from `loaf auth link`
+   - `LOAF_PROJECT_ENV` — `1`
+   - `LOAF_SYNC_URL` — optional
+2. Optionally add attach pre-warm to `.agents/resume` (same pattern as Cursor start):
+
+```bash
+if [[ -n "${LOAF_CLIENT_TOKEN:-}" ]]; then
+  loaf attach
+fi
+```
+
+The committed `.agents/resume` currently re-installs harness surfaces only; attach can run explicitly in the orb session or via the optional resume hook above.
+
+### What happens on orb prepare
+
+**Setup** (`.agents/setup`):
+
+```bash
+npm ci && npm run build:go   # when native binary missing
+export PATH="$ROOT/bin:$PATH"
+export LOAF_PROJECT_ENV=1
+loaf install --to amp --yes
+```
+
+**Resume** (`.agents/resume`):
+
+```bash
+export PATH="$ROOT/bin:$PATH"
+export LOAF_PROJECT_ENV=1
+loaf install --to amp --yes
+```
+
+Run attach once per session after setup/resume when the secret is present:
+
+```bash
+loaf attach
+```
+
+## CI (GitHub Actions)
+
+CI runners are ephemeral: no attach state persists between jobs. Each job that touches the substrate must install Loaf, export secrets, and attach before substrate commands.
+
+### Repository secrets
+
+Add these in **Settings → Secrets and variables → Actions**:
+
+| Secret | Value |
+|--------|-------|
+| `LOAF_CLIENT_TOKEN` | Bundled wire from `loaf auth link` (use a `ci:<repo>` connection name) |
+| `LOAF_SYNC_URL` | Optional relay override |
+
+Do not commit credentials. Do not use the operator master key in CI.
+
+### Example workflow fragment
+
+```yaml
+jobs:
+  substrate-check:
+    runs-on: ubuntu-latest
+    env:
+      LOAF_PROJECT_ENV: "1"
+      LOAF_CLIENT_TOKEN: ${{ secrets.LOAF_CLIENT_TOKEN }}
+      LOAF_SYNC_URL: ${{ secrets.LOAF_SYNC_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build Loaf CLI
+        run: |
+          npm ci
+          npm run build:go
+          echo "$PWD/bin" >> "$GITHUB_PATH"
+
+      - name: Attach to substrate
+        run: loaf attach --json
+
+      - name: Run substrate command
+        run: loaf journal recent --limit 5
+```
+
+Notes:
+
+- `LOAF_PROJECT_ENV=1` keeps any in-job `loaf install` on project-local paths if needed.
+- Attach runs every job; there is no persistent attach state on the runner.
+- Use `loaf attach --json` in CI so failures emit structured refusals in logs.
+- Jobs that only run `go test` against isolated temp state (`LOAF_DB` in tests) do not need attach unless they invoke substrate-touching CLI paths.
+
+### CI attach failures
+
+Common causes:
+
+- **Missing secret** — enforcement sees no token; attach never runs; substrate commands refuse.
+- **Wrong project scope** — credential `project_id` does not match `.agents/loaf.conf`; attach exits with `attach-identity-mismatch`.
+- **Reach/auth** — relay unreachable or token revoked; attach exits with `attach-reach-failed` or `attach-auth-failed`.
+
+## Failure modes
+
+Attach refusals are machine-readable. Use `--json` for automation.
+
+| Code | Cause | Remedy |
+|------|-------|--------|
+| `attach-conf-missing` | No `.agents/loaf.conf` | Ensure conf ships with the clone |
+| `attach-credential-missing` | `LOAF_CLIENT_TOKEN` empty | Add project secret from `loaf auth link` |
+| `attach-credential-invalid` | Malformed bundled wire | Re-mint with `loaf auth link` |
+| `attach-identity-mismatch` | Conf `project_id` ≠ credential scope | Mint a project-scoped token for this checkout |
+| `attach-endpoint-insecure` | Non-HTTPS endpoint | Use TLS or set `LOAF_SYNC_URL` to HTTPS relay |
+| `attach-reach-failed` | Relay health check failed | Verify relay URL and network egress |
+| `attach-auth-failed` | Token rejected or revoked | Re-mint or un-revoke the connection |
+| `attach-hlc-skew` | Clock grossly skewed from stream | Fix host NTP; retry attach |
+| `environment-unattached` | Substrate command before attach | Run `loaf attach` or fix secrets |
+
+## Verification
+
+**Operator machine (local):**
+
+```bash
+loaf auth list                              # connection visible with last-seen after cloud attach
+go test ./internal/cli/... -run CloudEnvironment -count=1
+```
+
+**Cloud / CI (after secrets configured):**
+
+```bash
+loaf attach --json                          # exit 0
+loaf journal recent                         # exit 0 (substrate reachable)
+```
+
+**Unattached refusal (negative check):**
+
+```bash
+unset LOAF_CLIENT_TOKEN
+loaf journal recent                         # exit 1, environment-unattached
+```
+
+Harness bootstrap script markers are tested by `TestCloudEnvironmentBootstrapArtifactsInstallCLI` in `internal/cli/cloud_environment_test.go`.

--- a/docs/reports/2026-06-10-native-go-cutover-test-map.md
+++ b/docs/reports/2026-06-10-native-go-cutover-test-map.md
@@ -65,7 +65,8 @@ This audit is generated from the Go-native dispatch in `internal/cli/cli.go`, wi
 | `setup` | Native Go | Go dispatcher only | One-step bootstrap is native: target directory creation, native project init, package build invocation, and native install orchestration. The TypeScript command registration has been removed. |
 | `spark` | Native Go | Go dispatcher only | SQLite-only knowledge-object lifecycle. |
 | `spec` | Native Go | Go dispatcher only | Top-level help and unknown-subcommand handling are native; SQLite-backed list/show/archive are native; markdown-only `spec list`, `spec show`, and `spec archive` are native. The TypeScript command registration and obsolete TS implementation have been removed. |
-| `auth` | Native Go | Go dispatcher only | Substrate attach ceremony: admin setup/link/list/revoke and fail-loud gate for unattached environments. |
+| `attach` | Native Go | Go dispatcher only | Unattended attach ceremony: conf ID + client credential, relay health/auth probe, decrypt/capability/HLC skew checks, then persist attach state. |
+| `auth` | Native Go | Go dispatcher only | Substrate attach ceremony: admin setup/link/list/revoke/attach and fail-loud gate for unattached environments. |
 | `sync` | Native Go | Go dispatcher only | Client sync engine: enqueue local facts, E2E-sealed push, cursor pull, journal projection refresh, and loud env-seq gap detection via bundled project credentials. |
 | `state` | Native Go | Go dispatcher only | Native operational-state control plane. |
 | `tag` | Native Go | Go dispatcher only | SQLite-backed tag operations. |

--- a/internal/auth/attach_test.go
+++ b/internal/auth/attach_test.go
@@ -1,0 +1,250 @@
+package auth_test
+
+import (
+	"context"
+	"fmt"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/levifig/loaf/internal/auth"
+	"github.com/levifig/loaf/internal/crypto"
+	"github.com/levifig/loaf/internal/project"
+	"github.com/levifig/loaf/internal/state"
+	"github.com/levifig/loaf/internal/syncserver"
+)
+
+func TestUnattendedAttachRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	h := newAttachHarness(t)
+
+	confDir := filepath.Join(h.repoRoot, ".agents")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	conf := map[string]string{"conf_id": "conf_attach_test", "project_id": h.projectID}
+	rawConf, _ := json.Marshal(conf)
+	if err := os.WriteFile(filepath.Join(confDir, "loaf.conf"), rawConf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := project.ResolveRoot(h.repoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire, err := crypto.EncodeBundledClientCredential(h.credential)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authStore := auth.NewStore(filepath.Join(h.stateHome, "auth"))
+	if err := os.MkdirAll(authStore.Dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := auth.UnattendedAttach(ctx, auth.AttachInput{
+		Root:              root,
+		Store:             authStore,
+		ClientWire:        wire,
+		ConnectionName:    "ci-attach",
+		HTTPClient:        h.server.Client(),
+		ProbeStore:        h.projectStore,
+		AllowInsecureHTTP: true,
+	})
+	if err != nil {
+		t.Fatalf("UnattendedAttach() error = %v", err)
+	}
+	if result.ProjectID != h.projectID {
+		t.Fatalf("project id = %q, want %q", result.ProjectID, h.projectID)
+	}
+	attached, err := authStore.IsAttached()
+	if err != nil || !attached {
+		t.Fatalf("IsAttached() = (%v, %v), want (true, nil)", attached, err)
+	}
+}
+
+func TestUnattendedAttachRefusesIdentityMismatch(t *testing.T) {
+	ctx := context.Background()
+	h := newAttachHarness(t)
+	confDir := filepath.Join(h.repoRoot, ".agents")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rawConf, _ := json.Marshal(map[string]string{"project_id": "proj_other"})
+	if err := os.WriteFile(filepath.Join(confDir, "loaf.conf"), rawConf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root, err := project.ResolveRoot(h.repoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire, err := crypto.EncodeBundledClientCredential(h.credential)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authStore := auth.NewStore(filepath.Join(h.stateHome, "auth"))
+	if err := os.MkdirAll(authStore.Dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	_, err = auth.UnattendedAttach(ctx, auth.AttachInput{
+		Root: root, Store: authStore, ClientWire: wire, HTTPClient: h.server.Client(), ProbeStore: h.projectStore, AllowInsecureHTTP: true,
+	})
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "identity") && !strings.Contains(strings.ToLower(err.Error()), "match") {
+		t.Fatalf("UnattendedAttach() = %v, want identity mismatch refusal", err)
+	}
+}
+
+type attachHarness struct {
+	repoRoot      string
+	stateHome     string
+	projectID     string
+	projectStore  *state.Store
+	credential    crypto.BundledClientCredential
+	server        *httptest.Server
+	serverStore   *syncserver.Store
+	projectKey    [32]byte
+	keyGen        int
+}
+
+func newAttachHarness(t *testing.T) *attachHarness {
+	t.Helper()
+	ctx := context.Background()
+	repoRoot := t.TempDir()
+
+	serverStore, err := syncserver.OpenStore(filepath.Join(t.TempDir(), "relay.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = serverStore.Close() })
+
+	projectID := "proj_" + strings.ReplaceAll(strings.TrimPrefix(t.Name(), "Test"), "/", "_")
+	adminSecret := "admin-secret"
+	_, adminKey, err := serverStore.CreateAccount(ctx, adminSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, tokenSecret, err := serverStore.MintConnectionToken(ctx, adminKey, adminSecret, "ci", projectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	master, err := crypto.GenerateMasterKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ring := crypto.NewProjectKeyRing(master, projectID)
+	projectKey, err := ring.WriteKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(syncserver.NewServer(serverStore).Handler())
+	t.Cleanup(server.Close)
+
+	stateHome := t.TempDir()
+	isolatedDB := filepath.Join(t.TempDir(), "loaf.sqlite")
+	t.Setenv("LOAF_DB", isolatedDB)
+	resolver := state.PathResolver{StateHome: stateHome}
+	root, err := project.ResolveRoot(repoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbPath, err := resolver.DatabasePath(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := state.OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.ApplyMigrations(ctx); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := store.DB().ExecContext(ctx, `INSERT INTO projects (id, identity_hash, created_at, updated_at) VALUES (?, ?, ?, ?)`, projectID, projectID+"-hash", now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	return &attachHarness{
+		repoRoot:     repoRoot,
+		stateHome:    stateHome,
+		projectID:    projectID,
+		projectStore: store,
+		credential: crypto.BundledClientCredential{
+			Endpoint: server.URL, ConnectionToken: token.TokenID + ":" + tokenSecret,
+			ProjectID: projectID, KeyGeneration: ring.WriteGeneration, ProjectKey: projectKey[:],
+		},
+		server: server, serverStore: serverStore, projectKey: projectKey, keyGen: ring.WriteGeneration,
+	}
+}
+
+func TestUnattendedAttachRefusesHLCSkew(t *testing.T) {
+	ctx := context.Background()
+	h := newAttachHarness(t)
+	confDir := filepath.Join(h.repoRoot, ".agents")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rawConf, _ := json.Marshal(map[string]string{"project_id": h.projectID})
+	if err := os.WriteFile(filepath.Join(confDir, "loaf.conf"), rawConf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root, err := project.ResolveRoot(h.repoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire, err := crypto.EncodeBundledClientCredential(h.credential)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authStore := auth.NewStore(filepath.Join(h.stateHome, "auth"))
+	if err := os.MkdirAll(authStore.Dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	farFuture := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	fact := state.FactEnvelope{
+		ID: "018f5c2a-0000-7000-8000-000000000099", ProjectID: h.projectID,
+		Kind: state.FactKindJournal,
+		Payload: `{"entry_type":"discover","message":"future","created_at":"2030-01-01T00:00:00Z","updated_at":"2030-01-01T00:00:00Z"}`,
+		EnvID: "skew-env", Seq: 1, HLC: fmt.Sprintf("%020d:%06d", farFuture.UnixMilli(), 0), EnvelopeV: 1,
+	}
+	sealed, err := sealAttachFact(h, fact)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := h.serverStore.PushFacts(ctx, h.projectID, []syncserver.PushInput{{FactID: fact.ID, Blob: sealed}}); err != nil {
+		t.Fatalf("push relay: %v", err)
+	}
+	if _, err := state.ReceiveFact(ctx, h.projectStore, state.FactEnvelope{
+		ID: "018f5c2a-0000-7000-8000-000000000010", ProjectID: h.projectID,
+		Kind: state.FactKindJournal,
+		Payload: `{"entry_type":"discover","message":"baseline","created_at":"2026-08-26T12:00:00Z","updated_at":"2026-08-26T12:00:00Z"}`,
+		EnvID: "receiver-env", Seq: 1, HLC: "00000000000000170000:000000", EnvelopeV: 1,
+	}, state.ReceiveFactOptions{}); err != nil {
+		t.Fatalf("seed baseline: %v", err)
+	}
+
+	_, err = auth.UnattendedAttach(ctx, auth.AttachInput{
+		Root: root, Store: authStore, ClientWire: wire, HTTPClient: h.server.Client(),
+		ProbeStore: h.projectStore, AllowInsecureHTTP: true, MaxHLCSkewMS: 60_000,
+	})
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "hlc skew") {
+		t.Fatalf("UnattendedAttach() = %v, want hlc skew refusal", err)
+	}
+}
+
+func sealAttachFact(h *attachHarness, fact state.FactEnvelope) ([]byte, error) {
+	env, err := crypto.EncryptFactEnvelope(h.projectKey, fact.ID, crypto.FactPlaintext{
+		Kind: fact.Kind, Payload: fact.Payload, EnvID: fact.EnvID, Seq: fact.Seq,
+		HLC: fact.HLC, EnvelopeV: fact.EnvelopeV, KeyGen: h.keyGen,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(env)
+}
+

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -5,4 +5,6 @@ import "errors"
 var (
 	// ErrAdminNotConfigured means no admin wire is stored locally.
 	ErrAdminNotConfigured = errors.New("admin is not configured; run loaf auth setup first")
+	// ErrClientNotConfigured means no bundled client credential is available.
+	ErrClientNotConfigured = errors.New("client credential is not configured")
 )

--- a/internal/auth/gate.go
+++ b/internal/auth/gate.go
@@ -3,6 +3,7 @@ package auth
 import "strings"
 
 var exemptTopLevelCommands = map[string]bool{
+	"attach":  true,
 	"auth":    true,
 	"build":   true,
 	"install": true,

--- a/internal/auth/provision.go
+++ b/internal/auth/provision.go
@@ -1,0 +1,242 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/levifig/loaf/internal/crypto"
+	"github.com/levifig/loaf/internal/project"
+	"github.com/levifig/loaf/internal/state"
+	"github.com/levifig/loaf/internal/sync"
+)
+
+const (
+	ClientTokenEnv = "LOAF_CLIENT_TOKEN"
+	SyncURLEnv     = "LOAF_SYNC_URL"
+
+	refusalCodeConfMissing       = "attach-conf-missing"
+	refusalCodeCredentialMissing = "attach-credential-missing"
+	refusalCodeCredentialInvalid = "attach-credential-invalid"
+	refusalCodeIdentityMismatch  = "attach-identity-mismatch"
+	refusalCodeEndpointInsecure  = "attach-endpoint-insecure"
+	refusalCodeReachFailed       = "attach-reach-failed"
+	refusalCodeAuthFailed        = "attach-auth-failed"
+	refusalCodeDecryptFailed     = "attach-decrypt-failed"
+	refusalCodeCapability        = "attach-capability-unsupported"
+	refusalCodeHLCSkew           = "attach-hlc-skew"
+)
+
+// AttachInput configures the unattended attach sequence for one environment.
+type AttachInput struct {
+	Root              project.Root
+	Store             Store
+	ClientWire        string
+	ConnectionName    string
+	HTTPClient        *http.Client
+	MaxHLCSkewMS      int64
+	AllowInsecureHTTP bool
+	ProbeStore        *state.Store
+}
+
+// AttachResult summarizes a successful attach.
+type AttachResult struct {
+	ProjectID      string `json:"project_id"`
+	ConfID         string `json:"conf_id,omitempty"`
+	Endpoint       string `json:"endpoint"`
+	ConnectionName string `json:"connection_name"`
+	PulledFacts    int    `json:"pulled_facts"`
+	DecryptedFacts int    `json:"decrypted_facts"`
+}
+
+// UnattendedAttach runs conf→cred→HTTPS→auth→pull→decrypt→capability→HLC skew→identity.
+func UnattendedAttach(ctx context.Context, in AttachInput) (AttachResult, error) {
+	conf, err := project.ReadProjectConf(in.Root)
+	if err != nil {
+		return AttachResult{}, newAttachRefusal(refusalCodeConfMissing, "project conf is missing or invalid", "ensure `.agents/loaf.conf` ships with the clone and includes project_id", err)
+	}
+	wire, err := resolveClientWire(in.Store, in.ClientWire)
+	if err != nil {
+		return AttachResult{}, err
+	}
+	cred, err := crypto.DecodeBundledClientCredential(wire)
+	if err != nil {
+		return AttachResult{}, newAttachRefusal(refusalCodeCredentialInvalid, "client credential is invalid", fmt.Sprintf("paste a bundled credential from `loaf auth link` into %s or pass --wire", ClientTokenEnv), err)
+	}
+	if cred.ProjectID != conf.ProjectID {
+		return AttachResult{}, &RefusalError{
+			Code:   refusalCodeIdentityMismatch,
+			Cause:  fmt.Sprintf("project conf id %q does not match credential project %q", conf.ProjectID, cred.ProjectID),
+			Remedy: "mint a project-scoped token with `loaf auth link --project <id> <name>` for this checkout's conf",
+		}
+	}
+	endpoint := strings.TrimSpace(os.Getenv(SyncURLEnv))
+	if endpoint == "" {
+		endpoint = strings.TrimSpace(cred.Endpoint)
+	}
+	if endpoint == "" {
+		return AttachResult{}, newAttachRefusal(refusalCodeReachFailed, "sync endpoint is empty", fmt.Sprintf("set %s or include endpoint in the bundled credential", SyncURLEnv), errors.New("endpoint is empty"))
+	}
+	if !in.AllowInsecureHTTP && !strings.HasPrefix(strings.ToLower(endpoint), "https://") {
+		return AttachResult{}, &RefusalError{
+			Code:   refusalCodeEndpointInsecure,
+			Cause:  "sync endpoint must use HTTPS",
+			Remedy: fmt.Sprintf("configure a TLS-terminated relay URL in the bundled credential or %s", SyncURLEnv),
+		}
+	}
+	cred.Endpoint = endpoint
+
+	httpClient := in.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	if err := sync.CheckRelayHealth(ctx, endpoint, httpClient); err != nil {
+		return AttachResult{}, classifyReachError(err)
+	}
+
+	probeStore := in.ProbeStore
+	if probeStore == nil {
+		return AttachResult{}, errors.New("attach probe store is required")
+	}
+	maxSkew := in.MaxHLCSkewMS
+	if maxSkew <= 0 {
+		maxSkew = int64((24 * time.Hour) / time.Millisecond)
+	}
+	probe, err := sync.ProbeRemote(ctx, sync.ProbeConfig{
+		Credential:   cred,
+		HTTPClient:   httpClient,
+		MaxHLCSkewMS: maxSkew,
+		Receive: func(ctx context.Context, envelope state.FactEnvelope) error {
+			if _, err := state.ReceiveFact(ctx, probeStore, envelope, state.ReceiveFactOptions{MaxHLCSkewMS: maxSkew}); err != nil {
+				return classifyReceiveError(err)
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		return AttachResult{}, classifyProbeError(err)
+	}
+
+	name := strings.TrimSpace(in.ConnectionName)
+	if name == "" {
+		name = connectionNameFromToken(cred.ConnectionToken)
+	}
+	if err := in.Store.SaveClientWire(wire); err != nil {
+		return AttachResult{}, err
+	}
+	if err := MarkAttached(in.Store, endpoint, name); err != nil {
+		return AttachResult{}, err
+	}
+	return AttachResult{
+		ProjectID:      conf.ProjectID,
+		ConfID:         conf.ConfID,
+		Endpoint:       endpoint,
+		ConnectionName: name,
+		PulledFacts:    probe.Pulled,
+		DecryptedFacts: probe.Decrypted,
+	}, nil
+}
+
+func resolveClientWire(store Store, override string) (string, error) {
+	override = strings.TrimSpace(override)
+	if override != "" {
+		return override, nil
+	}
+	if value := strings.TrimSpace(os.Getenv(ClientTokenEnv)); value != "" {
+		return value, nil
+	}
+	if wire, err := store.LoadClientWire(); err == nil {
+		return wire, nil
+	} else if !errors.Is(err, ErrClientNotConfigured) {
+		return "", err
+	}
+	return "", &RefusalError{
+		Code:   refusalCodeCredentialMissing,
+		Cause:  "no bundled client credential is configured for this environment",
+		Remedy: fmt.Sprintf("set %s to the output of `loaf auth link` on a trusted admin machine", ClientTokenEnv),
+	}
+}
+
+func connectionNameFromToken(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if idx := strings.Index(raw, ":"); idx > 0 {
+		return raw[:idx]
+	}
+	return raw
+}
+
+func newAttachRefusal(code, cause, remedy string, err error) *RefusalError {
+	msg := cause
+	if err != nil && err.Error() != "" {
+		msg = fmt.Sprintf("%s: %s", cause, err.Error())
+	}
+	return &RefusalError{Code: code, Cause: msg, Remedy: remedy}
+}
+
+func classifyReachError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return newAttachRefusal(refusalCodeReachFailed, "cannot reach sync server", fmt.Sprintf("verify relay URL and TLS termination; optionally set %s", SyncURLEnv), err)
+}
+
+func classifyProbeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var refusal *RefusalError
+	if errors.As(err, &refusal) {
+		return refusal
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "unauthorized"):
+		return newAttachRefusal(refusalCodeAuthFailed, "connection token authentication failed", "verify the bundled credential matches this project and has not been revoked", err)
+	case strings.Contains(msg, "decrypt"):
+		return newAttachRefusal(refusalCodeDecryptFailed, "cannot decrypt remote facts with the bundled project key", "re-mint the client credential with `loaf auth link` and update the environment secret", err)
+	case strings.Contains(msg, "unsupported kind"), strings.Contains(msg, "unsupported envelope"):
+		return newAttachRefusal(refusalCodeCapability, "remote fact uses an unsupported envelope or kind", "upgrade Loaf to a version that understands the remote stream", err)
+	default:
+		return newAttachRefusal(refusalCodeReachFailed, "attach probe against sync server failed", "verify relay health, token scope, and network reachability", err)
+	}
+}
+
+func classifyReceiveError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var skew *state.HLCSkewError
+	if errors.As(err, &skew) {
+		return &RefusalError{
+			Code:   refusalCodeHLCSkew,
+			Cause:  skew.Error(),
+			Remedy: "check relay and client clocks; gross HLC skew refuses attach until time is trustworthy",
+		}
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "unsupported envelope") || strings.Contains(strings.ToLower(err.Error()), "unknown kind") {
+		return newAttachRefusal(refusalCodeCapability, "remote fact capability check failed", "upgrade Loaf to a version that understands the remote stream", err)
+	}
+	return err
+}
+
+
+// AttachRefusalJSON renders an attach refusal for --json callers.
+func AttachRefusalJSON(err error) ([]byte, error) {
+	if err == nil {
+		return nil, fmt.Errorf("not an attach refusal")
+	}
+	var refusal *RefusalError
+	if errors.As(err, &refusal) {
+		return json.Marshal(refusal)
+	}
+	return json.Marshal(map[string]string{
+		"code":   "attach-failed",
+		"cause":  err.Error(),
+		"remedy": "inspect attach logs and retry loaf attach",
+	})
+}

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -12,6 +12,7 @@ import (
 const (
 	attachStateFileName = "attach.json"
 	adminWireFileName   = "admin.wire"
+	clientWireFileName  = "client.wire"
 	localConfigFileName = "local.json"
 )
 
@@ -55,6 +56,10 @@ func (s Store) adminWirePath() string {
 
 func (s Store) localConfigPath() string {
 	return filepath.Join(s.Dir, localConfigFileName)
+}
+
+func (s Store) clientWirePath() string {
+	return filepath.Join(s.Dir, clientWireFileName)
 }
 
 // LoadAttachState reads persisted attach state. Missing file means unattached.
@@ -164,13 +169,55 @@ func (s Store) SaveLocalConfig(cfg LocalConfig) error {
 	}
 	return os.Rename(tmp, s.localConfigPath())
 }
+
+// LoadClientWire returns the stored bundled client credential when present.
+func (s Store) LoadClientWire() (string, error) {
+	raw, err := os.ReadFile(s.clientWirePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", ErrClientNotConfigured
+		}
+		return "", fmt.Errorf("read client wire: %w", err)
+	}
+	wire := strings.TrimSpace(string(raw))
+	if wire == "" {
+		return "", ErrClientNotConfigured
+	}
+	return wire, nil
+}
+
+// SaveClientWire stores the bundled client credential for this environment.
+func (s Store) SaveClientWire(wire string) error {
+	wire = strings.TrimSpace(wire)
+	if wire == "" {
+		return errors.New("client wire is empty")
+	}
+	if err := s.ensureDir(); err != nil {
+		return err
+	}
+	tmp := s.clientWirePath() + ".tmp"
+	if err := os.WriteFile(tmp, []byte(wire+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write client wire: %w", err)
+	}
+	return os.Rename(tmp, s.clientWirePath())
+}
+
 // EnforcementActive reports whether attach refusal should gate substrate commands.
-// Gate engages once auth setup created admin wire or attach state exists on this machine.
+// Gate engages once auth setup created admin wire, a client credential is present,
+// or attach state exists on this machine.
 func (s Store) EnforcementActive() (bool, error) {
 	if _, err := os.Stat(s.adminWirePath()); err == nil {
 		return true, nil
 	} else if !os.IsNotExist(err) {
 		return false, err
+	}
+	if _, err := os.Stat(s.clientWirePath()); err == nil {
+		return true, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	if strings.TrimSpace(os.Getenv(ClientTokenEnv)) != "" {
+		return true, nil
 	}
 	if _, err := os.Stat(s.attachStatePath()); err == nil {
 		return true, nil

--- a/internal/cli/attach_gate.go
+++ b/internal/cli/attach_gate.go
@@ -55,6 +55,35 @@ func (r Runner) enforceAttachGate(args []string, errOut io.Writer) error {
 	return ExitError{Code: 1}
 }
 
+func (r Runner) enforceSessionStartAttach(errOut io.Writer, jsonOutput bool) error {
+	store, err := r.authStore()
+	if err != nil {
+		return err
+	}
+	active, err := store.EnforcementActive()
+	if err != nil || !active {
+		return err
+	}
+	attached, err := store.IsAttached()
+	if err != nil || attached {
+		return err
+	}
+	refusal := auth.NewUnattachedRefusal("journal context")
+	if jsonOutput {
+		payload, err := refusal.JSON()
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(errOut, string(payload))
+	} else {
+		fmt.Fprintln(errOut, refusal.Error())
+		if suggestion := strings.TrimSpace(refusal.Suggestion); suggestion != "" {
+			fmt.Fprintln(errOut, suggestion)
+		}
+	}
+	return ExitError{Code: 1}
+}
+
 func argsRequestHelp(args []string) bool {
 	for _, arg := range args {
 		switch arg {
@@ -64,3 +93,24 @@ func argsRequestHelp(args []string) bool {
 	}
 	return false
 }
+
+
+func writeAttachRefusal(errOut io.Writer, refusal *auth.RefusalError, jsonOutput bool) error {
+	if refusal == nil {
+		return ExitError{Code: 1}
+	}
+	if jsonOutput {
+		payload, err := refusal.JSON()
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(errOut, string(payload))
+	} else {
+		fmt.Fprintln(errOut, refusal.Error())
+		if suggestion := strings.TrimSpace(refusal.Suggestion); suggestion != "" {
+			fmt.Fprintln(errOut, suggestion)
+		}
+	}
+	return ExitError{Code: 1}
+}
+

--- a/internal/cli/attach_run.go
+++ b/internal/cli/attach_run.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/levifig/loaf/internal/auth"
+	"github.com/levifig/loaf/internal/project"
+	"github.com/levifig/loaf/internal/state"
+)
+
+func (r Runner) runAttach(args []string, out io.Writer, runtime state.Runtime) error {
+	if len(args) == 1 && isHelpArg(args) {
+		writeUsageHelp(out, "loaf attach [--name <connection>] [--json]", "Run the unattended attach ceremony from conf ID and LOAF_CLIENT_TOKEN.",
+			"--name <connection>  Connection name recorded in attach state (default: LOAF_CONNECTION_NAME or token id)",
+			"--json               Emit structured attach refusal on failure")
+		return nil
+	}
+	name := strings.TrimSpace(os.Getenv("LOAF_CONNECTION_NAME"))
+	jsonOutput := false
+	allowHTTP := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--name":
+			if i+1 >= len(args) {
+				return fmt.Errorf("attach --name requires a value")
+			}
+			i++
+			name = strings.TrimSpace(args[i])
+		case "--allow-insecure-http":
+			allowHTTP = true
+		case "--json":
+			jsonOutput = true
+		default:
+			return fmt.Errorf("attach: unknown option %q", args[i])
+		}
+	}
+	root, err := project.ResolveRoot(runtime.RootPath())
+	if err != nil {
+		return err
+	}
+	authStore, err := r.authStore()
+	if err != nil {
+		return err
+	}
+	resolver := state.PathResolver{StateHome: r.StateHome}
+	dbPath, err := resolver.DatabasePath(root)
+	if err != nil {
+		return err
+	}
+	projectStore, err := state.OpenStore(dbPath)
+	if err != nil {
+		return err
+	}
+	defer projectStore.Close()
+	if err := projectStore.ApplyMigrations(context.Background()); err != nil {
+		return err
+	}
+
+	result, err := auth.UnattendedAttach(context.Background(), auth.AttachInput{
+		Root:              root,
+		Store:             authStore,
+		ClientWire:        os.Getenv(auth.ClientTokenEnv),
+		ConnectionName:    name,
+		ProbeStore:        projectStore,
+		AllowInsecureHTTP: allowHTTP,
+	})
+	if err != nil {
+		errOut := r.Stderr
+		if errOut == nil {
+			errOut = os.Stderr
+		}
+		if jsonOutput {
+			if payload, jerr := auth.AttachRefusalJSON(err); jerr == nil {
+				fmt.Fprintln(errOut, string(payload))
+			}
+		}
+		var refusal *auth.RefusalError
+		if errors.As(err, &refusal) {
+			return writeAttachRefusal(errOut, refusal, jsonOutput)
+		}
+		return err
+	}
+	if jsonOutput {
+		return writeJSON(out, result)
+	}
+	fmt.Fprintf(out, "attached project %s as %q via %s\n", result.ProjectID, result.ConnectionName, result.Endpoint)
+	return nil
+}

--- a/internal/cli/attach_run_test.go
+++ b/internal/cli/attach_run_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/levifig/loaf/internal/auth"
+	"github.com/levifig/loaf/internal/state"
+)
+
+func TestSessionStartAttachGateFailsClosedWhenConfiguredButUnattached(t *testing.T) {
+	stateHome := testAuthStateHome(t)
+	authDir, err := state.PathResolver{StateHome: stateHome}.AuthDir()
+	if err != nil {
+		t.Fatalf("AuthDir() error = %v", err)
+	}
+	ctx := context.Background()
+	serverDB := filepath.Join(t.TempDir(), "sync.sqlite")
+	if _, err := auth.Setup(ctx, auth.NewStore(authDir), auth.SetupInput{
+		Endpoint: "http://127.0.0.1:8080",
+		ServerDB: serverDB,
+	}); err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+	var stderr bytes.Buffer
+	err = Runner{
+		Stderr:     &stderr,
+		WorkingDir: t.TempDir(),
+		StateHome:  stateHome,
+	}.Run([]string{"journal", "context", "--cursor-hook", "--from-hook"})
+	if err == nil {
+		t.Fatal("Run() error = nil, want SessionStart attach refusal")
+	}
+	var exit ExitError
+	if !errorsAsExit(err, &exit) || exit.Code != 1 {
+		t.Fatalf("Run() error = %v, want ExitError code 1", err)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("not attached")) {
+		t.Fatalf("stderr = %q, want unattached refusal", stderr.String())
+	}
+}

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -32,7 +33,7 @@ func (r Runner) runAuth(args []string, out io.Writer, runtime state.Runtime) err
 	case "revoke":
 		return r.runAuthRevoke(args[1:], out)
 	case "attach":
-		return r.runAuthAttach(args[1:], out)
+		return r.runAuthAttach(args[1:], out, runtime)
 	default:
 		return fmt.Errorf("auth: unknown subcommand %q", args[0])
 	}
@@ -247,14 +248,15 @@ func (r Runner) runAuthRevoke(args []string, out io.Writer) error {
 	return nil
 }
 
-func (r Runner) runAuthAttach(args []string, out io.Writer) error {
+func (r Runner) runAuthAttach(args []string, out io.Writer, runtime state.Runtime) error {
 	if len(args) == 1 && isHelpArg(args) {
-		writeUsageHelp(out, "loaf auth attach --name <connection> [--endpoint <url>]", "Record successful attach for this environment.")
+		writeUsageHelp(out, "loaf auth attach [--name <connection>] [--wire <credential>] [--json]", "Run the unattended attach sequence for this environment.")
 		return nil
 	}
 	name := ""
-	endpoint := ""
+	wire := ""
 	jsonOutput := false
+	allowHTTP := false
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--name":
@@ -263,40 +265,60 @@ func (r Runner) runAuthAttach(args []string, out io.Writer) error {
 			}
 			i++
 			name = strings.TrimSpace(args[i])
-		case "--endpoint":
+		case "--wire":
 			if i+1 >= len(args) {
-				return fmt.Errorf("auth attach --endpoint requires a value")
+				return fmt.Errorf("auth attach --wire requires a value")
 			}
 			i++
-			endpoint = strings.TrimSpace(args[i])
+			wire = strings.TrimSpace(args[i])
+		case "--allow-insecure-http":
+			allowHTTP = true
 		case "--json":
 			jsonOutput = true
 		default:
 			return fmt.Errorf("auth attach: unknown option %q", args[i])
 		}
 	}
-	if name == "" {
-		return fmt.Errorf("auth attach requires --name")
-	}
 	store, err := r.authStore()
 	if err != nil {
 		return err
 	}
-	if endpoint == "" {
-		var err error
-		endpoint, err = auth.AdminEndpoint(store)
-		if err != nil {
-			return err
-		}
+	root, err := project.ResolveRoot(runtime.RootPath())
+	if err != nil {
+		return err
 	}
-	if err := auth.MarkAttached(store, endpoint, name); err != nil {
+	resolver := state.PathResolver{StateHome: r.StateHome}
+	databasePath, err := resolver.DatabasePath(root)
+	if err != nil {
+		return err
+	}
+	probeStore, err := state.OpenStore(databasePath)
+	if err != nil {
+		return err
+	}
+	defer probeStore.Close()
+	if err := probeStore.ApplyMigrations(context.Background()); err != nil {
+		return err
+	}
+	result, err := auth.UnattendedAttach(context.Background(), auth.AttachInput{
+		Root:              root,
+		Store:             store,
+		ClientWire:        wire,
+		ConnectionName:    name,
+		AllowInsecureHTTP: allowHTTP,
+		ProbeStore:        probeStore,
+	})
+	if err != nil {
+		var refusal *auth.RefusalError
+		if errors.As(err, &refusal) {
+			return writeAttachRefusal(r.Stderr, refusal, jsonOutput)
+		}
 		return err
 	}
 	if jsonOutput {
-		state, _ := store.LoadAttachState()
-		return json.NewEncoder(out).Encode(state)
+		return json.NewEncoder(out).Encode(result)
 	}
-	fmt.Fprintf(out, "attached as %q via %s\n", name, endpoint)
+	fmt.Fprintf(out, "attached project %s as %q via %s\n", result.ProjectID, result.ConnectionName, result.Endpoint)
 	return nil
 }
 

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -250,7 +250,7 @@ func (r Runner) runAuthRevoke(args []string, out io.Writer) error {
 
 func (r Runner) runAuthAttach(args []string, out io.Writer, runtime state.Runtime) error {
 	if len(args) == 1 && isHelpArg(args) {
-		writeUsageHelp(out, "loaf auth attach [--name <connection>] [--wire <credential>] [--json]", "Run the unattended attach sequence for this environment.")
+		writeUsageHelp(out, "loaf auth attach [--name <connection>] [--wire <client-wire>] [--json]", "Run the unattended attach sequence for this environment.")
 		return nil
 	}
 	name := ""

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -296,6 +296,8 @@ func (r Runner) Run(args []string) error {
 		dispatchErr = r.runJournal(args[1:], out, runtime)
 	case "scratchpad":
 		dispatchErr = r.runScratchpad(args[1:], out, runtime)
+	case "attach":
+		dispatchErr = r.runAttach(args[1:], out, runtime)
 	case "auth":
 		dispatchErr = r.runAuth(args[1:], out, runtime)
 	case "serve":

--- a/internal/cli/cloud_environment_bootstrap.go
+++ b/internal/cli/cloud_environment_bootstrap.go
@@ -20,7 +20,7 @@ import (
 //   - Optional durable project env var with the same name keeps layout without
 //     relying on start/resume scripts alone.
 //
-// LOAF-67 attach client token (not wired until attach ceremony ships):
+// LOAF-67 attach client token:
 //   - Mint locally: loaf auth link --project
 //   - Cursor Cloud Agent: add project environment vars LOAF_CLIENT_TOKEN and
 //     preferably LOAF_PROJECT_ENV=1 (project-scoped client token; never the
@@ -28,10 +28,11 @@ import (
 //   - Amp Orb: add project env LOAF_CLIENT_TOKEN (and LOAF_PROJECT_ENV=1) via
 //     amp project configuration
 //   - Optional sync endpoint (when configured): LOAF_SYNC_URL
+//   - Full walkthrough: docs/knowledge/cloud-attach-walkthrough.md
 //
 // Cursor Cloud harness install runs in the install/build script so hooks and
-// skills exist before the agent starts. Attach pre-warm in the start script is
-// intentionally deferred until LOAF-67 lands.
+// skills exist before the agent starts. Attach pre-warm runs in the start script
+// when LOAF_CLIENT_TOKEN is present.
 const (
 	// projectEnvironmentClientTokenEnv is the provisional per-project env var name
 	// for the LOAF-67 client token in Cursor Cloud and Amp Orb environments.

--- a/internal/cli/cloud_environment_bootstrap.go
+++ b/internal/cli/cloud_environment_bootstrap.go
@@ -63,7 +63,7 @@ var requiredCloudBootstrapMarkers = map[string][]string{
 	},
 	cursorCloudStartScript: {
 		projectEnvironmentEnv + "=1",
-		"LOAF-67",
+		"loaf attach",
 	},
 	ampOrbSetupScript: {
 		"npm run build:go",

--- a/internal/cli/journal_hook_claude.go
+++ b/internal/cli/journal_hook_claude.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/levifig/loaf/internal/project"
@@ -38,6 +39,9 @@ var claudeSessionStartSources = map[string]bool{
 }
 
 func (r Runner) runClaudeSessionStartContext(out io.Writer, runtime state.Runtime, options journalContextCLIOptions) error {
+	if err := r.enforceSessionStartAttach(os.Stderr, options.jsonOutput); err != nil {
+		return err
+	}
 	if !options.fromHook {
 		return errors.New("Claude Code SessionStart context requires --from-hook")
 	}

--- a/internal/cli/journal_hook_codex.go
+++ b/internal/cli/journal_hook_codex.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/levifig/loaf/internal/project"
 	"github.com/levifig/loaf/internal/state"
@@ -54,6 +55,9 @@ var (
 )
 
 func (r Runner) runCodexSessionStartContext(out io.Writer, runtime state.Runtime, options journalContextCLIOptions) error {
+	if err := r.enforceSessionStartAttach(os.Stderr, options.jsonOutput); err != nil {
+		return err
+	}
 	if !options.fromHook {
 		return errors.New("Codex SessionStart context requires --from-hook")
 	}

--- a/internal/cli/journal_hook_cursor.go
+++ b/internal/cli/journal_hook_cursor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/levifig/loaf/internal/project"
@@ -39,6 +40,9 @@ type cursorSessionStartValidation struct {
 // sessionStart command-hook contract. It always renders the complete neutral
 // digest; selectors and output overrides are rejected by the generic parser.
 func (r Runner) runCursorSessionStartContext(out io.Writer, runtime state.Runtime, options journalContextCLIOptions) error {
+	if err := r.enforceSessionStartAttach(os.Stderr, options.jsonOutput); err != nil {
+		return err
+	}
 	if !options.fromHook {
 		return errors.New("Cursor sessionStart context requires --from-hook")
 	}

--- a/internal/cli/journal_hook_opencode.go
+++ b/internal/cli/journal_hook_opencode.go
@@ -23,6 +23,9 @@ const (
 )
 
 func (r Runner) runOpenCodeSessionStartContext(out io.Writer, runtime state.Runtime, options journalContextCLIOptions) error {
+	if err := r.enforceSessionStartAttach(r.Stderr, options.jsonOutput); err != nil {
+		return err
+	}
 	if !options.fromHook {
 		return errors.New("OpenCode session start context requires --from-hook")
 	}

--- a/internal/project/conf.go
+++ b/internal/project/conf.go
@@ -1,0 +1,40 @@
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const projectConfRelativePath = ".agents/loaf.conf"
+
+// ProjectConf is the conf-carried rendezvous label shipped with the clone.
+// It selects the project within an operator substrate; it never carries sync endpoints.
+type ProjectConf struct {
+	ConfID    string `json:"conf_id"`
+	ProjectID string `json:"project_id"`
+}
+
+// ReadProjectConf loads `.agents/loaf.conf` from the canonical project root.
+func ReadProjectConf(root Root) (ProjectConf, error) {
+	path := filepath.Join(root.Path(), projectConfRelativePath)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ProjectConf{}, fmt.Errorf("project conf missing at %s", path)
+		}
+		return ProjectConf{}, fmt.Errorf("read project conf: %w", err)
+	}
+	var conf ProjectConf
+	if err := json.Unmarshal(raw, &conf); err != nil {
+		return ProjectConf{}, fmt.Errorf("decode project conf: %w", err)
+	}
+	conf.ConfID = strings.TrimSpace(conf.ConfID)
+	conf.ProjectID = strings.TrimSpace(conf.ProjectID)
+	if conf.ProjectID == "" {
+		return ProjectConf{}, fmt.Errorf("project conf %s: project_id is required", path)
+	}
+	return conf, nil
+}

--- a/internal/project/conf_test.go
+++ b/internal/project/conf_test.go
@@ -1,0 +1,30 @@
+package project_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/levifig/loaf/internal/project"
+)
+
+func TestReadProjectConfRequiresProjectID(t *testing.T) {
+	t.Parallel()
+	rootDir := t.TempDir()
+	agents := filepath.Join(rootDir, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	confPath := filepath.Join(agents, "loaf.conf")
+	if err := os.WriteFile(confPath, []byte(`{"conf_id":"conf_test"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root, err := project.ResolveRoot(rootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = project.ReadProjectConf(root)
+	if err == nil {
+		t.Fatal("ReadProjectConf() error = nil, want missing project_id")
+	}
+}

--- a/internal/sync/probe.go
+++ b/internal/sync/probe.go
@@ -1,0 +1,108 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/levifig/loaf/internal/crypto"
+	"github.com/levifig/loaf/internal/state"
+)
+
+// ProbeConfig validates remote reachability, auth, decrypt, capability, and HLC skew.
+type ProbeConfig struct {
+	Credential   crypto.BundledClientCredential
+	HTTPClient   *http.Client
+	MaxHLCSkewMS int64
+	// Receive validates one opened fact envelope (capability + HLC skew). When the
+	// remote stream is empty, Receive is not called.
+	Receive func(ctx context.Context, envelope state.FactEnvelope) error
+}
+
+// ProbeResult summarizes a successful remote attach probe.
+type ProbeResult struct {
+	Pulled    int
+	Decrypted int
+}
+
+// ProbeRemote pulls the project fact stream from cursor zero, decrypts each blob,
+// and invokes Receive for every opened envelope.
+func ProbeRemote(ctx context.Context, cfg ProbeConfig) (ProbeResult, error) {
+	cred := cfg.Credential
+	projectID := strings.TrimSpace(cred.ProjectID)
+	if projectID == "" {
+		return ProbeResult{}, fmt.Errorf("attach probe: credential project id is empty")
+	}
+	var projectKey [32]byte
+	if len(cred.ProjectKey) != len(projectKey) {
+		return ProbeResult{}, fmt.Errorf("attach probe: credential project key must be %d bytes", len(projectKey))
+	}
+	copy(projectKey[:], cred.ProjectKey)
+	readKeys := make([][32]byte, 0, cred.KeyGeneration+1)
+	for gen := 0; gen <= cred.KeyGeneration; gen++ {
+		readKeys = append(readKeys, projectKey)
+	}
+	relay, err := newRelayClient(cred.Endpoint, cred.ConnectionToken, cfg.HTTPClient)
+	if err != nil {
+		return ProbeResult{}, err
+	}
+
+	result := ProbeResult{}
+	cursor := int64(0)
+	for {
+		resp, err := relay.pull(ctx, projectID, cursor)
+		if err != nil {
+			return result, err
+		}
+		if len(resp.Facts) == 0 {
+			break
+		}
+		for _, item := range resp.Facts {
+			result.Pulled++
+			raw, err := decodeBlob(item.Blob)
+			if err != nil {
+				return result, fmt.Errorf("attach probe: decode blob: %w", err)
+			}
+			envelope, err := openFactBlob(readKeys, projectID, raw)
+			if err != nil {
+				return result, fmt.Errorf("attach probe: decrypt fact %q: %w", item.FactID, err)
+			}
+			result.Decrypted++
+			if cfg.Receive != nil {
+				if err := cfg.Receive(ctx, envelope); err != nil {
+					return result, err
+				}
+			}
+		}
+		if resp.Cursor <= cursor {
+			break
+		}
+		cursor = resp.Cursor
+	}
+	return result, nil
+}
+
+// CheckRelayHealth verifies the sync server responds over HTTP(S).
+func CheckRelayHealth(ctx context.Context, endpoint string, httpClient *http.Client) error {
+	endpoint = strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	if endpoint == "" {
+		return fmt.Errorf("attach probe: endpoint is empty")
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/health", nil)
+	if err != nil {
+		return fmt.Errorf("attach probe: build health request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("attach probe: reach server: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("attach probe: health check status %d", resp.StatusCode)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

LOAF-67 slice 3 — H-tier connection walkthrough documentation:

- **Cursor Cloud Agents** — project secrets, install/start bootstrap, attach pre-warm
- **Amp Orbs** — per-project secrets, setup/resume, optional attach hook
- **CI (GitHub Actions)** — repository secrets, ephemeral attach per job, example workflow fragment
- Failure-mode table and verification steps

Also cross-links from `cloud_environment_bootstrap.go` and indexes in `docs/knowledge/README.md`.

Partially unblocks LOAF-78 H-tier walkthrough criterion (docs; live evidence still required).

Depends on #187 (slice 2) merging first.

## Test plan

- [x] Doc renders; paths and env var names match `internal/auth/provision.go` and bootstrap scripts
- [ ] H-tier review: operator can follow walkthrough to configure Cursor Cloud / Amp / CI