### PR TITLE
feat(LOAF-85): tracker-steering issue bootstrap

### DIFF
--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -76,6 +76,7 @@ func (r Runner) runIssue(args []string, out io.Writer, runtime state.Runtime) er
 		"render":    writeIssueRenderHelp,
 		"render-out": writeIssueRenderOutHelp,
 		"identity":  writeIssueIdentityHelp,
+		"bootstrap": writeIssueBootstrapHelp,
 		"export":    writeIssueExportHelp,
 		"pull":      writeIssuePullHelp,
 		"push":      writeIssuePushHelp,
@@ -131,6 +132,8 @@ func (r Runner) runIssue(args []string, out io.Writer, runtime state.Runtime) er
 		return r.runIssueRender(args[1:], out, runtime)
 	case "render-out":
 		return r.runIssueRenderOut(args[1:], out, runtime)
+	case "bootstrap":
+		return r.runIssueBootstrap(args[1:], out, runtime)
 	case "identity":
 		return r.runIssueIdentity(args[1:], out, runtime)
 	case "export":
@@ -312,6 +315,9 @@ func (r Runner) runIssueNew(args []string, out io.Writer, runtime state.Runtime)
 	}
 	projectRoot, err := r.requireIssueSQLiteState("issue new", runtime)
 	if err != nil {
+		return err
+	}
+	if err := state.RefuseUnsupportedIssueBootstrap(projectRoot.Path()); err != nil {
 		return err
 	}
 	body, ok, err := r.resolveBodyInput("issue new", options.body, false)

--- a/internal/cli/issue_bootstrap.go
+++ b/internal/cli/issue_bootstrap.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/levifig/loaf/internal/state"
+)
+
+func writeIssueBootstrapHelp(out io.Writer) {
+	writeUsageHelp(out, "loaf issue bootstrap [--json]", "Steer issue authority toward Linear when a tracker is configured, or emit trackerless branch:/pr: guidance.",
+		"--json  Output bootstrap result as JSON")
+}
+
+func (r Runner) runIssueBootstrap(args []string, out io.Writer, runtime state.Runtime) error {
+	jsonOutput := false
+	for _, arg := range args {
+		switch arg {
+		case "--json":
+			jsonOutput = true
+		default:
+			return fmt.Errorf("unknown issue bootstrap option %q", arg)
+		}
+	}
+	projectRoot, err := r.requireIssueSQLiteState("issue bootstrap", runtime)
+	if err != nil {
+		return err
+	}
+	resolver := state.PathResolver{StateHome: r.StateHome}
+	result, err := state.BootstrapTrackerSteering(context.Background(), projectRoot, resolver)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writeJSON(out, result)
+	}
+	fmt.Fprintf(out, "mode: %s\nauthority: %s\n", result.Mode, result.Authority)
+	if result.Prefix != "" {
+		fmt.Fprintf(out, "prefix: %s\n", result.Prefix)
+	}
+	fmt.Fprintf(out, "guidance: %s\n", result.Guidance)
+	return nil
+}

--- a/internal/state/issue_bootstrap.go
+++ b/internal/state/issue_bootstrap.go
@@ -145,7 +145,7 @@ func RefuseUnsupportedIssueBootstrap(projectRoot string) error {
 }
 
 func trackerBootstrapLinearReady(projectRoot string) (bool, error) {
-	if strings.TrimSpace(os.Getenv("LINEAR_API_KEY")) != "" {
+	if strings.TrimSpace(os.Getenv(linearAPITokenEnv())) != "" {
 		return true, nil
 	}
 	if enabled, err := linearIntegrationEnabled(projectRoot); err != nil {

--- a/internal/state/issue_bootstrap.go
+++ b/internal/state/issue_bootstrap.go
@@ -1,0 +1,160 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/levifig/loaf/internal/project"
+)
+
+// BootstrapTrackerMode is the steering lane selected during bootstrap.
+type BootstrapTrackerMode string
+
+const (
+	BootstrapTrackerModeLinear      BootstrapTrackerMode = "linear"
+	BootstrapTrackerModeTrackerless BootstrapTrackerMode = "trackerless"
+)
+
+// BootstrapTrackerSteeringResult reports the bootstrap lane and follow-on guidance.
+type BootstrapTrackerSteeringResult struct {
+	Mode      BootstrapTrackerMode `json:"mode"`
+	Authority string               `json:"authority"`
+	Prefix    string               `json:"prefix,omitempty"`
+	Guidance  string               `json:"guidance"`
+	Applied   bool                 `json:"applied"`
+}
+
+// UnsupportedIssueAuthorityBootstrapError refuses tracker adapters that have no v1 bootstrap path.
+type UnsupportedIssueAuthorityBootstrapError struct {
+	Authority string
+}
+
+func (e *UnsupportedIssueAuthorityBootstrapError) Error() string {
+	if e == nil {
+		return "issue authority bootstrap is not supported"
+	}
+	provider := strings.TrimSpace(e.Authority)
+	if provider == "" {
+		provider = "unknown"
+	}
+	ref := &UnsupportedAuthorityError{Provider: provider}
+	return fmt.Sprintf("issue.authority %q is not bootstrappable in v1; %s", provider, ref.Error())
+}
+
+// BootstrapTrackerSteering selects Linear when a tracker is configured and leaves
+// trackerless projects on branch:/pr: refs with explicit guidance.
+func BootstrapTrackerSteering(ctx context.Context, root project.Root, resolver PathResolver) (BootstrapTrackerSteeringResult, error) {
+	cfg, err := LoadIssueProjectConfig(root.Path())
+	if err != nil {
+		return BootstrapTrackerSteeringResult{}, err
+	}
+	if cfg.Authority == IssueAuthorityGitHub {
+		return BootstrapTrackerSteeringResult{}, &UnsupportedIssueAuthorityBootstrapError{Authority: cfg.Authority}
+	}
+	for provider := range futureAuthorityProviders {
+		if cfg.Authority == provider {
+			return BootstrapTrackerSteeringResult{}, &UnsupportedIssueAuthorityBootstrapError{Authority: cfg.Authority}
+		}
+	}
+
+	store, err := openInitializedStore(root, resolver)
+	if err != nil {
+		return BootstrapTrackerSteeringResult{}, err
+	}
+	defer store.Close()
+
+	linearReady, err := trackerBootstrapLinearReady(root.Path())
+	if err != nil {
+		return BootstrapTrackerSteeringResult{}, err
+	}
+
+	if linearReady {
+		prefix := strings.TrimSpace(cfg.Prefix)
+		if prefix == "" {
+			identity, ok, err := store.LookupIssueIdentity(ctx, root)
+			if err != nil {
+				return BootstrapTrackerSteeringResult{}, err
+			}
+			if ok {
+				prefix = identity.Prefix
+			}
+		}
+		opts := IssueIdentityOptions{Authority: IssueAuthorityLinear}
+		if prefix != "" {
+			opts.Prefix = prefix
+		}
+		identity, err := store.SetIssueIdentity(ctx, root, opts)
+		if err != nil {
+			return BootstrapTrackerSteeringResult{}, err
+		}
+		if err := persistIssueProjectConfig(root.Path(), IssueAuthorityLinear, identity.Prefix); err != nil {
+			return BootstrapTrackerSteeringResult{}, err
+		}
+		guidance := "tracker-backed: create work with `loaf issue new` (mints Linear) or address contracts as linear:<KEY>; unsupported providers refuse — use branch: or pr: only when trackerless"
+		if identity.Prefix == "" {
+			guidance = "Linear is configured but team prefix is missing; set `loaf issue identity --prefix <TEAM>` then re-run bootstrap"
+		}
+		return BootstrapTrackerSteeringResult{
+			Mode:      BootstrapTrackerModeLinear,
+			Authority: identity.Authority,
+			Prefix:    identity.Prefix,
+			Guidance:  guidance,
+			Applied:   true,
+		}, nil
+	}
+
+	identity, ok, err := store.LookupIssueIdentity(ctx, root)
+	if err != nil {
+		return BootstrapTrackerSteeringResult{}, err
+	}
+	authority := IssueAuthorityLocal
+	prefix := ""
+	if ok {
+		authority = identity.Authority
+		prefix = identity.Prefix
+	} else if cfg.Authority != "" {
+		authority = cfg.Authority
+		prefix = cfg.Prefix
+	}
+	return BootstrapTrackerSteeringResult{
+		Mode:      BootstrapTrackerModeTrackerless,
+		Authority: authority,
+		Prefix:    prefix,
+		Guidance:  "trackerless: use branch:<name> or pr:<number> authority refs and `loaf issue render-out`; internal LOAF-* rows are legacy — do not mint new tracker work as internal issues",
+		Applied:   false,
+	}, nil
+}
+
+// RefuseUnsupportedIssueBootstrap blocks issue creation when bootstrap would mint internal rows for unsupported tracker kinds.
+func RefuseUnsupportedIssueBootstrap(projectRoot string) error {
+	cfg, err := LoadIssueProjectConfig(projectRoot)
+	if err != nil {
+		return err
+	}
+	if cfg.Authority == IssueAuthorityGitHub {
+		return &UnsupportedIssueAuthorityBootstrapError{Authority: cfg.Authority}
+	}
+	for provider := range futureAuthorityProviders {
+		if cfg.Authority == provider {
+			return &UnsupportedIssueAuthorityBootstrapError{Authority: cfg.Authority}
+		}
+	}
+	return nil
+}
+
+func trackerBootstrapLinearReady(projectRoot string) (bool, error) {
+	if strings.TrimSpace(os.Getenv("LINEAR_API_KEY")) != "" {
+		return true, nil
+	}
+	if enabled, err := linearIntegrationEnabled(projectRoot); err != nil {
+		return false, err
+	} else if enabled {
+		return true, nil
+	}
+	if _, err := LinearClientFromEnv(); err == nil {
+		return true, nil
+	}
+	return false, nil
+}

--- a/internal/state/issue_bootstrap_test.go
+++ b/internal/state/issue_bootstrap_test.go
@@ -1,0 +1,123 @@
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/levifig/loaf/internal/project"
+)
+
+func TestBootstrapTrackerSteeringTrackerlessGuidance(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	root := projectRootInTempDir(t)
+	stateHome := t.TempDir()
+	resolver := PathResolver{StateHome: stateHome}
+	if _, err := Initialize(ctx, root, resolver); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	got, err := BootstrapTrackerSteering(ctx, root, resolver)
+	if err != nil {
+		t.Fatalf("BootstrapTrackerSteering() error = %v", err)
+	}
+	if got.Mode != BootstrapTrackerModeTrackerless {
+		t.Fatalf("Mode = %q, want %q", got.Mode, BootstrapTrackerModeTrackerless)
+	}
+	if !strings.Contains(got.Guidance, "branch:") || !strings.Contains(got.Guidance, "pr:") {
+		t.Fatalf("Guidance = %q, want branch/pr guidance", got.Guidance)
+	}
+}
+
+func TestBootstrapTrackerSteeringSteersLinear(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	rootDir := t.TempDir()
+	writeLinearBootstrapConfig(t, rootDir, "OPS")
+	root, err := project.ResolveRoot(rootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateHome := t.TempDir()
+	resolver := PathResolver{StateHome: stateHome}
+	if _, err := Initialize(ctx, root, resolver); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	got, err := BootstrapTrackerSteering(ctx, root, resolver)
+	if err != nil {
+		t.Fatalf("BootstrapTrackerSteering() error = %v", err)
+	}
+	if got.Mode != BootstrapTrackerModeLinear || !got.Applied {
+		t.Fatalf("result = %#v, want linear applied", got)
+	}
+	if got.Authority != IssueAuthorityLinear || got.Prefix != "OPS" {
+		t.Fatalf("authority/prefix = %q/%q, want linear/OPS", got.Authority, got.Prefix)
+	}
+}
+
+func TestBootstrapTrackerSteeringRefusesGitHubAuthority(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	rootDir := t.TempDir()
+	writeIssueAuthorityConfig(t, rootDir, "github")
+	root, err := project.ResolveRoot(rootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateHome := t.TempDir()
+	resolver := PathResolver{StateHome: stateHome}
+	if _, err := Initialize(ctx, root, resolver); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	_, err = BootstrapTrackerSteering(ctx, root, resolver)
+	var refused *UnsupportedIssueAuthorityBootstrapError
+	if !errors.As(err, &refused) {
+		t.Fatalf("BootstrapTrackerSteering() error = %v, want *UnsupportedIssueAuthorityBootstrapError", err)
+	}
+}
+
+func TestRefuseUnsupportedIssueBootstrap(t *testing.T) {
+	t.Parallel()
+	rootDir := t.TempDir()
+	writeIssueAuthorityConfig(t, rootDir, "gitlab")
+	err := RefuseUnsupportedIssueBootstrap(rootDir)
+	if err == nil {
+		t.Fatal("RefuseUnsupportedIssueBootstrap() = nil, want error")
+	}
+}
+
+func writeLinearBootstrapConfig(t *testing.T, rootDir, prefix string) {
+	t.Helper()
+	agents := filepath.Join(rootDir, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := map[string]any{
+		"schema_version": "1.0.0",
+		"integrations": map[string]any{
+			"linear": map[string]any{"enabled": true},
+		},
+		"issue": map[string]any{"authority": "local", "prefix": prefix},
+	}
+	raw, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(agents, "loaf.json"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeIssueAuthorityConfig(t *testing.T, rootDir, authority string) {
+	t.Helper()
+	agents := filepath.Join(rootDir, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := map[string]any{"schema_version": "1.0.0", "issue": map[string]any{"authority": authority}}
+	raw, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(agents, "loaf.json"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `loaf issue bootstrap` to steer Linear-enabled projects onto `linear` authority (SQLite + `.agents/loaf.json`)
- Emits explicit trackerless guidance for `branch:` / `pr:` refs and `loaf issue render-out`
- Refuses unsupported `issue.authority` values (github/gitlab/gitea/forgejo) at bootstrap and `loaf issue new`

## Test plan
- [x] `go test ./internal/state/ -run BootstrapTracker`
- [x] `go test ./internal/cli/ -run Bootstrap`