### PR TITLE
fix: scope scratchpad prune to the owning account

### DIFF
--- a/internal/syncserver/scratchpad_prune_auth_test.go
+++ b/internal/syncserver/scratchpad_prune_auth_test.go
@@ -1,0 +1,150 @@
+package syncserver_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/levifig/loaf/internal/syncserver"
+)
+
+func TestScratchpadPruneIsScopedToOwningAccount(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	defer store.Close()
+	srv := syncserver.NewServer(store)
+	httpSrv := httptest.NewServer(srv.Handler())
+	defer httpSrv.Close()
+
+	projectID := "proj_scratchpad_owned_by_a"
+	channel := "effort-prune"
+	ownerAdmin, ownerClient := bootstrapAccount(t, store, projectID, "owner-scratchpad", "owner-scratchpad-secret")
+	otherAdmin, _ := bootstrapAccount(t, store, "proj_scratchpad_owned_by_b", "other-scratchpad", "other-scratchpad-secret")
+
+	publishScratchpad(t, httpSrv.URL+"/v1/projects/"+projectID+"/scratchpad/"+channel, ownerClient, []byte(`{"text":"keep-me"}`))
+
+	cross := pruneScratchpad(t, httpSrv.URL+"/v1/projects/"+projectID+"/scratchpad/"+channel, otherAdmin)
+	if cross != http.StatusForbidden {
+		t.Fatalf("cross-account prune status = %d, want 403", cross)
+	}
+
+	bogus := pruneScratchpad(t, httpSrv.URL+"/v1/projects/"+projectID+"/scratchpad/"+channel, "LoafAdmin ak_missing:nope")
+	if bogus != http.StatusUnauthorized {
+		t.Fatalf("invalid admin prune status = %d, want 401", bogus)
+	}
+
+	clientPrune := pruneScratchpad(t, httpSrv.URL+"/v1/projects/"+projectID+"/scratchpad/"+channel, ownerClient)
+	if clientPrune != http.StatusUnauthorized {
+		t.Fatalf("client-token prune status = %d, want 401", clientPrune)
+	}
+
+	stillThere := pollScratchpad(t, httpSrv.URL+"/v1/projects/"+projectID+"/scratchpad/"+channel+"/poll?since=0&timeout_ms=10", ownerClient)
+	if len(stillThere) != 1 {
+		t.Fatalf("poll after forbidden prune = %d messages, want 1 still present", len(stillThere))
+	}
+
+	revokeBody, err := json.Marshal(map[string]string{"name": "owner-scratchpad"})
+	if err != nil {
+		t.Fatalf("marshal revoke: %v", err)
+	}
+	revokeReq, err := http.NewRequest(http.MethodDelete, httpSrv.URL+"/v1/admin/tokens", bytes.NewReader(revokeBody))
+	if err != nil {
+		t.Fatalf("revoke request: %v", err)
+	}
+	revokeReq.Header.Set("Authorization", ownerAdmin)
+	revokeReq.Header.Set("Content-Type", "application/json")
+	revokeResp, err := http.DefaultClient.Do(revokeReq)
+	if err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	_ = revokeResp.Body.Close()
+	if revokeResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("revoke status = %d, want 204", revokeResp.StatusCode)
+	}
+
+	owned := pruneScratchpad(t, httpSrv.URL+"/v1/projects/"+projectID+"/scratchpad/"+channel, ownerAdmin)
+	if owned != http.StatusOK {
+		t.Fatalf("owning admin prune after revoke status = %d, want 200", owned)
+	}
+
+	gone, err := store.ListScratchpadSince(t.Context(), projectID, channel, 0)
+	if err != nil {
+		t.Fatalf("list after owning prune: %v", err)
+	}
+	if len(gone) != 0 {
+		t.Fatalf("store list after owning prune = %d messages, want 0", len(gone))
+	}
+}
+
+func publishScratchpad(t *testing.T, url, auth string, payload []byte) {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"payload": base64.StdEncoding.EncodeToString(payload)})
+	if err != nil {
+		t.Fatalf("marshal scratchpad publish: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("publish request: %v", err)
+	}
+	req.Header.Set("Authorization", auth)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("publish status = %d body = %s", resp.StatusCode, raw)
+	}
+}
+
+func pruneScratchpad(t *testing.T, url, auth string) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("prune request: %v", err)
+	}
+	req.Header.Set("Authorization", auth)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+func pollScratchpad(t *testing.T, url, auth string) []struct {
+	Seq     int64  `json:"seq"`
+	Payload string `json:"payload"`
+} {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("poll request: %v", err)
+	}
+	req.Header.Set("Authorization", auth)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("poll status = %d body = %s", resp.StatusCode, raw)
+	}
+	var decoded struct {
+		Messages []struct {
+			Seq     int64  `json:"seq"`
+			Payload string `json:"payload"`
+		} `json:"messages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode poll: %v", err)
+	}
+	return decoded.Messages
+}

--- a/internal/syncserver/scratchpad_server.go
+++ b/internal/syncserver/scratchpad_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -175,8 +176,12 @@ func parseScratchpadTimeout(raw string) (int64, error) {
 func (s *Server) handleScratchpadPrune(w http.ResponseWriter, r *http.Request) {
 	projectID := strings.TrimSpace(r.PathValue("project_id"))
 	channel := strings.TrimSpace(r.PathValue("channel"))
-	if err := s.authorizeAdmin(r.Context(), r); err != nil {
-		writeError(w, http.StatusUnauthorized, err)
+	if err := s.authorizeAdminForProject(r.Context(), r, projectID); err != nil {
+		status := http.StatusUnauthorized
+		if errors.Is(err, errAdminProjectForbidden) {
+			status = http.StatusForbidden
+		}
+		writeError(w, status, err)
 		return
 	}
 	deleted, err := s.store.PruneScratchpadChannel(r.Context(), projectID, channel)
@@ -186,4 +191,3 @@ func (s *Server) handleScratchpadPrune(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": deleted})
 }
-


### PR DESCRIPTION
# Scope scratchpad prune to owning account

`DELETE /v1/projects/{project_id}/scratchpad/{channel}` (`handleScratchpadPrune`) treats any valid `LoafAdmin` account as authorized. `authorizeAdmin` only checks that credentials match some `sync_accounts` row; `PruneScratchpadChannel` then deletes by `project_id`/`channel` with no account–project binding.

This is the same IDOR shape as the fact-delete finding on #183. LOAF-91 / #198 scoped `handleDelete` via `authorizeAdminForProject` (connection-token binding; revoked tokens still count) and left scratchpad prune out of scope as scratchpad channel auth.

On a shared multi-account relay, another tenant can purge another tenant's scratchpad channel blobs if they know or guess those IDs.

Fix: reuse the same project-scoped admin check as fact delete. Cross-account prune → 403. Owning account (including after token revoke) still can.

Out of scope: broader scratchpad channel auth (SSE/append/read/claim token model); namespacing channels by account; client-token prune; server-side TTL; managed-product tenant isolation beyond connection-token binding.

No-gos: a global super-admin prune that still crosses accounts; letting a client token delete blobs.

Standalone (not parented under LOAF-74) so `loaf issue start` does not join the occupied `issue/loaf-74` worktree. Same reason LOAF-91 stayed off LOAF-62/65.

## Definition of Done

- [ ] Cross-account LoafAdmin cannot prune another tenant's scratchpad channel; owning account (including after token revoke) still can
- [ ] handleScratchpadPrune uses project-scoped admin binding (authorizeAdminForProject or equivalent); unscoped authorizeAdmin is gone from that path