### PR TITLE
fix: scope sync-server admin delete and bind HTTP off TLS ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ is a Loaf workflow staging section for curated entries before release.
 
 ### Changed
 
+- **Breaking:** The distroless sync-server image now binds HTTP `:8080` instead of `:8443`. Terminate TLS at a reverse proxy, or pass `--tls-cert` and `--tls-key` to `loaf serve`.
 - `loaf issue start` walks to the shippable root of the issue tree. Only that root gets `issue/<root-alias>` and a worktree; starting a child creates or joins the root workspace and marks the child active. `loaf issue stop` on a child that does not own a worktree names the root (LOAF-50).
 
 ### Fixed
+
+- Sync-server admin `DELETE` of facts is scoped to projects the authenticating account has minted a connection token for, so a second tenant cannot delete another tenant's blobs.
+- `loaf serve` refuses ports `443` and `8443` unless `--tls-cert` and `--tls-key` are set, so `LoafToken` / `LoafAdmin` credentials are not sent on a TLS-looking cleartext port.
 
 - Development builds stage native targets before replacing `bin/native` and `bin/.loaf-dev-commit`, so a later target failure cannot leave a new binary reporting a previous commit. Activation updates a Loaf-owned launcher pointer and creates `~/.local/bin/loaf` only when that name is absent; existing operator-owned paths are never replaced, and activation failures no longer fail a successful native build. Release tags that are not strict SemVer fail resolve instead of being skipped as dev identities.
 - `loaf issue start` on a child refuses if the root workspace is missing or the root is already `done` / archived, instead of joining a stale or closed workspace.

--- a/cli/docker/sync-server/Dockerfile
+++ b/cli/docker/sync-server/Dockerfile
@@ -7,7 +7,7 @@ RUN CGO_ENABLED=0 go build -o /out/loaf ./cmd/loaf
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /out/loaf /usr/local/bin/loaf
-EXPOSE 8443
+EXPOSE 8080
 VOLUME ["/data"]
 ENV LOAF_SYNC_DB=/data/sync.sqlite
-ENTRYPOINT ["/usr/local/bin/loaf", "serve", "--listen", ":8443", "--db", "/data/sync.sqlite"]
+ENTRYPOINT ["/usr/local/bin/loaf", "serve", "--listen", ":8080", "--db", "/data/sync.sqlite"]

--- a/docs/knowledge/cloud-attach-walkthrough.md
+++ b/docs/knowledge/cloud-attach-walkthrough.md
@@ -32,7 +32,7 @@ Complete these steps once on a trusted operator machine before configuring cloud
 Self-host the sync server (`loaf serve`) or use your deployed relay. The endpoint must be HTTPS in production (TLS-terminated reverse proxy is fine).
 
 ```bash
-loaf serve --listen :8443 --db /path/to/sync.sqlite
+loaf serve --listen :8080 --db /path/to/sync.sqlite
 ```
 
 ### 2. Create the substrate account

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -17,8 +18,10 @@ import (
 )
 
 type serveOptions struct {
-	listen string
-	dbPath string
+	listen  string
+	dbPath  string
+	tlsCert string
+	tlsKey  string
 }
 
 func (r Runner) runServe(args []string, out io.Writer) error {
@@ -56,7 +59,7 @@ func (r Runner) runServe(args []string, out io.Writer) error {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- httpSrv.ListenAndServe()
+		errCh <- listenAndServe(httpSrv, opts.tlsCert, opts.tlsKey)
 	}()
 
 	select {
@@ -74,9 +77,11 @@ func (r Runner) runServe(args []string, out io.Writer) error {
 }
 
 func writeServeHelp(out io.Writer) {
-	writeUsageHelp(out, "loaf serve", "Run the self-hostable sync relay (opaque blobs + token auth).",
-		"--listen <addr>   Listen address (default :8080)",
-		"--db <path>       Sync server SQLite path (default $XDG_DATA_HOME/loaf/sync.sqlite)")
+	writeUsageHelp(out, "loaf serve", "Run the self-hostable sync relay (opaque blobs + token auth). Speaks HTTP; terminate TLS at a reverse proxy or pass --tls-cert and --tls-key.",
+		"--listen <addr>     Listen address (default :8080). Ports 443 and 8443 require TLS.",
+		"--tls-cert <path>   TLS certificate file (enables HTTPS)",
+		"--tls-key <path>    TLS private key file",
+		"--db <path>         Sync server SQLite path (default $XDG_DATA_HOME/loaf/sync.sqlite)")
 }
 
 func parseServeArgs(args []string) (serveOptions, error) {
@@ -95,14 +100,60 @@ func parseServeArgs(args []string) (serveOptions, error) {
 			}
 			opts.dbPath = strings.TrimSpace(args[i+1])
 			i++
+		case "--tls-cert":
+			if i+1 >= len(args) {
+				return serveOptions{}, fmt.Errorf("serve --tls-cert requires a value")
+			}
+			opts.tlsCert = strings.TrimSpace(args[i+1])
+			i++
+		case "--tls-key":
+			if i+1 >= len(args) {
+				return serveOptions{}, fmt.Errorf("serve --tls-key requires a value")
+			}
+			opts.tlsKey = strings.TrimSpace(args[i+1])
+			i++
 		default:
 			return serveOptions{}, fmt.Errorf("serve: unknown option %q", args[i])
 		}
 	}
-	if opts.listen == "" {
-		return serveOptions{}, fmt.Errorf("serve --listen cannot be empty")
+	if err := opts.validate(); err != nil {
+		return serveOptions{}, err
 	}
 	return opts, nil
+}
+
+func (opts serveOptions) validate() error {
+	if opts.listen == "" {
+		return fmt.Errorf("serve --listen cannot be empty")
+	}
+	hasCert := opts.tlsCert != ""
+	hasKey := opts.tlsKey != ""
+	if hasCert != hasKey {
+		return errors.New("serve --tls-cert and --tls-key must be set together")
+	}
+	if listenImpliesTLS(opts.listen) && !hasCert {
+		return fmt.Errorf("serve --listen %s requires --tls-cert and --tls-key (or bind a non-TLS port and terminate TLS at a reverse proxy)", opts.listen)
+	}
+	return nil
+}
+
+func listenImpliesTLS(addr string) bool {
+	addr = strings.TrimSpace(addr)
+	if addr == "443" || addr == "8443" {
+		return true
+	}
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	return port == "443" || port == "8443"
+}
+
+func listenAndServe(srv *http.Server, certFile, keyFile string) error {
+	if strings.TrimSpace(certFile) != "" {
+		return srv.ListenAndServeTLS(certFile, keyFile)
+	}
+	return srv.ListenAndServe()
 }
 
 func resolveServeDBPath(explicit, stateHome string) (string, error) {

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestServeListenRequiresTLS(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "8443 without certs", args: []string{"--listen", ":8443", "--db", "sync.sqlite"}, wantErr: "requires --tls-cert and --tls-key"},
+		{name: "443 without certs", args: []string{"--listen", "127.0.0.1:443", "--db", "sync.sqlite"}, wantErr: "requires --tls-cert and --tls-key"},
+		{name: "bare 8443", args: []string{"--listen", "8443", "--db", "sync.sqlite"}, wantErr: "requires --tls-cert and --tls-key"},
+		{name: "cert without key", args: []string{"--listen", ":8080", "--tls-cert", "cert.pem", "--db", "sync.sqlite"}, wantErr: "must be set together"},
+		{name: "key without cert", args: []string{"--listen", ":8080", "--tls-key", "key.pem", "--db", "sync.sqlite"}, wantErr: "must be set together"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseServeArgs(tc.args)
+			if err == nil {
+				t.Fatal("parseServeArgs() error = nil, want TLS validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("parseServeArgs() error = %q, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestServeListenAllowsCleartextHTTP(t *testing.T) {
+	t.Parallel()
+	opts, err := parseServeArgs([]string{"--listen", ":8080", "--db", "sync.sqlite"})
+	if err != nil {
+		t.Fatalf("parseServeArgs() error = %v", err)
+	}
+	if opts.listen != ":8080" {
+		t.Fatalf("listen = %q, want :8080", opts.listen)
+	}
+	opts, err = parseServeArgs([]string{"--listen", ":8443", "--tls-cert", "cert.pem", "--tls-key", "key.pem", "--db", "sync.sqlite"})
+	if err != nil {
+		t.Fatalf("parseServeArgs() with TLS files error = %v", err)
+	}
+	if opts.tlsCert != "cert.pem" || opts.tlsKey != "key.pem" {
+		t.Fatalf("tls files = %q %q, want cert.pem key.pem", opts.tlsCert, opts.tlsKey)
+	}
+}
+
+func TestSyncServerDockerfileBindsHTTP8080(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join("..", "..", "cli", "docker", "sync-server", "Dockerfile")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	body := string(data)
+	if strings.Contains(body, "8443") {
+		t.Fatal("sync-server Dockerfile still mentions 8443; bind cleartext HTTP on :8080")
+	}
+	if !strings.Contains(body, `EXPOSE 8080`) {
+		t.Fatal("sync-server Dockerfile must EXPOSE 8080")
+	}
+	if !strings.Contains(body, `":8080"`) {
+		t.Fatal("sync-server Dockerfile must listen on :8080")
+	}
+}

--- a/internal/syncserver/delete_auth_test.go
+++ b/internal/syncserver/delete_auth_test.go
@@ -1,0 +1,106 @@
+package syncserver_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/levifig/loaf/internal/syncserver"
+)
+
+func TestRelayDeleteIsScopedToOwningAccount(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	srv := syncserver.NewServer(store)
+	httpSrv := httptest.NewServer(srv.Handler())
+	defer httpSrv.Close()
+
+	projectID := "proj_owned_by_a"
+	ownerAdmin, ownerClient := bootstrapAccount(t, store, projectID, "owner-token", "owner-secret")
+	otherAdmin, _ := bootstrapAccount(t, store, "proj_owned_by_b", "other-token", "other-secret")
+
+	factID := "018f5c2a-0000-7000-8000-0000000000aa"
+	blob := []byte(`{"version":1,"fact_id":"` + factID + `","ciphertext":"opaque"}`)
+	postPush(t, httpSrv.URL+"/v1/projects/"+projectID+"/facts", ownerClient, pushRequest{
+		Blobs: []pushBlob{{FactID: factID, Blob: base64.StdEncoding.EncodeToString(blob)}},
+	})
+
+	cross := deleteFact(t, httpSrv.URL+"/v1/projects/"+projectID+"/facts/"+factID, otherAdmin)
+	if cross != http.StatusForbidden {
+		t.Fatalf("cross-account delete status = %d, want 403", cross)
+	}
+
+	bogus := deleteFact(t, httpSrv.URL+"/v1/projects/"+projectID+"/facts/"+factID, "LoafAdmin ak_missing:nope")
+	if bogus != http.StatusUnauthorized {
+		t.Fatalf("invalid admin delete status = %d, want 401", bogus)
+	}
+
+	stillThere := getPull(t, httpSrv.URL+"/v1/projects/"+projectID+"/facts?since=0", ownerClient)
+	if len(stillThere.Facts) != 1 || stillThere.Facts[0].FactID != factID {
+		t.Fatalf("pull after forbidden delete = %#v, want the fact still present", stillThere.Facts)
+	}
+
+	revokeBody, err := json.Marshal(map[string]string{"name": "owner-token"})
+	if err != nil {
+		t.Fatalf("marshal revoke: %v", err)
+	}
+	revokeReq, err := http.NewRequest(http.MethodDelete, httpSrv.URL+"/v1/admin/tokens", bytes.NewReader(revokeBody))
+	if err != nil {
+		t.Fatalf("revoke request: %v", err)
+	}
+	revokeReq.Header.Set("Authorization", ownerAdmin)
+	revokeReq.Header.Set("Content-Type", "application/json")
+	revokeResp, err := http.DefaultClient.Do(revokeReq)
+	if err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	_ = revokeResp.Body.Close()
+	if revokeResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("revoke status = %d, want 204", revokeResp.StatusCode)
+	}
+
+	owned := deleteFact(t, httpSrv.URL+"/v1/projects/"+projectID+"/facts/"+factID, ownerAdmin)
+	if owned != http.StatusNoContent {
+		t.Fatalf("owning admin delete after revoke status = %d, want 204", owned)
+	}
+	missing := deleteFact(t, httpSrv.URL+"/v1/projects/"+projectID+"/facts/"+factID, ownerAdmin)
+	if missing != http.StatusNotFound {
+		t.Fatalf("repeat delete status = %d, want 404", missing)
+	}
+}
+
+func bootstrapAccount(t *testing.T, store *syncserver.Store, projectID, tokenName, accountSecret string) (adminAuth, clientAuth string) {
+	t.Helper()
+	account, accessKeyID, err := store.CreateAccount(t.Context(), accountSecret)
+	if err != nil {
+		t.Fatalf("CreateAccount() error = %v", err)
+	}
+	_ = account
+	adminAuth = "LoafAdmin " + accessKeyID + ":" + accountSecret
+
+	token, tokenSecret, err := store.MintConnectionToken(t.Context(), accessKeyID, accountSecret, tokenName, projectID)
+	if err != nil {
+		t.Fatalf("MintConnectionToken() error = %v", err)
+	}
+	clientAuth = "LoafToken " + token.TokenID + ":" + tokenSecret
+	return adminAuth, clientAuth
+}
+
+func deleteFact(t *testing.T, url, auth string) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	req.Header.Set("Authorization", auth)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}

--- a/internal/syncserver/server.go
+++ b/internal/syncserver/server.go
@@ -177,8 +177,12 @@ func (s *Server) handlePull(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
 	projectID := strings.TrimSpace(r.PathValue("project_id"))
 	factID := strings.TrimSpace(r.PathValue("fact_id"))
-	if err := s.authorizeAdmin(r.Context(), r); err != nil {
-		writeError(w, http.StatusUnauthorized, err)
+	if err := s.authorizeAdminForProject(r.Context(), r, projectID); err != nil {
+		status := http.StatusUnauthorized
+		if errors.Is(err, errAdminProjectForbidden) {
+			status = http.StatusForbidden
+		}
+		writeError(w, status, err)
 		return
 	}
 	deleted, err := s.store.DeleteFact(r.Context(), projectID, factID)
@@ -230,6 +234,14 @@ func (s *Server) authorizeAdmin(ctx context.Context, r *http.Request) error {
 		return err
 	}
 	return s.store.AuthenticateAdmin(ctx, accessKeyID, accessSecret)
+}
+
+func (s *Server) authorizeAdminForProject(ctx context.Context, r *http.Request, projectID string) error {
+	accessKeyID, accessSecret, err := parseAdminAuthorization(r.Header.Get("Authorization"))
+	if err != nil {
+		return err
+	}
+	return s.store.AuthenticateAdminForProject(ctx, accessKeyID, accessSecret, projectID)
 }
 
 func parseConnectionAuthorization(authHeader string) (string, string, error) {

--- a/internal/syncserver/store.go
+++ b/internal/syncserver/store.go
@@ -185,7 +185,6 @@ func normalizeFactID(factID string) (string, error) {
 	return factID, nil
 }
 
-
 func (s *Store) HasKeyMaterial(ctx context.Context) (bool, error) {
 	return s.SchemaHasKeyMaterial(ctx)
 }
@@ -357,9 +356,37 @@ WHERE token_id = ?`, strings.TrimSpace(tokenID)).Scan(&storedHash, &scopedProjec
 	return nil
 }
 
+var (
+	errInvalidAccountCredentials = errors.New("invalid account credentials")
+	errAdminProjectForbidden     = errors.New("admin is not authorized for this project")
+)
+
 func (s *Store) AuthenticateAdmin(ctx context.Context, accessKeyID, accessSecret string) error {
 	if !s.verifyAccount(ctx, accessKeyID, accessSecret) {
-		return errors.New("invalid account credentials")
+		return errInvalidAccountCredentials
+	}
+	return nil
+}
+
+func (s *Store) AuthenticateAdminForProject(ctx context.Context, accessKeyID, accessSecret, projectID string) error {
+	if err := s.AuthenticateAdmin(ctx, accessKeyID, accessSecret); err != nil {
+		return err
+	}
+	projectID, err := normalizeProjectID(projectID)
+	if err != nil {
+		return err
+	}
+	var n int
+	err = s.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM connection_tokens
+WHERE account_access_key_id = ? AND project_id = ?`,
+		strings.TrimSpace(accessKeyID), projectID,
+	).Scan(&n)
+	if err != nil {
+		return fmt.Errorf("lookup admin project binding: %w", err)
+	}
+	if n == 0 {
+		return errAdminProjectForbidden
 	}
 	return nil
 }
@@ -609,7 +636,6 @@ func (s *Store) SchemaHasKeyMaterial(ctx context.Context) (bool, error) {
 	}
 	return false, rows.Err()
 }
-
 
 func sqliteDSN(path string) string {
 	values := url.Values{}


### PR DESCRIPTION
# Scope sync-server admin delete and bind HTTP off TLS ports

#183 shipped the self-hostable sync relay with two leftover Cursor Security Reviewer findings that were not addressed before merge (review at 11:49Z, merge at 11:58Z; only follow-up commit registered `serve` in a docs audit map).

HIGH: `DELETE /v1/projects/{project_id}/facts/{fact_id}` treats any valid `LoafAdmin` account as authorized. `authorizeAdmin` only checks that credentials match some `sync_accounts` row; `DeleteFact` then deletes by `project_id`/`fact_id` with no account–project binding. Token revoke is already scoped to the authenticating account. On a shared multi-account relay, another tenant can destroy another tenant's facts if they know or guess those IDs.

MEDIUM: `loaf serve` always calls `ListenAndServe` (cleartext HTTP). The distroless image still exposes and binds `:8443` with no certificates and no TLS terminator. Operators who treat that port as HTTPS (matching the slice's HTTPS framing) put `LoafToken` / `LoafAdmin` credentials on the wire.

Fix: scope admin delete to accounts that have minted a connection token for that `project_id` (revoked tokens still count as ownership). Keep `loaf serve` HTTP by default for reverse-proxy deployment; refuse ports 443 and 8443 unless `--tls-cert` and `--tls-key` are set; bind the packaged image on `:8080`.

Out of scope: namespacing `fact_blobs` by account (shared `project_id` string collision); ACME or automatic certificates; changing the reverse-proxy TLS deployment model; scratchpad channel auth; managed-product tenant isolation beyond connection-token binding.

No-gos: a global super-admin delete that still crosses accounts; keeping the image on 8443 without TLS.

## Definition of Done

- [ ] Cross-account LoafAdmin cannot delete another tenant's facts; owning account (including after token revoke) still can
- [ ] loaf serve refuses 443/8443 without TLS files; packaged image binds HTTP :8080