### PR TITLE
fix(LOAF-62): preserve curated changelog and add --version on release cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,12 +39,18 @@ One operator's durable memory â€” journal, wraps, handoffs, refs, verification â
 - Findings, verdicts, and runs schema and CLI surface (migration 0018) ([#176](https://github.com/levifig/loaf/pull/176)).
 - SQLite document-layer authority for reports, councils, and shaping drafts ([#175](https://github.com/levifig/loaf/pull/175)).
 
+### Added
+
+- `loaf release cut --version <X.Y.Z>` cuts an explicit semver that must be greater than the current version and at least the minimum for the derived bump (LOAF-62).
+
 ### Fixed
 
+- `loaf release cut` preserves operator-curated `[Unreleased]` changelog prose as the release body instead of replacing it with auto-drafted issue notes; drafted notes are used only when unreleased is empty or stub-only.
 - Sync refresh rebuilds ref, worktree, and verification projections from pulled facts so a receiving replica shows CLI-facing mappings, start bindings, and receipts ([#204](https://github.com/levifig/loaf/pull/204)).
 - Repeated work-contract mapping and receipt upserts reuse the existing projection row id as the fact SubjectID, so a second render-out of the same ref rebuilds without colliding on the unique key ([#206](https://github.com/levifig/loaf/pull/206)).
 - Sync-server admin `DELETE` of facts is scoped to projects the authenticating account has minted a connection token for, so a second tenant cannot delete another tenant's blobs ([#198](https://github.com/levifig/loaf/pull/198)).
 - Development builds stage native targets before replacing `bin/native` and `bin/.loaf-dev-commit`, so a later target failure cannot leave a new binary reporting a previous commit. Activation updates a Loaf-owned launcher pointer and creates `~/.local/bin/loaf` only when that name is absent; existing operator-owned paths are never replaced, and activation failures no longer fail a successful native build.
+
 - `loaf issue start` on a child refuses if the root workspace is missing or the root is already `done` / archived, instead of joining a stale or closed workspace.
 - `loaf issue verify` runs in the invoking worktree ([#172](https://github.com/levifig/loaf/pull/172)).
 - Homebrew formula generation pins an explicit `version` so older `brew` does not infer `64` from `darwin-arm64` in the asset URL.

--- a/content/skills/release/SKILL.md
+++ b/content/skills/release/SKILL.md
@@ -33,7 +33,7 @@ Cut a version from work that has already landed.
 2. **Release is not merge** — do not review, approve, or land a PR here. Verification authority is the ship workflow (PR review and CI at merge). If the user is asking to merge, stop and route to ship.
 3. **A release is cut from what landed** — the surface is `loaf release suggest` and `loaf release cut`. Do not run unsubcommmanded `loaf release`, `--pre-merge`, or `--post-merge`; this skill does not own that path.
 4. **Suggest writes nothing** — it reads `baseline-tag..HEAD` (or `--base <ref>..HEAD`), attributes commits to issues, rolls up through parents, reports partially-landed parents and unattributed commits as information, derives the bump, reports the advisory bucket delta, and drafts notes.
-5. **Cut records facts** — it applies the version, prepends the drafted notes into `CHANGELOG.md`, tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
+5. **Cut records facts** — it applies the version, moves curated `[Unreleased]` prose into the release section (or prepends drafted notes when unreleased is stub-only), tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
 6. **No forward version stamp** — do not bind an issue to a future version. Members are what already landed. Buckets (`loaf issue bucket`) are advisory labels; planned-vs-landed is information only.
 7. **No suite, no re-record, no publication stop in this skill** — ship already verified the merged work. Cut's operational refusals (dirty worktree, disagreeing version files, missing version, `--no-tag` without an existing tag) are command errors, not a substitute for ship.
 8. **Confirm before cut** — present the suggest report (or `cut --dry-run`) first. Ask one question at a time, with a recommendation, using your harness's structured question tool if it has one. `--dry-run` previews everything and writes nothing.
@@ -65,7 +65,7 @@ Cut a version from work that has already landed.
 
 ```text
 loaf release suggest [--base <ref>] [--json]
-loaf release cut [--base <ref>] [--bump <type>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
+loaf release cut [--base <ref>] [--bump <type>] [--version <X.Y.Z>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
 loaf issue bucket <ref> now|next|later|none [--json]
 loaf issue link <from> blocks|relates-to <to> [--json]
 ```
@@ -94,6 +94,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 |------|---------|
 | `--base <ref>` | Commits since `<ref>` instead of the last tag |
 | `--bump <type>` | Override the derived bump: `major`, `minor`, `patch`, `prerelease`, `release` |
+| `--version <X.Y.Z>` | Cut an explicit version (must be valid semver, greater than current, and at least the minimum for the derived bump) |
 | `--includes <version\|tag>` | Record a prior release as a member (repeatable). Use this to hang prerelease references on a stable |
 | `--no-tag` | Do not create a git tag; tag `v<version>` must already exist |
 | `--no-gh` | Skip the GitHub Release draft |
@@ -108,7 +109,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 2. Resolve each `--includes` ref to an existing release
 3. Require a clean worktree
 4. Apply the version to detected version files (they must exist and agree)
-5. Prepend drafted notes into `CHANGELOG.md` (after `[Unreleased]`, ahead of prior versions; creates the file if missing)
+5. Move `[Unreleased]` into `CHANGELOG.md` under `## [version]` — operator-curated unreleased prose is preserved as the release body; drafted notes are used only when unreleased is empty or stub-only
 6. Commit `chore: release vX.Y.Z`
 7. Unless `--no-tag`: create annotated tag `vX.Y.Z` (`git tag -a`). Signing follows git config (`tag.gpgSign`); cut never passes `-s` or `--no-sign`
 8. Record the release row, issue members, and `--includes` members as facts

--- a/dist/amp/skills/release/SKILL.md
+++ b/dist/amp/skills/release/SKILL.md
@@ -34,7 +34,7 @@ Cut a version from work that has already landed.
 2. **Release is not merge** — do not review, approve, or land a PR here. Verification authority is the ship workflow (PR review and CI at merge). If the user is asking to merge, stop and route to ship.
 3. **A release is cut from what landed** — the surface is `loaf release suggest` and `loaf release cut`. Do not run unsubcommmanded `loaf release`, `--pre-merge`, or `--post-merge`; this skill does not own that path.
 4. **Suggest writes nothing** — it reads `baseline-tag..HEAD` (or `--base <ref>..HEAD`), attributes commits to issues, rolls up through parents, reports partially-landed parents and unattributed commits as information, derives the bump, reports the advisory bucket delta, and drafts notes.
-5. **Cut records facts** — it applies the version, prepends the drafted notes into `CHANGELOG.md`, tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
+5. **Cut records facts** — it applies the version, moves curated `[Unreleased]` prose into the release section (or prepends drafted notes when unreleased is stub-only), tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
 6. **No forward version stamp** — do not bind an issue to a future version. Members are what already landed. Buckets (`loaf issue bucket`) are advisory labels; planned-vs-landed is information only.
 7. **No suite, no re-record, no publication stop in this skill** — ship already verified the merged work. Cut's operational refusals (dirty worktree, disagreeing version files, missing version, `--no-tag` without an existing tag) are command errors, not a substitute for ship.
 8. **Confirm before cut** — present the suggest report (or `cut --dry-run`) first. Ask one question at a time, with a recommendation, using your harness's structured question tool if it has one. `--dry-run` previews everything and writes nothing.
@@ -66,7 +66,7 @@ Cut a version from work that has already landed.
 
 ```text
 loaf release suggest [--base <ref>] [--json]
-loaf release cut [--base <ref>] [--bump <type>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
+loaf release cut [--base <ref>] [--bump <type>] [--version <X.Y.Z>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
 loaf issue bucket <ref> now|next|later|none [--json]
 loaf issue link <from> blocks|relates-to <to> [--json]
 ```
@@ -95,6 +95,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 |------|---------|
 | `--base <ref>` | Commits since `<ref>` instead of the last tag |
 | `--bump <type>` | Override the derived bump: `major`, `minor`, `patch`, `prerelease`, `release` |
+| `--version <X.Y.Z>` | Cut an explicit version (must be valid semver, greater than current, and at least the minimum for the derived bump) |
 | `--includes <version\|tag>` | Record a prior release as a member (repeatable). Use this to hang prerelease references on a stable |
 | `--no-tag` | Do not create a git tag; tag `v<version>` must already exist |
 | `--no-gh` | Skip the GitHub Release draft |
@@ -109,7 +110,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 2. Resolve each `--includes` ref to an existing release
 3. Require a clean worktree
 4. Apply the version to detected version files (they must exist and agree)
-5. Prepend drafted notes into `CHANGELOG.md` (after `[Unreleased]`, ahead of prior versions; creates the file if missing)
+5. Move `[Unreleased]` into `CHANGELOG.md` under `## [version]` — operator-curated unreleased prose is preserved as the release body; drafted notes are used only when unreleased is empty or stub-only
 6. Commit `chore: release vX.Y.Z`
 7. Unless `--no-tag`: create annotated tag `vX.Y.Z` (`git tag -a`). Signing follows git config (`tag.gpgSign`); cut never passes `-s` or `--no-sign`
 8. Record the release row, issue members, and `--includes` members as facts

--- a/dist/codex/skills/release/SKILL.md
+++ b/dist/codex/skills/release/SKILL.md
@@ -34,7 +34,7 @@ Cut a version from work that has already landed.
 2. **Release is not merge** — do not review, approve, or land a PR here. Verification authority is the ship workflow (PR review and CI at merge). If the user is asking to merge, stop and route to ship.
 3. **A release is cut from what landed** — the surface is `loaf release suggest` and `loaf release cut`. Do not run unsubcommmanded `loaf release`, `--pre-merge`, or `--post-merge`; this skill does not own that path.
 4. **Suggest writes nothing** — it reads `baseline-tag..HEAD` (or `--base <ref>..HEAD`), attributes commits to issues, rolls up through parents, reports partially-landed parents and unattributed commits as information, derives the bump, reports the advisory bucket delta, and drafts notes.
-5. **Cut records facts** — it applies the version, prepends the drafted notes into `CHANGELOG.md`, tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
+5. **Cut records facts** — it applies the version, moves curated `[Unreleased]` prose into the release section (or prepends drafted notes when unreleased is stub-only), tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
 6. **No forward version stamp** — do not bind an issue to a future version. Members are what already landed. Buckets (`loaf issue bucket`) are advisory labels; planned-vs-landed is information only.
 7. **No suite, no re-record, no publication stop in this skill** — ship already verified the merged work. Cut's operational refusals (dirty worktree, disagreeing version files, missing version, `--no-tag` without an existing tag) are command errors, not a substitute for ship.
 8. **Confirm before cut** — present the suggest report (or `cut --dry-run`) first. Ask one question at a time, with a recommendation, using your harness's structured question tool if it has one. `--dry-run` previews everything and writes nothing.
@@ -66,7 +66,7 @@ Cut a version from work that has already landed.
 
 ```text
 loaf release suggest [--base <ref>] [--json]
-loaf release cut [--base <ref>] [--bump <type>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
+loaf release cut [--base <ref>] [--bump <type>] [--version <X.Y.Z>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
 loaf issue bucket <ref> now|next|later|none [--json]
 loaf issue link <from> blocks|relates-to <to> [--json]
 ```
@@ -95,6 +95,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 |------|---------|
 | `--base <ref>` | Commits since `<ref>` instead of the last tag |
 | `--bump <type>` | Override the derived bump: `major`, `minor`, `patch`, `prerelease`, `release` |
+| `--version <X.Y.Z>` | Cut an explicit version (must be valid semver, greater than current, and at least the minimum for the derived bump) |
 | `--includes <version\|tag>` | Record a prior release as a member (repeatable). Use this to hang prerelease references on a stable |
 | `--no-tag` | Do not create a git tag; tag `v<version>` must already exist |
 | `--no-gh` | Skip the GitHub Release draft |
@@ -109,7 +110,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 2. Resolve each `--includes` ref to an existing release
 3. Require a clean worktree
 4. Apply the version to detected version files (they must exist and agree)
-5. Prepend drafted notes into `CHANGELOG.md` (after `[Unreleased]`, ahead of prior versions; creates the file if missing)
+5. Move `[Unreleased]` into `CHANGELOG.md` under `## [version]` — operator-curated unreleased prose is preserved as the release body; drafted notes are used only when unreleased is empty or stub-only
 6. Commit `chore: release vX.Y.Z`
 7. Unless `--no-tag`: create annotated tag `vX.Y.Z` (`git tag -a`). Signing follows git config (`tag.gpgSign`); cut never passes `-s` or `--no-sign`
 8. Record the release row, issue members, and `--includes` members as facts

--- a/dist/cursor/skills/release/SKILL.md
+++ b/dist/cursor/skills/release/SKILL.md
@@ -34,7 +34,7 @@ Cut a version from work that has already landed.
 2. **Release is not merge** — do not review, approve, or land a PR here. Verification authority is the ship workflow (PR review and CI at merge). If the user is asking to merge, stop and route to ship.
 3. **A release is cut from what landed** — the surface is `loaf release suggest` and `loaf release cut`. Do not run unsubcommmanded `loaf release`, `--pre-merge`, or `--post-merge`; this skill does not own that path.
 4. **Suggest writes nothing** — it reads `baseline-tag..HEAD` (or `--base <ref>..HEAD`), attributes commits to issues, rolls up through parents, reports partially-landed parents and unattributed commits as information, derives the bump, reports the advisory bucket delta, and drafts notes.
-5. **Cut records facts** — it applies the version, prepends the drafted notes into `CHANGELOG.md`, tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
+5. **Cut records facts** — it applies the version, moves curated `[Unreleased]` prose into the release section (or prepends drafted notes when unreleased is stub-only), tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
 6. **No forward version stamp** — do not bind an issue to a future version. Members are what already landed. Buckets (`loaf issue bucket`) are advisory labels; planned-vs-landed is information only.
 7. **No suite, no re-record, no publication stop in this skill** — ship already verified the merged work. Cut's operational refusals (dirty worktree, disagreeing version files, missing version, `--no-tag` without an existing tag) are command errors, not a substitute for ship.
 8. **Confirm before cut** — present the suggest report (or `cut --dry-run`) first. Ask one question at a time, with a recommendation, using your harness's structured question tool if it has one. `--dry-run` previews everything and writes nothing.
@@ -66,7 +66,7 @@ Cut a version from work that has already landed.
 
 ```text
 loaf release suggest [--base <ref>] [--json]
-loaf release cut [--base <ref>] [--bump <type>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
+loaf release cut [--base <ref>] [--bump <type>] [--version <X.Y.Z>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
 loaf issue bucket <ref> now|next|later|none [--json]
 loaf issue link <from> blocks|relates-to <to> [--json]
 ```
@@ -95,6 +95,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 |------|---------|
 | `--base <ref>` | Commits since `<ref>` instead of the last tag |
 | `--bump <type>` | Override the derived bump: `major`, `minor`, `patch`, `prerelease`, `release` |
+| `--version <X.Y.Z>` | Cut an explicit version (must be valid semver, greater than current, and at least the minimum for the derived bump) |
 | `--includes <version\|tag>` | Record a prior release as a member (repeatable). Use this to hang prerelease references on a stable |
 | `--no-tag` | Do not create a git tag; tag `v<version>` must already exist |
 | `--no-gh` | Skip the GitHub Release draft |
@@ -109,7 +110,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 2. Resolve each `--includes` ref to an existing release
 3. Require a clean worktree
 4. Apply the version to detected version files (they must exist and agree)
-5. Prepend drafted notes into `CHANGELOG.md` (after `[Unreleased]`, ahead of prior versions; creates the file if missing)
+5. Move `[Unreleased]` into `CHANGELOG.md` under `## [version]` — operator-curated unreleased prose is preserved as the release body; drafted notes are used only when unreleased is empty or stub-only
 6. Commit `chore: release vX.Y.Z`
 7. Unless `--no-tag`: create annotated tag `vX.Y.Z` (`git tag -a`). Signing follows git config (`tag.gpgSign`); cut never passes `-s` or `--no-sign`
 8. Record the release row, issue members, and `--includes` members as facts

--- a/dist/opencode/commands/release.md
+++ b/dist/opencode/commands/release.md
@@ -33,7 +33,7 @@ Cut a version from work that has already landed.
 2. **Release is not merge** — do not review, approve, or land a PR here. Verification authority is the ship workflow (PR review and CI at merge). If the user is asking to merge, stop and route to ship.
 3. **A release is cut from what landed** — the surface is `loaf release suggest` and `loaf release cut`. Do not run unsubcommmanded `loaf release`, `--pre-merge`, or `--post-merge`; this skill does not own that path.
 4. **Suggest writes nothing** — it reads `baseline-tag..HEAD` (or `--base <ref>..HEAD`), attributes commits to issues, rolls up through parents, reports partially-landed parents and unattributed commits as information, derives the bump, reports the advisory bucket delta, and drafts notes.
-5. **Cut records facts** — it applies the version, prepends the drafted notes into `CHANGELOG.md`, tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
+5. **Cut records facts** — it applies the version, moves curated `[Unreleased]` prose into the release section (or prepends drafted notes when unreleased is stub-only), tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
 6. **No forward version stamp** — do not bind an issue to a future version. Members are what already landed. Buckets (`loaf issue bucket`) are advisory labels; planned-vs-landed is information only.
 7. **No suite, no re-record, no publication stop in this skill** — ship already verified the merged work. Cut's operational refusals (dirty worktree, disagreeing version files, missing version, `--no-tag` without an existing tag) are command errors, not a substitute for ship.
 8. **Confirm before cut** — present the suggest report (or `cut --dry-run`) first. Ask one question at a time, with a recommendation, using your harness's structured question tool if it has one. `--dry-run` previews everything and writes nothing.
@@ -65,7 +65,7 @@ Cut a version from work that has already landed.
 
 ```text
 loaf release suggest [--base <ref>] [--json]
-loaf release cut [--base <ref>] [--bump <type>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
+loaf release cut [--base <ref>] [--bump <type>] [--version <X.Y.Z>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
 loaf issue bucket <ref> now|next|later|none [--json]
 loaf issue link <from> blocks|relates-to <to> [--json]
 ```
@@ -94,6 +94,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 |------|---------|
 | `--base <ref>` | Commits since `<ref>` instead of the last tag |
 | `--bump <type>` | Override the derived bump: `major`, `minor`, `patch`, `prerelease`, `release` |
+| `--version <X.Y.Z>` | Cut an explicit version (must be valid semver, greater than current, and at least the minimum for the derived bump) |
 | `--includes <version\|tag>` | Record a prior release as a member (repeatable). Use this to hang prerelease references on a stable |
 | `--no-tag` | Do not create a git tag; tag `v<version>` must already exist |
 | `--no-gh` | Skip the GitHub Release draft |
@@ -108,7 +109,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 2. Resolve each `--includes` ref to an existing release
 3. Require a clean worktree
 4. Apply the version to detected version files (they must exist and agree)
-5. Prepend drafted notes into `CHANGELOG.md` (after `[Unreleased]`, ahead of prior versions; creates the file if missing)
+5. Move `[Unreleased]` into `CHANGELOG.md` under `## [version]` — operator-curated unreleased prose is preserved as the release body; drafted notes are used only when unreleased is empty or stub-only
 6. Commit `chore: release vX.Y.Z`
 7. Unless `--no-tag`: create annotated tag `vX.Y.Z` (`git tag -a`). Signing follows git config (`tag.gpgSign`); cut never passes `-s` or `--no-sign`
 8. Record the release row, issue members, and `--includes` members as facts

--- a/dist/opencode/skills/release/SKILL.md
+++ b/dist/opencode/skills/release/SKILL.md
@@ -34,7 +34,7 @@ Cut a version from work that has already landed.
 2. **Release is not merge** — do not review, approve, or land a PR here. Verification authority is the ship workflow (PR review and CI at merge). If the user is asking to merge, stop and route to ship.
 3. **A release is cut from what landed** — the surface is `loaf release suggest` and `loaf release cut`. Do not run unsubcommmanded `loaf release`, `--pre-merge`, or `--post-merge`; this skill does not own that path.
 4. **Suggest writes nothing** — it reads `baseline-tag..HEAD` (or `--base <ref>..HEAD`), attributes commits to issues, rolls up through parents, reports partially-landed parents and unattributed commits as information, derives the bump, reports the advisory bucket delta, and drafts notes.
-5. **Cut records facts** — it applies the version, prepends the drafted notes into `CHANGELOG.md`, tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
+5. **Cut records facts** — it applies the version, moves curated `[Unreleased]` prose into the release section (or prepends drafted notes when unreleased is stub-only), tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
 6. **No forward version stamp** — do not bind an issue to a future version. Members are what already landed. Buckets (`loaf issue bucket`) are advisory labels; planned-vs-landed is information only.
 7. **No suite, no re-record, no publication stop in this skill** — ship already verified the merged work. Cut's operational refusals (dirty worktree, disagreeing version files, missing version, `--no-tag` without an existing tag) are command errors, not a substitute for ship.
 8. **Confirm before cut** — present the suggest report (or `cut --dry-run`) first. Ask one question at a time, with a recommendation, using your harness's structured question tool if it has one. `--dry-run` previews everything and writes nothing.
@@ -66,7 +66,7 @@ Cut a version from work that has already landed.
 
 ```text
 loaf release suggest [--base <ref>] [--json]
-loaf release cut [--base <ref>] [--bump <type>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
+loaf release cut [--base <ref>] [--bump <type>] [--version <X.Y.Z>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
 loaf issue bucket <ref> now|next|later|none [--json]
 loaf issue link <from> blocks|relates-to <to> [--json]
 ```
@@ -95,6 +95,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 |------|---------|
 | `--base <ref>` | Commits since `<ref>` instead of the last tag |
 | `--bump <type>` | Override the derived bump: `major`, `minor`, `patch`, `prerelease`, `release` |
+| `--version <X.Y.Z>` | Cut an explicit version (must be valid semver, greater than current, and at least the minimum for the derived bump) |
 | `--includes <version\|tag>` | Record a prior release as a member (repeatable). Use this to hang prerelease references on a stable |
 | `--no-tag` | Do not create a git tag; tag `v<version>` must already exist |
 | `--no-gh` | Skip the GitHub Release draft |
@@ -109,7 +110,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 2. Resolve each `--includes` ref to an existing release
 3. Require a clean worktree
 4. Apply the version to detected version files (they must exist and agree)
-5. Prepend drafted notes into `CHANGELOG.md` (after `[Unreleased]`, ahead of prior versions; creates the file if missing)
+5. Move `[Unreleased]` into `CHANGELOG.md` under `## [version]` — operator-curated unreleased prose is preserved as the release body; drafted notes are used only when unreleased is empty or stub-only
 6. Commit `chore: release vX.Y.Z`
 7. Unless `--no-tag`: create annotated tag `vX.Y.Z` (`git tag -a`). Signing follows git config (`tag.gpgSign`); cut never passes `-s` or `--no-sign`
 8. Record the release row, issue members, and `--includes` members as facts

--- a/dist/skills/release/SKILL.md
+++ b/dist/skills/release/SKILL.md
@@ -33,7 +33,7 @@ Cut a version from work that has already landed.
 2. **Release is not merge** — do not review, approve, or land a PR here. Verification authority is the ship workflow (PR review and CI at merge). If the user is asking to merge, stop and route to ship.
 3. **A release is cut from what landed** — the surface is `loaf release suggest` and `loaf release cut`. Do not run unsubcommmanded `loaf release`, `--pre-merge`, or `--post-merge`; this skill does not own that path.
 4. **Suggest writes nothing** — it reads `baseline-tag..HEAD` (or `--base <ref>..HEAD`), attributes commits to issues, rolls up through parents, reports partially-landed parents and unattributed commits as information, derives the bump, reports the advisory bucket delta, and drafts notes.
-5. **Cut records facts** — it applies the version, prepends the drafted notes into `CHANGELOG.md`, tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
+5. **Cut records facts** — it applies the version, moves curated `[Unreleased]` prose into the release section (or prepends drafted notes when unreleased is stub-only), tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
 6. **No forward version stamp** — do not bind an issue to a future version. Members are what already landed. Buckets (`loaf issue bucket`) are advisory labels; planned-vs-landed is information only.
 7. **No suite, no re-record, no publication stop in this skill** — ship already verified the merged work. Cut's operational refusals (dirty worktree, disagreeing version files, missing version, `--no-tag` without an existing tag) are command errors, not a substitute for ship.
 8. **Confirm before cut** — present the suggest report (or `cut --dry-run`) first. Ask one question at a time, with a recommendation, using your harness's structured question tool if it has one. `--dry-run` previews everything and writes nothing.
@@ -65,7 +65,7 @@ Cut a version from work that has already landed.
 
 ```text
 loaf release suggest [--base <ref>] [--json]
-loaf release cut [--base <ref>] [--bump <type>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
+loaf release cut [--base <ref>] [--bump <type>] [--version <X.Y.Z>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
 loaf issue bucket <ref> now|next|later|none [--json]
 loaf issue link <from> blocks|relates-to <to> [--json]
 ```
@@ -94,6 +94,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 |------|---------|
 | `--base <ref>` | Commits since `<ref>` instead of the last tag |
 | `--bump <type>` | Override the derived bump: `major`, `minor`, `patch`, `prerelease`, `release` |
+| `--version <X.Y.Z>` | Cut an explicit version (must be valid semver, greater than current, and at least the minimum for the derived bump) |
 | `--includes <version\|tag>` | Record a prior release as a member (repeatable). Use this to hang prerelease references on a stable |
 | `--no-tag` | Do not create a git tag; tag `v<version>` must already exist |
 | `--no-gh` | Skip the GitHub Release draft |
@@ -108,7 +109,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 2. Resolve each `--includes` ref to an existing release
 3. Require a clean worktree
 4. Apply the version to detected version files (they must exist and agree)
-5. Prepend drafted notes into `CHANGELOG.md` (after `[Unreleased]`, ahead of prior versions; creates the file if missing)
+5. Move `[Unreleased]` into `CHANGELOG.md` under `## [version]` — operator-curated unreleased prose is preserved as the release body; drafted notes are used only when unreleased is empty or stub-only
 6. Commit `chore: release vX.Y.Z`
 7. Unless `--no-tag`: create annotated tag `vX.Y.Z` (`git tag -a`). Signing follows git config (`tag.gpgSign`); cut never passes `-s` or `--no-sign`
 8. Record the release row, issue members, and `--includes` members as facts

--- a/internal/cli/release_dry_run.go
+++ b/internal/cli/release_dry_run.go
@@ -457,6 +457,90 @@ func writeReleaseChangelog(root string, releaseSection string) error {
 	return os.WriteFile(path, []byte(updated), 0o644)
 }
 
+// resolveReleaseNotesFromChangelog prefers operator-curated [Unreleased] prose
+// for release notes when the section has real entries; otherwise keeps drafted notes.
+func resolveReleaseNotesFromChangelog(root string, draftedNotes string) string {
+	path := filepath.Join(root, "CHANGELOG.md")
+	body, err := readRegularFile(path, projectFileReadLimit)
+	if err != nil {
+		return draftedNotes
+	}
+	return mergeReleaseChangelogSection(extractReleaseUnreleasedBody(string(body)), draftedNotes)
+}
+
+func extractReleaseUnreleasedBody(existing string) string {
+	lines := strings.Split(existing, "\n")
+	unreleased := -1
+	for i, line := range lines {
+		if releaseUnreleasedHeadingRE.MatchString(strings.TrimSpace(line)) {
+			unreleased = i
+			break
+		}
+	}
+	if unreleased == -1 {
+		return ""
+	}
+	nextRelease := len(lines)
+	for i := unreleased + 1; i < len(lines); i++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), "## [") {
+			nextRelease = i
+			break
+		}
+	}
+	return strings.Join(lines[unreleased+1:nextRelease], "\n")
+}
+
+func releaseUnreleasedIsStubOnly(body string) bool {
+	hasContent := false
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if releaseUnreleasedStubRE.MatchString(trimmed) {
+			continue
+		}
+		hasContent = true
+		break
+	}
+	return !hasContent
+}
+
+func mergeReleaseChangelogSection(unreleasedBody, draftedSection string) string {
+	if releaseUnreleasedIsStubOnly(unreleasedBody) {
+		return draftedSection
+	}
+	header := strings.TrimSpace(firstReleaseChangelogLine(draftedSection))
+	if header == "" {
+		return strings.TrimSpace(unreleasedBody)
+	}
+	curated := strings.TrimSpace(trimReleaseUnreleasedStubs(unreleasedBody))
+	if curated == "" {
+		return draftedSection
+	}
+	return header + "\n\n" + curated
+}
+
+func firstReleaseChangelogLine(section string) string {
+	for _, line := range strings.Split(section, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func trimReleaseUnreleasedStubs(body string) string {
+	var kept []string
+	for _, line := range strings.Split(body, "\n") {
+		if releaseUnreleasedStubRE.MatchString(strings.TrimSpace(line)) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimRight(strings.Join(kept, "\n"), "\n")
+}
+
 func insertReleaseChangelog(existing string, releaseSection string) string {
 	lines := strings.Split(existing, "\n")
 	unreleased := -1
@@ -476,10 +560,66 @@ func insertReleaseChangelog(existing string, releaseSection string) string {
 			break
 		}
 	}
+	unreleasedBody := strings.Join(lines[unreleased+1:nextRelease], "\n")
+	releaseBlock := mergeReleaseChangelogSection(unreleasedBody, releaseSection)
 	result := append([]string{}, lines[:unreleased+1]...)
-	result = append(result, "", "- _No unreleased changes yet._", "", releaseSection, "")
+	result = append(result, "", "- _No unreleased changes yet._", "", releaseBlock, "")
 	result = append(result, lines[nextRelease:]...)
 	return strings.Join(result, "\n")
+}
+
+func compareReleaseSemver(left, right releaseSemver) int {
+	if left.major != right.major {
+		return left.major - right.major
+	}
+	if left.minor != right.minor {
+		return left.minor - right.minor
+	}
+	if left.patch != right.patch {
+		return left.patch - right.patch
+	}
+	if left.prerelease == right.prerelease {
+		return 0
+	}
+	if left.prerelease == "" {
+		return 1
+	}
+	if right.prerelease == "" {
+		return -1
+	}
+	if left.prerelease < right.prerelease {
+		return -1
+	}
+	if left.prerelease > right.prerelease {
+		return 1
+	}
+	return 0
+}
+
+func validateExplicitReleaseVersion(current, bump, explicit string) error {
+	parsedExplicit, ok := parseReleaseSemver(explicit)
+	if !ok {
+		return fmt.Errorf("Invalid version %q", explicit)
+	}
+	parsedCurrent, currentOK := parseReleaseSemver(current)
+	if !currentOK {
+		return nil
+	}
+	if compareReleaseSemver(parsedExplicit, parsedCurrent) <= 0 {
+		return fmt.Errorf("version %s must be greater than current %s", explicit, current)
+	}
+	minimum := bumpReleaseVersion(current, bump)
+	if minimum == "" {
+		return fmt.Errorf("could not compute minimum version for %s bump from %s", bump, current)
+	}
+	parsedMinimum, ok := parseReleaseSemver(minimum)
+	if !ok {
+		return fmt.Errorf("could not parse minimum version %s", minimum)
+	}
+	if compareReleaseSemver(parsedExplicit, parsedMinimum) < 0 {
+		return fmt.Errorf("version %s is below minimum %s for %s bump", explicit, minimum, bump)
+	}
+	return nil
 }
 
 func createReleaseChangelog(releaseSection string) string {

--- a/internal/cli/release_test.go
+++ b/internal/cli/release_test.go
@@ -98,3 +98,74 @@ func gitOutputReleaseTest(t *testing.T, dir string, args ...string) string {
 	}
 	return strings.TrimSpace(string(out))
 }
+
+func TestInsertReleaseChangelogPreservesCuratedUnreleased(t *testing.T) {
+	existing := strings.Join([]string{
+		"# Changelog",
+		"",
+		"## [Unreleased]",
+		"",
+		"### Added",
+		"- Curated operator note for the release",
+		"",
+		"## [1.0.0] - 2025-01-01",
+		"",
+		"- Initial release",
+		"",
+	}, "\n")
+	drafted := "## [1.1.0] - 2026-08-27\n\n### LOAF-1 — Ship auth\n- feat: add auth (abc1234)"
+	got := insertReleaseChangelog(existing, drafted)
+	if !strings.Contains(got, "Curated operator note for the release") {
+		t.Fatalf("curated unreleased prose missing:\n%s", got)
+	}
+	if strings.Contains(got, "### LOAF-1") {
+		t.Fatalf("drafted issue section should not replace curated prose:\n%s", got)
+	}
+	if !strings.Contains(got, "## [1.1.0] - 2026-08-27") {
+		t.Fatalf("release header missing:\n%s", got)
+	}
+	if !strings.Contains(got, "- _No unreleased changes yet._") {
+		t.Fatalf("unreleased stub not reset:\n%s", got)
+	}
+}
+
+func TestInsertReleaseChangelogUsesDraftWhenUnreleasedEmpty(t *testing.T) {
+	existing := strings.Join([]string{
+		"# Changelog",
+		"",
+		"## [Unreleased]",
+		"",
+		"- _No unreleased changes yet._",
+		"",
+		"## [1.0.0] - 2025-01-01",
+		"",
+		"- Initial release",
+		"",
+	}, "\n")
+	drafted := "## [1.1.0] - 2026-08-27\n\n### LOAF-1 — Ship auth\n- feat: add auth (abc1234)"
+	got := insertReleaseChangelog(existing, drafted)
+	if !strings.Contains(got, "### LOAF-1 — Ship auth") {
+		t.Fatalf("drafted notes missing:\n%s", got)
+	}
+}
+
+func TestValidateExplicitReleaseVersionAllowsHigherMinor(t *testing.T) {
+	if err := validateExplicitReleaseVersion("0.3.1", "minor", "0.5.0"); err != nil {
+		t.Fatalf("0.5.0 should be allowed for minor bump from 0.3.1: %v", err)
+	}
+}
+
+func TestValidateExplicitReleaseVersionRejectsBelowMinimum(t *testing.T) {
+	err := validateExplicitReleaseVersion("0.3.1", "minor", "0.3.2")
+	if err == nil || !strings.Contains(err.Error(), "below minimum") {
+		t.Fatalf("expected below minimum error, got %v", err)
+	}
+}
+
+func TestValidateExplicitReleaseVersionRejectsInvalidSemver(t *testing.T) {
+	err := validateExplicitReleaseVersion("0.3.1", "minor", "not-a-version")
+	if err == nil || !strings.Contains(err.Error(), "Invalid version") {
+		t.Fatalf("expected invalid version error, got %v", err)
+	}
+}
+

--- a/internal/cli/release_track.go
+++ b/internal/cli/release_track.go
@@ -21,6 +21,7 @@ type releaseTrackOptions struct {
 	dryRun     bool
 	base       string
 	bump       string
+	version    string
 	noTag      bool
 	noGh       bool
 	includes   []string
@@ -132,9 +133,18 @@ func (r Runner) runReleaseCut(args []string, out io.Writer, runtimeRoot string) 
 		}
 		suggestion.Notes = draftReleaseTrackNotes(suggestion.SuggestedVersion, time.Now().UTC().Format("2006-01-02"), suggestion.Landed, suggestion.Unattributed)
 	}
+	if options.version != "" {
+		if err := validateExplicitReleaseVersion(suggestion.CurrentVersion, suggestion.SuggestedBump, options.version); err != nil {
+			return err
+		}
+		suggestion.SuggestedVersion = options.version
+		suggestion.BumpEvidence = "overridden by --version " + options.version
+		suggestion.Notes = draftReleaseTrackNotes(suggestion.SuggestedVersion, time.Now().UTC().Format("2006-01-02"), suggestion.Landed, suggestion.Unattributed)
+	}
 	if suggestion.SuggestedVersion == "" {
 		return fmt.Errorf("could not compute a version to cut")
 	}
+	suggestion.Notes = resolveReleaseNotesFromChangelog(runtimeRoot, suggestion.Notes)
 
 	projectRoot, resolver, err := r.releaseTrackState(runtimeRoot)
 	if err != nil {
@@ -469,6 +479,17 @@ func parseReleaseTrackArgs(args []string, cut bool) (releaseTrackOptions, error)
 			if options.bump == "" {
 				return releaseTrackOptions{}, fmt.Errorf("--bump requires a value")
 			}
+		case arg == "--version":
+			value, err := consumeFlagValue(args, &i, "--version")
+			if err != nil {
+				return releaseTrackOptions{}, err
+			}
+			options.version = value
+		case strings.HasPrefix(arg, "--version="):
+			options.version = strings.TrimPrefix(arg, "--version=")
+			if options.version == "" {
+				return releaseTrackOptions{}, fmt.Errorf("--version requires a value")
+			}
 		case arg == "--base":
 			value, err := consumeFlagValue(args, &i, "--base")
 			if err != nil {
@@ -503,7 +524,7 @@ func parseReleaseTrackArgs(args []string, cut bool) (releaseTrackOptions, error)
 		if options.dryRun {
 			return releaseTrackOptions{}, fmt.Errorf("suggest is read-only; --dry-run is not valid")
 		}
-		if options.noTag || options.noGh || len(options.includes) > 0 || options.bump != "" {
+		if options.noTag || options.noGh || len(options.includes) > 0 || options.bump != "" || options.version != "" {
 			return releaseTrackOptions{}, fmt.Errorf("suggest does not accept cut-only flags")
 		}
 	} else if options.jsonOutput {
@@ -1170,6 +1191,7 @@ func writeReleaseCutHelp(out io.Writer) {
 		"Options:",
 		"  --base <ref>              Use commits since <ref> instead of last tag",
 		"  --bump <type>             Override the suggested bump",
+		"  --version <X.Y.Z>         Cut an explicit version (must satisfy bump rules)",
 		"  --includes <version|tag>  Reference a prior release (repeatable)",
 		"  --no-tag                  Skip git tag creation (tag v<version> must already exist)",
 		"  --no-gh                   Skip GitHub release draft",

--- a/internal/cli/release_track_test.go
+++ b/internal/cli/release_track_test.go
@@ -1027,3 +1027,91 @@ func TestReleaseCutCommitFailureRemovesCreatedChangelog(t *testing.T) {
 		t.Fatalf("failed cut tags = %q", tags)
 	}
 }
+
+func TestReleaseCutPreservesCuratedChangelog(t *testing.T) {
+	repo, stateHome := releaseTrackFixture(t)
+	writeFile(t, filepath.Join(repo, "CHANGELOG.md"), strings.Join([]string{
+		"# Changelog",
+		"",
+		"## [Unreleased]",
+		"",
+		"### Added",
+		"- Operator curated release summary",
+		"",
+		"## [1.0.0] - 2025-01-01",
+		"",
+		"- Initial release",
+		"",
+	}, "\n"))
+	gitCLI(t, repo, "add", "CHANGELOG.md")
+	gitCLI(t, repo, "commit", "-m", "docs: curate unreleased changelog")
+
+	if _, err := runIssue(t, repo, stateHome, "new", "Ship auth"); err != nil {
+		t.Fatalf("issue new error = %v", err)
+	}
+	if _, err := runIssue(t, repo, stateHome, "status", "LOAF-1", "done"); err != nil {
+		t.Fatalf("status error = %v", err)
+	}
+	writeFile(t, filepath.Join(repo, "auth.txt"), "auth\n")
+	gitCLI(t, repo, "add", "auth.txt")
+	gitCLI(t, repo, "commit", "-m", "feat: add auth LOAF-1")
+
+	gitCLI(t, repo, "tag", "v1.1.0")
+	cutOut, err := runReleaseTrack(t, repo, stateHome, "cut", "--no-tag", "--no-gh", "--base", "v1.0.0")
+	if err != nil {
+		t.Fatalf("release cut error = %v\n%s", err, cutOut)
+	}
+	logBody, err := os.ReadFile(filepath.Join(repo, "CHANGELOG.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(logBody)
+	if !strings.Contains(body, "Operator curated release summary") {
+		t.Fatalf("curated unreleased prose not preserved:\n%s", body)
+	}
+	if strings.Contains(body, "### LOAF-1") {
+		t.Fatalf("drafted issue section replaced curated prose:\n%s", body)
+	}
+}
+
+func TestReleaseCutVersionFlagDryRun(t *testing.T) {
+	repo := realpath(t, t.TempDir())
+	stateHome := t.TempDir()
+	gitCLI(t, repo, "init", "-b", "main")
+	gitCLI(t, repo, "config", "user.name", "Loaf Test")
+	gitCLI(t, repo, "config", "user.email", "loaf@example.test")
+	gitCLI(t, repo, "config", "commit.gpgsign", "false")
+	gitCLI(t, repo, "config", "tag.gpgsign", "false")
+	writeFile(t, filepath.Join(repo, "package.json"), "{\n  \"name\": \"release-fixture\",\n  \"version\": \"0.3.1\",\n  \"scripts\": {\n    \"build\": \"echo build\"\n  }\n}\n")
+	writeFile(t, filepath.Join(repo, "CHANGELOG.md"), strings.Join([]string{
+		"# Changelog",
+		"",
+		"## [Unreleased]",
+		"",
+		"- _No unreleased changes yet._",
+		"",
+	}, "\n"))
+	gitCLI(t, repo, "add", ".")
+	gitCLI(t, repo, "commit", "-m", "chore: initial release")
+	gitCLI(t, repo, "tag", "v0.3.1")
+	if err := (Runner{Stdout: &bytes.Buffer{}, WorkingDir: repo, StateHome: stateHome}).Run([]string{"state", "init"}); err != nil {
+		t.Fatalf("state init error = %v", err)
+	}
+	commitBootstrapAgentsFiles(t, repo)
+
+	writeFile(t, filepath.Join(repo, "feature.txt"), "feature\n")
+	gitCLI(t, repo, "add", "feature.txt")
+	gitCLI(t, repo, "commit", "-m", "feat: add feature")
+
+	out, err := runReleaseTrack(t, repo, stateHome, "cut", "--dry-run", "--no-gh", "--version", "0.5.0")
+	if err != nil {
+		t.Fatalf("release cut --dry-run --version error = %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "0.5.0") {
+		t.Fatalf("dry-run output missing 0.5.0:\n%s", out)
+	}
+	if strings.Contains(out, "0.4.0") {
+		t.Fatalf("dry-run should target explicit 0.5.0, not suggested 0.4.0:\n%s", out)
+	}
+}
+

--- a/plugins/loaf/skills/release/SKILL.md
+++ b/plugins/loaf/skills/release/SKILL.md
@@ -36,7 +36,7 @@ Cut a version from work that has already landed.
 2. **Release is not merge** — do not review, approve, or land a PR here. Verification authority is the ship workflow (PR review and CI at merge). If the user is asking to merge, stop and route to ship.
 3. **A release is cut from what landed** — the surface is `loaf release suggest` and `loaf release cut`. Do not run unsubcommmanded `loaf release`, `--pre-merge`, or `--post-merge`; this skill does not own that path.
 4. **Suggest writes nothing** — it reads `baseline-tag..HEAD` (or `--base <ref>..HEAD`), attributes commits to issues, rolls up through parents, reports partially-landed parents and unattributed commits as information, derives the bump, reports the advisory bucket delta, and drafts notes.
-5. **Cut records facts** — it applies the version, prepends the drafted notes into `CHANGELOG.md`, tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
+5. **Cut records facts** — it applies the version, moves curated `[Unreleased]` prose into the release section (or prepends drafted notes when unreleased is stub-only), tags, records the release row plus members, then attempts a GitHub Release draft. A `gh` failure degrades to a warning with a paste-ready retry command; the recorded row stays.
 6. **No forward version stamp** — do not bind an issue to a future version. Members are what already landed. Buckets (`loaf issue bucket`) are advisory labels; planned-vs-landed is information only.
 7. **No suite, no re-record, no publication stop in this skill** — ship already verified the merged work. Cut's operational refusals (dirty worktree, disagreeing version files, missing version, `--no-tag` without an existing tag) are command errors, not a substitute for ship.
 8. **Confirm before cut** — present the suggest report (or `cut --dry-run`) first. Ask one question at a time, with a recommendation, using your harness's structured question tool if it has one. `--dry-run` previews everything and writes nothing.
@@ -68,7 +68,7 @@ Cut a version from work that has already landed.
 
 ```text
 loaf release suggest [--base <ref>] [--json]
-loaf release cut [--base <ref>] [--bump <type>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
+loaf release cut [--base <ref>] [--bump <type>] [--version <X.Y.Z>] [--includes <version|tag>] [--no-tag] [--no-gh] [--dry-run]
 loaf issue bucket <ref> now|next|later|none [--json]
 loaf issue link <from> blocks|relates-to <to> [--json]
 ```
@@ -97,6 +97,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 |------|---------|
 | `--base <ref>` | Commits since `<ref>` instead of the last tag |
 | `--bump <type>` | Override the derived bump: `major`, `minor`, `patch`, `prerelease`, `release` |
+| `--version <X.Y.Z>` | Cut an explicit version (must be valid semver, greater than current, and at least the minimum for the derived bump) |
 | `--includes <version\|tag>` | Record a prior release as a member (repeatable). Use this to hang prerelease references on a stable |
 | `--no-tag` | Do not create a git tag; tag `v<version>` must already exist |
 | `--no-gh` | Skip the GitHub Release draft |
@@ -111,7 +112,7 @@ Both commands need initialized SQLite state (`loaf state init`, or `loaf state m
 2. Resolve each `--includes` ref to an existing release
 3. Require a clean worktree
 4. Apply the version to detected version files (they must exist and agree)
-5. Prepend drafted notes into `CHANGELOG.md` (after `[Unreleased]`, ahead of prior versions; creates the file if missing)
+5. Move `[Unreleased]` into `CHANGELOG.md` under `## [version]` — operator-curated unreleased prose is preserved as the release body; drafted notes are used only when unreleased is empty or stub-only
 6. Commit `chore: release vX.Y.Z`
 7. Unless `--no-tag`: create annotated tag `vX.Y.Z` (`git tag -a`). Signing follows git config (`tag.gpgSign`); cut never passes `-s` or `--no-sign`
 8. Record the release row, issue members, and `--includes` members as facts


### PR DESCRIPTION
## Summary

Unblocks the LOAF-62 release ceremony by fixing two `loaf release cut` gaps discovered during parent closeout prep:

- **Curated changelog preservation** — `insertReleaseChangelog` now moves operator-written `[Unreleased]` prose into the release section instead of overwriting it with auto-drafted issue notes. Drafted notes are used only when unreleased is empty or stub-only.
- **Explicit version** — `loaf release cut --version <X.Y.Z>` cuts a semver greater than current and at least the minimum for the derived bump (e.g. cut `0.5.0` when suggest derives `0.4.0` minor).

Release skill docs updated to match.

## Context

This is a targeted fix ahead of the LOAF-62 parent closeout ([#207](https://github.com/levifig/loaf/pull/207)). Merge after #207 lands, or stack/rebase as needed for the release ceremony.

## Test plan

- [x] `go test ./internal/cli/... -count=1`
- [x] `TestInsertReleaseChangelogPreservesCuratedUnreleased` / stub-only draft fallback
- [x] `TestReleaseCutPreservesCuratedChangelog` integration
- [x] `TestReleaseCutVersionFlagDryRun` for `--version 0.5.0`
- [x] `validateExplicitReleaseVersion` unit cases