### PR TITLE
docs(LOAF-90): reflect personal-substrate model into canonical docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,11 +54,30 @@ General workflow skills call `loaf` for Loaf-owned state and route user-scoped e
 
 ### Operational State Identity
 
+> **Revision 2026-08-26 (LOAF-90):** The XDG SQLite file is a local replica of the personal substrate, not the complete destination store. See Personal Memory Substrate below.
+
 Loaf stores operational state in one global SQLite database at `$XDG_DATA_HOME/loaf/loaf.sqlite`, partitioned by project ID. New project IDs are generated and stored in SQLite; they are not derived from checkout path or friendly name. The `projects` row carries the friendly display name and current path, while `project_paths` records path mappings so a checkout can move without changing identity. Legacy path-hash IDs remain only as an adoption key for migrated pre-stable-identity data.
 
 Entity identity follows the same discipline one level down (ADR-028). Derived entity IDs are mint-once opaque keys: computed at first creation, never recomputed for resolution. The aliases table — with the schema's only content-meaningful unique constraint, `UNIQUE (project_id, namespace, alias)` — is the identity registry, and the markdown importer resolves through it before deriving an ID for anything. Unaliased kinds resolve by natural key: journal entries by (entry type, scope, message) for markdown-origin rows, sources by project and path. Sparks whose message normalizes to an empty slug receive a deterministic content-hash alias so no row is born unreachable.
 
 The standing invariant is alias parity: for every project and every aliased entity table, raw row counts equal alias-reachable counts, with zero dead aliases. `loaf state doctor` checks it on demand (read-only, error severity without invalidating the database, naming `loaf state migrate alias-orphans` as the repair). The June-24 identity fork — a project rekey silently invalidating every derived ID, repaired by the state-dedupe Change — is the incident this invariant exists to catch on day one instead of week six.
+
+### Personal Memory Substrate
+
+> **Revision 2026-08-26 (LOAF-90):** New section. Supersedes: implicit single-machine SQLite as sufficient for Loaf-flow work.
+
+One operator's substrate is **identical across every environment** they operate. Local SQLite on a trusted machine is a full replica (local-first). A self-hostable sync relay (`loaf serve`, LOAF-75) converges facts between environments; the server holds opaque ciphertext blobs and auth tokens only — never keys, never plaintext semantics. The client sync engine (LOAF-76) queues, pulls by cursor, and detects env-seq gaps with loud warnings. Environments that cannot attach hard-refuse substrate-touching commands (LOAF-67); there is no detached override in v1.
+
+**Synced minimal core:** project identity and attachment evidence, ref mappings and work contracts, ledger facts (journal, sparks, wraps, handoffs, decisions), verification-run records, releases. **Never synced:** FTS indexes, hook trust, conversation handles, vocabulary fossils (local archive).
+
+The fleet agrees on the **fact envelope** (versioned cleartext contract + E2E payload), not the SQLite schema. Schema evolves per machine; facts replay into projections via latest-event-wins folds ordered by `(hlc, env_id, id)` (LOAF-71, ADR-029).
+
+**Credentials (two-mode):** admin credentials (master key + account access key/secret) live on trusted machines only; client credentials bundle endpoint + project-scoped token + derived project key in per-project harness secrets. Repo `.agents/loaf.conf` carries project ID and tracker binding — never the sync endpoint.
+
+**Permanence classes:** ledger (permanent), notebook (durable retrieval), scratchpad (effort-scoped ephemeral). Promoted exports (PR bodies, rendered artifacts, tracker rows) are never re-imported as authority.
+
+**Ship status:** LOAF-66–67, 71, 75–76 shipped on main. LOAF-63/72 (full mutable-core migration), LOAF-64 (attachment evidence beyond remote URL normalization), LOAF-88–89 (scratchpad server channel and prune) remain.
+
 
 ### Recovery Tiers and Restore Safety
 
@@ -80,6 +99,19 @@ Four rules the third instance made explicit:
 - **FTS mirrors are derived data.** Rollback re-derives index state from restored content rows rather than restoring captured index bytes, and delete paths tolerate a desynced mirror instead of aborting (an unindexed FTS5 external-content delete raises SQLITE_CORRUPT — the tolerance probe exists because a pre-existing desync once made a repair unrunnable).
 
 The operational gate is rehearsal on a disposable production copy: `LOAF_DB` and `XDG_DATA_HOME` redirected to a sandbox, first apply must exit 0, second must no-op, and the acceptance queries must hold before the same invocation touches the real database. The state-dedupe ceremony (2026-08-09, receipts in the Change folder) ran exactly as rehearsed, including catching a generated-flags bug in preview that never reached apply.
+
+### Dead State Retirement and Document Demotion
+
+> **Revision 2026-08-26 (LOAF-90):** Supersedes: reports/councils/shaping_drafts as SQLite authority; findings/verdicts/runs as live schema.
+
+LOAF-79 (migration 0018) deletes zero-row findings/verdicts/runs schema. LOAF-80 (migration 0021) demotes document-layer rows to files; CLI serves file-backed reports/councils/drafts. LOAF-81 classifies every project-scoped table (sync, local-archive, machine-local, gone) and prunes fossil relationship edges. Handoffs remain in the synced core as ledger facts.
+
+### Scratchpad Coordination
+
+> **Revision 2026-08-26 (LOAF-90):** Ephemeral multi-agent coordination without journal pollution.
+
+Permanence taxonomy: **ledger** (journal, decisions, wraps), **notebook** (sparks, ideas), **scratchpad** (effort-scoped agent messages). LOAF-87 ships `loaf scratchpad append|read|list|claim|release` with closed fact kinds. LOAF-88 (server SSE/long-poll fanout) and LOAF-89 (logical close + admin-only `loaf scratchpad prune`) remain pending — fact sync stays poll-shaped.
+
 
 ### Targets
 
@@ -132,6 +164,8 @@ Fresh installs pre-create an empty root canonical so the Claude symlink is never
 This extends the "CLI is the correct protocol layer" principle to filesystem convention enforcement: the CLI owns the on-disk overlay state, not the skills or the user. ADR-010 records the consolidation from per-harness writes to one canonical file.
 
 ### Work Records and Optional Linear Coordination
+
+> **Revision 2026-08-26 (LOAF-90):** Contract machinery keys to provider-qualified refs (LOAF-82 shipped). Internal issue rows retire after render-out (LOAF-83 shipped); decision-kind issues re-home to ledger facts (LOAF-84 pending); flow skills on refs (LOAF-86 pending).
 
 New bounded work is a Loaf issue, with authored shaping and implementation artifacts kept beside the code and operational issue state stored in project-scoped SQLite. Existing specs and task records remain supported compatibility surfaces until their named removal boundaries.
 
@@ -186,7 +220,7 @@ Principles that shape how Loaf is designed and operated. Unlike ADRs, these are 
 
 Authored durable artifacts — Changes, plans, research, specs, ADRs, knowledge, reports, code, and generated deliverables — live in Git and are edited in place. Operational, queryable state — the journal, Intent, Exploration, checkpoints, conversation provenance, relationships, deferrals, and derived indexes — lives in project-scoped SQLite. Neither store mirrors the other: SQLite never becomes a hidden Markdown repository, and Git never holds per-conversation operational facts. An elected tracker may own explicitly bounded issue identity and workflow fields, but it never owns either durable store; publication and reconciliation remain explicit.
 
-The intent-exploration-foundation Change proved the operational side as append-only facts rather than mutable lifecycle state. An Intent's disposition (`tracked`, `deferred`, `resolved`) and an Exploration's latest portable checkpoint are derived from transactionally sequenced immutable records — the row with the greatest committed per-aggregate sequence wins, never a timestamp and never a status column. Compound writes are retry-safe through one canonical per-project operation-key mapping (`intent_operations`), which the transitional `journal defer` adapter and legacy conversion share with the native commands, so no entry point can mint a parallel canonical record. Machine-local conversation handles and log locators are optional provenance with observed availability; portable context is exclusively the checkpoint's four required fields, and their presence is reported honestly (`portable_context_present`) rather than inferred from handles.
+The intent-exploration-foundation Change proved the operational side as append-only facts rather than mutable lifecycle state. An Intent's disposition (`tracked`, `deferred`, `resolved`) and an Exploration's latest portable checkpoint are derived from transactionally sequenced immutable records — the row with the greatest committed per-aggregate sequence wins, never a timestamp and never a status column. **Revision 2026-08-26 (LOAF-90):** Synced-core projections fold latest-event-wins using HLC total order `(hlc, env_id, id)` (LOAF-71); legacy Intent/Exploration sequence semantics remain until LOAF-72 migrates those entities. Compound writes are retry-safe through one canonical per-project operation-key mapping (`intent_operations`), which the transitional `journal defer` adapter and legacy conversion share with the native commands, so no entry point can mint a parallel canonical record. Machine-local conversation handles and log locators are optional provenance with observed availability; portable context is exclusively the checkpoint's four required fields, and their presence is reported honestly (`portable_context_present`) rather than inferred from handles.
 
 The judgment boundary follows from the storage boundary: humans and Skills interpret, classify, and choose operations; the CLI validates, proves, and performs Loaf state transitions deterministically. General Loaf workflow skills do not branch on provider configuration, call providers directly, or maintain lifecycle flags. Dedicated provider skills may select an already-configured provider MCP for user-scoped external collaboration, but they neither configure nor authenticate it and never take ownership of Loaf issue identity/state, provider mappings, retries, conflict resolution, or reconciliation. The CLI never decides whether input is a Spark, Idea, Intent, Exploration, or Change.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -58,6 +58,13 @@ The implication for both personas: Loaf's value is the *framework* -- mechanical
 
 ## Current Priorities
 
+
+> **Revision 2026-08-26 (LOAF-90):** Inserts substrate arc priorities. Supersedes: priorities listing only journal reliability and Loaf Flow without personal-substrate destination.
+
+- **Personal memory substrate (LOAF-62).** Land fact envelope, E2E crypto, sync server/client, and attach-or-refuse (LOAF-66–67, 71, 75–76 shipped on main). Remaining: full mutable-core migration (LOAF-63/72), identity attachment evidence (LOAF-64 partial), grow-only union semantics documentation.
+- **Refs + contracts cutover (LOAF-68).** Contract machinery keys to refs (LOAF-82) and render-out (LOAF-83) shipped; branch/PR bootstrap (LOAF-85), flow-skill ref cutover (LOAF-86), and decision re-home (LOAF-84) remain.
+- **Dead state before sync (LOAF-69).** Delete zero-row schema (LOAF-79), demote document layer (LOAF-80), and inventory lock (LOAF-81) shipped — minimal sync contract enforced.
+- **Scratchpad (LOAF-74).** CLI and closed kind set (LOAF-87) shipped; server SSE channel (LOAF-88) and close/prune (LOAF-89) remain.
 - **Journal reliability across installed targets.** Converge content-addressed installation, target adapter ownership, capability diagnosis, and isolated installed-runtime dogfood without mutating users' production state.
 - **Loaf Flow completeness.** The entry stage shipped in v0.2.17: `/pitch` at both scales, captured-folder promotion in `loaf change init`, bootstrap series-prep under the landing matrix. Next is dogfood-driven fine-tuning (the deferred end-to-end pitch→shape proof, seam oiling), then the Intent-tracked follow-ons: the Arc decision-map, the review-convergence loop, and the skills audit. Existing spec and task records remain supported compatibility surfaces until deliberately converted.
 - **The fix cadence, collecting its dividend.** 0.2.21 shipped the identity-fork repair (#159, ADR-028) and per-entry hook reconciliation (#161) as one combined cut — the first release since the reset to leave every harness current with zero refusals, and the first to exercise all four incident-born release mechanisms (release-PR flow, mechanical receipt gate, receipt-vouched cohort grading, changelog staging) without incident. The remaining queue, numbered at cut time per the revised ADR-026: the OpenCode session-start fix, the content-addressed skills store, and the skills audit.
@@ -66,6 +73,11 @@ The implication for both personas: Loaf's value is the *framework* -- mechanical
 - **Durable knowledge with low ceremony.** Preserve decisions, discoveries, and operational lessons where later work can retrieve them, while removing lifecycle machinery and planning vocabulary that do not carry product meaning.
 
 ## Strategic Tensions
+
+
+**Personal continuity vs collaboration surfaces.** The substrate is private and E2E; team coordination stays on trackers and git promote paths. Building a shared memory layer in the substrate is explicitly out of scope for v1.
+
+**Local-first vs cloud attach.** Local SQLite remains authoritative for reads; sync is convergent relay. Fail-loud attach prioritizes invariant trust over run availability.
 
 **Portability versus native leverage.** A shared skill should express the common contract, but each native adapter expands the compatibility and test surface. Native behavior earns its place only when it is observable and maintainable.
 
@@ -76,6 +88,10 @@ The implication for both personas: Loaf's value is the *framework* -- mechanical
 **Durability versus noise.** The journal must retain information that changes future decisions, not duplicate lifecycle state or syntheses that can be derived from source, git, and pull requests.
 
 ## Open Questions
+
+
+- **Master-key recovery (resolved LOAF-66):** Emergency Kit + surviving-machine re-key; no escrow.
+- **Supersession collision UX (resolved LOAF-63 lock):** Grow-only union; no supersession ceremony in v1.
 
 - Which target-native signals can provide durable event identity and trustworthy success evidence without coupling Loaf to unstable client internals?
 - How should scheduled client-version discovery produce reviewable candidate evidence without automatically changing capability classifications?

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -18,7 +18,13 @@ Functional profiles define what agents can mechanically touch (tool access). Ski
 
 ### Continuity
 
-Work survives context loss, compaction, tool restarts, and cross-conversation handoffs. The project journal is external memory, while Change artifacts and compatible task records keep intent and execution inspectable outside any one conversation.
+> **Revision 2026-08-26 (LOAF-90):** Continuity is personal-first and environment-agnostic. Supersedes: continuity described only as project-journal handoff on a single machine.
+
+Loaf's durable memory — journal, wraps, handoffs, decisions, work-unit refs, verification records — lives in one operator's **personal memory substrate**. Every environment the operator uses (laptop, second machine, Cursor Cloud Agent, Amp Orb, CI) attaches to the same substrate or **hard-refuses** Loaf-flow work. There is no silent empty universe and no memoryless degraded mode.
+
+Work survives context loss, compaction, tool restarts, and cross-conversation handoffs because the substrate is external to any single harness session. The project journal is a **projection** of grow-only ledger facts, not a hand-authored file. Context at conversation start is a derived digest — never a lifecycle transition.
+
+Sharing with other humans happens only through explicit **promote surfaces** (PR bodies, committed files, external trackers). The substrate itself is private.
 
 ## What Success Looks Like
 
@@ -29,6 +35,8 @@ A developer installs Loaf and immediately gets:
 - **Project journal history that enables handoff** -- pick up where you left off, or hand off to a colleague
 - **Hooks that enforce quality without friction** -- secrets scanning, commit conventions, push guards
 - **Domain expertise that loads automatically** -- the right engineering standards for the current task
+- **Same project, any session, any harness, any host** — a cloud agent picks up the same journal, wraps, and open work definitions as the operator's laptop after attach
+- **Fail-loud provisioning** — misconfigured credentials or unknown project identity refuse with cause and remedy; no quarantine buffer
 
 ## What Loaf Is Not
 
@@ -37,3 +45,14 @@ A developer installs Loaf and immediately gets:
 **Not Claude-only.** Multi-target by design. Claude Code is the primary development target, but skills are authored once and built for all supported harnesses.
 
 **Not opinionated about what you build.** Opinionated about *how* you build it. The Change contract, conventions, and quality checks are explicit; the domain knowledge is yours.
+
+**Not a team memory product.** Collaboration is deliberate export through trackers and git; the synced core is one operator's facts, E2E-encrypted on the wire.
+
+## Product boundary
+
+| Layer | Owns |
+|-------|------|
+| Trackers (Linear v1) | Work definition, DoD text, workflow state |
+| Git | Code and promoted artifacts |
+| Harnesses | Execution, tool boundaries |
+| Loaf substrate | Context, journal, wraps, handoffs, decisions, continuity digest, ref mappings |

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -22,7 +22,7 @@ Functional profiles define what agents can mechanically touch (tool access). Ski
 
 Loaf's durable memory — journal, wraps, handoffs, decisions, work-unit refs, verification records — lives in one operator's **personal memory substrate**. Every environment the operator uses (laptop, second machine, Cursor Cloud Agent, Amp Orb, CI) attaches to the same substrate or **hard-refuses** Loaf-flow work. There is no silent empty universe and no memoryless degraded mode.
 
-Work survives context loss, compaction, tool restarts, and cross-conversation handoffs because the substrate is external to any single harness session. The project journal is a **projection** of grow-only ledger facts, not a hand-authored file. Context at conversation start is a derived digest — never a lifecycle transition.
+Work survives context loss, compaction, tool restarts, and cross-conversation handoffs because the substrate is external to any single harness session. The project journal is a **projection** of grow-only ledger facts, not a hand-authored file. Change artifacts and compatible task records keep intent and execution inspectable outside any one conversation. Context at conversation start is a derived digest — never a lifecycle transition.
 
 Sharing with other humans happens only through explicit **promote surfaces** (PR bodies, committed files, external trackers). The substrate itself is private.
 


### PR DESCRIPTION
## Summary

- Revises `docs/VISION.md`, `docs/STRATEGY.md`, and `docs/ARCHITECTURE.md` with dated LOAF-90 revision notes
- Documents shipped substrate work on main @ 2997c186 (attach/sync, fact envelope, E2E crypto, dead-state retirement, partial refs cutover, scratchpad CLI)
- Explicitly marks pending work: LOAF-84 (decision re-home), LOAF-88 (SSE channel), LOAF-89 (close/prune), LOAF-85/86, LOAF-63/72/64

## Context

Orchestration reconciliation found LOAF-84/88/89 incorrectly marked `done` in issue state (subagent 83fc0ed5) while code on main lacks those features; reverted to `triage`. Subagent 8f65aa76 was correct that LOAF-88 remains unimplemented.

## Test plan

- [ ] Review revision notes for accuracy against main
- [ ] Confirm pending items match open issue statuses
- [ ] `loaf issue verify LOAF-90` (H-tier — human review of doc claims)