### PR TITLE
fix(LOAF-62): rebuild ref, worktree, and verification projections on sync refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ is a Loaf workflow staging section for curated entries before release.
 
 ### Fixed
 
+- Sync refresh rebuilds ref, worktree, and verification projections from pulled facts so a receiving replica shows CLI-facing mappings, start bindings, and receipts (LOAF-62).
 - Sync-server admin `DELETE` of facts is scoped to projects the authenticating account has minted a connection token for, so a second tenant cannot delete another tenant's blobs.
 - `loaf serve` refuses ports `443` and `8443` unless `--tls-cert` and `--tls-key` are set, so `LoafToken` / `LoafAdmin` credentials are not sent on a TLS-looking cleartext port.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,7 +66,7 @@ The standing invariant is alias parity: for every project and every aliased enti
 
 > **Revision 2026-08-26 (LOAF-90):** New section. Supersedes: implicit single-machine SQLite as sufficient for Loaf-flow work.
 
-One operator's substrate is **identical across every environment** they operate. Local SQLite on a trusted machine is a full replica (local-first). A self-hostable sync relay (`loaf serve`, LOAF-75) converges facts between environments; the server holds opaque ciphertext blobs and auth tokens only — never keys, never plaintext semantics. The client sync engine (LOAF-76) queues, pulls by cursor, and detects env-seq gaps with loud warnings. Environments that cannot attach hard-refuse substrate-touching commands (LOAF-67); there is no detached override in v1.
+One operator's substrate is **identical across every environment** they operate. Local SQLite on a trusted machine is a full replica (local-first). A self-hostable sync relay (`loaf serve`, LOAF-75) converges facts between environments; the server holds opaque ciphertext blobs and auth tokens only — never keys, never plaintext semantics. The client sync engine (LOAF-76) queues, pulls by cursor, and detects env-seq gaps with loud warnings. Environments that cannot attach hard-refuse substrate-touching commands (LOAF-67); there is no detached override in v1. Never-attached local use remains valid local-first; fail-loud attach applies when joining the sync fleet.
 
 **Synced minimal core:** project identity and attachment evidence, ref mappings and work contracts, ledger facts (journal, sparks, wraps, handoffs, decisions), verification-run records, releases. **Never synced:** FTS indexes, hook trust, conversation handles, vocabulary fossils (local archive).
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -62,9 +62,11 @@ The implication for both personas: Loaf's value is the *framework* -- mechanical
 > **Revision 2026-08-26 (LOAF-90):** Inserts substrate arc priorities. Supersedes: priorities listing only journal reliability and Loaf Flow without personal-substrate destination.
 >
 > **Revision 2026-08-26 (LOAF-90, schema 25):** LOAF-63/64/72 landed on main. Supersedes: "remaining mutable-core migration" and "LOAF-64 partial".
+>
+> **Revision 2026-08-26 (LOAF-62 closeout):** LOAF-68 children 84–86 shipped; sync refresh folds refs, worktrees, and verification. Grow-only union docs shipped with the LOAF-63 lock.
 
-- **Personal memory substrate (LOAF-62).** Fact envelope, E2E crypto, sync server/client, attach-or-refuse, identity evidence, and mutable-core event facts shipped (LOAF-63–67, 71–72, 75–76). Writers append through the LOAF-71 chokepoint; the `events` table remains local archive (migration 0025). Parent closeout is independent review and ship.
-- **Refs + contracts cutover (LOAF-68).** Contract machinery keys to refs (LOAF-82) and render-out (LOAF-83) shipped; branch/PR bootstrap (LOAF-85), flow-skill ref cutover (LOAF-86), and decision re-home (LOAF-84) remain.
+- **Personal memory substrate (LOAF-62).** Fact envelope, E2E crypto, sync server/client, attach-or-refuse, identity evidence, grow-only union, and mutable-core event facts shipped (LOAF-63–67, 71–72, 75–76). Writers append through the LOAF-71 chokepoint; the `events` table remains local archive (migration 0025). Sync refresh rebuilds spark/idea/handoff/release/ref/verification projections and worktree start bindings from facts (worktree paths may not exist on the receiving machine). Parent closeout is independent review and ship.
+- **Refs + contracts cutover (LOAF-68).** Contract machinery keys to refs (LOAF-82), render-out (LOAF-83), branch/PR bootstrap (LOAF-85), flow-skill ref cutover (LOAF-86), and decision re-home (LOAF-84) shipped.
 - **Dead state before sync (LOAF-69).** Delete zero-row schema (LOAF-79), demote document layer (LOAF-80), and inventory lock (LOAF-81) shipped — minimal sync contract enforced.
 - **Scratchpad (LOAF-74).** CLI and closed kind set (LOAF-87) and server SSE/long-poll fanout (LOAF-88) shipped; close/prune (LOAF-89) shipped.
 - **Journal reliability across installed targets.** Converge content-addressed installation, target adapter ownership, capability diagnosis, and isolated installed-runtime dogfood without mutating users' production state.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -20,7 +20,7 @@ Functional profiles define what agents can mechanically touch (tool access). Ski
 
 > **Revision 2026-08-26 (LOAF-90):** Continuity is personal-first and environment-agnostic. Supersedes: continuity described only as project-journal handoff on a single machine.
 
-Loaf's durable memory — journal, wraps, handoffs, decisions, work-unit refs, verification records — lives in one operator's **personal memory substrate**. Every environment the operator uses (laptop, second machine, Cursor Cloud Agent, Amp Orb, CI) attaches to the same substrate or **hard-refuses** Loaf-flow work. There is no silent empty universe and no memoryless degraded mode.
+Loaf's durable memory — journal, wraps, handoffs, decisions, work-unit refs, verification records — lives in one operator's **personal memory substrate**. Every environment the operator uses (laptop, second machine, Cursor Cloud Agent, Amp Orb, CI) attaches to the same substrate or **hard-refuses** Loaf-flow work. There is no silent empty universe and no memoryless degraded mode. A never-attached trusted machine remains a complete local-first replica; attach is the multi-environment join, not a prerequisite for first use.
 
 Work survives context loss, compaction, tool restarts, and cross-conversation handoffs because the substrate is external to any single harness session. The project journal is a **projection** of grow-only ledger facts, not a hand-authored file. Change artifacts and compatible task records keep intent and execution inspectable outside any one conversation. Context at conversation start is a derived digest — never a lifecycle transition.
 

--- a/docs/security/substrate-e2e-threat-model.md
+++ b/docs/security/substrate-e2e-threat-model.md
@@ -12,7 +12,7 @@ attach ceremony, or authorization enforcement.
 
 ## Server-visible metadata (v1 design target)
 
-When a sync relay exists (LOAF-65), it is designed to see opaque ciphertext
+The sync relay (`loaf serve`, LOAF-75) sees opaque ciphertext
 blobs plus transport metadata only:
 
 - Blob count and byte sizes per project channel
@@ -36,9 +36,9 @@ is **operator/admin-only** (account admin secret).
 
 Enforcement of those capabilities lives outside this crypto slice:
 
-- **Write gating / sync upload** — LOAF-65 relay + client engine (token scope)
+- **Write gating / sync upload** — LOAF-75 relay + LOAF-76 client engine (token scope)
 - **Attach / provisioning of credentials** — LOAF-67
-- **Delete (tombstone + server-side blob deletion by fact id)** — LOAF-65/67 operator path
+- **Delete (tombstone + server-side blob deletion by fact id)** — LOAF-75/67 operator path
 
 LOAF-66 only encodes the credential types and cryptographic material so those
 later layers can enforce the rule without inventing a second key model.
@@ -50,16 +50,16 @@ later layers can enforce the rule without inventing a second key model.
    verified by `go test ./internal/crypto/...`. Auditors can check AEAD/HKDF
    behavior and that client credentials are a distinct type from admin
    credentials (no master key / account admin secret fields on the client wire).
-2. **Relay inspection (when LOAF-65 lands)** — audit that relay persistence
+2. **Relay inspection (LOAF-75 shipped)** — audit that relay persistence
    contains blobs + auth tokens only (empty cryptographic material set).
-3. **Gap detection (LOAF-65 client engine)** — per-environment monotonic seq
+3. **Gap detection (LOAF-76 client engine)** — per-environment monotonic seq
    inside ciphertext enables clients to detect interior tamper/drop.
 
 ## Honest limits (v1)
 
 - Withheld suffix vs idleness is indistinguishable without cross-environment corroboration (future work).
 - Padding/traffic-analysis defenses are out of scope for v1.
-- Delete semantics (tombstone + opaque blob delete by fact id) are specified here for threat-model clarity; runtime enforcement is LOAF-65/67.
+- Delete semantics (tombstone + opaque blob delete by fact id) are specified here for threat-model clarity; runtime enforcement shipped with LOAF-75/67.
 
 ## Attach ceremony
 

--- a/internal/state/event_fact_fold.go
+++ b/internal/state/event_fact_fold.go
@@ -457,8 +457,190 @@ func rebuildReleaseProjectionFromFactsTx(ctx context.Context, tx *sql.Tx, projec
 	return len(folded), nil
 }
 
+func isWorkContractRefPayload(payload CoreEventPayload) bool {
+	return strings.TrimSpace(payload.MappingKind) != "" || strings.TrimSpace(payload.MappingValue) != ""
+}
+
+func upsertBackendMappingProjectionTx(ctx context.Context, execer journalWriteExecer, projectID, mappingID string, payload CoreEventPayload) error {
+	createdAt := firstNonEmpty(payload.CreatedAt, payload.UpdatedAt)
+	updatedAt := firstNonEmpty(payload.UpdatedAt, createdAt)
+	syncStatus := strings.TrimSpace(payload.SyncStatus)
+	if syncStatus == "" {
+		syncStatus = linearSyncLinked
+	}
+	_, err := execer.ExecContext(ctx, `
+INSERT INTO backend_mappings (id, project_id, backend, entity_kind, entity_id, external_kind, external_id, external_url, sync_status, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+  backend = excluded.backend,
+  entity_kind = excluded.entity_kind,
+  entity_id = excluded.entity_id,
+  external_kind = excluded.external_kind,
+  external_id = excluded.external_id,
+  external_url = excluded.external_url,
+  sync_status = excluded.sync_status,
+  updated_at = excluded.updated_at
+`, mappingID, projectID, payload.Backend, payload.EntityKind, payload.EntityID, payload.ExternalKind, payload.ExternalID, emptyToNil(payload.ExternalURL), syncStatus, createdAt, updatedAt)
+	if err != nil {
+		return fmt.Errorf("upsert backend mapping projection %q: %w", mappingID, err)
+	}
+	return nil
+}
+
+func upsertWorkContractMappingProjectionTx(ctx context.Context, execer journalWriteExecer, projectID, mappingID string, payload CoreEventPayload) error {
+	createdAt := firstNonEmpty(payload.CreatedAt, payload.UpdatedAt)
+	updatedAt := firstNonEmpty(payload.UpdatedAt, createdAt)
+	_, err := execer.ExecContext(ctx, `
+INSERT INTO work_contract_mappings (id, project_id, provider, provider_ref, mapping_kind, mapping_value, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+  provider = excluded.provider,
+  provider_ref = excluded.provider_ref,
+  mapping_kind = excluded.mapping_kind,
+  mapping_value = excluded.mapping_value,
+  updated_at = excluded.updated_at
+`, mappingID, projectID, payload.Provider, payload.ProviderRef, payload.MappingKind, payload.MappingValue, createdAt, updatedAt)
+	if err != nil {
+		return fmt.Errorf("upsert work-contract mapping projection %q: %w", mappingID, err)
+	}
+	return nil
+}
+
+func upsertVerificationProjectionTx(ctx context.Context, execer journalWriteExecer, projectID, receiptID string, payload CoreEventPayload) error {
+	createdAt := firstNonEmpty(payload.CreatedAt, payload.UpdatedAt)
+	updatedAt := firstNonEmpty(payload.UpdatedAt, createdAt)
+	_, err := execer.ExecContext(ctx, `
+INSERT INTO work_contract_receipts (id, project_id, provider, provider_ref, receipt_kind, receipt_value, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+  provider = excluded.provider,
+  provider_ref = excluded.provider_ref,
+  receipt_kind = excluded.receipt_kind,
+  receipt_value = excluded.receipt_value,
+  updated_at = excluded.updated_at
+`, receiptID, projectID, payload.Provider, payload.ProviderRef, payload.ReceiptKind, payload.ReceiptValue, createdAt, updatedAt)
+	if err != nil {
+		return fmt.Errorf("upsert verification projection %q: %w", receiptID, err)
+	}
+	return nil
+}
+
+func applyWorktreeProjectionTx(ctx context.Context, tx *sql.Tx, projectID, subjectID string, payload CoreEventPayload) error {
+	createdAt := firstNonEmpty(payload.CreatedAt, payload.UpdatedAt)
+	updatedAt := firstNonEmpty(payload.UpdatedAt, createdAt)
+	branch := strings.TrimSpace(payload.Branch)
+	worktree := strings.TrimSpace(payload.Worktree)
+	switch strings.TrimSpace(payload.SubjectKind) {
+	case "issue":
+		_, err := tx.ExecContext(ctx, `
+UPDATE issues
+SET started_branch = ?, started_worktree = ?, updated_at = ?
+WHERE project_id = ? AND id = ?
+`, emptyToNil(branch), emptyToNil(worktree), updatedAt, projectID, subjectID)
+		if err != nil {
+			return fmt.Errorf("apply issue worktree projection %q: %w", subjectID, err)
+		}
+		return nil
+	case "work_contract":
+		if !tableExists(ctx, tx, "work_contracts") || !tableExists(ctx, tx, "work_contract_workspace") {
+			return nil
+		}
+		var exists int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM work_contracts WHERE project_id = ? AND id = ?`, projectID, subjectID).Scan(&exists); err != nil {
+			return fmt.Errorf("lookup work contract for worktree projection %q: %w", subjectID, err)
+		}
+		if exists == 0 {
+			return nil
+		}
+		return upsertWorkContractWorkspaceTx(ctx, tx, projectID, subjectID, branch, worktree, firstNonEmpty(updatedAt, createdAt))
+	default:
+		return nil
+	}
+}
+
+func rebuildRefProjectionFromFactsTx(ctx context.Context, execer journalWriteExecer, projectID string) (int, error) {
+	folded, err := foldRefFacts(ctx, execer, projectID)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := execer.ExecContext(ctx, `DELETE FROM backend_mappings WHERE project_id = ?`, projectID); err != nil {
+		return 0, fmt.Errorf("clear backend mapping projection: %w", err)
+	}
+	if tableExists(ctx, execer, "work_contract_mappings") {
+		if _, err := execer.ExecContext(ctx, `DELETE FROM work_contract_mappings WHERE project_id = ?`, projectID); err != nil {
+			return 0, fmt.Errorf("clear work-contract mapping projection: %w", err)
+		}
+	}
+	for mappingID, row := range folded {
+		if isWorkContractRefPayload(row.Payload) {
+			if !tableExists(ctx, execer, "work_contract_mappings") {
+				continue
+			}
+			if err := upsertWorkContractMappingProjectionTx(ctx, execer, projectID, mappingID, row.Payload); err != nil {
+				return 0, err
+			}
+			continue
+		}
+		if err := upsertBackendMappingProjectionTx(ctx, execer, projectID, mappingID, row.Payload); err != nil {
+			return 0, err
+		}
+	}
+	return len(folded), nil
+}
+
+func rebuildWorktreeProjectionFromFactsTx(ctx context.Context, tx *sql.Tx, projectID string) (int, error) {
+	// Worktree bindings are machine-local paths, but worktree.bound / worktree.unbound
+	// facts sync. Refresh applies the latest fact onto issues.started_* and
+	// work_contract_workspace even when the path does not exist here. Missing
+	// parent issue/contract rows are skipped so a remote fact cannot fail the
+	// whole rebuild.
+	folded, err := foldWorktreeFacts(ctx, tx, projectID)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := tx.ExecContext(ctx, `
+UPDATE issues
+SET started_branch = NULL, started_worktree = NULL
+WHERE project_id = ?
+`, projectID); err != nil {
+		return 0, fmt.Errorf("clear issue worktree projection: %w", err)
+	}
+	if tableExists(ctx, tx, "work_contract_workspace") {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM work_contract_workspace WHERE project_id = ?`, projectID); err != nil {
+			return 0, fmt.Errorf("clear work-contract worktree projection: %w", err)
+		}
+	}
+	for subjectID, row := range folded {
+		if err := applyWorktreeProjectionTx(ctx, tx, projectID, subjectID, row.Payload); err != nil {
+			return 0, err
+		}
+	}
+	return len(folded), nil
+}
+
+func rebuildVerificationProjectionFromFactsTx(ctx context.Context, execer journalWriteExecer, projectID string) (int, error) {
+	if !tableExists(ctx, execer, "work_contract_receipts") {
+		return 0, nil
+	}
+	folded, err := foldVerificationFacts(ctx, execer, projectID)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := execer.ExecContext(ctx, `DELETE FROM work_contract_receipts WHERE project_id = ?`, projectID); err != nil {
+		return 0, fmt.Errorf("clear verification projection: %w", err)
+	}
+	for receiptID, row := range folded {
+		if err := upsertVerificationProjectionTx(ctx, execer, projectID, receiptID, row.Payload); err != nil {
+			return 0, err
+		}
+	}
+	return len(folded), nil
+}
+
 // RebuildMutableCoreProjectionsForProject rebuilds spark/idea/handoff/release
-// projections from grow-only facts for one project.
+// plus ref, worktree, and verification projections from grow-only facts for
+// one project. Worktree paths are applied from facts as-is (see
+// rebuildWorktreeProjectionFromFactsTx).
 func RebuildMutableCoreProjectionsForProject(ctx context.Context, store *Store, projectID string) (int, error) {
 	if store == nil || store.db == nil {
 		return 0, fmt.Errorf("rebuild mutable core projections: store is nil")
@@ -485,6 +667,21 @@ func RebuildMutableCoreProjectionsForProject(ctx context.Context, store *Store, 
 	}
 	count += n
 	n, err = rebuildReleaseProjectionFromFactsTx(ctx, tx, projectID)
+	if err != nil {
+		return 0, err
+	}
+	count += n
+	n, err = rebuildRefProjectionFromFactsTx(ctx, tx, projectID)
+	if err != nil {
+		return 0, err
+	}
+	count += n
+	n, err = rebuildWorktreeProjectionFromFactsTx(ctx, tx, projectID)
+	if err != nil {
+		return 0, err
+	}
+	count += n
+	n, err = rebuildVerificationProjectionFromFactsTx(ctx, tx, projectID)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/state/event_fact_test.go
+++ b/internal/state/event_fact_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -241,8 +242,12 @@ func TestIdeaAndReleaseWritersUseFactChokepoint(t *testing.T) {
 }
 
 func TestRebuildMutableCoreProjectionsFromFacts(t *testing.T) {
+	requireGit(t)
 	ctx := context.Background()
-	root := projectRoot(t)
+	root, err := project.ResolveRoot(initGitRepo(t))
+	if err != nil {
+		t.Fatalf("ResolveRoot() error = %v", err)
+	}
 	resolver := PathResolver{StateHome: t.TempDir()}
 	status, err := Initialize(ctx, root, resolver)
 	if err != nil {
@@ -274,5 +279,164 @@ func TestRebuildMutableCoreProjectionsFromFacts(t *testing.T) {
 	}
 	if !parity.Sparks.Ready || parity.Sparks.ProjectionRows != 1 {
 		t.Fatalf("spark parity after rebuild = %#v", parity.Sparks)
+	}
+}
+
+func TestRebuildMutableCoreProjectionsFromReceivedRefAndVerificationFacts(t *testing.T) {
+	requireGit(t)
+	ctx := context.Background()
+	root, err := project.ResolveRoot(initGitRepo(t))
+	if err != nil {
+		t.Fatalf("ResolveRoot() error = %v", err)
+	}
+	resolver := PathResolver{StateHome: t.TempDir()}
+	status, err := Initialize(ctx, root, resolver)
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	store, err := OpenStore(status.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+	projectID, err := store.projectID(ctx, root)
+	if err != nil {
+		t.Fatalf("projectID() error = %v", err)
+	}
+
+	now := time.Date(2026, 8, 26, 18, 0, 0, 0, time.UTC)
+	receiveCoreFact(t, store, projectID, "018f5c2a-0000-7000-8000-000000000101", FactKindRefRegistered, "env-recv", 1, now.UnixMilli(), CoreEventPayload{
+		SubjectKind:  "ref",
+		SubjectID:    "bmap-recv-1",
+		Backend:      "linear",
+		EntityKind:   "issue",
+		EntityID:     "issue-recv-1",
+		ExternalKind: "issue",
+		ExternalID:   "LOAF-62",
+		ExternalURL:  "https://linear.app/loaf/issue/LOAF-62",
+		SyncStatus:   linearSyncLinked,
+		CreatedAt:    now.Format(time.RFC3339),
+		UpdatedAt:    now.Format(time.RFC3339),
+	})
+	receiveCoreFact(t, store, projectID, "018f5c2a-0000-7000-8000-000000000102", FactKindVerificationRecorded, "env-recv", 2, now.UnixMilli()+1, CoreEventPayload{
+		SubjectKind:  "verification",
+		SubjectID:    "wcr-recv-1",
+		Provider:     "branch",
+		ProviderRef:  "issue/loaf-62",
+		ReceiptKind:  "pr",
+		ReceiptValue: "https://github.com/levifig/loaf/pull/204",
+		CreatedAt:    now.Format(time.RFC3339),
+		UpdatedAt:    now.Format(time.RFC3339),
+	})
+
+	var mappings, receipts int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM backend_mappings WHERE id = ?`, "bmap-recv-1").Scan(&mappings); err != nil {
+		t.Fatalf("count mappings before rebuild: %v", err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM work_contract_receipts WHERE id = ?`, "wcr-recv-1").Scan(&receipts); err != nil {
+		t.Fatalf("count receipts before rebuild: %v", err)
+	}
+	if mappings != 0 || receipts != 0 {
+		t.Fatalf("projections before rebuild mappings=%d receipts=%d, want 0 (ReceiveFact is insert-only)", mappings, receipts)
+	}
+
+	if _, err := RebuildMutableCoreProjectionsForProject(ctx, store, projectID); err != nil {
+		t.Fatalf("RebuildMutableCoreProjectionsForProject() error = %v", err)
+	}
+
+	var externalID, receiptValue string
+	if err := store.db.QueryRowContext(ctx, `SELECT external_id FROM backend_mappings WHERE id = ?`, "bmap-recv-1").Scan(&externalID); err != nil {
+		t.Fatalf("backend mapping after rebuild: %v", err)
+	}
+	if externalID != "LOAF-62" {
+		t.Fatalf("backend mapping external_id = %q, want LOAF-62", externalID)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT receipt_value FROM work_contract_receipts WHERE id = ?`, "wcr-recv-1").Scan(&receiptValue); err != nil {
+		t.Fatalf("verification receipt after rebuild: %v", err)
+	}
+	if receiptValue != "https://github.com/levifig/loaf/pull/204" {
+		t.Fatalf("receipt_value = %q", receiptValue)
+	}
+}
+
+func TestRebuildMutableCoreProjectionsFoldsWorktreeFacts(t *testing.T) {
+	requireGit(t)
+	ctx := context.Background()
+	root, err := project.ResolveRoot(initGitRepo(t))
+	if err != nil {
+		t.Fatalf("ResolveRoot() error = %v", err)
+	}
+	resolver := PathResolver{StateHome: t.TempDir()}
+	status, err := Initialize(ctx, root, resolver)
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	store, err := OpenStore(status.DatabasePath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+	projectID, err := store.projectID(ctx, root)
+	if err != nil {
+		t.Fatalf("projectID() error = %v", err)
+	}
+	now := time.Date(2026, 8, 26, 18, 30, 0, 0, time.UTC).Format(time.RFC3339)
+	mustExec(t, store, `INSERT INTO issues (id, project_id, kind, title, body, status, created_at, updated_at) VALUES (?, ?, 'delivery', 'worktree fold', '', 'todo', ?, ?)`, "issue-wt-1", projectID, now, now)
+
+	boundAt := time.Date(2026, 8, 26, 18, 31, 0, 0, time.UTC)
+	receiveCoreFact(t, store, projectID, "018f5c2a-0000-7000-8000-000000000201", FactKindWorktreeBound, "env-wt", 1, boundAt.UnixMilli(), CoreEventPayload{
+		SubjectKind: "issue",
+		SubjectID:   "issue-wt-1",
+		Branch:      "issue/loaf-62",
+		Worktree:    "/tmp/remote-machine/issue-loaf-62",
+		CreatedAt:   boundAt.Format(time.RFC3339),
+		UpdatedAt:   boundAt.Format(time.RFC3339),
+	})
+	if _, err := RebuildMutableCoreProjectionsForProject(ctx, store, projectID); err != nil {
+		t.Fatalf("rebuild after bind: %v", err)
+	}
+	var branch, worktree string
+	if err := store.db.QueryRowContext(ctx, `SELECT COALESCE(started_branch, ''), COALESCE(started_worktree, '') FROM issues WHERE id = ?`, "issue-wt-1").Scan(&branch, &worktree); err != nil {
+		t.Fatalf("read started workspace: %v", err)
+	}
+	if branch != "issue/loaf-62" || worktree != "/tmp/remote-machine/issue-loaf-62" {
+		t.Fatalf("started = (%q, %q), want bound fact applied", branch, worktree)
+	}
+
+	unboundAt := boundAt.Add(time.Minute)
+	receiveCoreFact(t, store, projectID, "018f5c2a-0000-7000-8000-000000000202", FactKindWorktreeUnbound, "env-wt", 2, unboundAt.UnixMilli(), CoreEventPayload{
+		SubjectKind: "issue",
+		SubjectID:   "issue-wt-1",
+		CreatedAt:   unboundAt.Format(time.RFC3339),
+		UpdatedAt:   unboundAt.Format(time.RFC3339),
+	})
+	if _, err := RebuildMutableCoreProjectionsForProject(ctx, store, projectID); err != nil {
+		t.Fatalf("rebuild after unbind: %v", err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT COALESCE(started_branch, ''), COALESCE(started_worktree, '') FROM issues WHERE id = ?`, "issue-wt-1").Scan(&branch, &worktree); err != nil {
+		t.Fatalf("read started workspace after unbind: %v", err)
+	}
+	if branch != "" || worktree != "" {
+		t.Fatalf("started after unbind = (%q, %q), want cleared", branch, worktree)
+	}
+}
+
+func receiveCoreFact(t *testing.T, store *Store, projectID, id, kind, envID string, seq, wallMS int64, payload CoreEventPayload) {
+	t.Helper()
+	encoded, err := encodeCoreEventPayload(payload)
+	if err != nil {
+		t.Fatalf("encode payload: %v", err)
+	}
+	inserted, err := ReceiveFact(context.Background(), store, FactEnvelope{
+		ID: id, ProjectID: projectID, Kind: kind, Payload: encoded,
+		EnvID: envID, Seq: seq,
+		HLC:       fmt.Sprintf("%020d:%06d", wallMS, 0),
+		EnvelopeV: factEnvelopeVersion,
+	}, ReceiveFactOptions{})
+	if err != nil {
+		t.Fatalf("ReceiveFact(%s) error = %v", kind, err)
+	}
+	if !inserted {
+		t.Fatalf("ReceiveFact(%s) inserted = false", kind)
 	}
 }

--- a/internal/sync/convergence_test.go
+++ b/internal/sync/convergence_test.go
@@ -27,7 +27,7 @@ func TestTwoClientConvergenceUnion(t *testing.T) {
 	factA, err := state.AppendFact(ctx, homeA, state.AppendFactInput{
 		ProjectID: h.projectID, Kind: state.FactKindJournal,
 		Payload: `{"entry_type":"discover","message":"from-a","created_at":"2026-08-26T12:00:00Z","updated_at":"2026-08-26T12:00:00Z"}`,
-		EnvID: "env-a", Now: now,
+		EnvID:   "env-a", Now: now,
 	})
 	if err != nil {
 		t.Fatalf("append A: %v", err)
@@ -35,7 +35,7 @@ func TestTwoClientConvergenceUnion(t *testing.T) {
 	factB, err := state.AppendFact(ctx, homeB, state.AppendFactInput{
 		ProjectID: h.projectID, Kind: state.FactKindJournal,
 		Payload: `{"entry_type":"discover","message":"from-b","created_at":"2026-08-26T12:00:01Z","updated_at":"2026-08-26T12:00:01Z"}`,
-		EnvID: "env-b", Now: now.Add(time.Second),
+		EnvID:   "env-b", Now: now.Add(time.Second),
 	})
 	if err != nil {
 		t.Fatalf("append B: %v", err)
@@ -81,9 +81,9 @@ func TestGapInjectionIsLoud(t *testing.T) {
 	for _, seq := range []int64{1, 3} {
 		if _, err := state.ReceiveFact(ctx, store, state.FactEnvelope{
 			ID: fmt.Sprintf("018f5c2a-0000-7000-8000-%012d", seq), ProjectID: h.projectID,
-			Kind: state.FactKindJournal,
+			Kind:    state.FactKindJournal,
 			Payload: fmt.Sprintf(`{"entry_type":"discover","message":"seq-%d","created_at":"2026-08-26T12:00:00Z","updated_at":"2026-08-26T12:00:00Z"}`, seq),
-			EnvID: "gap-env", Seq: seq, HLC: fmt.Sprintf("%020d:%06d", 1_700_000_000_000+seq, 0), EnvelopeV: 1,
+			EnvID:   "gap-env", Seq: seq, HLC: fmt.Sprintf("%020d:%06d", 1_700_000_000_000+seq, 0), EnvelopeV: 1,
 		}, state.ReceiveFactOptions{}); err != nil {
 			t.Fatalf("receive seq %d: %v", seq, err)
 		}
@@ -108,7 +108,7 @@ func TestSkewRefusal(t *testing.T) {
 	fact, err := state.AppendFact(ctx, publisher, state.AppendFactInput{
 		ProjectID: h.projectID, Kind: state.FactKindJournal,
 		Payload: `{"entry_type":"discover","message":"future","created_at":"2030-01-01T00:00:00Z","updated_at":"2030-01-01T00:00:00Z"}`,
-		EnvID: "skew-env", Now: farFuture,
+		EnvID:   "skew-env", Now: farFuture,
 	})
 	if err != nil {
 		t.Fatalf("append future: %v", err)
@@ -124,9 +124,9 @@ func TestSkewRefusal(t *testing.T) {
 	receiver := openIsolatedStore(t, h.projectID)
 	if _, err := state.ReceiveFact(ctx, receiver, state.FactEnvelope{
 		ID: "018f5c2a-0000-7000-8000-000000000010", ProjectID: h.projectID,
-		Kind: state.FactKindJournal,
+		Kind:    state.FactKindJournal,
 		Payload: `{"entry_type":"discover","message":"baseline","created_at":"2026-08-26T12:00:00Z","updated_at":"2026-08-26T12:00:00Z"}`,
-		EnvID: "receiver-env", Seq: 1, HLC: "00000000000000170000:000000", EnvelopeV: 1,
+		EnvID:   "receiver-env", Seq: 1, HLC: "00000000000000170000:000000", EnvelopeV: 1,
 	}, state.ReceiveFactOptions{}); err != nil {
 		t.Fatalf("seed baseline: %v", err)
 	}
@@ -246,5 +246,78 @@ func mustExec(t *testing.T, store *state.Store, query string, args ...any) {
 	t.Helper()
 	if _, err := store.DB().ExecContext(context.Background(), query, args...); err != nil {
 		t.Fatalf("exec: %v", err)
+	}
+}
+
+func TestPullRefAndVerificationFactsRefreshProjections(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	h := newConvergenceHarness(t)
+	publisher := openIsolatedStore(t, h.projectID)
+	receiver := openIsolatedStore(t, h.projectID)
+
+	now := time.Date(2026, 8, 26, 19, 0, 0, 0, time.UTC)
+	refPayload, err := json.Marshal(state.CoreEventPayload{
+		SubjectKind:  "ref",
+		SubjectID:    "bmap-sync-1",
+		Backend:      "linear",
+		EntityKind:   "issue",
+		EntityID:     "issue-sync-1",
+		ExternalKind: "issue",
+		ExternalID:   "LOAF-62",
+		ExternalURL:  "https://linear.app/loaf/issue/LOAF-62",
+		SyncStatus:   "linked",
+		CreatedAt:    now.Format(time.RFC3339),
+		UpdatedAt:    now.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("marshal ref payload: %v", err)
+	}
+	verifyPayload, err := json.Marshal(state.CoreEventPayload{
+		SubjectKind:  "verification",
+		SubjectID:    "wcr-sync-1",
+		Provider:     "branch",
+		ProviderRef:  "issue/loaf-62",
+		ReceiptKind:  "pr",
+		ReceiptValue: "https://github.com/levifig/loaf/pull/204",
+		CreatedAt:    now.Format(time.RFC3339),
+		UpdatedAt:    now.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("marshal verification payload: %v", err)
+	}
+
+	if _, err := state.AppendFact(ctx, publisher, state.AppendFactInput{
+		ProjectID: h.projectID, Kind: state.FactKindRefRegistered,
+		Payload: string(refPayload), EnvID: "env-pub", Now: now,
+	}); err != nil {
+		t.Fatalf("append ref: %v", err)
+	}
+	if _, err := state.AppendFact(ctx, publisher, state.AppendFactInput{
+		ProjectID: h.projectID, Kind: state.FactKindVerificationRecorded,
+		Payload: string(verifyPayload), EnvID: "env-pub", Now: now.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("append verification: %v", err)
+	}
+
+	if _, err := newEngine(t, publisher, h).Sync(ctx); err != nil {
+		t.Fatalf("sync publisher: %v", err)
+	}
+	if _, err := newEngine(t, receiver, h).Sync(ctx); err != nil {
+		t.Fatalf("sync receiver: %v", err)
+	}
+
+	var externalID, receiptValue string
+	if err := receiver.DB().QueryRowContext(ctx, `SELECT external_id FROM backend_mappings WHERE id = ?`, "bmap-sync-1").Scan(&externalID); err != nil {
+		t.Fatalf("receiver backend mapping: %v", err)
+	}
+	if externalID != "LOAF-62" {
+		t.Fatalf("receiver external_id = %q, want LOAF-62", externalID)
+	}
+	if err := receiver.DB().QueryRowContext(ctx, `SELECT receipt_value FROM work_contract_receipts WHERE id = ?`, "wcr-sync-1").Scan(&receiptValue); err != nil {
+		t.Fatalf("receiver verification receipt: %v", err)
+	}
+	if receiptValue != "https://github.com/levifig/loaf/pull/204" {
+		t.Fatalf("receiver receipt_value = %q", receiptValue)
 	}
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -209,6 +209,7 @@ func refreshProjections(ctx context.Context, store *state.Store, projectID strin
 	if _, err := state.RebuildJournalProjectionForProject(ctx, store, projectID); err != nil {
 		return err
 	}
+	// Rebuilds spark/idea/handoff/release plus refs, worktrees, and verification.
 	_, err := state.RebuildMutableCoreProjectionsForProject(ctx, store, projectID)
 	return err
 }


### PR DESCRIPTION
## Summary

Independent review of LOAF-62 was ship-with-nits: `ReceiveFact` only inserts grow-only rows, and `refreshProjections` / `RebuildMutableCoreProjectionsForProject` rebuilt sparks, ideas, handoffs, and releases — not refs, worktrees, or verification. After pull, the receiving replica had the facts but no CLI-facing projection.

This closeout wires those folds onto the same refresh path:

- **Refs** → `backend_mappings` and `work_contract_mappings`
- **Verification** → `work_contract_receipts`
- **Worktrees** → `issues.started_*` and `work_contract_workspace` (folded, not carved out). Paths are machine-local at write time but the bound/unbound facts sync; refresh applies the latest fact even when the path does not exist here. Missing parent issue/contract rows are skipped so a remote fact cannot fail the whole rebuild.

Targeted tests cover receive-then-rebuild for refs, verification, and worktree bind/unbind, plus a two-client pull that asserts the receiving side has the mapping and receipt after `Sync`.

Docs:

- `STRATEGY.md` inventory matches main (63/64/72 and LOAF-68 children 84–86 shipped; grow-only union already documented). Worktree fold is called out explicitly.
- Threat model tense: LOAF-75/76 shipped, no more “when LOAF-65 lands”.
- One-line local-first vs attach honesty in VISION / ARCHITECTURE. Attach opt-in is **not** redesigned here.

**LOAF-62 stays active.** This PR does not mark the parent done; that waits for a later verify pass.

## Test plan

- [x] `go test ./internal/state/ -run 'TestRebuildMutableCore|TestCaptureSparkWritesEventFact|TestSparkStatusFactsFold|TestMutableCoreMigration|TestIdeaAndRelease'`
- [x] `go test ./internal/sync/`
- [ ] CI green on this PR
- [ ] After merge: do **not** mark LOAF-62 done