### PR TITLE
feat(LOAF-85): bootstrap branch authority refs on issue start

### DIFF
--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -417,6 +417,9 @@ func (r Runner) runIssueShow(args []string, out io.Writer, runtime state.Runtime
 	if err != nil {
 		return err
 	}
+	if authorityRefCommand(ref) {
+		return r.runIssueShowContract(context.Background(), projectRoot, ref, jsonOutput, out)
+	}
 	result, err := state.ShowIssue(context.Background(), projectRoot, state.PathResolver{StateHome: r.StateHome}, ref)
 	if err != nil {
 		return err

--- a/internal/cli/issue_contract.go
+++ b/internal/cli/issue_contract.go
@@ -330,3 +330,27 @@ func (r Runner) runIssueStopContract(ctx context.Context, projectRoot project.Ro
 	}
 	return nil
 }
+
+func (r Runner) runIssueShowContract(ctx context.Context, projectRoot project.Root, ref string, jsonOutput bool, out io.Writer) error {
+	shown, err := state.ShowWorkContract(ctx, projectRoot, state.PathResolver{StateHome: r.StateHome}, ref)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writeJSON(out, shown)
+	}
+	fmt.Fprintf(out, "contract %s
+", shown.Contract.AuthorityRef.String())
+	fmt.Fprintf(out, "kind: %s
+", shown.Contract.Kind)
+	fmt.Fprintf(out, "status: %s
+", shown.Contract.Status)
+	fmt.Fprintf(out, "title: %s
+", shown.Contract.Title)
+	if shown.Contract.Body != "" {
+		fmt.Fprintf(out, "
+%s
+", shown.Contract.Body)
+	}
+	return nil
+}

--- a/internal/cli/issue_worktree.go
+++ b/internal/cli/issue_worktree.go
@@ -144,6 +144,13 @@ func (r Runner) runIssueStart(args []string, out io.Writer, runtime state.Runtim
 	}); err != nil {
 		return wrapIssueStartUpdateError(err, rollbackIssueWorktree(repoRoot, worktree, branch, createdBranch), worktree, branch)
 	}
+	if _, err := state.BootstrapIssueBranchContract(ctx, projectRoot, resolver, state.BootstrapIssueBranchContractOptions{
+		IssueID:         owner.ID,
+		Branch:          branch,
+		StartedWorktree: worktree,
+	}); err != nil {
+		return wrapIssueStartUpdateError(err, rollbackIssueWorktree(repoRoot, worktree, branch, createdBranch), worktree, branch)
+	}
 	if requested.ID != owner.ID {
 		if err := activateIssue(ctx, projectRoot, resolver, requested); err != nil {
 			return err

--- a/internal/state/issue_branch_bootstrap.go
+++ b/internal/state/issue_branch_bootstrap.go
@@ -1,0 +1,163 @@
+package state
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/levifig/loaf/internal/project"
+)
+
+const BootstrapReceiptKind = "bootstrap"
+
+type BootstrapIssueBranchContractOptions struct {
+	IssueID         string
+	Branch          string
+	StartedWorktree string
+}
+
+type BootstrapIssueBranchContractResult struct {
+	ContractVersion    int          `json:"contract_version"`
+	DatabaseScope      string       `json:"database_scope"`
+	DatabasePath       string       `json:"database_path,omitempty"`
+	ProjectID          string       `json:"project_id,omitempty"`
+	ProjectName        string       `json:"project_name,omitempty"`
+	ProjectCurrentPath string       `json:"project_current_path,omitempty"`
+	Issue              Issue        `json:"issue"`
+	AuthorityRef       AuthorityRef `json:"authority_ref"`
+	Contract           WorkContract `json:"contract"`
+	Created            bool         `json:"created"`
+}
+
+func BootstrapIssueBranchContract(ctx context.Context, root project.Root, resolver PathResolver, options BootstrapIssueBranchContractOptions) (BootstrapIssueBranchContractResult, error) {
+	store, err := openProjectStoreMutateExisting(ctx, root, resolver)
+	if err != nil {
+		return BootstrapIssueBranchContractResult{}, err
+	}
+	defer store.Close()
+	return store.BootstrapIssueBranchContract(ctx, root, options)
+}
+
+func (s *Store) BootstrapIssueBranchContract(ctx context.Context, root project.Root, options BootstrapIssueBranchContractOptions) (BootstrapIssueBranchContractResult, error) {
+	issueID := strings.TrimSpace(options.IssueID)
+	branch := strings.TrimSpace(options.Branch)
+	if issueID == "" || branch == "" {
+		return BootstrapIssueBranchContractResult{}, fmt.Errorf("bootstrap branch contract requires issue id and branch")
+	}
+	projectID, err := s.projectID(ctx, root)
+	if err != nil {
+		return BootstrapIssueBranchContractResult{}, err
+	}
+	identity, err := s.projectIdentity(ctx, projectID)
+	if err != nil {
+		return BootstrapIssueBranchContractResult{}, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return BootstrapIssueBranchContractResult{}, fmt.Errorf("begin branch bootstrap: %w", err)
+	}
+	defer tx.Rollback()
+
+	issue, err := loadIssueTx(ctx, tx, projectID, issueID)
+	if err != nil {
+		return BootstrapIssueBranchContractResult{}, err
+	}
+	issueAlias := ""
+	if err := tx.QueryRowContext(ctx, `
+SELECT alias FROM aliases
+WHERE project_id = ? AND namespace = ? AND entity_id = ?
+`, projectID, issueNamespace, issueID).Scan(&issueAlias); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return BootstrapIssueBranchContractResult{}, fmt.Errorf("lookup issue alias: %w", err)
+	}
+
+	authorityRef := AuthorityRef{Provider: AuthorityProviderBranch, Key: branch}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	criteria := issueCriteriaToInputs(issue.Criteria)
+	created := false
+
+	contract, err := loadWorkContractByRefTx(ctx, tx, projectID, authorityRef)
+	switch {
+	case err == nil:
+		if _, err := tx.ExecContext(ctx, `
+UPDATE work_contracts
+SET title = ?, body = ?, fog = ?, status = ?, updated_at = ?
+WHERE project_id = ? AND id = ?
+`, issue.Title, issue.Body, emptyToNil(strings.TrimSpace(issue.Fog)), issue.Status, now, projectID, contract.ID); err != nil {
+			return BootstrapIssueBranchContractResult{}, fmt.Errorf("refresh bootstrapped contract: %w", err)
+		}
+		if err := replaceWorkContractCriteriaTx(ctx, tx, projectID, contract.ID, criteria, now); err != nil {
+			return BootstrapIssueBranchContractResult{}, err
+		}
+	case strings.Contains(err.Error(), "not found"):
+		contract, err = createWorkContractTx(ctx, tx, projectID, WorkContractCreateOptions{
+			AuthorityRef: authorityRef,
+			Title:        issue.Title,
+			Body:         issue.Body,
+			Fog:          issue.Fog,
+			Kind:         issue.Kind,
+			Criteria:     criteria,
+		}, now)
+		if err != nil {
+			return BootstrapIssueBranchContractResult{}, err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE work_contracts SET status = ?, updated_at = ? WHERE project_id = ? AND id = ?`, issue.Status, now, projectID, contract.ID); err != nil {
+			return BootstrapIssueBranchContractResult{}, fmt.Errorf("set bootstrapped contract status: %w", err)
+		}
+		created = true
+	default:
+		return BootstrapIssueBranchContractResult{}, err
+	}
+
+	if strings.TrimSpace(options.StartedWorktree) != "" {
+		if err := upsertWorkContractWorkspaceTx(ctx, tx, projectID, contract.ID, branch, strings.TrimSpace(options.StartedWorktree), now); err != nil {
+			return BootstrapIssueBranchContractResult{}, fmt.Errorf("record bootstrapped workspace: %w", err)
+		}
+	}
+
+	receiptID, err := newOpaqueStateID("wcr")
+	if err != nil {
+		return BootstrapIssueBranchContractResult{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO work_contract_receipts (id, project_id, provider, provider_ref, receipt_kind, receipt_value, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(project_id, provider, provider_ref, receipt_kind) DO UPDATE SET
+  receipt_value = excluded.receipt_value,
+  updated_at = excluded.updated_at
+`, receiptID, projectID, authorityRef.Provider, authorityRef.Key, BootstrapReceiptKind, issueID, now, now); err != nil {
+		return BootstrapIssueBranchContractResult{}, fmt.Errorf("record bootstrap receipt: %w", err)
+	}
+	if err := upsertWorkContractMappingTx(ctx, tx, projectID, authorityRef, RenderOutMappingIssueID, issueID, now); err != nil {
+		return BootstrapIssueBranchContractResult{}, err
+	}
+	if issueAlias != "" {
+		if err := upsertWorkContractMappingTx(ctx, tx, projectID, authorityRef, RenderOutMappingIssueAlias, issueAlias, now); err != nil {
+			return BootstrapIssueBranchContractResult{}, err
+		}
+	}
+
+	contract, err = loadWorkContractTx(ctx, tx, projectID, contract.ID)
+	if err != nil {
+		return BootstrapIssueBranchContractResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BootstrapIssueBranchContractResult{}, fmt.Errorf("commit branch bootstrap: %w", err)
+	}
+
+	return BootstrapIssueBranchContractResult{
+		ContractVersion:    StateJSONContractVersion,
+		DatabaseScope:      identity.DatabaseScope,
+		DatabasePath:       identity.DatabasePath,
+		ProjectID:          identity.ID,
+		ProjectName:        identity.FriendlyName,
+		ProjectCurrentPath: identity.CurrentPath,
+		Issue:              issue,
+		AuthorityRef:       authorityRef,
+		Contract:           contract,
+		Created:            created,
+	}, nil
+}

--- a/internal/state/issue_branch_bootstrap_test.go
+++ b/internal/state/issue_branch_bootstrap_test.go
@@ -1,0 +1,79 @@
+package state_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/levifig/loaf/internal/project"
+	"github.com/levifig/loaf/internal/state"
+)
+
+func TestBootstrapIssueBranchContractCreatesBranchAuthority(t *testing.T) {
+	ctx := context.Background()
+	root, resolver := bootstrapFixture(t)
+	created, err := state.CreateIssue(ctx, root, resolver, state.IssueCreateOptions{
+		Title: "Bootstrap me",
+		Body:  "Problem body.",
+		Kind:  state.IssueKindDelivery,
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+
+	result, err := state.BootstrapIssueBranchContract(ctx, root, resolver, state.BootstrapIssueBranchContractOptions{
+		IssueID:         created.ID,
+		Branch:          "issue/loaf-bootstrap",
+		StartedWorktree: filepath.Join(filepath.Dir(root.Path()), "wt-bootstrap"),
+	})
+	if err != nil {
+		t.Fatalf("BootstrapIssueBranchContract() error = %v", err)
+	}
+	if !result.Created {
+		t.Fatal("Created = false, want true on first bootstrap")
+	}
+	if result.AuthorityRef.String() != "branch:issue/loaf-bootstrap" {
+		t.Fatalf("authority ref = %q", result.AuthorityRef.String())
+	}
+
+	shown, err := state.ShowWorkContract(ctx, root, resolver, result.AuthorityRef.String())
+	if err != nil {
+		t.Fatalf("ShowWorkContract() error = %v", err)
+	}
+	if shown.Contract.StartedBranch != "issue/loaf-bootstrap" {
+		t.Fatalf("StartedBranch = %q", shown.Contract.StartedBranch)
+	}
+
+	second, err := state.BootstrapIssueBranchContract(ctx, root, resolver, state.BootstrapIssueBranchContractOptions{
+		IssueID: created.ID,
+		Branch:  "issue/loaf-bootstrap",
+	})
+	if err != nil {
+		t.Fatalf("second BootstrapIssueBranchContract() error = %v", err)
+	}
+	if second.Created {
+		t.Fatal("second Created = true, want idempotent refresh")
+	}
+}
+
+func bootstrapFixture(t *testing.T) (project.Root, state.PathResolver) {
+	t.Helper()
+	dir := t.TempDir()
+	agents := filepath.Join(dir, ".agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agents, "loaf.json"), []byte(`{"issue":{"prefix":"LOAF"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root, err := project.ResolveRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := state.PathResolver{StateHome: t.TempDir()}
+	if _, err := state.Initialize(context.Background(), root, resolver); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	return root, resolver
+}


### PR DESCRIPTION
## Summary
- Mint or refresh `branch:` work contracts when `loaf issue start` creates a branch, linking internal issue rows without retiring them
- Record workspace metadata on the contract and bootstrap receipts/mappings for traceability
- Route `loaf issue show branch:…` to the ref-keyed contract store

## Test plan
- [x] `go test ./internal/state/ -run TestBootstrapIssueBranchContract`
- [ ] `loaf issue start LOAF-XX` on trackerless project → `loaf issue show branch:issue/loaf-XX` resolves contract
- [ ] Idempotent re-start refreshes contract without duplicate rows