### PR TITLE
feat(LOAF-84): re-home decision issues to ledger facts

### DIFF
--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -130,6 +130,8 @@ func (r Runner) runIssue(args []string, out io.Writer, runtime state.Runtime) er
 		return r.runIssueLink(args[1:], out, runtime)
 	case "render":
 		return r.runIssueRender(args[1:], out, runtime)
+	case "rehome":
+		return r.runIssueRehome(args[1:], out, runtime)
 	case "render-out":
 		return r.runIssueRenderOut(args[1:], out, runtime)
 	case "bootstrap":
@@ -169,6 +171,7 @@ func writeIssueHelp(out io.Writer) {
 		{Name: "bucket", Summary: "Set an advisory Now/Next/Later label"},
 		{Name: "link", Summary: "Create or remove an issue relationship"},
 		{Name: "render", Summary: "Emit a paste-ready PR body"},
+		{Name: "rehome", Summary: "Re-home a decision-kind issue row to ledger question/resolution facts"},
 		{Name: "render-out", Summary: "Render an internal issue row onto a durable authority ref"},
 		{Name: "identity", Summary: "Show, define, or align the local issue prefix"},
 		{Name: "export", Summary: "Export issues, identity, criteria, claims, and relationships as JSON"},
@@ -328,6 +331,17 @@ func (r Runner) runIssueNew(args []string, out io.Writer, runtime state.Runtime)
 		options.create.Body = body
 	}
 	resolver := state.PathResolver{StateHome: r.StateHome}
+	if strings.TrimSpace(options.create.Kind) == state.IssueKindDecision {
+		record, err := state.RecordDecisionQuestion(context.Background(), projectRoot, resolver, state.DecisionRecordOptions{
+			Title:  options.create.Title,
+			Body:   options.create.Body,
+			Parent: options.create.Parent,
+		})
+		if err != nil {
+			return err
+		}
+		return r.finishDecisionNew(out, record, options)
+	}
 	created, err := r.createIssueWithIdentity(projectRoot, resolver, options.create)
 	if err != nil {
 		return err
@@ -1380,4 +1394,75 @@ func renderIssueMarkdown(result state.IssueResult) string {
 
 func issueDisplayRef(issue state.Issue) string {
 	return firstNonEmpty(issue.Alias, issue.ID)
+}
+
+func (r Runner) finishDecisionNew(out io.Writer, record state.DecisionRecord, options issueNewOptions) error {
+	if options.jsonOutput {
+		return writeJSON(out, record)
+	}
+	fmt.Fprintf(out, "recorded decision question %s\n", record.QuestionID)
+	return nil
+}
+
+func (r Runner) runIssueRehome(args []string, out io.Writer, runtime state.Runtime) error {
+	options, ref, err := parseIssueRehomeArgs(args)
+	if err != nil {
+		return err
+	}
+	projectRoot, err := r.requireIssueSQLiteState("issue rehome", runtime)
+	if err != nil {
+		return err
+	}
+	result, err := state.ReHomeDecisionIssue(context.Background(), projectRoot, state.PathResolver{StateHome: r.StateHome}, state.DecisionReHomeOptions{
+		Ref: ref, Resolution: options.resolution, DryRun: options.dryRun,
+	})
+	if err != nil {
+		return err
+	}
+	if options.jsonOutput {
+		return writeJSON(out, result)
+	}
+	fmt.Fprintf(out, "re-homed decision %s -> question %s", firstNonEmpty(result.IssueAlias, result.IssueID), result.QuestionID)
+	if result.ResolutionID != "" {
+		fmt.Fprintf(out, " + resolution %s", result.ResolutionID)
+	}
+	fmt.Fprintln(out)
+	return nil
+}
+
+type issueRehomeOptions struct {
+	resolution string
+	dryRun     bool
+	jsonOutput bool
+}
+
+func parseIssueRehomeArgs(args []string) (issueRehomeOptions, string, error) {
+	var options issueRehomeOptions
+	ref := ""
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--resolution":
+			if i+1 >= len(args) {
+				return options, "", fmt.Errorf("issue rehome --resolution requires a value")
+			}
+			i++
+			options.resolution = args[i]
+		case "--dry-run":
+			options.dryRun = true
+		case "--json":
+			options.jsonOutput = true
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return options, "", fmt.Errorf("issue rehome: unknown option %s", args[i])
+			}
+			if ref != "" {
+				return options, "", fmt.Errorf("issue rehome accepts one ref")
+			}
+			ref = args[i]
+		}
+	}
+	if ref == "" {
+		return options, "", fmt.Errorf("issue rehome requires a decision issue ref")
+	}
+	return options, ref, nil
 }

--- a/internal/cli/issue_linear_test.go
+++ b/internal/cli/issue_linear_test.go
@@ -303,9 +303,21 @@ func TestRunnerIssuePushThenReconcileHasNoFalseDescriptionDrift(t *testing.T) {
 
 func TestRunnerIssueCheckPublishesReadyForAgentThroughLinear(t *testing.T) {
 	workingDir, stateHome, fake := linearIssueCLIFixture(t)
-	out, err := runIssue(t, workingDir, stateHome, "new", "Should we ship the adapter?", "--kind", "decision")
+	root, err := project.ResolveRoot(workingDir)
 	if err != nil {
-		t.Fatalf("issue new error = %v\n%s", err, out)
+		t.Fatalf("ResolveRoot() error = %v", err)
+	}
+	legacy, err := state.CreateIssueLegacyDecisionRow(context.Background(), root, state.PathResolver{StateHome: stateHome}, state.IssueCreateOptions{
+		Title: "Should we ship the adapter?",
+		Kind:  state.IssueKindDecision,
+		Alias: "ENG-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateIssueLegacyDecisionRow() error = %v", err)
+	}
+	fake.SeedIssue("ENG-1", legacy.Title, "", "backlog", "")
+	if err := state.BindLinearIssue(context.Background(), root, state.PathResolver{StateHome: stateHome}, legacy.ID, "ENG-1", ""); err != nil {
+		t.Fatalf("BindLinearIssue() error = %v", err)
 	}
 	checkOut, err := runIssue(t, workingDir, stateHome, "check", "ENG-1", "--json")
 	if err != nil {
@@ -333,9 +345,21 @@ func TestRunnerIssueCheckAttachesConfiguredTeamLabel(t *testing.T) {
 	workingDir, stateHome, fake := linearIssueCLIFixture(t)
 	other := fake.SeedLabel("team_other", readinessLabelAgent)
 	want := fake.SeedLabel(fake.Team.ID, readinessLabelAgent)
-	out, err := runIssue(t, workingDir, stateHome, "new", "Should we ship the adapter?", "--kind", "decision")
+	root, err := project.ResolveRoot(workingDir)
 	if err != nil {
-		t.Fatalf("issue new error = %v\n%s", err, out)
+		t.Fatalf("ResolveRoot() error = %v", err)
+	}
+	legacy, err := state.CreateIssueLegacyDecisionRow(context.Background(), root, state.PathResolver{StateHome: stateHome}, state.IssueCreateOptions{
+		Title: "Should we ship the adapter?",
+		Kind:  state.IssueKindDecision,
+		Alias: "ENG-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateIssueLegacyDecisionRow() error = %v", err)
+	}
+	fake.SeedIssue("ENG-1", legacy.Title, "", "backlog", "")
+	if err := state.BindLinearIssue(context.Background(), root, state.PathResolver{StateHome: stateHome}, legacy.ID, "ENG-1", ""); err != nil {
+		t.Fatalf("BindLinearIssue() error = %v", err)
 	}
 	if _, err := runIssue(t, workingDir, stateHome, "check", "ENG-1"); err != nil {
 		t.Fatalf("issue check error = %v", err)

--- a/internal/cli/issue_readiness_test.go
+++ b/internal/cli/issue_readiness_test.go
@@ -260,26 +260,52 @@ func parsePOSIXArgv(command string) ([]string, error) {
 
 func TestRunnerIssueCheckDecisionReadyOnQuestion(t *testing.T) {
 	workingDir, stateHome := issueCLIFixture(t)
-	if _, err := runIssue(t, workingDir, stateHome, "new", "Pick a store", "--kind", "decision", "--body", "Need a direction."); err != nil {
-		t.Fatalf("issue new blank decision error = %v", err)
-	}
-	blankOut, err := runIssue(t, workingDir, stateHome, "check", "LOAF-1")
-	if err == nil {
-		t.Fatalf("blank decision check error = nil, want not ready\n%s", blankOut)
-	}
-	if !strings.Contains(blankOut, "sharp question") {
-		t.Fatalf("blank decision output = %q", blankOut)
+	if _, err := runIssue(t, workingDir, stateHome, "new", "Pick a store", "--kind", "decision", "--body", "Need a direction."); err == nil {
+		t.Fatal("issue new blank decision error = nil, want validation failure")
 	}
 
-	if _, err := runIssue(t, workingDir, stateHome, "new", "Should we keep the local store?", "--kind", "decision"); err != nil {
+	recordedOut, err := runIssue(t, workingDir, stateHome, "new", "Should we keep the local store?", "--kind", "decision")
+	if err != nil {
 		t.Fatalf("issue new question error = %v", err)
 	}
-	readyOut, err := runIssue(t, workingDir, stateHome, "check", "LOAF-2")
-	if err != nil {
-		t.Fatalf("question decision check error = %v\n%s", err, readyOut)
+	if !strings.Contains(recordedOut, "recorded decision question") {
+		t.Fatalf("question decision output = %q", recordedOut)
 	}
-	if !strings.Contains(readyOut, "issue LOAF-2 is ready") {
-		t.Fatalf("question decision output = %q", readyOut)
+
+	root, err := project.ResolveRoot(workingDir)
+	if err != nil {
+		t.Fatalf("ResolveRoot() error = %v", err)
+	}
+	resolver := state.PathResolver{StateHome: stateHome}
+	legacyBlank, err := state.CreateIssueLegacyDecisionRow(context.Background(), root, resolver, state.IssueCreateOptions{
+		Title: "Pick a store",
+		Kind:  state.IssueKindDecision,
+		Body:  "Need a direction.",
+	})
+	if err != nil {
+		t.Fatalf("CreateIssueLegacyDecisionRow(blank) error = %v", err)
+	}
+	blankOut, err := runIssue(t, workingDir, stateHome, "check", legacyBlank.Alias)
+	if err == nil {
+		t.Fatalf("blank legacy decision check error = nil, want not ready\n%s", blankOut)
+	}
+	if !strings.Contains(blankOut, "sharp question") {
+		t.Fatalf("blank legacy decision output = %q", blankOut)
+	}
+
+	legacyQuestion, err := state.CreateIssueLegacyDecisionRow(context.Background(), root, resolver, state.IssueCreateOptions{
+		Title: "Should we keep the local store?",
+		Kind:  state.IssueKindDecision,
+	})
+	if err != nil {
+		t.Fatalf("CreateIssueLegacyDecisionRow(question) error = %v", err)
+	}
+	readyOut, err := runIssue(t, workingDir, stateHome, "check", legacyQuestion.Alias)
+	if err != nil {
+		t.Fatalf("legacy question decision check error = %v\n%s", err, readyOut)
+	}
+	if !strings.Contains(readyOut, "is ready") {
+		t.Fatalf("legacy question decision output = %q", readyOut)
 	}
 }
 
@@ -358,21 +384,15 @@ func TestRunnerIssueCheckPublishesThroughReadinessSeam(t *testing.T) {
 	if _, err := state.SetIssueIdentity(context.Background(), root, state.PathResolver{StateHome: stateHome}, state.IssueIdentityOptions{Authority: state.IssueAuthorityGitHub}); err != nil {
 		t.Fatalf("SetIssueIdentity() error = %v", err)
 	}
-	if _, err := runIssue(t, workingDir, stateHome, "new", "Should we publish readiness?", "--kind", "decision"); err != nil {
-		t.Fatalf("issue new error = %v", err)
-	}
-	listOut, err := runIssue(t, workingDir, stateHome, "list", "--json")
+	resolver := state.PathResolver{StateHome: stateHome}
+	legacy, err := state.CreateIssueLegacyDecisionRow(context.Background(), root, resolver, state.IssueCreateOptions{
+		Title: "Should we publish readiness?",
+		Kind:  state.IssueKindDecision,
+	})
 	if err != nil {
-		t.Fatalf("issue list error = %v", err)
+		t.Fatalf("CreateIssueLegacyDecisionRow() error = %v", err)
 	}
-	var listed state.IssueListResult
-	if err := json.Unmarshal([]byte(listOut), &listed); err != nil {
-		t.Fatalf("list json error = %v", err)
-	}
-	if len(listed.Issues) != 1 {
-		t.Fatalf("listed = %#v, want one issue", listed)
-	}
-	ref := listed.Issues[0].ID
+	ref := legacy.ID
 
 	fake := &recordingReadinessPublisher{}
 	previous := defaultReadinessPublisher

--- a/internal/cli/issue_test.go
+++ b/internal/cli/issue_test.go
@@ -235,8 +235,16 @@ func TestRunnerIssueStatusHonorsRemovalSemantics(t *testing.T) {
 
 func TestRunnerIssueListDodPromoteBucketExportAndHelp(t *testing.T) {
 	workingDir, stateHome := issueCLIFixture(t)
-	if _, err := runIssue(t, workingDir, stateHome, "new", "Listed", "--kind", "decision", "--fog", "still fuzzy"); err != nil {
-		t.Fatalf("issue new listed error = %v", err)
+	root, err := project.ResolveRoot(workingDir)
+	if err != nil {
+		t.Fatalf("ResolveRoot() error = %v", err)
+	}
+	if _, err := state.CreateIssueLegacyDecisionRow(context.Background(), root, state.PathResolver{StateHome: stateHome}, state.IssueCreateOptions{
+		Title: "Should we list?",
+		Kind:  state.IssueKindDecision,
+		Fog:   "still fuzzy",
+	}); err != nil {
+		t.Fatalf("CreateIssueLegacyDecisionRow() error = %v", err)
 	}
 	if _, err := runIssue(t, workingDir, stateHome, "new", "Other"); err != nil {
 		t.Fatalf("issue new other error = %v", err)

--- a/internal/state/issue.go
+++ b/internal/state/issue.go
@@ -256,6 +256,9 @@ func createIssueTx(ctx context.Context, tx *sql.Tx, projectID string, options Is
 	if err != nil {
 		return Issue{}, err
 	}
+	if kind == IssueKindDecision {
+		return createDecisionLedgerIssueTx(ctx, tx, projectID, options, now)
+	}
 	criteria, err := normalizeIssueCriteria(options.Criteria)
 	if err != nil {
 		return Issue{}, err

--- a/internal/state/issue_decision.go
+++ b/internal/state/issue_decision.go
@@ -1,0 +1,473 @@
+package state
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/levifig/loaf/internal/project"
+)
+
+const (
+	JournalEntryTypeQuestion   = "question"
+	JournalEntryTypeResolution = "resolution"
+
+	DecisionReHomeOriginKind = "decision-rehome"
+)
+
+// DecisionRecordOptions describes a ledger-stored decision question.
+type DecisionRecordOptions struct {
+	Title  string
+	Body   string
+	Parent string
+	Scope  string
+}
+
+// DecisionRecord is the ledger projection for a decision question.
+type DecisionRecord struct {
+	ContractVersion    int    `json:"contract_version,omitempty"`
+	DatabaseScope      string `json:"database_scope,omitempty"`
+	DatabasePath       string `json:"database_path,omitempty"`
+	ProjectID          string `json:"project_id,omitempty"`
+	ProjectName        string `json:"project_name,omitempty"`
+	ProjectCurrentPath string `json:"project_current_path,omitempty"`
+	QuestionID         string `json:"question_id"`
+	ResolutionID       string `json:"resolution_id,omitempty"`
+	Scope              string `json:"scope"`
+	Question           string `json:"question"`
+	Resolution         string `json:"resolution,omitempty"`
+	Kind               string `json:"kind"`
+}
+
+// DecisionReHomeOptions controls migration of one decision-kind issue row.
+type DecisionReHomeOptions struct {
+	Ref        string
+	Resolution string
+	DryRun     bool
+}
+
+// DecisionReHomeResult reports ledger facts created from a retired issue row.
+type DecisionReHomeResult struct {
+	ContractVersion    int    `json:"contract_version,omitempty"`
+	DatabaseScope      string `json:"database_scope,omitempty"`
+	DatabasePath       string `json:"database_path,omitempty"`
+	ProjectID          string `json:"project_id,omitempty"`
+	ProjectName        string `json:"project_name,omitempty"`
+	ProjectCurrentPath string `json:"project_current_path,omitempty"`
+	IssueID            string `json:"issue_id"`
+	IssueAlias         string `json:"issue_alias,omitempty"`
+	QuestionID         string `json:"question_id"`
+	ResolutionID       string `json:"resolution_id,omitempty"`
+	Scope              string `json:"scope"`
+	Question           string `json:"question"`
+	Resolution         string `json:"resolution,omitempty"`
+	Retired            bool   `json:"retired"`
+	Action             string `json:"action"`
+}
+
+// RecordDecisionQuestion writes a decision question to the ledger without minting an issue row.
+func RecordDecisionQuestion(ctx context.Context, root project.Root, resolver PathResolver, options DecisionRecordOptions) (DecisionRecord, error) {
+	store, err := openProjectStoreMutateExisting(ctx, root, resolver)
+	if err != nil {
+		return DecisionRecord{}, err
+	}
+	defer store.Close()
+	return store.RecordDecisionQuestion(ctx, root, options)
+}
+
+func (s *Store) RecordDecisionQuestion(ctx context.Context, root project.Root, options DecisionRecordOptions) (DecisionRecord, error) {
+	projectID, err := s.projectID(ctx, root)
+	if err != nil {
+		return DecisionRecord{}, err
+	}
+	identity, err := s.projectIdentity(ctx, projectID)
+	if err != nil {
+		return DecisionRecord{}, err
+	}
+	question, err := normalizeDecisionQuestion(options.Title, options.Body)
+	if err != nil {
+		return DecisionRecord{}, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return DecisionRecord{}, fmt.Errorf("begin decision question: %w", err)
+	}
+	defer tx.Rollback()
+
+	scope, err := decisionScopeTx(ctx, tx, projectID, options.Scope, options.Parent)
+	if err != nil {
+		return DecisionRecord{}, err
+	}
+	nowTime := time.Now().UTC()
+	questionID, err := appendDecisionJournalFactTx(ctx, tx, projectID, scope, question, JournalEntryTypeQuestion, nowTime, "", "")
+	if err != nil {
+		return DecisionRecord{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return DecisionRecord{}, fmt.Errorf("commit decision question: %w", err)
+	}
+	return DecisionRecord{
+		ContractVersion:    StateJSONContractVersion,
+		DatabaseScope:      identity.DatabaseScope,
+		DatabasePath:       identity.DatabasePath,
+		ProjectID:          identity.ID,
+		ProjectName:        identity.FriendlyName,
+		ProjectCurrentPath: identity.CurrentPath,
+		QuestionID:         questionID,
+		Scope:              scope,
+		Question:           question,
+		Kind:               IssueKindDecision,
+	}, nil
+}
+
+// ReHomeDecisionIssue migrates one decision-kind issue row to ledger question/resolution facts.
+func ReHomeDecisionIssue(ctx context.Context, root project.Root, resolver PathResolver, options DecisionReHomeOptions) (DecisionReHomeResult, error) {
+	store, err := openProjectStoreMutateExisting(ctx, root, resolver)
+	if err != nil {
+		return DecisionReHomeResult{}, err
+	}
+	defer store.Close()
+	return store.ReHomeDecisionIssue(ctx, root, options)
+}
+
+func (s *Store) ReHomeDecisionIssue(ctx context.Context, root project.Root, options DecisionReHomeOptions) (DecisionReHomeResult, error) {
+	ref := strings.TrimSpace(options.Ref)
+	if ref == "" {
+		return DecisionReHomeResult{}, fmt.Errorf("decision re-home requires an issue ref")
+	}
+	projectID, err := s.projectID(ctx, root)
+	if err != nil {
+		return DecisionReHomeResult{}, err
+	}
+	identity, err := s.projectIdentity(ctx, projectID)
+	if err != nil {
+		return DecisionReHomeResult{}, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return DecisionReHomeResult{}, fmt.Errorf("begin decision re-home: %w", err)
+	}
+	defer tx.Rollback()
+
+	issueID, issueAlias, err := resolveIssueRefTx(ctx, tx, projectID, ref)
+	if err != nil {
+		return DecisionReHomeResult{}, err
+	}
+	issue, err := loadIssueTx(ctx, tx, projectID, issueID)
+	if err != nil {
+		return DecisionReHomeResult{}, err
+	}
+	if issue.Kind != IssueKindDecision {
+		return DecisionReHomeResult{}, fmt.Errorf("issue %s is kind %q; decision re-home applies only to decision-kind rows", firstNonEmpty(issueAlias, ref), issue.Kind)
+	}
+	if issue.ArchivedAt != "" {
+		return DecisionReHomeResult{}, fmt.Errorf("issue %s is already archived", firstNonEmpty(issueAlias, ref))
+	}
+	question, err := normalizeDecisionQuestion(issue.Title, issue.Body)
+	if err != nil {
+		return DecisionReHomeResult{}, err
+	}
+	parentRef := ""
+	if issue.ParentID != "" {
+		parentRef = issue.ParentID
+	}
+	scope, err := decisionScopeTx(ctx, tx, projectID, "", parentRef)
+	if err != nil {
+		return DecisionReHomeResult{}, err
+	}
+	resolution := strings.TrimSpace(options.Resolution)
+	if resolution == "" && issue.Status == IssueStatusDone {
+		resolution = decisionResolutionFromBody(issue.Title, issue.Body)
+	}
+
+	result := DecisionReHomeResult{
+		ContractVersion:    StateJSONContractVersion,
+		DatabaseScope:      identity.DatabaseScope,
+		DatabasePath:       identity.DatabasePath,
+		ProjectID:          identity.ID,
+		ProjectName:        identity.FriendlyName,
+		ProjectCurrentPath: identity.CurrentPath,
+		IssueID:            issue.ID,
+		IssueAlias:         issueAlias,
+		Scope:              scope,
+		Question:           question,
+		Resolution:         resolution,
+		Action:             "applied",
+	}
+	if options.DryRun {
+		result.Action = "dry-run"
+		return result, nil
+	}
+
+	nowTime := time.Now().UTC()
+	now := nowTime.Format(time.RFC3339Nano)
+	originIssueID := issue.ID
+	questionID, err := appendDecisionJournalFactTx(ctx, tx, projectID, scope, question, JournalEntryTypeQuestion, nowTime, DecisionReHomeOriginKind, originIssueID)
+	if err != nil {
+		return DecisionReHomeResult{}, err
+	}
+	result.QuestionID = questionID
+
+	if resolution != "" {
+		resolutionID, err := appendDecisionJournalFactTx(ctx, tx, projectID, scope, resolution, JournalEntryTypeResolution, nowTime, DecisionReHomeOriginKind, originIssueID)
+		if err != nil {
+			return DecisionReHomeResult{}, err
+		}
+		result.ResolutionID = resolutionID
+	}
+
+	archivedAt := now
+	if _, err := tx.ExecContext(ctx, `
+UPDATE issues SET status = ?, archived_at = ?, updated_at = ? WHERE project_id = ? AND id = ?
+`, IssueStatusCancelled, archivedAt, now, projectID, issue.ID); err != nil {
+		return DecisionReHomeResult{}, fmt.Errorf("retire re-homed decision issue: %w", err)
+	}
+	if issue.Status != IssueStatusCancelled {
+		if _, err := insertIssueStatusEventTx(ctx, tx, projectID, issue.ID, issue.Status, IssueStatusCancelled, "re-homed to ledger question/resolution facts", now); err != nil {
+			return DecisionReHomeResult{}, err
+		}
+	}
+	result.Retired = true
+
+	if err := tx.Commit(); err != nil {
+		return DecisionReHomeResult{}, fmt.Errorf("commit decision re-home: %w", err)
+	}
+	return result, nil
+}
+
+func normalizeDecisionQuestion(title, body string) (string, error) {
+	title = strings.TrimSpace(title)
+	body = strings.TrimSpace(body)
+	if !decisionHasQuestion(title, body) {
+		return "", &IssueValidationError{Field: "question", Err: fmt.Errorf("decision needs a sharp question (a '?' in the title or body)")}
+	}
+	switch {
+	case title == "":
+		return body, nil
+	case body == "" || body == title:
+		return title, nil
+	default:
+		return title + "\n\n" + body, nil
+	}
+}
+
+func decisionHasQuestion(title, body string) bool {
+	return strings.Contains(title, "?") || strings.Contains(body, "?")
+}
+
+func decisionResolutionFromBody(title, body string) string {
+	body = strings.TrimSpace(body)
+	title = strings.TrimSpace(title)
+	switch {
+	case body == "":
+		return ""
+	case body == title:
+		return ""
+	case strings.Contains(body, "?"):
+		return ""
+	default:
+		return body
+	}
+}
+
+func decisionScopeTx(ctx context.Context, tx *sql.Tx, projectID, explicitScope, parentRef string) (string, error) {
+	if scope := strings.TrimSpace(explicitScope); scope != "" {
+		return scope, nil
+	}
+	parentRef = strings.TrimSpace(parentRef)
+	if parentRef == "" {
+		return "project", nil
+	}
+	if IsAuthorityRef(parentRef) {
+		ref, err := ParseAuthorityRef(parentRef)
+		if err != nil {
+			return "", err
+		}
+		return ref.String(), nil
+	}
+	parentID, parentAlias, err := resolveIssueRefTx(ctx, tx, projectID, parentRef)
+	if err != nil {
+		return "", err
+	}
+	if authorityRef, ok, err := lookupAuthorityRefForIssueTx(ctx, tx, projectID, parentID); err != nil {
+		return "", err
+	} else if ok {
+		return authorityRef.String(), nil
+	}
+	parent, err := loadIssueTx(ctx, tx, projectID, parentID)
+	if err != nil {
+		return "", err
+	}
+	if branch := strings.TrimSpace(parent.StartedBranch); branch != "" {
+		return AuthorityRef{Provider: AuthorityProviderBranch, Key: branch}.String(), nil
+	}
+	if parentAlias != "" {
+		return parentAlias, nil
+	}
+	return "project", nil
+}
+
+func lookupAuthorityRefForIssueTx(ctx context.Context, tx *sql.Tx, projectID, issueID string) (AuthorityRef, bool, error) {
+	var provider, key string
+	err := tx.QueryRowContext(ctx, `
+SELECT provider, provider_ref
+FROM work_contract_mappings
+WHERE project_id = ? AND mapping_kind = ? AND mapping_value = ?
+LIMIT 1
+`, projectID, RenderOutMappingIssueID, issueID).Scan(&provider, &key)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AuthorityRef{}, false, nil
+	}
+	if err != nil {
+		return AuthorityRef{}, false, fmt.Errorf("lookup authority ref for issue %q: %w", issueID, err)
+	}
+	return AuthorityRef{Provider: provider, Key: key}, true, nil
+}
+
+func appendDecisionJournalFactTx(ctx context.Context, tx *sql.Tx, projectID, scope, message, entryType string, nowTime time.Time, originKind, originID string) (string, error) {
+	now := nowTime.Format(time.RFC3339Nano)
+	id, err := mintFactID(nowTime)
+	if err != nil {
+		return "", err
+	}
+	payload := JournalFactPayload{
+		EntryType: entryType,
+		Scope:     scope,
+		Message:   message,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if _, err := appendJournalFactTx(ctx, tx, projectID, id, payload, nowTime); err != nil {
+		return "", err
+	}
+	if err := insertJournalProjectionTx(ctx, tx, projectID, id, payload); err != nil {
+		return "", err
+	}
+	if err := insertJournalSearchTx(ctx, tx, projectID, id, "", entryType, scope, message); err != nil {
+		return "", err
+	}
+	if originKind != "" && originID != "" {
+		if err := insertJournalOriginTx(ctx, tx, id, JournalOriginInput{
+			EnvelopeVersion:   JournalOriginEnvelopeVersion,
+			CaptureMechanism:  JournalOriginMechanismMigration,
+			DurableResultKind: originKind,
+			DurableResultID:   originID,
+		}); err != nil {
+			return "", err
+		}
+	}
+	return id, nil
+}
+
+func createDecisionLedgerIssueTx(ctx context.Context, tx *sql.Tx, projectID string, options IssueCreateOptions, now string) (Issue, error) {
+	question, err := normalizeDecisionQuestion(options.Title, options.Body)
+	if err != nil {
+		return Issue{}, err
+	}
+	scope, err := decisionScopeTx(ctx, tx, projectID, "", options.Parent)
+	if err != nil {
+		return Issue{}, err
+	}
+	nowTime, err := time.Parse(time.RFC3339Nano, now)
+	if err != nil {
+		return Issue{}, fmt.Errorf("parse decision timestamp: %w", err)
+	}
+	questionID, err := appendDecisionJournalFactTx(ctx, tx, projectID, scope, question, JournalEntryTypeQuestion, nowTime, "", "")
+	if err != nil {
+		return Issue{}, err
+	}
+	return Issue{
+		ID:        questionID,
+		Kind:      IssueKindDecision,
+		Title:     strings.TrimSpace(options.Title),
+		Body:      options.Body,
+		Status:    IssueStatusTriage,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}, nil
+}
+
+// CreateIssueLegacyDecisionRow inserts a decision-kind issue row for tests and
+// legacy migration scenarios. New decision questions should use RecordDecisionQuestion.
+func CreateIssueLegacyDecisionRow(ctx context.Context, root project.Root, resolver PathResolver, options IssueCreateOptions) (Issue, error) {
+	store, err := openProjectStoreMutateExisting(ctx, root, resolver)
+	if err != nil {
+		return Issue{}, err
+	}
+	defer store.Close()
+	return store.CreateIssueLegacyDecisionRow(ctx, root, options)
+}
+
+func (s *Store) CreateIssueLegacyDecisionRow(ctx context.Context, root project.Root, options IssueCreateOptions) (Issue, error) {
+	projectID, err := s.projectID(ctx, root)
+	if err != nil {
+		return Issue{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return Issue{}, &IssueTransactionError{Stage: "begin", Err: err}
+	}
+	defer tx.Rollback()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	issue, err := createLegacyDecisionIssueTx(ctx, tx, projectID, options, now)
+	if err != nil {
+		return Issue{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Issue{}, &IssueTransactionError{Stage: "commit", Err: err}
+	}
+	return issue, nil
+}
+
+func createLegacyDecisionIssueTx(ctx context.Context, tx *sql.Tx, projectID string, options IssueCreateOptions, now string) (Issue, error) {
+	title, err := normalizeIssueTitle(options.Title)
+	if err != nil {
+		return Issue{}, err
+	}
+	kind, err := normalizeIssueKind(options.Kind)
+	if err != nil {
+		return Issue{}, err
+	}
+	if kind != IssueKindDecision {
+		return Issue{}, &IssueValidationError{Field: "kind", Err: fmt.Errorf("legacy decision row helper requires decision kind")}
+	}
+	issueID, err := newOpaqueStateID("issue")
+	if err != nil {
+		return Issue{}, &IssueTransactionError{Stage: "id", Err: err}
+	}
+	parentID := ""
+	if strings.TrimSpace(options.Parent) != "" {
+		parentID, _, err = resolveIssueRefTx(ctx, tx, projectID, options.Parent)
+		if err != nil {
+			return Issue{}, err
+		}
+	}
+	alias := strings.TrimSpace(options.Alias)
+	if alias == "" {
+		alias, err = mintLocalIssueAliasTx(ctx, tx, projectID, now)
+		if err != nil {
+			return Issue{}, err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO issues (id, project_id, parent_id, kind, title, body, fog, status, archived_at, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
+`, issueID, projectID, emptyToNil(parentID), kind, title, options.Body, emptyToNil(strings.TrimSpace(options.Fog)), IssueStatusTriage, now, now); err != nil {
+		return Issue{}, &IssueTransactionError{Stage: "issue", Err: err}
+	}
+	if alias != "" {
+		if err := insertAlias(ctx, tx, projectID, issueEntityKind, issueID, issueNamespace, alias, now); err != nil {
+			return Issue{}, &IssueTransactionError{Stage: "alias", Err: err}
+		}
+	}
+	if _, err := insertIssueStatusEventTx(ctx, tx, projectID, issueID, "", IssueStatusTriage, "recorded by legacy decision create", now); err != nil {
+		return Issue{}, err
+	}
+	return loadIssueTx(ctx, tx, projectID, issueID)
+}
+

--- a/internal/state/issue_decision_test.go
+++ b/internal/state/issue_decision_test.go
@@ -1,0 +1,190 @@
+package state_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/levifig/loaf/internal/project"
+	"github.com/levifig/loaf/internal/state"
+)
+
+func TestRecordDecisionQuestionWritesLedgerWithoutIssueRow(t *testing.T) {
+	ctx := context.Background()
+	root, resolver, stateHome := decisionFixture(t)
+
+	record, err := state.RecordDecisionQuestion(ctx, root, resolver, state.DecisionRecordOptions{
+		Title: "Should tokens live in httpOnly cookies?",
+	})
+	if err != nil {
+		t.Fatalf("RecordDecisionQuestion() error = %v", err)
+	}
+	if record.QuestionID == "" || record.Scope != "project" {
+		t.Fatalf("record = %#v", record)
+	}
+
+	store := openDecisionStore(t, root, resolver, stateHome)
+	defer store.Close()
+	if got := countQuery(t, store, `SELECT COUNT(*) FROM issues WHERE kind = ?`, state.IssueKindDecision); got != 0 {
+		t.Fatalf("issues decision rows = %d, want 0", got)
+	}
+	if got := countQuery(t, store, `SELECT COUNT(*) FROM journal_entries WHERE id = ? AND entry_type = ? AND scope = ?`, record.QuestionID, state.JournalEntryTypeQuestion, "project"); got != 1 {
+		t.Fatalf("question projection rows = %d, want 1", got)
+	}
+	if got := countQuery(t, store, `SELECT COUNT(*) FROM facts WHERE id = ? AND kind = ?`, record.QuestionID, state.FactKindJournal); got != 1 {
+		t.Fatalf("question fact rows = %d, want 1", got)
+	}
+}
+
+func TestRecordDecisionQuestionRequiresSharpQuestion(t *testing.T) {
+	ctx := context.Background()
+	root, resolver, _ := decisionFixture(t)
+
+	if _, err := state.RecordDecisionQuestion(ctx, root, resolver, state.DecisionRecordOptions{
+		Title: "Pick a store",
+		Body:  "Need a direction.",
+	}); err == nil {
+		t.Fatal("RecordDecisionQuestion() error = nil, want sharp question validation")
+	}
+}
+
+func TestReHomeDecisionIssueCreatesQuestionAndRetiresRow(t *testing.T) {
+	ctx := context.Background()
+	root, resolver, stateHome := decisionFixture(t)
+
+	created, err := state.CreateIssueLegacyDecisionRow(ctx, root, resolver, state.IssueCreateOptions{
+		Title: "Should we keep SQLite?",
+		Kind:  state.IssueKindDecision,
+	})
+	if err != nil {
+		t.Fatalf("CreateIssueLegacyDecisionRow() error = %v", err)
+	}
+
+	result, err := state.ReHomeDecisionIssue(ctx, root, resolver, state.DecisionReHomeOptions{Ref: created.Alias})
+	if err != nil {
+		t.Fatalf("ReHomeDecisionIssue() error = %v", err)
+	}
+	if !result.Retired || result.QuestionID == "" || result.ResolutionID != "" {
+		t.Fatalf("result = %#v", result)
+	}
+
+	store := openDecisionStore(t, root, resolver, stateHome)
+	defer store.Close()
+	if got := countQuery(t, store, `SELECT COUNT(*) FROM issues WHERE id = ? AND archived_at IS NOT NULL`, created.ID); got != 1 {
+		t.Fatalf("archived issue rows = %d, want 1", got)
+	}
+	if got := countQuery(t, store, `SELECT COUNT(*) FROM journal_entries WHERE id = ? AND entry_type = ?`, result.QuestionID, state.JournalEntryTypeQuestion); got != 1 {
+		t.Fatalf("question rows = %d, want 1", got)
+	}
+}
+
+func TestReHomeDecisionIssueCreatesResolutionWhenDone(t *testing.T) {
+	ctx := context.Background()
+	root, resolver, _ := decisionFixture(t)
+
+	created, err := state.CreateIssueLegacyDecisionRow(ctx, root, resolver, state.IssueCreateOptions{
+		Title: "Should we keep SQLite?",
+		Body:  "Yes — single-writer local store stays canonical.",
+		Kind:  state.IssueKindDecision,
+	})
+	if err != nil {
+		t.Fatalf("CreateIssueLegacyDecisionRow() error = %v", err)
+	}
+	if _, err := state.UpdateIssue(ctx, root, resolver, state.IssueUpdateOptions{
+		Ref: created.Alias, Status: state.IssueStatusDone, SetStatus: true,
+	}); err != nil {
+		t.Fatalf("UpdateIssue() error = %v", err)
+	}
+
+	result, err := state.ReHomeDecisionIssue(ctx, root, resolver, state.DecisionReHomeOptions{Ref: created.Alias})
+	if err != nil {
+		t.Fatalf("ReHomeDecisionIssue() error = %v", err)
+	}
+	if result.ResolutionID == "" {
+		t.Fatalf("result = %#v, want resolution fact", result)
+	}
+}
+
+func TestReHomeDecisionIssueRefusesDeliveryKind(t *testing.T) {
+	ctx := context.Background()
+	root, resolver, _ := decisionFixture(t)
+
+	created, err := state.CreateIssue(ctx, root, resolver, state.IssueCreateOptions{
+		Title: "Delivery row",
+		Kind:  state.IssueKindDelivery,
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+	if _, err := state.ReHomeDecisionIssue(ctx, root, resolver, state.DecisionReHomeOptions{Ref: created.Alias}); err == nil {
+		t.Fatal("ReHomeDecisionIssue() error = nil, want refusal")
+	}
+}
+
+func TestCreateIssueDecisionKindDoesNotMintTrackerRow(t *testing.T) {
+	ctx := context.Background()
+	root, resolver, stateHome := decisionFixture(t)
+
+	created, err := state.CreateIssue(ctx, root, resolver, state.IssueCreateOptions{
+		Title: "Should we ship v1 now?",
+		Kind:  state.IssueKindDecision,
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+	if created.ID == "" || created.Alias != "" {
+		t.Fatalf("created = %#v, want journal id without alias", created)
+	}
+
+	store := openDecisionStore(t, root, resolver, stateHome)
+	defer store.Close()
+	if got := countQuery(t, store, `SELECT COUNT(*) FROM issues WHERE id = ?`, created.ID); got != 0 {
+		t.Fatalf("issue rows for ledger decision = %d, want 0", got)
+	}
+	if got := countQuery(t, store, `SELECT COUNT(*) FROM journal_entries WHERE id = ? AND entry_type = ?`, created.ID, state.JournalEntryTypeQuestion); got != 1 {
+		t.Fatalf("question rows = %d, want 1", got)
+	}
+}
+
+func decisionFixture(t *testing.T) (project.Root, state.PathResolver, string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	stateHome := t.TempDir()
+	t.Setenv("LOAF_DB", filepath.Join(stateHome, "loaf.sqlite"))
+	root, err := project.ResolveRoot(dir)
+	if err != nil {
+		t.Fatalf("ResolveRoot() error = %v", err)
+	}
+	resolver := state.PathResolver{StateHome: stateHome}
+	ctx := context.Background()
+	if _, err := state.Initialize(ctx, root, resolver); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	return root, resolver, stateHome
+}
+
+func openDecisionStore(t *testing.T, root project.Root, resolver state.PathResolver, stateHome string) *state.Store {
+	t.Helper()
+	status, err := state.Inspect(root, resolver)
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	store, err := state.OpenStoreReadOnly(status.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStoreReadOnly() error = %v", err)
+	}
+	return store
+}
+
+func countQuery(t *testing.T, store *state.Store, query string, args ...any) int {
+	t.Helper()
+	var count int
+	if err := store.QueryRowContext(context.Background(), query, args...).Scan(&count); err != nil {
+		t.Fatalf("count query error = %v", err)
+	}
+	return count
+}

--- a/internal/state/issue_query_test.go
+++ b/internal/state/issue_query_test.go
@@ -14,7 +14,7 @@ func TestListIssuesFiltersStatusKindAndArchived(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateIssue(delivery) error = %v", err)
 	}
-	if _, err := store.CreateIssue(ctx, root, IssueCreateOptions{Title: "Decision", Kind: IssueKindDecision}); err != nil {
+	if _, err := store.CreateIssueLegacyDecisionRow(ctx, root, IssueCreateOptions{Title: "Should we ship?", Kind: IssueKindDecision}); err != nil {
 		t.Fatalf("CreateIssue(decision) error = %v", err)
 	}
 	if _, err := store.UpdateIssue(ctx, root, IssueUpdateOptions{Ref: delivery.ID, Status: IssueStatusTodo, SetStatus: true}); err != nil {
@@ -48,7 +48,7 @@ func TestListIssuesFiltersStatusKindAndArchived(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListIssues(decision) error = %v", err)
 	}
-	if len(decisions.Issues) != 1 || decisions.Issues[0].Title != "Decision" {
+	if len(decisions.Issues) != 1 || decisions.Issues[0].Title != "Should we ship?" {
 		t.Fatalf("decision list = %#v, want Decision", decisions.Issues)
 	}
 

--- a/internal/state/issue_readiness_test.go
+++ b/internal/state/issue_readiness_test.go
@@ -164,7 +164,7 @@ func TestDecisionIssueReadyOnSharpQuestion(t *testing.T) {
 	root, store := issueTestFixture(t)
 	ctx := context.Background()
 
-	blank, err := store.CreateIssue(ctx, root, IssueCreateOptions{
+	blank, err := store.CreateIssueLegacyDecisionRow(ctx, root, IssueCreateOptions{
 		Title: "Pick a store",
 		Kind:  IssueKindDecision,
 		Body:  "Need a direction.",
@@ -183,7 +183,7 @@ func TestDecisionIssueReadyOnSharpQuestion(t *testing.T) {
 		t.Fatalf("blank failures = %#v, want no_question only", notReady.Failures)
 	}
 
-	question, err := store.CreateIssue(ctx, root, IssueCreateOptions{
+	question, err := store.CreateIssueLegacyDecisionRow(ctx, root, IssueCreateOptions{
 		Title: "Should we keep the local store?",
 		Kind:  IssueKindDecision,
 	})

--- a/internal/state/issue_test.go
+++ b/internal/state/issue_test.go
@@ -62,20 +62,20 @@ func TestIssueCreateMintsLocalAliasFromPrefix(t *testing.T) {
 		t.Fatalf("first = %#v, want LOAF-1 triage delivery", first)
 	}
 
-	second, err := store.CreateIssue(ctx, root, IssueCreateOptions{Title: "Second issue", Kind: IssueKindDecision})
+	second, err := store.CreateIssue(ctx, root, IssueCreateOptions{Title: "Should this mint an alias?", Kind: IssueKindDecision})
 	if err != nil {
 		t.Fatalf("CreateIssue(second) error = %v", err)
 	}
-	if second.Alias != "LOAF-2" {
-		t.Fatalf("second alias = %q, want LOAF-2", second.Alias)
+	if second.Alias != "" {
+		t.Fatalf("second alias = %q, want empty ledger decision", second.Alias)
 	}
 
 	after, err := store.GetIssueIdentity(ctx, root)
 	if err != nil {
 		t.Fatalf("GetIssueIdentity() error = %v", err)
 	}
-	if after.NextNumber != 3 {
-		t.Fatalf("next_number = %d, want 3", after.NextNumber)
+	if after.NextNumber != 2 {
+		t.Fatalf("next_number = %d, want 2 (decision questions skip alias mint)", after.NextNumber)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `loaf issue new --kind decision` records a ledger **question** journal fact (no internal issue row / alias mint)
- `loaf issue rehome <ref>` migrates legacy decision-kind rows to question (+ resolution when done) facts and retires the issue row
- Parent scope resolves via render-out authority ref, started branch, or issue alias; standalone decisions attach to project ledger

## Test plan
- [x] `go test ./internal/state/...`
- [x] Targeted CLI tests for decision new/rehome and legacy row compatibility
- [ ] CI green before merge