### PR TITLE
fix(LOAF-62): reuse mapping and receipt ids so rebuild stays unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ is a Loaf workflow staging section for curated entries before release.
 
 ### Fixed
 
+- Repeated work-contract mapping and receipt upserts reuse the existing projection row id as the fact SubjectID, so a second render-out of the same ref rebuilds without colliding on the unique key (LOAF-62).
 - Sync refresh rebuilds ref, worktree, and verification projections from pulled facts so a receiving replica shows CLI-facing mappings, start bindings, and receipts (LOAF-62).
 - Sync-server admin `DELETE` of facts is scoped to projects the authenticating account has minted a connection token for, so a second tenant cannot delete another tenant's blobs.
 - `loaf serve` refuses ports `443` and `8443` unless `--tls-cert` and `--tls-key` are set, so `LoafToken` / `LoafAdmin` credentials are not sent on a TLS-looking cleartext port.

--- a/internal/state/issue_render_out.go
+++ b/internal/state/issue_render_out.go
@@ -198,17 +198,7 @@ WHERE project_id = ? AND id = ?
 		return IssueRenderOutResult{}, err
 	}
 
-	receiptID, err := newOpaqueStateID("wcr")
-	if err != nil {
-		return IssueRenderOutResult{}, err
-	}
-	if _, err := tx.ExecContext(ctx, `
-INSERT INTO work_contract_receipts (id, project_id, provider, provider_ref, receipt_kind, receipt_value, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-ON CONFLICT(project_id, provider, provider_ref, receipt_kind) DO UPDATE SET
-  receipt_value = excluded.receipt_value,
-  updated_at = excluded.updated_at
-`, receiptID, projectID, authorityRef.Provider, authorityRef.Key, RenderOutReceiptKind, issue.ID, now, now); err != nil {
+	if err := upsertWorkContractReceiptTx(ctx, tx, projectID, authorityRef, RenderOutReceiptKind, issue.ID, now); err != nil {
 		return IssueRenderOutResult{}, fmt.Errorf("record render-out receipt: %w", err)
 	}
 	if err := upsertWorkContractMappingTx(ctx, tx, projectID, authorityRef, RenderOutMappingIssueID, issue.ID, now); err != nil {
@@ -251,34 +241,6 @@ UPDATE issues SET status = ?, archived_at = ?, updated_at = ? WHERE project_id =
 	}
 	result.Contract = contract
 	return result, nil
-}
-
-func upsertWorkContractMappingTx(ctx context.Context, tx *sql.Tx, projectID string, ref AuthorityRef, kind, value, now string) error {
-	mappingID, err := newOpaqueStateID("wcm")
-	if err != nil {
-		return err
-	}
-	_, err = tx.ExecContext(ctx, `
-INSERT INTO work_contract_mappings (id, project_id, provider, provider_ref, mapping_kind, mapping_value, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-ON CONFLICT(project_id, provider, provider_ref, mapping_kind) DO UPDATE SET
-  mapping_value = excluded.mapping_value,
-  updated_at = excluded.updated_at
-`, mappingID, projectID, ref.Provider, ref.Key, kind, value, now, now)
-	if err != nil {
-		return err
-	}
-	_, err = appendCoreEventFactTx(ctx, tx, projectID, FactKindRefRegistered, "", CoreEventPayload{
-		SubjectKind:  "ref",
-		SubjectID:    mappingID,
-		Provider:     ref.Provider,
-		ProviderRef:  ref.Key,
-		MappingKind:  kind,
-		MappingValue: value,
-		CreatedAt:    now,
-		UpdatedAt:    now,
-	}, parseCoreEventTime(now), "")
-	return err
 }
 
 func lookupLinearIssueIdentifierTx(ctx context.Context, tx *sql.Tx, projectID, issueID string) (string, error) {

--- a/internal/state/work_contract_mapping.go
+++ b/internal/state/work_contract_mapping.go
@@ -3,6 +3,8 @@ package state
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/levifig/loaf/internal/project"
@@ -43,6 +45,48 @@ func (s *Store) UpsertWorkContractMapping(ctx context.Context, root project.Root
 		return err
 	}
 	return tx.Commit()
+}
+
+func upsertWorkContractMappingTx(ctx context.Context, tx *sql.Tx, projectID string, ref AuthorityRef, kind, value, now string) error {
+	var mappingID string
+	err := tx.QueryRowContext(ctx, `
+SELECT id FROM work_contract_mappings
+WHERE project_id = ? AND provider = ? AND provider_ref = ? AND mapping_kind = ?
+`, projectID, ref.Provider, ref.Key, kind).Scan(&mappingID)
+	switch {
+	case err == nil:
+		if _, err := tx.ExecContext(ctx, `
+UPDATE work_contract_mappings
+SET mapping_value = ?, updated_at = ?
+WHERE id = ?
+`, value, now, mappingID); err != nil {
+			return fmt.Errorf("update work-contract mapping: %w", err)
+		}
+	case errors.Is(err, sql.ErrNoRows):
+		mappingID, err = newOpaqueStateID("wcm")
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO work_contract_mappings (id, project_id, provider, provider_ref, mapping_kind, mapping_value, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+`, mappingID, projectID, ref.Provider, ref.Key, kind, value, now, now); err != nil {
+			return fmt.Errorf("insert work-contract mapping: %w", err)
+		}
+	default:
+		return fmt.Errorf("lookup work-contract mapping: %w", err)
+	}
+	_, err = appendCoreEventFactTx(ctx, tx, projectID, FactKindRefRegistered, "", CoreEventPayload{
+		SubjectKind:  "ref",
+		SubjectID:    mappingID,
+		Provider:     ref.Provider,
+		ProviderRef:  ref.Key,
+		MappingKind:  kind,
+		MappingValue: value,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}, parseCoreEventTime(now), "")
+	return err
 }
 
 func loadWorkContractMappingsTx(ctx context.Context, tx *sql.Tx, projectID string, ref AuthorityRef) ([]WorkContractMapping, error) {

--- a/internal/state/work_contract_receipt.go
+++ b/internal/state/work_contract_receipt.go
@@ -3,6 +3,8 @@ package state
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/levifig/loaf/internal/project"
@@ -34,38 +36,57 @@ func (s *Store) UpsertWorkContractReceipt(ctx context.Context, root project.Root
 		return err
 	}
 	now := time.Now().UTC().Format(time.RFC3339Nano)
-	receiptID, err := newOpaqueStateID("wcr")
-	if err != nil {
-		return err
-	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
-	_, err = tx.ExecContext(ctx, `
-INSERT INTO work_contract_receipts (id, project_id, provider, provider_ref, receipt_kind, receipt_value, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-ON CONFLICT(project_id, provider, provider_ref, receipt_kind) DO UPDATE SET
-  receipt_value = excluded.receipt_value,
-  updated_at = excluded.updated_at
-`, receiptID, projectID, authorityRef.Provider, authorityRef.Key, kind, value, now, now)
-	if err != nil {
+	if err := upsertWorkContractReceiptTx(ctx, tx, projectID, authorityRef, kind, value, now); err != nil {
 		return err
 	}
-	if _, err := appendCoreEventFactTx(ctx, tx, projectID, FactKindVerificationRecorded, "", CoreEventPayload{
+	return tx.Commit()
+}
+
+func upsertWorkContractReceiptTx(ctx context.Context, tx *sql.Tx, projectID string, ref AuthorityRef, kind, value, now string) error {
+	var receiptID string
+	err := tx.QueryRowContext(ctx, `
+SELECT id FROM work_contract_receipts
+WHERE project_id = ? AND provider = ? AND provider_ref = ? AND receipt_kind = ?
+`, projectID, ref.Provider, ref.Key, kind).Scan(&receiptID)
+	switch {
+	case err == nil:
+		if _, err := tx.ExecContext(ctx, `
+UPDATE work_contract_receipts
+SET receipt_value = ?, updated_at = ?
+WHERE id = ?
+`, value, now, receiptID); err != nil {
+			return fmt.Errorf("update work-contract receipt: %w", err)
+		}
+	case errors.Is(err, sql.ErrNoRows):
+		receiptID, err = newOpaqueStateID("wcr")
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO work_contract_receipts (id, project_id, provider, provider_ref, receipt_kind, receipt_value, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+`, receiptID, projectID, ref.Provider, ref.Key, kind, value, now, now); err != nil {
+			return fmt.Errorf("insert work-contract receipt: %w", err)
+		}
+	default:
+		return fmt.Errorf("lookup work-contract receipt: %w", err)
+	}
+	_, err = appendCoreEventFactTx(ctx, tx, projectID, FactKindVerificationRecorded, "", CoreEventPayload{
 		SubjectKind:  "verification",
 		SubjectID:    receiptID,
-		Provider:     authorityRef.Provider,
-		ProviderRef:  authorityRef.Key,
+		Provider:     ref.Provider,
+		ProviderRef:  ref.Key,
 		ReceiptKind:  kind,
 		ReceiptValue: value,
 		CreatedAt:    now,
 		UpdatedAt:    now,
-	}, parseCoreEventTime(now), ""); err != nil {
-		return err
-	}
-	return tx.Commit()
+	}, parseCoreEventTime(now), "")
+	return err
 }
 
 func loadWorkContractReceiptsTx(ctx context.Context, tx *sql.Tx, projectID string, ref AuthorityRef) ([]WorkContractReceipt, error) {

--- a/internal/state/work_contract_test.go
+++ b/internal/state/work_contract_test.go
@@ -93,6 +93,149 @@ func TestWorkContractReceiptAndMapping(t *testing.T) {
 	_ = resolver
 }
 
+func TestRepeatedWorkContractUpsertsRebuildSingleProjection(t *testing.T) {
+	ctx, root, store, ref := workContractFixture(t)
+	projectID, err := store.projectID(ctx, root)
+	if err != nil {
+		t.Fatalf("projectID() error = %v", err)
+	}
+
+	if err := store.UpsertWorkContractMapping(ctx, root, ref.String(), "linear_url", "https://linear.app/issue/ENG-82"); err != nil {
+		t.Fatalf("UpsertWorkContractMapping(first) error = %v", err)
+	}
+	if err := store.UpsertWorkContractMapping(ctx, root, ref.String(), "linear_url", "https://linear.app/issue/ENG-82-updated"); err != nil {
+		t.Fatalf("UpsertWorkContractMapping(second) error = %v", err)
+	}
+	if err := store.UpsertWorkContractReceipt(ctx, root, ref.String(), "export", "first"); err != nil {
+		t.Fatalf("UpsertWorkContractReceipt(first) error = %v", err)
+	}
+	if err := store.UpsertWorkContractReceipt(ctx, root, ref.String(), "export", "second"); err != nil {
+		t.Fatalf("UpsertWorkContractReceipt(second) error = %v", err)
+	}
+
+	if _, err := RebuildMutableCoreProjectionsForProject(ctx, store, projectID); err != nil {
+		t.Fatalf("RebuildMutableCoreProjectionsForProject() error = %v", err)
+	}
+
+	var mappings, receipts int
+	if err := store.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM work_contract_mappings
+WHERE project_id = ? AND provider = ? AND provider_ref = ? AND mapping_kind = ?
+`, projectID, ref.Provider, ref.Key, "linear_url").Scan(&mappings); err != nil {
+		t.Fatalf("count mappings: %v", err)
+	}
+	if mappings != 1 {
+		t.Fatalf("mapping rows = %d, want 1", mappings)
+	}
+	if err := store.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM work_contract_receipts
+WHERE project_id = ? AND provider = ? AND provider_ref = ? AND receipt_kind = ?
+`, projectID, ref.Provider, ref.Key, "export").Scan(&receipts); err != nil {
+		t.Fatalf("count receipts: %v", err)
+	}
+	if receipts != 1 {
+		t.Fatalf("receipt rows = %d, want 1", receipts)
+	}
+
+	var mappingValue, receiptValue string
+	if err := store.db.QueryRowContext(ctx, `
+SELECT mapping_value FROM work_contract_mappings
+WHERE project_id = ? AND provider = ? AND provider_ref = ? AND mapping_kind = ?
+`, projectID, ref.Provider, ref.Key, "linear_url").Scan(&mappingValue); err != nil {
+		t.Fatalf("read mapping: %v", err)
+	}
+	if mappingValue != "https://linear.app/issue/ENG-82-updated" {
+		t.Fatalf("mapping_value = %q, want updated URL", mappingValue)
+	}
+	if err := store.db.QueryRowContext(ctx, `
+SELECT receipt_value FROM work_contract_receipts
+WHERE project_id = ? AND provider = ? AND provider_ref = ? AND receipt_kind = ?
+`, projectID, ref.Provider, ref.Key, "export").Scan(&receiptValue); err != nil {
+		t.Fatalf("read receipt: %v", err)
+	}
+	if receiptValue != "second" {
+		t.Fatalf("receipt_value = %q, want second", receiptValue)
+	}
+
+	assertDistinctFactSubjects(t, store, projectID, FactKindRefRegistered, "mapping_kind", "linear_url", 2, 1)
+	assertDistinctFactSubjects(t, store, projectID, FactKindVerificationRecorded, "receipt_kind", "export", 2, 1)
+}
+
+func TestRepeatedRenderOutRebuildsSingleProjection(t *testing.T) {
+	root, store := issueTestFixture(t)
+	ctx := context.Background()
+	issue, err := store.CreateIssue(ctx, root, IssueCreateOptions{
+		Title: "Render twice",
+		Body:  "Problem body.\n\nOut of scope: none.",
+		Kind:  IssueKindDelivery,
+		Criteria: []IssueCriterionInput{{
+			Text: "Holds",
+			Tier: IssueCriterionTierH,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+
+	first, err := store.RenderOutIssue(ctx, root, IssueRenderOutOptions{
+		Ref:    issue.ID,
+		Branch: "issue/loaf-62-rebuild",
+	})
+	if err != nil {
+		t.Fatalf("RenderOutIssue(first) error = %v", err)
+	}
+	if _, err := store.RenderOutIssue(ctx, root, IssueRenderOutOptions{
+		Ref:    issue.ID,
+		Branch: "issue/loaf-62-rebuild",
+	}); err != nil {
+		t.Fatalf("RenderOutIssue(second) error = %v", err)
+	}
+
+	projectID := first.ProjectID
+	if _, err := RebuildMutableCoreProjectionsForProject(ctx, store, projectID); err != nil {
+		t.Fatalf("RebuildMutableCoreProjectionsForProject() error = %v", err)
+	}
+
+	var mappings, receipts int
+	if err := store.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM work_contract_mappings
+WHERE project_id = ? AND provider = ? AND provider_ref = ? AND mapping_kind = ?
+`, projectID, first.AuthorityRef.Provider, first.AuthorityRef.Key, RenderOutMappingIssueID).Scan(&mappings); err != nil {
+		t.Fatalf("count render-out mappings: %v", err)
+	}
+	if mappings != 1 {
+		t.Fatalf("render-out mapping rows = %d, want 1", mappings)
+	}
+	if err := store.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM work_contract_receipts
+WHERE project_id = ? AND provider = ? AND provider_ref = ? AND receipt_kind = ?
+`, projectID, first.AuthorityRef.Provider, first.AuthorityRef.Key, RenderOutReceiptKind).Scan(&receipts); err != nil {
+		t.Fatalf("count render-out receipts: %v", err)
+	}
+	if receipts != 1 {
+		t.Fatalf("render-out receipt rows = %d, want 1", receipts)
+	}
+
+	assertDistinctFactSubjects(t, store, projectID, FactKindRefRegistered, "mapping_kind", RenderOutMappingIssueID, 2, 1)
+	assertDistinctFactSubjects(t, store, projectID, FactKindVerificationRecorded, "receipt_kind", RenderOutReceiptKind, 2, 1)
+}
+
+func assertDistinctFactSubjects(t *testing.T, store *Store, projectID, kind, payloadKey, payloadValue string, wantFacts, wantSubjects int) {
+	t.Helper()
+	var facts, subjects int
+	query := `
+SELECT COUNT(*), COUNT(DISTINCT json_extract(payload, '$.subject_id'))
+FROM facts
+WHERE project_id = ? AND kind = ? AND json_extract(payload, '$.` + payloadKey + `') = ?
+`
+	if err := store.db.QueryRowContext(context.Background(), query, projectID, kind, payloadValue).Scan(&facts, &subjects); err != nil {
+		t.Fatalf("count %s facts: %v", kind, err)
+	}
+	if facts != wantFacts || subjects != wantSubjects {
+		t.Fatalf("%s facts=%d subjects=%d, want facts=%d subjects=%d", kind, facts, subjects, wantFacts, wantSubjects)
+	}
+}
+
 func containsAll(s string, parts ...string) bool {
 	for _, part := range parts {
 		if !strings.Contains(s, part) {


### PR DESCRIPTION
## Summary

Re-review of #204 found a remaining H2/H5 blocker: live write paths minted a new opaque id, `INSERT … ON CONFLICT` updated the existing unique row (id stays), then always appended a fact whose `SubjectID` was the unused minted id.

Fold is latest-wins per `SubjectID`, so both facts survive. Rebuild deletes the projection and inserts each subject with `ON CONFLICT(id)` only. A second render of the same ref then hits `UNIQUE (project_id, provider, provider_ref, mapping_kind)` / `receipt_kind`. Rebuild rolls back; `Engine.Sync` errors.

This PR follows the Linear mapping pattern: look up the existing row id and reuse it as `SubjectID` on update; mint only on first insert.

- `upsertWorkContractMappingTx` and `upsertWorkContractReceiptTx` lookup-then-update/insert
- `loaf issue render` out uses the shared receipt helper
- Two upserts / two render-outs of the same ref, then `RebuildMutableCoreProjectionsForProject`, leave one projection row

**LOAF-62 stays active.** This does not mark the parent done.

## Test plan

- [x] `go test ./internal/state/ -count=1 -run 'TestRepeatedWorkContractUpsertsRebuildSingleProjection|TestRepeatedRenderOutRebuildsSingleProjection|TestWorkContractReceiptAndMapping|TestRenderOutIssueCreatesBranchContractWithReceipt|TestRebuildMutableCoreProjectionsFromReceivedRefAndVerificationFacts'`
- [x] `go test ./internal/state/ -count=1 -run 'TestWorkContract|TestRenderOut|TestRebuildMutableCore'`
- [ ] CI green on this PR
- [ ] After merge: do **not** mark LOAF-62 done

## Migration / breaking changes

None.

## Out of scope

Sibling docs/binary PR #205. STRATEGY and committed binaries are left alone.