### PR TITLE
feat(LOAF-64): conf-ID attachment evidence and duplicate-universe doctor

### DIFF
--- a/docs/schema/0024_project_attachment.sql
+++ b/docs/schema/0024_project_attachment.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS project_conf_labels (
+  conf_id TEXT PRIMARY KEY NOT NULL,
+  project_id TEXT NOT NULL,
+  first_seen_at TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL,
+  FOREIGN KEY (project_id) REFERENCES projects(id)
+);
+
+CREATE TABLE IF NOT EXISTS project_attachment_evidence (
+  id TEXT PRIMARY KEY NOT NULL,
+  project_id TEXT NOT NULL,
+  evidence_kind TEXT NOT NULL,
+  evidence_value TEXT NOT NULL,
+  first_seen_at TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL,
+  FOREIGN KEY (project_id) REFERENCES projects(id),
+  UNIQUE (project_id, evidence_kind, evidence_value)
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_attachment_evidence_lookup
+  ON project_attachment_evidence (evidence_kind, evidence_value);

--- a/docs/schema/operational-state.dbml
+++ b/docs/schema/operational-state.dbml
@@ -743,3 +743,23 @@ Table sync_project_cursors {
   updated_at text [not null]
 }
 
+// Project attachment evidence (migration 0024).
+Table project_conf_labels {
+  conf_id text [pk, not null]
+  project_id text [not null, ref: > projects.id]
+  first_seen_at text [not null]
+  last_seen_at text [not null]
+}
+
+Table project_attachment_evidence {
+  id text [pk, not null]
+  project_id text [not null, ref: > projects.id]
+  evidence_kind text [not null]
+  evidence_value text [not null]
+  first_seen_at text [not null]
+  last_seen_at text [not null]
+  indexes {
+    (project_id, evidence_kind, evidence_value) [unique]
+    (evidence_kind, evidence_value)
+  }
+}

--- a/docs/schema/operational-state.mmd
+++ b/docs/schema/operational-state.mmd
@@ -606,6 +606,23 @@ erDiagram
     text updated_at
   }
 
+  project_conf_labels {
+    text conf_id PK
+    text project_id FK
+    text first_seen_at
+    text last_seen_at
+  }
+
+  project_attachment_evidence {
+    text id PK
+    text project_id FK
+    text evidence_kind
+    text evidence_value
+    text first_seen_at
+    text last_seen_at
+  }
+
   projects ||--o{ sync_outbound_queue : scopes
   projects ||--o{ sync_project_cursors : scopes
-
+  projects ||--o{ project_conf_labels : scopes
+  projects ||--o{ project_attachment_evidence : scopes

--- a/internal/auth/attach_test.go
+++ b/internal/auth/attach_test.go
@@ -26,7 +26,11 @@ func TestUnattendedAttachRoundTrip(t *testing.T) {
 	if err := os.MkdirAll(confDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	conf := map[string]string{"conf_id": "conf_attach_test", "project_id": h.projectID}
+	confID := "conf_attach_test"
+	if err := h.projectStore.RegisterConfLabel(ctx, confID, h.projectID); err != nil {
+		t.Fatal(err)
+	}
+	conf := map[string]string{"conf_id": confID, "project_id": h.projectID}
 	rawConf, _ := json.Marshal(conf)
 	if err := os.WriteFile(filepath.Join(confDir, "loaf.conf"), rawConf, 0o644); err != nil {
 		t.Fatal(err)
@@ -188,7 +192,11 @@ func TestUnattendedAttachRefusesHLCSkew(t *testing.T) {
 	if err := os.MkdirAll(confDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	rawConf, _ := json.Marshal(map[string]string{"project_id": h.projectID})
+	confID := "conf_hlc_skew"
+	if err := h.projectStore.RegisterConfLabel(ctx, confID, h.projectID); err != nil {
+		t.Fatal(err)
+	}
+	rawConf, _ := json.Marshal(map[string]string{"conf_id": confID, "project_id": h.projectID})
 	if err := os.WriteFile(filepath.Join(confDir, "loaf.conf"), rawConf, 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -219,11 +227,13 @@ func TestUnattendedAttachRefusesHLCSkew(t *testing.T) {
 	if _, err := h.serverStore.PushFacts(ctx, h.projectID, []syncserver.PushInput{{FactID: fact.ID, Blob: sealed}}); err != nil {
 		t.Fatalf("push relay: %v", err)
 	}
+	baselineNow := time.Now().UTC()
+	baselineHLC := fmt.Sprintf("%020d:%06d", baselineNow.UnixMilli(), 0)
 	if _, err := state.ReceiveFact(ctx, h.projectStore, state.FactEnvelope{
 		ID: "018f5c2a-0000-7000-8000-000000000010", ProjectID: h.projectID,
 		Kind: state.FactKindJournal,
-		Payload: `{"entry_type":"discover","message":"baseline","created_at":"2026-08-26T12:00:00Z","updated_at":"2026-08-26T12:00:00Z"}`,
-		EnvID: "receiver-env", Seq: 1, HLC: "00000000000000170000:000000", EnvelopeV: 1,
+		Payload: fmt.Sprintf(`{"entry_type":"discover","message":"baseline","created_at":%q,"updated_at":%q}`, baselineNow.Format(time.RFC3339), baselineNow.Format(time.RFC3339)),
+		EnvID: "receiver-env", Seq: 1, HLC: baselineHLC, EnvelopeV: 1,
 	}, state.ReceiveFactOptions{}); err != nil {
 		t.Fatalf("seed baseline: %v", err)
 	}

--- a/internal/auth/provision.go
+++ b/internal/auth/provision.go
@@ -103,6 +103,9 @@ func UnattendedAttach(ctx context.Context, in AttachInput) (AttachResult, error)
 	if probeStore == nil {
 		return AttachResult{}, errors.New("attach probe store is required")
 	}
+	if _, err := probeStore.ResolveProjectByConf(ctx, conf, state.ConfResolutionUnattended); err != nil {
+		return AttachResult{}, classifyConfResolutionError(err)
+	}
 	maxSkew := in.MaxHLCSkewMS
 	if maxSkew <= 0 {
 		maxSkew = int64((24 * time.Hour) / time.Millisecond)
@@ -224,6 +227,30 @@ func classifyReceiveError(err error) error {
 	return err
 }
 
+
+
+func classifyConfResolutionError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var required *state.ConfResolutionRequiredError
+	if errors.As(err, &required) {
+		return &RefusalError{
+			Code:   refusalCodeConfMissing,
+			Cause:  required.Error(),
+			Remedy: "confirm first contact on this substrate before unattended attach; register the conf label interactively",
+		}
+	}
+	var outOfScope *state.ConfOutOfScopeError
+	if errors.As(err, &outOfScope) {
+		return &RefusalError{
+			Code:   refusalCodeIdentityMismatch,
+			Cause:  outOfScope.Error(),
+			Remedy: "ensure `.agents/loaf.conf` project_id matches the registered conf label on this substrate",
+		}
+	}
+	return err
+}
 
 // AttachRefusalJSON renders an attach refusal for --json callers.
 func AttachRefusalJSON(err error) ([]byte, error) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2406,7 +2406,7 @@ func (r Runner) runStateDoctor(args []string, out io.Writer, runtime state.Runti
 		}
 		return err
 	}
-	status, err := r.inspectStateWithOptions(runtime, state.InspectOptions{AliasParity: true, LeftoverAbsorb: true})
+	status, err := r.inspectStateWithOptions(runtime, state.InspectOptions{AliasParity: true, LeftoverAbsorb: true, DuplicateUniverse: true})
 	if err != nil {
 		if jsonOutput {
 			return writeJSONCommandError(out, "state doctor", err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1655,9 +1655,7 @@ func TestRunnerLinkedWorktreesShareSQLiteState(t *testing.T) {
 	}
 
 	for _, dir := range []string{main, linked} {
-		if _, err := os.Stat(filepath.Join(dir, ".agents")); !os.IsNotExist(err) {
-			t.Fatalf("state commands created repository .agents directory in %q; err = %v", dir, err)
-		}
+		assertNoRepositoryAgentsDir(t, dir)
 	}
 }
 
@@ -3004,9 +3002,7 @@ func TestRunnerStateInitHumanOutputPrintsRepositoryExternalDatabaseWithoutSecret
 	if _, err := os.Stat(databasePath); err != nil {
 		t.Fatalf("database was not created at printed path: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(workingDir, ".agents")); !os.IsNotExist(err) {
-		t.Fatalf("state init created repository .agents directory; err = %v", err)
-	}
+	assertNoRepositoryAgentsDir(t, workingDir)
 	lowerOutput := strings.ToLower(output)
 	for _, forbidden := range []string{"token", "password", "secret", "api_key", "api key", "credential"} {
 		if strings.Contains(lowerOutput, forbidden) {
@@ -5466,9 +5462,7 @@ func TestRunnerReportGenerateDoesNotMutateStateOrCreateRepoFiles(t *testing.T) {
 	if firstOut.String() != secondOut.String() {
 		t.Fatalf("report output changed:\nfirst=%s\nsecond=%s", firstOut.String(), secondOut.String())
 	}
-	if _, err := os.Stat(filepath.Join(workingDir, ".agents")); !os.IsNotExist(err) {
-		t.Fatalf("report generate created repository .agents directory; err = %v", err)
-	}
+	assertNoRepositoryAgentsDir(t, workingDir)
 	var snapshotOut bytes.Buffer
 	if err := (Runner{Stdout: &snapshotOut, WorkingDir: workingDir, StateHome: stateHome}).Run([]string{"state", "export", "all", "--format", "json"}); err != nil {
 		t.Fatalf("state export all error = %v", err)
@@ -5767,9 +5761,7 @@ func TestRunnerStateExportAllJSONDoesNotMutateStateOrCreateRepoFiles(t *testing.
 	if len(first.Tables["exports"]) != 0 || len(second.Tables["exports"]) != 0 {
 		t.Fatalf("exports table mutated: first=%#v second=%#v", first.Tables["exports"], second.Tables["exports"])
 	}
-	if _, err := os.Stat(filepath.Join(workingDir, ".agents")); !os.IsNotExist(err) {
-		t.Fatalf("state export created repository .agents directory; err = %v", err)
-	}
+	assertNoRepositoryAgentsDir(t, workingDir)
 }
 
 func TestRunnerStateExportReleaseReadinessMarkdownDoesNotMutateStateOrCreateRepoFiles(t *testing.T) {
@@ -5800,9 +5792,7 @@ func TestRunnerStateExportReleaseReadinessMarkdownDoesNotMutateStateOrCreateRepo
 	if firstOut.String() != secondOut.String() {
 		t.Fatalf("export output changed:\nfirst=%s\nsecond=%s", firstOut.String(), secondOut.String())
 	}
-	if _, err := os.Stat(filepath.Join(workingDir, ".agents")); !os.IsNotExist(err) {
-		t.Fatalf("state export created repository .agents directory; err = %v", err)
-	}
+	assertNoRepositoryAgentsDir(t, workingDir)
 	var snapshotOut bytes.Buffer
 	err = Runner{
 		Stdout:     &snapshotOut,
@@ -5891,9 +5881,7 @@ func TestRunnerStateExportTriageMarkdownDoesNotCreateRepoFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("state export triage error = %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(workingDir, ".agents")); !os.IsNotExist(err) {
-		t.Fatalf("state export created repository .agents directory; err = %v", err)
-	}
+	assertNoRepositoryAgentsDir(t, workingDir)
 }
 
 func TestRunnerStateExportRejectsMissingInvalidUnsupportedState(t *testing.T) {
@@ -13602,7 +13590,25 @@ func assertNoStateDatabase(t *testing.T, workingDir string, stateHome string) {
 
 func assertNoRepositoryAgentsDir(t *testing.T, workingDir string) {
 	t.Helper()
-	if _, err := os.Stat(filepath.Join(workingDir, ".agents")); !os.IsNotExist(err) {
-		t.Fatalf("repository .agents directory exists or stat failed after read-only command; err = %v", err)
+	agentsDir := filepath.Join(workingDir, ".agents")
+	info, err := os.Stat(agentsDir)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("repository .agents stat error = %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("repository .agents is not a directory")
+	}
+	entries, err := os.ReadDir(agentsDir)
+	if err != nil {
+		t.Fatalf("ReadDir(.agents) error = %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == "loaf.conf" {
+			continue
+		}
+		t.Fatalf("repository .agents contains unexpected entry %q after read-only command", entry.Name())
 	}
 }

--- a/internal/cli/release_test.go
+++ b/internal/cli/release_test.go
@@ -52,6 +52,19 @@ func TestReleaseLegacyFlagsFailWithGuidance(t *testing.T) {
 	}
 }
 
+
+// commitBootstrapAgentsFiles records genesis .agents/ files (e.g. loaf.conf) so
+// release cut's clean-tree gate passes after state init.
+func commitBootstrapAgentsFiles(t *testing.T, repo string) {
+	t.Helper()
+	status := gitOutputReleaseTest(t, repo, "status", "--porcelain=v1", ".agents")
+	if strings.TrimSpace(status) == "" {
+		return
+	}
+	gitCLI(t, repo, "add", ".agents")
+	gitCLI(t, repo, "commit", "-m", "chore: bootstrap loaf project files")
+}
+
 func seedReleaseTaggedRepo(t *testing.T) string {
 	t.Helper()
 	repo := realpath(t, t.TempDir())

--- a/internal/cli/release_track_test.go
+++ b/internal/cli/release_track_test.go
@@ -23,6 +23,7 @@ func releaseTrackFixture(t *testing.T) (repo, stateHome string) {
 	if err := (Runner{Stdout: &bytes.Buffer{}, WorkingDir: repo, StateHome: stateHome}).Run([]string{"state", "init"}); err != nil {
 		t.Fatalf("state init error = %v", err)
 	}
+	commitBootstrapAgentsFiles(t, repo)
 	return repo, stateHome
 }
 
@@ -889,6 +890,7 @@ func releaseTrackUntaggedFixture(t *testing.T) (repo, stateHome string) {
 	if err := (Runner{Stdout: &bytes.Buffer{}, WorkingDir: repo, StateHome: stateHome}).Run([]string{"state", "init"}); err != nil {
 		t.Fatalf("state init error = %v", err)
 	}
+	commitBootstrapAgentsFiles(t, repo)
 	return repo, stateHome
 }
 

--- a/internal/project/conf.go
+++ b/internal/project/conf.go
@@ -1,11 +1,14 @@
 package project
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const projectConfRelativePath = ".agents/loaf.conf"
@@ -37,4 +40,43 @@ func ReadProjectConf(root Root) (ProjectConf, error) {
 		return ProjectConf{}, fmt.Errorf("project conf %s: project_id is required", path)
 	}
 	return conf, nil
+}
+
+// WriteProjectConf writes `.agents/loaf.conf` under the project root.
+func WriteProjectConf(root Root, conf ProjectConf) error {
+	conf.ConfID = strings.TrimSpace(conf.ConfID)
+	conf.ProjectID = strings.TrimSpace(conf.ProjectID)
+	if conf.ProjectID == "" {
+		return fmt.Errorf("write project conf: project_id is required")
+	}
+	if conf.ConfID == "" {
+		id, err := GenerateConfID()
+		if err != nil {
+			return err
+		}
+		conf.ConfID = id
+	}
+	path := filepath.Join(root.Path(), projectConfRelativePath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create agents directory: %w", err)
+	}
+	raw, err := json.MarshalIndent(conf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode project conf: %w", err)
+	}
+	raw = append(raw, '\n')
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		return fmt.Errorf("write project conf: %w", err)
+	}
+	return nil
+}
+
+// GenerateConfID mints a time-ordered rendezvous label for `.agents/loaf.conf`.
+func GenerateConfID() (string, error) {
+	var entropy [8]byte
+	if _, err := rand.Read(entropy[:]); err != nil {
+		return "", fmt.Errorf("generate conf id: %w", err)
+	}
+	ms := time.Now().UTC().UnixMilli()
+	return fmt.Sprintf("conf_%x_%s", ms, hex.EncodeToString(entropy[:])), nil
 }

--- a/internal/project/git_evidence.go
+++ b/internal/project/git_evidence.go
@@ -1,0 +1,61 @@
+package project
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os/exec"
+	"strings"
+)
+
+// OriginRemoteURL returns the normalized origin remote when git is available.
+func OriginRemoteURL(root Root) (string, error) {
+	raw, ok := gitOutput(root.Path(), "remote", "get-url", "origin")
+	if !ok {
+		return "", nil
+	}
+	return NormalizeRemoteURL(raw)
+}
+
+// RootCommitFingerprint returns a stable fingerprint for the repository root
+// commit. It is used for doctor twin-audit only, not steady-state attach.
+func RootCommitFingerprint(root Root) (string, error) {
+	sha, ok := gitOutput(root.Path(), "rev-list", "--max-parents=0", "HEAD")
+	if !ok {
+		return "", nil
+	}
+	sha = strings.TrimSpace(sha)
+	if sha == "" {
+		return "", nil
+	}
+	sum := sha256.Sum256([]byte("loaf-root-commit:" + sha))
+	return hex.EncodeToString(sum[:8]), nil
+}
+
+// ListNormalizedRemotes returns normalized remote URLs for every configured git remote.
+func ListNormalizedRemotes(root Root) ([]string, error) {
+	cmd := exec.Command("git", "remote")
+	cmd.Dir = root.Path()
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, nil
+	}
+	names := strings.Fields(strings.TrimSpace(string(out)))
+	keys := make([]string, 0, len(names))
+	seen := map[string]struct{}{}
+	for _, name := range names {
+		raw, ok := gitOutput(root.Path(), "remote", "get-url", name)
+		if !ok {
+			continue
+		}
+		key, err := NormalizeRemoteURL(raw)
+		if err != nil || key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}

--- a/internal/state/journal_first_migration_test.go
+++ b/internal/state/journal_first_migration_test.go
@@ -583,8 +583,8 @@ func TestBackupVerifiesMigratedJournalFirstDatabase(t *testing.T) {
 }
 
 func TestJournalFirstMigrationExcludedFromAutoApply(t *testing.T) {
-	if CurrentSchemaVersion() != 23 {
-		t.Fatalf("CurrentSchemaVersion() = %d, want 23 (migration 10 must not auto-apply on store open)", CurrentSchemaVersion())
+	if CurrentSchemaVersion() != 24 {
+		t.Fatalf("CurrentSchemaVersion() = %d, want 24 (migration 10 must not auto-apply on store open)", CurrentSchemaVersion())
 	}
 	for _, m := range SchemaMigrations() {
 		if m.Version == journalFirstMigrationVersion {

--- a/internal/state/migrations/0024_project_attachment.sql
+++ b/internal/state/migrations/0024_project_attachment.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS project_conf_labels (
+  conf_id TEXT PRIMARY KEY NOT NULL,
+  project_id TEXT NOT NULL,
+  first_seen_at TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL,
+  FOREIGN KEY (project_id) REFERENCES projects(id)
+);
+
+CREATE TABLE IF NOT EXISTS project_attachment_evidence (
+  id TEXT PRIMARY KEY NOT NULL,
+  project_id TEXT NOT NULL,
+  evidence_kind TEXT NOT NULL,
+  evidence_value TEXT NOT NULL,
+  first_seen_at TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL,
+  FOREIGN KEY (project_id) REFERENCES projects(id),
+  UNIQUE (project_id, evidence_kind, evidence_value)
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_attachment_evidence_lookup
+  ON project_attachment_evidence (evidence_kind, evidence_value);

--- a/internal/state/project_attachment.go
+++ b/internal/state/project_attachment.go
@@ -1,0 +1,367 @@
+package state
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/levifig/loaf/internal/project"
+)
+
+const (
+	FactKindProjectMinted   = "project.minted"
+	FactKindProjectEvidence = "project.evidence"
+
+	EvidenceKindRemote     = "remote"
+	EvidenceKindRootCommit = "root_commit"
+	EvidenceKindPath       = "path"
+	EvidenceKindConf       = "conf"
+
+	DuplicateUniverseSuspectCode = "duplicate-universe-suspect"
+
+	ConfResolutionUnattended = "unattended"
+	ConfResolutionInteractive = "interactive"
+)
+
+func init() {
+	RegisterFactKind(FactKindProjectMinted, "ledger")
+	RegisterFactKind(FactKindProjectEvidence, "ledger")
+}
+
+// ProjectEvidencePayload is the fact body for attachment evidence.
+type ProjectEvidencePayload struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value"`
+	Raw   string `json:"raw,omitempty"`
+}
+
+// ConfResolutionRequiredError reports an unknown conf label that needs first-contact confirm.
+type ConfResolutionRequiredError struct {
+	ConfID            string `json:"conf_id"`
+	ConfProjectID     string `json:"conf_project_id"`
+	SuggestedProject  string `json:"suggested_project_id,omitempty"`
+	KnownConfProjects []string `json:"known_conf_projects,omitempty"`
+}
+
+func (e *ConfResolutionRequiredError) Error() string {
+	if e == nil {
+		return "project conf requires first-contact confirmation"
+	}
+	return fmt.Sprintf("conf label %q is unknown on this substrate; first contact must confirm project %q before mapping", e.ConfID, e.ConfProjectID)
+}
+
+// ConfOutOfScopeError reports a conf label mapped to a different project.
+type ConfOutOfScopeError struct {
+	ConfID         string `json:"conf_id"`
+	ConfProjectID  string `json:"conf_project_id"`
+	MappedProjectID string `json:"mapped_project_id"`
+}
+
+func (e *ConfOutOfScopeError) Error() string {
+	if e == nil {
+		return "project conf is out of scope"
+	}
+	return fmt.Sprintf("conf label %q maps to project %q but conf declares %q", e.ConfID, e.MappedProjectID, e.ConfProjectID)
+}
+
+// DuplicateUniverseReport lists substrate projects that share attachment evidence.
+type DuplicateUniverseReport struct {
+	RemoteGroups     []DuplicateEvidenceGroup `json:"remote_groups,omitempty"`
+	RootCommitGroups []DuplicateEvidenceGroup `json:"root_commit_groups,omitempty"`
+	Ready            bool                     `json:"ready"`
+}
+
+type DuplicateEvidenceGroup struct {
+	Kind       string   `json:"kind"`
+	Value      string   `json:"value"`
+	ProjectIDs []string `json:"project_ids"`
+}
+
+// RegisterConfLabel maps a conf rendezvous label to a durable project id.
+func (s *Store) RegisterConfLabel(ctx context.Context, confID, projectID string) error {
+	confID = strings.TrimSpace(confID)
+	projectID = strings.TrimSpace(projectID)
+	if confID == "" || projectID == "" {
+		return fmt.Errorf("register conf label: conf_id and project_id are required")
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO project_conf_labels (conf_id, project_id, first_seen_at, last_seen_at)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(conf_id) DO UPDATE SET
+  project_id = excluded.project_id,
+  last_seen_at = excluded.last_seen_at
+`, confID, projectID, now, now); err != nil {
+		return fmt.Errorf("register conf label: %w", err)
+	}
+	payload, err := encodeProjectEvidencePayload(ProjectEvidencePayload{Kind: EvidenceKindConf, Value: confID})
+	if err != nil {
+		return err
+	}
+	_, err = AppendFact(ctx, s, AppendFactInput{
+		ProjectID: projectID,
+		Kind:      FactKindProjectEvidence,
+		Payload:   payload,
+	})
+	return err
+}
+
+// RecordAttachmentEvidence accumulates one attachment evidence row and ledger fact.
+func (s *Store) RecordAttachmentEvidence(ctx context.Context, projectID, kind, value, raw string) error {
+	projectID = strings.TrimSpace(projectID)
+	kind = strings.TrimSpace(kind)
+	value = strings.TrimSpace(value)
+	if projectID == "" || kind == "" || value == "" {
+		return fmt.Errorf("record attachment evidence: project_id, kind, and value are required")
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	id := stableMigrationID("project-evidence", projectID, kind, value)
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO project_attachment_evidence (id, project_id, evidence_kind, evidence_value, first_seen_at, last_seen_at)
+VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT(project_id, evidence_kind, evidence_value) DO UPDATE SET
+  last_seen_at = excluded.last_seen_at
+`, id, projectID, kind, value, now, now); err != nil {
+		return fmt.Errorf("record attachment evidence: %w", err)
+	}
+	payload, err := encodeProjectEvidencePayload(ProjectEvidencePayload{Kind: kind, Value: value, Raw: raw})
+	if err != nil {
+		return err
+	}
+	_, err = AppendFact(ctx, s, AppendFactInput{
+		ProjectID: projectID,
+		Kind:      FactKindProjectEvidence,
+		Payload:   payload,
+	})
+	return err
+}
+
+// RecordCheckoutAttachmentEvidence captures git remotes, root fingerprint, and path for one checkout.
+func (s *Store) RecordCheckoutAttachmentEvidence(ctx context.Context, root project.Root, projectID string) error {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return fmt.Errorf("record checkout attachment evidence: project_id is required")
+	}
+	if err := s.RecordAttachmentEvidence(ctx, projectID, EvidenceKindPath, root.Path(), ""); err != nil {
+		return err
+	}
+	remotes, err := project.ListNormalizedRemotes(root)
+	if err != nil {
+		return err
+	}
+	for _, remote := range remotes {
+		if err := s.RecordAttachmentEvidence(ctx, projectID, EvidenceKindRemote, remote, ""); err != nil {
+			return err
+		}
+	}
+	fingerprint, err := project.RootCommitFingerprint(root)
+	if err != nil {
+		return err
+	}
+	if fingerprint != "" {
+		if err := s.RecordAttachmentEvidence(ctx, projectID, EvidenceKindRootCommit, fingerprint, ""); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ResolveProjectByConf resolves substrate identity from `.agents/loaf.conf`.
+func (s *Store) ResolveProjectByConf(ctx context.Context, conf project.ProjectConf, mode string) (ProjectIdentity, error) {
+	confID := strings.TrimSpace(conf.ConfID)
+	projectID := strings.TrimSpace(conf.ProjectID)
+	if projectID == "" {
+		return ProjectIdentity{}, fmt.Errorf("resolve project by conf: project_id is required")
+	}
+	if confID == "" {
+		if mode == ConfResolutionUnattended {
+			return ProjectIdentity{}, fmt.Errorf("resolve project by conf: conf_id is required for unattended resolution")
+		}
+		return s.projectIdentity(ctx, projectID)
+	}
+	mappedID, err := s.confLabelProjectID(ctx, confID)
+	if err != nil {
+		return ProjectIdentity{}, err
+	}
+	switch {
+	case mappedID == "":
+		if mode == ConfResolutionUnattended {
+			return ProjectIdentity{}, &ConfResolutionRequiredError{ConfID: confID, ConfProjectID: projectID}
+		}
+		return ProjectIdentity{}, &ConfResolutionRequiredError{
+			ConfID:           confID,
+			ConfProjectID:    projectID,
+			SuggestedProject: projectID,
+		}
+	case mappedID != projectID:
+		return ProjectIdentity{}, &ConfOutOfScopeError{ConfID: confID, ConfProjectID: projectID, MappedProjectID: mappedID}
+	default:
+		return s.projectIdentity(ctx, projectID)
+	}
+}
+
+func (s *Store) confLabelProjectID(ctx context.Context, confID string) (string, error) {
+	var projectID string
+	err := s.db.QueryRowContext(ctx, `SELECT project_id FROM project_conf_labels WHERE conf_id = ?`, confID).Scan(&projectID)
+	switch {
+	case err == nil:
+		return projectID, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return "", nil
+	default:
+		return "", fmt.Errorf("read conf label: %w", err)
+	}
+}
+
+// InspectDuplicateUniverseSuspects flags projects sharing normalized remotes or root fingerprints.
+func InspectDuplicateUniverseSuspects(ctx context.Context, store *Store) (DuplicateUniverseReport, error) {
+	if store == nil || store.db == nil {
+		return DuplicateUniverseReport{}, fmt.Errorf("inspect duplicate universe: store is nil")
+	}
+	report := DuplicateUniverseReport{Ready: true}
+	for _, kind := range []string{EvidenceKindRemote, EvidenceKindRootCommit} {
+		groups, err := duplicateEvidenceGroups(ctx, store, kind)
+		if err != nil {
+			return DuplicateUniverseReport{}, err
+		}
+		for _, group := range groups {
+			if len(group.ProjectIDs) < 2 {
+				continue
+			}
+			report.Ready = false
+			switch kind {
+			case EvidenceKindRemote:
+				report.RemoteGroups = append(report.RemoteGroups, group)
+			case EvidenceKindRootCommit:
+				report.RootCommitGroups = append(report.RootCommitGroups, group)
+			}
+		}
+	}
+	return report, nil
+}
+
+func duplicateEvidenceGroups(ctx context.Context, store *Store, kind string) ([]DuplicateEvidenceGroup, error) {
+	rows, err := store.db.QueryContext(ctx, `
+SELECT evidence_value, project_id
+FROM project_attachment_evidence
+WHERE evidence_kind = ?
+ORDER BY evidence_value, project_id
+`, kind)
+	if err != nil {
+		return nil, fmt.Errorf("list attachment evidence for %q: %w", kind, err)
+	}
+	defer rows.Close()
+	byValue := map[string][]string{}
+	for rows.Next() {
+		var value, projectID string
+		if err := rows.Scan(&value, &projectID); err != nil {
+			return nil, fmt.Errorf("scan attachment evidence: %w", err)
+		}
+		byValue[value] = append(byValue[value], projectID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate attachment evidence: %w", err)
+	}
+	groups := make([]DuplicateEvidenceGroup, 0, len(byValue))
+	for value, projectIDs := range byValue {
+		groups = append(groups, DuplicateEvidenceGroup{Kind: kind, Value: value, ProjectIDs: projectIDs})
+	}
+	return groups, nil
+}
+
+func duplicateUniverseDiagnostics(report DuplicateUniverseReport) []Diagnostic {
+	if report.Ready {
+		return nil
+	}
+	details := map[string]any{}
+	if len(report.RemoteGroups) > 0 {
+		details["remote_groups"] = report.RemoteGroups
+	}
+	if len(report.RootCommitGroups) > 0 {
+		details["root_commit_groups"] = report.RootCommitGroups
+	}
+	return []Diagnostic{{
+		Severity: "warn",
+		Code:     DuplicateUniverseSuspectCode,
+		Category: RepairCategoryProjectIdentity,
+		Policy:   DiagnosticPolicyWarningDrift,
+		Message:  "multiple projects share attachment evidence; inspect for duplicate universes before attach",
+		Details:  details,
+	}}
+}
+
+func encodeProjectEvidencePayload(payload ProjectEvidencePayload) (string, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("encode project evidence payload: %w", err)
+	}
+	return string(raw), nil
+}
+
+// BootstrapProjectConf registers conf labels and records attachment evidence.
+// It writes `.agents/loaf.conf` only for genesis projects that have no conf file
+// and no prior attachment evidence — never silently backfilling existing projects.
+func (s *Store) BootstrapProjectConf(ctx context.Context, root project.Root) error {
+	identity, err := s.LookupProjectIdentityForRoot(ctx, root)
+	if err != nil {
+		return err
+	}
+	if conf, readErr := project.ReadProjectConf(root); readErr == nil {
+		if conf.ConfID != "" {
+			return s.RegisterConfLabel(ctx, conf.ConfID, identity.ID)
+		}
+		return nil
+	}
+	hasEvidence, err := s.projectHasAttachmentEvidence(ctx, identity.ID)
+	if err != nil {
+		return err
+	}
+	if hasEvidence {
+		return nil
+	}
+	conf := project.ProjectConf{ProjectID: identity.ID}
+	if err := project.WriteProjectConf(root, conf); err != nil {
+		return err
+	}
+	written, err := project.ReadProjectConf(root)
+	if err != nil {
+		return err
+	}
+	if err := s.RegisterConfLabel(ctx, written.ConfID, identity.ID); err != nil {
+		return err
+	}
+	if err := s.RecordCheckoutAttachmentEvidence(ctx, root, identity.ID); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(map[string]string{
+		"project_id": identity.ID,
+		"conf_id":    written.ConfID,
+		"path":       root.Path(),
+	})
+	if err != nil {
+		return fmt.Errorf("encode project minted payload: %w", err)
+	}
+	_, err = AppendFact(ctx, s, AppendFactInput{
+		ProjectID: identity.ID,
+		Kind:      FactKindProjectMinted,
+		Payload:   string(payload),
+	})
+	return err
+}
+
+func (s *Store) projectHasAttachmentEvidence(ctx context.Context, projectID string) (bool, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `
+SELECT COUNT(*)
+FROM project_attachment_evidence
+WHERE project_id = ?
+`, projectID).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("count attachment evidence: %w", err)
+	}
+	return count > 0, nil
+}

--- a/internal/state/project_attachment_test.go
+++ b/internal/state/project_attachment_test.go
@@ -1,0 +1,208 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/levifig/loaf/internal/project"
+)
+
+func TestResolveProjectByConfUnattendedRefusesUnknownLabel(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openAttachmentTestStore(t)
+	root := projectRootInTempDir(t)
+	identity, err := store.EnsureProject(ctx, root)
+	if err != nil {
+		t.Fatalf("EnsureProject() error = %v", err)
+	}
+	conf := project.ProjectConf{ConfID: "conf_unknown", ProjectID: identity.ID}
+	_, err = store.ResolveProjectByConf(ctx, conf, ConfResolutionUnattended)
+	var required *ConfResolutionRequiredError
+	if !errors.As(err, &required) {
+		t.Fatalf("ResolveProjectByConf() error = %v, want *ConfResolutionRequiredError", err)
+	}
+}
+
+func TestResolveProjectByConfRefusesOutOfScopeMapping(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openAttachmentTestStore(t)
+	first := projectRootInTempDir(t)
+	second := projectRootInTempDir(t)
+	firstID, err := store.EnsureProject(ctx, first)
+	if err != nil {
+		t.Fatalf("EnsureProject(first) error = %v", err)
+	}
+	secondID, err := store.EnsureProject(ctx, second)
+	if err != nil {
+		t.Fatalf("EnsureProject(second) error = %v", err)
+	}
+	if err := store.RegisterConfLabel(ctx, "conf_shared", firstID.ID); err != nil {
+		t.Fatalf("RegisterConfLabel() error = %v", err)
+	}
+	conf := project.ProjectConf{ConfID: "conf_shared", ProjectID: secondID.ID}
+	_, err = store.ResolveProjectByConf(ctx, conf, ConfResolutionUnattended)
+	var outOfScope *ConfOutOfScopeError
+	if !errors.As(err, &outOfScope) {
+		t.Fatalf("ResolveProjectByConf() error = %v, want *ConfOutOfScopeError", err)
+	}
+}
+
+func TestResolveProjectByConfSucceedsForRegisteredLabel(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openAttachmentTestStore(t)
+	root := projectRootInTempDir(t)
+	identity, err := store.EnsureProject(ctx, root)
+	if err != nil {
+		t.Fatalf("EnsureProject() error = %v", err)
+	}
+	if err := store.RegisterConfLabel(ctx, "conf_ok", identity.ID); err != nil {
+		t.Fatalf("RegisterConfLabel() error = %v", err)
+	}
+	got, err := store.ResolveProjectByConf(ctx, project.ProjectConf{ConfID: "conf_ok", ProjectID: identity.ID}, ConfResolutionUnattended)
+	if err != nil {
+		t.Fatalf("ResolveProjectByConf() error = %v", err)
+	}
+	if got.ID != identity.ID {
+		t.Fatalf("ID = %q, want %q", got.ID, identity.ID)
+	}
+}
+
+func TestInspectDuplicateUniverseSuspectsFlagsSharedRemote(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openAttachmentTestStore(t)
+	first := projectRootInTempDir(t)
+	second := projectRootInTempDir(t)
+	firstID, err := store.EnsureProject(ctx, first)
+	if err != nil {
+		t.Fatalf("EnsureProject(first) error = %v", err)
+	}
+	secondID, err := store.EnsureProject(ctx, second)
+	if err != nil {
+		t.Fatalf("EnsureProject(second) error = %v", err)
+	}
+	shared := "github.com/example/shared"
+	if err := store.RecordAttachmentEvidence(ctx, firstID.ID, EvidenceKindRemote, shared, ""); err != nil {
+		t.Fatalf("RecordAttachmentEvidence(first) error = %v", err)
+	}
+	if err := store.RecordAttachmentEvidence(ctx, secondID.ID, EvidenceKindRemote, shared, ""); err != nil {
+		t.Fatalf("RecordAttachmentEvidence(second) error = %v", err)
+	}
+	report, err := InspectDuplicateUniverseSuspects(ctx, store)
+	if err != nil {
+		t.Fatalf("InspectDuplicateUniverseSuspects() error = %v", err)
+	}
+	if report.Ready {
+		t.Fatal("Ready = true, want duplicate remote suspect")
+	}
+	if len(report.RemoteGroups) != 1 || len(report.RemoteGroups[0].ProjectIDs) != 2 {
+		t.Fatalf("RemoteGroups = %#v, want one group with two projects", report.RemoteGroups)
+	}
+}
+
+func TestWriteProjectConfRoundTrip(t *testing.T) {
+	t.Parallel()
+	rootDir := t.TempDir()
+	root, err := project.ResolveRoot(rootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := project.ProjectConf{ProjectID: "proj_test123"}
+	if err := project.WriteProjectConf(root, want); err != nil {
+		t.Fatalf("WriteProjectConf() error = %v", err)
+	}
+	got, err := project.ReadProjectConf(root)
+	if err != nil {
+		t.Fatalf("ReadProjectConf() error = %v", err)
+	}
+	if got.ProjectID != want.ProjectID {
+		t.Fatalf("ProjectID = %q, want %q", got.ProjectID, want.ProjectID)
+	}
+	if got.ConfID == "" {
+		t.Fatal("ConfID is empty, want generated label")
+	}
+	path := filepath.Join(rootDir, ".agents", "loaf.conf")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Stat(conf) error = %v", err)
+	}
+}
+
+func openAttachmentTestStore(t *testing.T) *Store {
+	t.Helper()
+	stateHome := t.TempDir()
+	root := projectRootInTempDir(t)
+	status, err := Initialize(context.Background(), root, PathResolver{StateHome: stateHome})
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	store, err := OpenStore(status.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+
+func TestBootstrapProjectConfSkipsSilentBackfill(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openAttachmentTestStore(t)
+	root := projectRootInTempDir(t)
+	identity, err := store.EnsureProject(ctx, root)
+	if err != nil {
+		t.Fatalf("EnsureProject() error = %v", err)
+	}
+	if err := store.RecordAttachmentEvidence(ctx, identity.ID, EvidenceKindPath, root.Path(), ""); err != nil {
+		t.Fatalf("RecordAttachmentEvidence() error = %v", err)
+	}
+	if err := store.BootstrapProjectConf(ctx, root); err != nil {
+		t.Fatalf("BootstrapProjectConf() error = %v", err)
+	}
+	if _, err := project.ReadProjectConf(root); err == nil {
+		t.Fatal("ReadProjectConf() succeeded, want missing conf for backfill-skipped project")
+	}
+}
+
+func TestInspectOperationalInvariantsFlagsDuplicateUniverse(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openAttachmentTestStore(t)
+	first := projectRootInTempDir(t)
+	second := projectRootInTempDir(t)
+	firstID, err := store.EnsureProject(ctx, first)
+	if err != nil {
+		t.Fatalf("EnsureProject(first) error = %v", err)
+	}
+	secondID, err := store.EnsureProject(ctx, second)
+	if err != nil {
+		t.Fatalf("EnsureProject(second) error = %v", err)
+	}
+	shared := "github.com/example/shared-root"
+	if err := store.RecordAttachmentEvidence(ctx, firstID.ID, EvidenceKindRemote, shared, ""); err != nil {
+		t.Fatalf("RecordAttachmentEvidence(first) error = %v", err)
+	}
+	if err := store.RecordAttachmentEvidence(ctx, secondID.ID, EvidenceKindRemote, shared, ""); err != nil {
+		t.Fatalf("RecordAttachmentEvidence(second) error = %v", err)
+	}
+	diagnostics, _, err := inspectOperationalInvariants(ctx, store, InspectOptions{DuplicateUniverse: true})
+	if err != nil {
+		t.Fatalf("inspectOperationalInvariants() error = %v", err)
+	}
+	found := false
+	for _, d := range diagnostics {
+		if d.Code == DuplicateUniverseSuspectCode {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("diagnostics = %#v, want %s", diagnostics, DuplicateUniverseSuspectCode)
+	}
+}

--- a/internal/state/project_delete.go
+++ b/internal/state/project_delete.go
@@ -74,6 +74,8 @@ var projectScopedDeleteTables = []string{
 	"brainstorms",
 	"aliases",
 	"sources",
+	"project_attachment_evidence",
+	"project_conf_labels",
 	"project_paths",
 }
 

--- a/internal/state/project_delete.go
+++ b/internal/state/project_delete.go
@@ -76,6 +76,8 @@ var projectScopedDeleteTables = []string{
 	"sources",
 	"project_attachment_evidence",
 	"project_conf_labels",
+	"sync_outbound_queue",
+	"sync_project_cursors",
 	"project_paths",
 }
 

--- a/internal/state/schema.go
+++ b/internal/state/schema.go
@@ -75,6 +75,9 @@ var pruneFossilRelationshipEdgesSQL string
 //go:embed migrations/0023_sync_client.sql
 var syncClientSQL string
 
+//go:embed migrations/0024_project_attachment.sql
+var projectAttachmentSQL string
+
 const schemaMigrationsDDL = `CREATE TABLE IF NOT EXISTS schema_migrations (
   version INTEGER PRIMARY KEY NOT NULL,
   name TEXT NOT NULL,
@@ -202,6 +205,11 @@ func SchemaMigrations() []SchemaMigration {
 			Version: 23,
 			Name:    "sync_client",
 			SQL:     normalizeMigrationSQL(syncClientSQL),
+		},
+		{
+			Version: 24,
+			Name:    "project_attachment",
+			SQL:     normalizeMigrationSQL(projectAttachmentSQL),
 		},
 	}
 }

--- a/internal/state/schema_test.go
+++ b/internal/state/schema_test.go
@@ -72,6 +72,8 @@ var requiredInitialTables = []string{
 	"fact_env_clocks",
 	"sync_outbound_queue",
 	"sync_project_cursors",
+	"project_conf_labels",
+	"project_attachment_evidence",
 	"schema_migrations",
 }
 
@@ -108,11 +110,11 @@ var userScopedTables = map[string]bool{
 
 func TestSchemaMigrationsAreOrderedAndChecksummed(t *testing.T) {
 	migrations := SchemaMigrations()
-	if len(migrations) != 22 {
-		t.Fatalf("len(SchemaMigrations()) = %d, want 22", len(migrations))
+	if len(migrations) != 23 {
+		t.Fatalf("len(SchemaMigrations()) = %d, want 23", len(migrations))
 	}
 
-	wantVersions := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}
+	wantVersions := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}
 	for i, migration := range migrations {
 		if migration.Version != wantVersions[i] {
 			t.Fatalf("migration[%d].Version = %d, want %d", i, migration.Version, wantVersions[i])
@@ -184,6 +186,9 @@ func TestSchemaMigrationsAreOrderedAndChecksummed(t *testing.T) {
 	if migrations[21].Name != "sync_client" {
 		t.Fatalf("migration[21].Name = %q, want sync_client", migrations[21].Name)
 	}
+	if migrations[22].Name != "project_attachment" {
+		t.Fatalf("migration[22].Name = %q, want project_attachment", migrations[22].Name)
+	}
 	for _, migration := range migrations {
 		if strings.TrimSpace(migration.SQL) == "" {
 			t.Fatalf("migration %d SQL is empty", migration.Version)
@@ -238,7 +243,7 @@ func TestOperationalTablesHaveStableIDsAndTimestamps(t *testing.T) {
 	}
 	sql := currentSchemaSQL()
 	for _, table := range requiredInitialTables {
-		if table == "schema_migrations" || table == "journal_origins" || table == "journal_deferrals" || table == "intent_operations" || table == "release_members" || table == "facts" || table == "fact_env_clocks" || table == "sync_outbound_queue" || table == "sync_project_cursors" {
+		if table == "schema_migrations" || table == "project_conf_labels" || table == "project_attachment_evidence" || table == "journal_origins" || table == "journal_deferrals" || table == "intent_operations" || table == "release_members" || table == "facts" || table == "fact_env_clocks" || table == "sync_outbound_queue" || table == "sync_project_cursors" {
 			continue
 		}
 		body := tableBody(t, sql, table)
@@ -450,6 +455,10 @@ func TestSchemaDocumentationMirrorsExecutableMigration(t *testing.T) {
 	if sqlDoc != SchemaMigrations()[21].SQL {
 		t.Fatal("docs/schema/0023_sync_client.sql must match embedded migration 0023 exactly")
 	}
+	sqlDoc = readRepoFile(t, "docs", "schema", "0024_project_attachment.sql")
+	if sqlDoc != SchemaMigrations()[22].SQL {
+		t.Fatal("docs/schema/0024_project_attachment.sql must match embedded migration 0024 exactly")
+	}
 
 	dbmlDoc := readRepoFile(t, "docs", "schema", "operational-state.dbml")
 	mermaidDoc := readRepoFile(t, "docs", "schema", "operational-state.mmd")
@@ -519,6 +528,8 @@ func TestSchemaDocumentationMirrorsExecutableMigration(t *testing.T) {
 		"projects ||--o{ journal_origins : scopes",
 		"projects ||--o{ logical_conversations : scopes",
 		"projects ||--o{ plans : scopes",
+		"projects ||--o{ project_attachment_evidence : scopes",
+		"projects ||--o{ project_conf_labels : scopes",
 		"projects ||--o{ project_paths : locates",
 		"projects ||--o{ relationships : scopes",
 		"projects ||--o{ session_state_snapshots : scopes",

--- a/internal/state/status.go
+++ b/internal/state/status.go
@@ -98,6 +98,8 @@ type InspectOptions struct {
 	// LeftoverAbsorb inventories leftover SQLite tasks and intents and names
 	// the absorb course of action. Off on `loaf state status`.
 	LeftoverAbsorb bool
+	// DuplicateUniverse flags projects sharing normalized remotes or root fingerprints.
+	DuplicateUniverse bool
 }
 
 // Inspect returns the current state-runtime status without creating files.
@@ -746,6 +748,14 @@ func inspectOperationalInvariants(ctx context.Context, store *Store, options Ins
 		// error when orphan/dangling diverged, warn for multi-alias. Mode stays
 		// ready either way — identity damage is detectable, not invalidating.
 		diagnostics = append(diagnostics, aliasParityDiagnostics(aliasParity)...)
+	}
+
+	if options.DuplicateUniverse {
+		duplicateReport, err := InspectDuplicateUniverseSuspects(ctx, store)
+		if err != nil {
+			return nil, false, err
+		}
+		diagnostics = append(diagnostics, duplicateUniverseDiagnostics(duplicateReport)...)
 	}
 
 	journalProvenance, err := InspectJournalProvenanceIntegrity(ctx, store)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -210,6 +210,9 @@ func Initialize(ctx context.Context, root project.Root, resolver PathResolver) (
 	if err := store.ApplyIssueProjectConfig(ctx, root); err != nil {
 		return Status{}, err
 	}
+	if err := store.BootstrapProjectConf(ctx, root); err != nil {
+		return Status{}, err
+	}
 	return Inspect(root, resolver)
 }
 

--- a/internal/state/table_class.go
+++ b/internal/state/table_class.go
@@ -44,6 +44,8 @@ var projectScopedTableClasses = map[string]TableClass{
 	// Sync — minimal core (LOAF-62): identity evidence, refs/contracts, ledger,
 	// releases. FTS and machine-local projections are excluded.
 	"project_paths":                    TableClassSync,
+	"project_conf_labels":              TableClassMachineLocal,
+	"project_attachment_evidence":      TableClassSync,
 	"aliases":                          TableClassSync,
 	"sources":                          TableClassSync,
 	"ideas":                            TableClassSync,


### PR DESCRIPTION
## Summary
- Adds migration 0024 (`project_conf_labels`, `project_attachment_evidence`) and grow-only `project.minted` / `project.evidence` facts
- Implements `ResolveProjectByConf` with unattended hard-refuse for unknown/out-of-scope labels; wires into `UnattendedAttach`
- Enables `loaf state doctor` duplicate-universe diagnostics (shared normalized remotes / root-commit fingerprints)
- Genesis-only `.agents/loaf.conf` mint — no silent backfill for existing projects

## Test plan
- [x] `go test ./internal/project/...`
- [x] `go test ./internal/state/ -run 'Attachment|Conf|Duplicate|Bootstrap|InspectOperational|DeleteProject'`
- [x] `go test ./internal/auth/ -run UnattendedAttach`
- [x] `npm run typecheck`