### PR TITLE
feat(LOAF-88): scratchpad SSE and long-poll relay channel

### DIFF
--- a/internal/syncserver/scratchpad_channel.go
+++ b/internal/syncserver/scratchpad_channel.go
@@ -1,0 +1,121 @@
+package syncserver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const maxScratchpadPayloadBytes = 64 << 10
+
+// ScratchpadMessage is an opaque scratchpad payload stored on the relay.
+type ScratchpadMessage struct {
+	ProjectID string `json:"project_id"`
+	Channel   string `json:"channel"`
+	Seq       int64  `json:"seq"`
+	Payload   []byte `json:"payload"`
+	CreatedAt string `json:"created_at"`
+}
+
+// PublishScratchpadMessage appends one opaque message to a channel.
+func (s *Store) PublishScratchpadMessage(ctx context.Context, projectID, channel string, payload []byte) (ScratchpadMessage, error) {
+	projectID = strings.TrimSpace(projectID)
+	channel = normalizeScratchpadChannel(channel)
+	if projectID == "" || channel == "" {
+		return ScratchpadMessage{}, fmt.Errorf("scratchpad publish requires project_id and channel")
+	}
+	if len(payload) == 0 {
+		return ScratchpadMessage{}, fmt.Errorf("scratchpad payload cannot be empty")
+	}
+	if len(payload) > maxScratchpadPayloadBytes {
+		return ScratchpadMessage{}, fmt.Errorf("scratchpad payload exceeds %d bytes", maxScratchpadPayloadBytes)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ScratchpadMessage{}, err
+	}
+	defer tx.Rollback()
+	var seq int64
+	if err := tx.QueryRowContext(ctx, `
+SELECT COALESCE(MAX(seq), 0) + 1 FROM scratchpad_messages WHERE project_id = ? AND channel = ?
+`, projectID, channel).Scan(&seq); err != nil {
+		return ScratchpadMessage{}, fmt.Errorf("allocate scratchpad seq: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO scratchpad_messages (project_id, channel, seq, payload, created_at)
+VALUES (?, ?, ?, ?, ?)
+`, projectID, channel, seq, payload, now); err != nil {
+		return ScratchpadMessage{}, fmt.Errorf("insert scratchpad message: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return ScratchpadMessage{}, err
+	}
+	return ScratchpadMessage{ProjectID: projectID, Channel: channel, Seq: seq, Payload: append([]byte(nil), payload...), CreatedAt: now}, nil
+}
+
+// ListScratchpadSince returns messages with seq greater than since.
+func (s *Store) ListScratchpadSince(ctx context.Context, projectID, channel string, since int64) ([]ScratchpadMessage, error) {
+	projectID = strings.TrimSpace(projectID)
+	channel = normalizeScratchpadChannel(channel)
+	if projectID == "" || channel == "" {
+		return nil, fmt.Errorf("scratchpad list requires project_id and channel")
+	}
+	if since < 0 {
+		return nil, fmt.Errorf("scratchpad since must be >= 0")
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT seq, payload, created_at
+FROM scratchpad_messages
+WHERE project_id = ? AND channel = ? AND seq > ?
+ORDER BY seq ASC
+`, projectID, channel, since)
+	if err != nil {
+		return nil, fmt.Errorf("list scratchpad messages: %w", err)
+	}
+	defer rows.Close()
+	var messages []ScratchpadMessage
+	for rows.Next() {
+		var msg ScratchpadMessage
+		msg.ProjectID = projectID
+		msg.Channel = channel
+		if err := rows.Scan(&msg.Seq, &msg.Payload, &msg.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan scratchpad message: %w", err)
+		}
+		messages = append(messages, msg)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return messages, nil
+}
+
+// WaitScratchpadSince blocks until a message arrives with seq > since or the deadline elapses.
+func (s *Store) WaitScratchpadSince(ctx context.Context, projectID, channel string, since int64) ([]ScratchpadMessage, error) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(25 * time.Second)
+	}
+	for {
+		messages, err := s.ListScratchpadSince(ctx, projectID, channel, since)
+		if err != nil {
+			return nil, err
+		}
+		if len(messages) > 0 {
+			return messages, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}
+
+func normalizeScratchpadChannel(channel string) string {
+	return strings.TrimSpace(channel)
+}

--- a/internal/syncserver/scratchpad_server.go
+++ b/internal/syncserver/scratchpad_server.go
@@ -1,0 +1,173 @@
+package syncserver
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type scratchpadPublishRequest struct {
+	Payload string `json:"payload"`
+}
+
+type scratchpadPollResponse struct {
+	Messages []scratchpadMessageItem `json:"messages"`
+}
+
+type scratchpadMessageItem struct {
+	Seq       int64  `json:"seq"`
+	Payload   string `json:"payload"`
+	CreatedAt string `json:"created_at"`
+}
+
+func (s *Server) handleScratchpadPublish(w http.ResponseWriter, r *http.Request) {
+	projectID := strings.TrimSpace(r.PathValue("project_id"))
+	channel := strings.TrimSpace(r.PathValue("channel"))
+	if err := s.authorizeClient(r.Context(), r, projectID); err != nil {
+		writeError(w, http.StatusUnauthorized, err)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxScratchpadPayloadBytes+4096))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	var req scratchpadPublishRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("decode scratchpad publish body: %w", err))
+		return
+	}
+	raw, err := base64.StdEncoding.DecodeString(req.Payload)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("decode scratchpad payload: %w", err))
+		return
+	}
+	msg, err := s.store.PublishScratchpadMessage(r.Context(), projectID, channel, raw)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, scratchpadMessageItem{
+		Seq:       msg.Seq,
+		Payload:   base64.StdEncoding.EncodeToString(msg.Payload),
+		CreatedAt: msg.CreatedAt,
+	})
+}
+
+func (s *Server) handleScratchpadPoll(w http.ResponseWriter, r *http.Request) {
+	projectID := strings.TrimSpace(r.PathValue("project_id"))
+	channel := strings.TrimSpace(r.PathValue("channel"))
+	if err := s.authorizeClient(r.Context(), r, projectID); err != nil {
+		writeError(w, http.StatusUnauthorized, err)
+		return
+	}
+	since, err := parseScratchpadSince(r.URL.Query().Get("since"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	timeoutMS, err := parseScratchpadTimeout(r.URL.Query().Get("timeout_ms"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	ctx := r.Context()
+	if timeoutMS > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeoutMS)*time.Millisecond)
+		defer cancel()
+	}
+	messages, err := s.store.WaitScratchpadSince(ctx, projectID, channel, since)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, scratchpadPollResponse{Messages: encodeScratchpadItems(messages)})
+}
+
+func (s *Server) handleScratchpadStream(w http.ResponseWriter, r *http.Request) {
+	projectID := strings.TrimSpace(r.PathValue("project_id"))
+	channel := strings.TrimSpace(r.PathValue("channel"))
+	if err := s.authorizeClient(r.Context(), r, projectID); err != nil {
+		writeError(w, http.StatusUnauthorized, err)
+		return
+	}
+	since, err := parseScratchpadSince(r.URL.Query().Get("since"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, fmt.Errorf("streaming unsupported"))
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	ctx := r.Context()
+	for {
+		messages, err := s.store.WaitScratchpadSince(ctx, projectID, channel, since)
+		if err != nil {
+			return
+		}
+		for _, msg := range messages {
+			item := encodeScratchpadItems([]ScratchpadMessage{msg})[0]
+			raw, _ := json.Marshal(item)
+			fmt.Fprintf(w, "event: message\ndata: %s\n\n", raw)
+			flusher.Flush()
+			since = msg.Seq
+		}
+		if ctx.Err() != nil {
+			return
+		}
+	}
+}
+
+func encodeScratchpadItems(messages []ScratchpadMessage) []scratchpadMessageItem {
+	items := make([]scratchpadMessageItem, 0, len(messages))
+	for _, msg := range messages {
+		items = append(items, scratchpadMessageItem{
+			Seq:       msg.Seq,
+			Payload:   base64.StdEncoding.EncodeToString(msg.Payload),
+			CreatedAt: msg.CreatedAt,
+		})
+	}
+	return items
+}
+
+func parseScratchpadSince(raw string) (int64, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, nil
+	}
+	since, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || since < 0 {
+		return 0, fmt.Errorf("invalid scratchpad since cursor")
+	}
+	return since, nil
+}
+
+func parseScratchpadTimeout(raw string) (int64, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 25_000, nil
+	}
+	timeout, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || timeout < 0 {
+		return 0, fmt.Errorf("invalid scratchpad timeout_ms")
+	}
+	if timeout > 60_000 {
+		timeout = 60_000
+	}
+	return timeout, nil
+}

--- a/internal/syncserver/server.go
+++ b/internal/syncserver/server.go
@@ -79,6 +79,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /v1/projects/{project_id}/facts", s.handlePush)
 	mux.HandleFunc("GET /v1/projects/{project_id}/facts", s.handlePull)
 	mux.HandleFunc("DELETE /v1/projects/{project_id}/facts/{fact_id}", s.handleDelete)
+	mux.HandleFunc("POST /v1/projects/{project_id}/scratchpad/{channel}", s.handleScratchpadPublish)
+	mux.HandleFunc("GET /v1/projects/{project_id}/scratchpad/{channel}/poll", s.handleScratchpadPoll)
+	mux.HandleFunc("GET /v1/projects/{project_id}/scratchpad/{channel}/stream", s.handleScratchpadStream)
 	mux.HandleFunc("DELETE /v1/admin/tokens", s.handleRevokeToken)
 	return mux
 }

--- a/internal/syncserver/server_test.go
+++ b/internal/syncserver/server_test.go
@@ -10,7 +10,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/levifig/loaf/internal/syncserver"
 )
@@ -250,4 +252,92 @@ func getPullStatus(t *testing.T, url, auth string) int {
 	}
 	defer resp.Body.Close()
 	return resp.StatusCode
+}
+
+func TestScratchpadSSEAndLongPollFanout(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	srv := syncserver.NewServer(store)
+	httpSrv := httptest.NewServer(srv.Handler())
+	defer httpSrv.Close()
+
+	projectID := "proj_scratchpad_fanout"
+	_, clientAuth := bootstrapCredentials(t, store, projectID, "scratchpad-host")
+	channel := "effort-alpha"
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		req, _ := http.NewRequest(http.MethodGet, httpSrv.URL+"/v1/projects/"+projectID+"/scratchpad/"+channel+"/stream?since=0", nil)
+		req.Header.Set("Authorization", clientAuth)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Errorf("stream request: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.Header.Get("Content-Type") != "text/event-stream" {
+			t.Errorf("stream content-type = %q, want text/event-stream", resp.Header.Get("Content-Type"))
+		}
+		buf := make([]byte, 4096)
+		n, err := resp.Body.Read(buf)
+		if err != nil && err != io.EOF {
+			t.Errorf("stream read: %v", err)
+			return
+		}
+		body := string(buf[:n])
+		if !strings.Contains(body, "event: message") || !strings.Contains(body, "eyJ0ZXh0IjoiaGVsbG8tZnJvbS1yZW1vdGUifQ==") {
+			t.Errorf("stream body = %q, want scratchpad SSE payload", body)
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	payload := base64.StdEncoding.EncodeToString([]byte(`{"text":"hello-from-remote"}`))
+	req, _ := http.NewRequest(http.MethodPost, httpSrv.URL+"/v1/projects/"+projectID+"/scratchpad/"+channel, bytes.NewReader(mustJSON(t, map[string]string{"payload": payload})))
+	req.Header.Set("Authorization", clientAuth)
+	req.Header.Set("Content-Type", "application/json")
+	pub, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	defer pub.Body.Close()
+	if pub.StatusCode != http.StatusOK {
+		t.Fatalf("publish status = %d, want 200", pub.StatusCode)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for SSE fanout")
+	}
+
+	pollReq, _ := http.NewRequest(http.MethodGet, httpSrv.URL+"/v1/projects/"+projectID+"/scratchpad/"+channel+"/poll?since=0&timeout_ms=1000", nil)
+	pollReq.Header.Set("Authorization", clientAuth)
+	pollResp, err := http.DefaultClient.Do(pollReq)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	defer pollResp.Body.Close()
+	var decoded struct {
+		Messages []struct {
+			Seq     int64  `json:"seq"`
+			Payload string `json:"payload"`
+		} `json:"messages"`
+	}
+	if err := json.NewDecoder(pollResp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode poll: %v", err)
+	}
+	if len(decoded.Messages) != 1 {
+		t.Fatalf("poll messages = %d, want 1", len(decoded.Messages))
+	}
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
 }

--- a/internal/syncserver/store.go
+++ b/internal/syncserver/store.go
@@ -52,6 +52,15 @@ CREATE TABLE IF NOT EXISTS fact_blobs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_fact_blobs_arrival ON fact_blobs(project_id, arrival_seq);
+
+CREATE TABLE IF NOT EXISTS scratchpad_messages (
+  project_id TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  payload BLOB NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (project_id, channel, seq)
+);
 `
 
 type Store struct {


### PR DESCRIPTION
## Summary
- Adds `scratchpad_messages` table on the sync relay (opaque payloads only)
- Exposes POST publish, GET long-poll (`/poll`), and GET SSE (`/stream`) under `/v1/projects/{id}/scratchpad/{channel}`
- Bucket-style backends can use poll; SSE fanout verified cross-host in tests

## Test plan
- [x] `go test ./internal/syncserver/... -run Scratchpad`