### PR TITLE
docs: codify shippable Git history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ One operator's durable memory â€” journal, wraps, handoffs, refs, verification â
 
 ### Changed
 
+- Git workflow guidance treats working commits as implementation checkpoints, squash-merges one reviewed shippable root per PR, assembles related stacked work with verified fast-forwards, and preserves merge commits only for explicitly justified durable topology ([#211](https://github.com/levifig/loaf/issues/211)).
 - **Breaking:** The distroless sync-server image now binds HTTP `:8080` instead of `:8443`. Terminate TLS at a reverse proxy, or pass `--tls-cert` and `--tls-key` to `loaf serve`.
 - **Breaking:** `loaf serve` refuses ports `443` and `8443` unless `--tls-cert` and `--tls-key` are set, so `LoafToken` / `LoafAdmin` credentials are not sent on a TLS-looking cleartext listener ([#198](https://github.com/levifig/loaf/pull/198)).
 - `loaf issue start` walks to the shippable root of the issue tree. Only that root gets `issue/<root-alias>` and a worktree; starting a child creates or joins the root workspace and marks the child active. `loaf issue stop` on a child that does not own a worktree names the root ([#166](https://github.com/levifig/loaf/pull/166)).

--- a/content/hooks/instructions/pre-pr-checklist.md
+++ b/content/hooks/instructions/pre-pr-checklist.md
@@ -1,6 +1,10 @@
 ## Before creating this PR, complete these steps:
 
-### 1. CHANGELOG entry
+### 1. Shipping unit
+
+Confirm that the branch represents exactly one shippable root. Related stacked children must have verified ancestry and be assembled into the root with `git merge --ff-only`; independent shippable roots need separate PRs unless an explicit human decision records why one atomic landing is safer.
+
+### 2. CHANGELOG entry
 
 Add an entry under `## [Unreleased]` in `CHANGELOG.md`, categorized by Common Changelog impact:
 
@@ -37,7 +41,7 @@ is a workflow staging section for curated entries that land with PRs before a la
 - Your entry here
 ```
 
-### 2. PR title
+### 3. PR title
 
 Conventional commit format, under 70 characters:
 
@@ -48,7 +52,7 @@ fix: prevent divide by zero in sag calculation
 
 No scope prefixes. No SPEC/TASK IDs in the title.
 
-### 3. PR body
+### 4. PR body
 
 The body is `loaf issue render <ref>` output. No project headers, no hand-edited summary. Checkboxes stay unchecked until `loaf issue status <ref> done`.
 
@@ -56,9 +60,9 @@ The body is `loaf issue render <ref>` output. No project headers, no hand-edited
 gh pr create --title "type: summary" --body "$(loaf issue render <ref>)"
 ```
 
-### 4. Merge strategy
+### 5. Merge strategy
 
-Squash merge. Write a clean extended description (2-4 lines summarizing the branch). Never use the auto-generated squash description.
+Squash merge this one shippable unit. Write a clean extended description (2-4 lines summarizing the outcome). Never use the auto-generated squash description or create a merge commit merely to preserve feature-branch topology.
 
 ---
 

--- a/content/hooks/instructions/pre-pr-format.md
+++ b/content/hooks/instructions/pre-pr-format.md
@@ -1,7 +1,9 @@
 ## PR format reminder
 
+**Root:** One shippable root. Assemble related stacked children with verified ancestry and `--ff-only`; split independent roots unless a human explicitly approves one atomic landing.
+
 **Title:** Conventional commit, <70 chars. No scope prefixes, no SPEC/TASK IDs.
 
 **Body:** `## Summary` (2-4 bullets) + `## Test plan` (checklist).
 
-**Merge:** Squash merge with clean extended description (2-4 lines). Do not use auto-generated squash description.
+**Merge:** Squash this shippable unit with a clean extended description (2-4 lines). Do not use an auto-generated description or an incidental merge commit.

--- a/content/skills/git-workflow/SKILL.md
+++ b/content/skills/git-workflow/SKILL.md
@@ -20,8 +20,11 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Critical Rules
 
 - Use Conventional Commits format for all commit messages
-- Commit complete units of work -- don't commit partial or in-progress changes
-- Squash merge feature branches -- never merge commits directly
+- Working-branch commits are complete implementation checkpoints. Keep each one atomic and buildable enough to support review, diagnosis, and safe continuation; do not commit partial or knowingly broken work.
+- A pull request is one shippable unit. Squash merge a reviewed feature or shippable-root PR into the default branch with a deliberately authored Conventional Commit title and useful extended description; never use an automatic dump of branch commit messages.
+- Related child or stacked branches join their shippable root without synthetic topology. Verify ancestry with `git merge-base --is-ancestor <root> <child>`, then use `git merge --ff-only <child>` from the root branch. If ancestry diverged, stop and reassess instead of creating a merge commit by default.
+- Merge commits are exceptions. Preserve one only when topology, provenance, or a long-lived integration is itself durable project information, and record the explicit rationale. Never create one merely to assemble related feature work.
+- Independent shippable roots must not disappear inside one giant squash solely because they share an implementation branch. Split them into separate reviewed PRs, or obtain an explicit human decision that one atomic landing is safer.
 - One branch per shippable root; `loaf issue start` walks to that root and creates or joins `issue/<root-alias-or-id>` (or use `feat/{slug}` / `fix/{slug}` when not starting from an issue). Related child issues share the parent's branch and the PR to main.
 - Never force-push to `main` or shared branches
 - Never push without explicit user confirmation
@@ -29,8 +32,12 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Verification
 
 - Commit messages follow unscoped Conventional Commits format (`type: description`)
-- Branch is up to date with base branch before creating PR
+- Every working-branch commit is a complete checkpoint, and the candidate diff represents exactly one shippable root
+- Stacked work was verified as ancestral and assembled with `--ff-only`; no incidental merge commit exists
+- Independent shippable roots have separate PRs unless an explicit human decision documents why one atomic landing is safer
+- Branch is up to date with its base branch before creating the PR
 - PR title is under 70 characters with PR# suffix convention
+- The squash title and extended description describe the shipped outcome rather than replaying implementation commits
 
 ## Quick Reference
 
@@ -38,7 +45,9 @@ Git conventions for branching, commits, PRs, and merge workflow.
 |--------|----------------|
 | Branch naming | `issue/<root-alias-or-id>` from `loaf issue start`; else `feat/{slug}`, `fix/{slug}`, `chore/{slug}` |
 | Commit format | `type: description` |
-| Squash merge | `gh pr merge --squash` |
+| Assemble stacked child | Verify `git merge-base --is-ancestor <root> <child>`, then run `git merge --ff-only <child>` from the root |
+| Squash shippable PR | `gh pr merge --squash`; author the final title and description deliberately |
+| Preserve merge topology | Exceptional only; require explicit durable rationale before using a merge commit |
 | PR creation | `gh pr create --title "..." --body "..."` |
 
 ## Topics

--- a/content/skills/git-workflow/references/commits.md
+++ b/content/skills/git-workflow/references/commits.md
@@ -5,6 +5,7 @@
 - Commit Body
 - Linear Integration
 - Branch Naming
+- History Model
 - Pull Request Format
 - Changelog Discipline
 - Critical Rules
@@ -129,6 +130,32 @@ issue/<alias-or-id>
 - Short but descriptive (max 50 chars)
 - Prefer the started worktree branch from `loaf issue start` when implementing an issue
 
+## History Model
+
+Treat the three levels of Git history differently:
+
+1. **Working-branch commits are implementation checkpoints.** Keep them atomic, coherent, and useful for review or diagnosis. They may record how a shippable outcome was built, but they are not automatically permanent product-history units.
+2. **A pull request is one shippable unit.** It carries one reviewed root journey and normally lands as one deliberately authored squash commit on the default branch.
+3. **The default branch is product history.** Each commit should describe an observable, deployable outcome that can be reverted as a unit.
+
+### Stacked or Child Branches
+
+Related child work that belongs to one shippable root should not create an artificial merge bubble. Before assembling it, prove that the root is an ancestor of the child:
+
+```bash
+git merge-base --is-ancestor <root> <child>
+git switch <root>
+git merge --ff-only <child>
+```
+
+The second command must refuse if the histories diverged. When that happens, stop and inspect the competing changes; do not silently fall back to a merge commit or rewrite a shared branch.
+
+### Independent Roots and Merge Exceptions
+
+Independent shippable roots need separate reviewed PRs even when implementation happened on one branch. Do not conceal them inside one giant squash merely for convenience. If splitting would make the landing less safe, obtain an explicit human decision that names why one atomic change is preferable.
+
+Merge commits are reserved for cases where the topology is itself durable evidence, such as a long-lived integration branch, provenance-sensitive upstream import, or deliberately preserved parallel history. Record that rationale before merging. Ordinary feature assembly is not sufficient reason.
+
 ## Pull Request Format
 
 ### Title
@@ -149,10 +176,12 @@ gh pr create --title "type: summary" --body "$(loaf issue render <ref>)"
 
 ### Merge Strategy
 
-- **Prefer squash merge** unless explicitly told otherwise
+- **Squash merge one reviewed shippable-root PR** unless an explicitly approved topology-preservation exception applies
 - GitHub defaults the merge title to `PR title (#N)` — this is the desired format
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
+- Assemble related stacked branches into their root with verified ancestry and `git merge --ff-only`; never create a merge commit merely to combine them
+- Split independent shippable roots before the PR, or record an explicit human decision that one atomic squash is safer
 - Don't push or merge without explicit request
 - The ship skill automates this workflow when ready to squash merge a PR; release publishes a version later from already-landed work
 
@@ -197,15 +226,15 @@ Before approving a release bump, compare `[Unreleased]` against the actual relea
 
 ### Always
 
-- Write atomic commits (one logical change)
-- Commit complete units of work — finish the change, review it, then commit once
+- Write atomic working-branch checkpoints, each representing one coherent logical change
+- Keep every checkpoint complete and buildable enough for review, diagnosis, and safe continuation
 - Use imperative mood in messages
 - Reference issue numbers when applicable
-- Test before committing
+- Run the checks proportionate to that checkpoint before committing
 
 ### Never
 
-- Commit partial or in-progress work — if feedback is likely, wait for it before committing
+- Commit a knowingly broken or internally incomplete checkpoint
 - Skip commit signing (wait for user if it fails)
 - Push without explicit user confirmation
 - Use scoped commit subjects (for example, `feat(auth):`; write `feat:` instead)

--- a/dist/amp/skills/git-workflow/SKILL.md
+++ b/dist/amp/skills/git-workflow/SKILL.md
@@ -22,8 +22,11 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Critical Rules
 
 - Use Conventional Commits format for all commit messages
-- Commit complete units of work -- don't commit partial or in-progress changes
-- Squash merge feature branches -- never merge commits directly
+- Working-branch commits are complete implementation checkpoints. Keep each one atomic and buildable enough to support review, diagnosis, and safe continuation; do not commit partial or knowingly broken work.
+- A pull request is one shippable unit. Squash merge a reviewed feature or shippable-root PR into the default branch with a deliberately authored Conventional Commit title and useful extended description; never use an automatic dump of branch commit messages.
+- Related child or stacked branches join their shippable root without synthetic topology. Verify ancestry with `git merge-base --is-ancestor <root> <child>`, then use `git merge --ff-only <child>` from the root branch. If ancestry diverged, stop and reassess instead of creating a merge commit by default.
+- Merge commits are exceptions. Preserve one only when topology, provenance, or a long-lived integration is itself durable project information, and record the explicit rationale. Never create one merely to assemble related feature work.
+- Independent shippable roots must not disappear inside one giant squash solely because they share an implementation branch. Split them into separate reviewed PRs, or obtain an explicit human decision that one atomic landing is safer.
 - One branch per shippable root; `loaf issue start` walks to that root and creates or joins `issue/<root-alias-or-id>` (or use `feat/{slug}` / `fix/{slug}` when not starting from an issue). Related child issues share the parent's branch and the PR to main.
 - Never force-push to `main` or shared branches
 - Never push without explicit user confirmation
@@ -31,8 +34,12 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Verification
 
 - Commit messages follow unscoped Conventional Commits format (`type: description`)
-- Branch is up to date with base branch before creating PR
+- Every working-branch commit is a complete checkpoint, and the candidate diff represents exactly one shippable root
+- Stacked work was verified as ancestral and assembled with `--ff-only`; no incidental merge commit exists
+- Independent shippable roots have separate PRs unless an explicit human decision documents why one atomic landing is safer
+- Branch is up to date with its base branch before creating the PR
 - PR title is under 70 characters with PR# suffix convention
+- The squash title and extended description describe the shipped outcome rather than replaying implementation commits
 
 ## Quick Reference
 
@@ -40,7 +47,9 @@ Git conventions for branching, commits, PRs, and merge workflow.
 |--------|----------------|
 | Branch naming | `issue/<root-alias-or-id>` from `loaf issue start`; else `feat/{slug}`, `fix/{slug}`, `chore/{slug}` |
 | Commit format | `type: description` |
-| Squash merge | `gh pr merge --squash` |
+| Assemble stacked child | Verify `git merge-base --is-ancestor <root> <child>`, then run `git merge --ff-only <child>` from the root |
+| Squash shippable PR | `gh pr merge --squash`; author the final title and description deliberately |
+| Preserve merge topology | Exceptional only; require explicit durable rationale before using a merge commit |
 | PR creation | `gh pr create --title "..." --body "..."` |
 
 ## Topics

--- a/dist/amp/skills/git-workflow/references/commits.md
+++ b/dist/amp/skills/git-workflow/references/commits.md
@@ -5,6 +5,7 @@
 - Commit Body
 - Linear Integration
 - Branch Naming
+- History Model
 - Pull Request Format
 - Changelog Discipline
 - Critical Rules
@@ -129,6 +130,32 @@ issue/<alias-or-id>
 - Short but descriptive (max 50 chars)
 - Prefer the started worktree branch from `loaf issue start` when implementing an issue
 
+## History Model
+
+Treat the three levels of Git history differently:
+
+1. **Working-branch commits are implementation checkpoints.** Keep them atomic, coherent, and useful for review or diagnosis. They may record how a shippable outcome was built, but they are not automatically permanent product-history units.
+2. **A pull request is one shippable unit.** It carries one reviewed root journey and normally lands as one deliberately authored squash commit on the default branch.
+3. **The default branch is product history.** Each commit should describe an observable, deployable outcome that can be reverted as a unit.
+
+### Stacked or Child Branches
+
+Related child work that belongs to one shippable root should not create an artificial merge bubble. Before assembling it, prove that the root is an ancestor of the child:
+
+```bash
+git merge-base --is-ancestor <root> <child>
+git switch <root>
+git merge --ff-only <child>
+```
+
+The second command must refuse if the histories diverged. When that happens, stop and inspect the competing changes; do not silently fall back to a merge commit or rewrite a shared branch.
+
+### Independent Roots and Merge Exceptions
+
+Independent shippable roots need separate reviewed PRs even when implementation happened on one branch. Do not conceal them inside one giant squash merely for convenience. If splitting would make the landing less safe, obtain an explicit human decision that names why one atomic change is preferable.
+
+Merge commits are reserved for cases where the topology is itself durable evidence, such as a long-lived integration branch, provenance-sensitive upstream import, or deliberately preserved parallel history. Record that rationale before merging. Ordinary feature assembly is not sufficient reason.
+
 ## Pull Request Format
 
 ### Title
@@ -149,10 +176,12 @@ gh pr create --title "type: summary" --body "$(loaf issue render <ref>)"
 
 ### Merge Strategy
 
-- **Prefer squash merge** unless explicitly told otherwise
+- **Squash merge one reviewed shippable-root PR** unless an explicitly approved topology-preservation exception applies
 - GitHub defaults the merge title to `PR title (#N)` — this is the desired format
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
+- Assemble related stacked branches into their root with verified ancestry and `git merge --ff-only`; never create a merge commit merely to combine them
+- Split independent shippable roots before the PR, or record an explicit human decision that one atomic squash is safer
 - Don't push or merge without explicit request
 - The ship skill automates this workflow when ready to squash merge a PR; release publishes a version later from already-landed work
 
@@ -197,15 +226,15 @@ Before approving a release bump, compare `[Unreleased]` against the actual relea
 
 ### Always
 
-- Write atomic commits (one logical change)
-- Commit complete units of work — finish the change, review it, then commit once
+- Write atomic working-branch checkpoints, each representing one coherent logical change
+- Keep every checkpoint complete and buildable enough for review, diagnosis, and safe continuation
 - Use imperative mood in messages
 - Reference issue numbers when applicable
-- Test before committing
+- Run the checks proportionate to that checkpoint before committing
 
 ### Never
 
-- Commit partial or in-progress work — if feedback is likely, wait for it before committing
+- Commit a knowingly broken or internally incomplete checkpoint
 - Skip commit signing (wait for user if it fails)
 - Push without explicit user confirmation
 - Use scoped commit subjects (for example, `feat(auth):`; write `feat:` instead)

--- a/dist/codex/skills/git-workflow/SKILL.md
+++ b/dist/codex/skills/git-workflow/SKILL.md
@@ -22,8 +22,11 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Critical Rules
 
 - Use Conventional Commits format for all commit messages
-- Commit complete units of work -- don't commit partial or in-progress changes
-- Squash merge feature branches -- never merge commits directly
+- Working-branch commits are complete implementation checkpoints. Keep each one atomic and buildable enough to support review, diagnosis, and safe continuation; do not commit partial or knowingly broken work.
+- A pull request is one shippable unit. Squash merge a reviewed feature or shippable-root PR into the default branch with a deliberately authored Conventional Commit title and useful extended description; never use an automatic dump of branch commit messages.
+- Related child or stacked branches join their shippable root without synthetic topology. Verify ancestry with `git merge-base --is-ancestor <root> <child>`, then use `git merge --ff-only <child>` from the root branch. If ancestry diverged, stop and reassess instead of creating a merge commit by default.
+- Merge commits are exceptions. Preserve one only when topology, provenance, or a long-lived integration is itself durable project information, and record the explicit rationale. Never create one merely to assemble related feature work.
+- Independent shippable roots must not disappear inside one giant squash solely because they share an implementation branch. Split them into separate reviewed PRs, or obtain an explicit human decision that one atomic landing is safer.
 - One branch per shippable root; `loaf issue start` walks to that root and creates or joins `issue/<root-alias-or-id>` (or use `feat/{slug}` / `fix/{slug}` when not starting from an issue). Related child issues share the parent's branch and the PR to main.
 - Never force-push to `main` or shared branches
 - Never push without explicit user confirmation
@@ -31,8 +34,12 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Verification
 
 - Commit messages follow unscoped Conventional Commits format (`type: description`)
-- Branch is up to date with base branch before creating PR
+- Every working-branch commit is a complete checkpoint, and the candidate diff represents exactly one shippable root
+- Stacked work was verified as ancestral and assembled with `--ff-only`; no incidental merge commit exists
+- Independent shippable roots have separate PRs unless an explicit human decision documents why one atomic landing is safer
+- Branch is up to date with its base branch before creating the PR
 - PR title is under 70 characters with PR# suffix convention
+- The squash title and extended description describe the shipped outcome rather than replaying implementation commits
 
 ## Quick Reference
 
@@ -40,7 +47,9 @@ Git conventions for branching, commits, PRs, and merge workflow.
 |--------|----------------|
 | Branch naming | `issue/<root-alias-or-id>` from `loaf issue start`; else `feat/{slug}`, `fix/{slug}`, `chore/{slug}` |
 | Commit format | `type: description` |
-| Squash merge | `gh pr merge --squash` |
+| Assemble stacked child | Verify `git merge-base --is-ancestor <root> <child>`, then run `git merge --ff-only <child>` from the root |
+| Squash shippable PR | `gh pr merge --squash`; author the final title and description deliberately |
+| Preserve merge topology | Exceptional only; require explicit durable rationale before using a merge commit |
 | PR creation | `gh pr create --title "..." --body "..."` |
 
 ## Topics

--- a/dist/codex/skills/git-workflow/references/commits.md
+++ b/dist/codex/skills/git-workflow/references/commits.md
@@ -5,6 +5,7 @@
 - Commit Body
 - Linear Integration
 - Branch Naming
+- History Model
 - Pull Request Format
 - Changelog Discipline
 - Critical Rules
@@ -129,6 +130,32 @@ issue/<alias-or-id>
 - Short but descriptive (max 50 chars)
 - Prefer the started worktree branch from `loaf issue start` when implementing an issue
 
+## History Model
+
+Treat the three levels of Git history differently:
+
+1. **Working-branch commits are implementation checkpoints.** Keep them atomic, coherent, and useful for review or diagnosis. They may record how a shippable outcome was built, but they are not automatically permanent product-history units.
+2. **A pull request is one shippable unit.** It carries one reviewed root journey and normally lands as one deliberately authored squash commit on the default branch.
+3. **The default branch is product history.** Each commit should describe an observable, deployable outcome that can be reverted as a unit.
+
+### Stacked or Child Branches
+
+Related child work that belongs to one shippable root should not create an artificial merge bubble. Before assembling it, prove that the root is an ancestor of the child:
+
+```bash
+git merge-base --is-ancestor <root> <child>
+git switch <root>
+git merge --ff-only <child>
+```
+
+The second command must refuse if the histories diverged. When that happens, stop and inspect the competing changes; do not silently fall back to a merge commit or rewrite a shared branch.
+
+### Independent Roots and Merge Exceptions
+
+Independent shippable roots need separate reviewed PRs even when implementation happened on one branch. Do not conceal them inside one giant squash merely for convenience. If splitting would make the landing less safe, obtain an explicit human decision that names why one atomic change is preferable.
+
+Merge commits are reserved for cases where the topology is itself durable evidence, such as a long-lived integration branch, provenance-sensitive upstream import, or deliberately preserved parallel history. Record that rationale before merging. Ordinary feature assembly is not sufficient reason.
+
 ## Pull Request Format
 
 ### Title
@@ -149,10 +176,12 @@ gh pr create --title "type: summary" --body "$(loaf issue render <ref>)"
 
 ### Merge Strategy
 
-- **Prefer squash merge** unless explicitly told otherwise
+- **Squash merge one reviewed shippable-root PR** unless an explicitly approved topology-preservation exception applies
 - GitHub defaults the merge title to `PR title (#N)` — this is the desired format
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
+- Assemble related stacked branches into their root with verified ancestry and `git merge --ff-only`; never create a merge commit merely to combine them
+- Split independent shippable roots before the PR, or record an explicit human decision that one atomic squash is safer
 - Don't push or merge without explicit request
 - The ship skill automates this workflow when ready to squash merge a PR; release publishes a version later from already-landed work
 
@@ -197,15 +226,15 @@ Before approving a release bump, compare `[Unreleased]` against the actual relea
 
 ### Always
 
-- Write atomic commits (one logical change)
-- Commit complete units of work — finish the change, review it, then commit once
+- Write atomic working-branch checkpoints, each representing one coherent logical change
+- Keep every checkpoint complete and buildable enough for review, diagnosis, and safe continuation
 - Use imperative mood in messages
 - Reference issue numbers when applicable
-- Test before committing
+- Run the checks proportionate to that checkpoint before committing
 
 ### Never
 
-- Commit partial or in-progress work — if feedback is likely, wait for it before committing
+- Commit a knowingly broken or internally incomplete checkpoint
 - Skip commit signing (wait for user if it fails)
 - Push without explicit user confirmation
 - Use scoped commit subjects (for example, `feat(auth):`; write `feat:` instead)

--- a/dist/cursor/.loaf-target-manifest.json
+++ b/dist/cursor/.loaf-target-manifest.json
@@ -28,7 +28,7 @@
       "kind": "hook-file",
       "source_path": "hooks/instructions/pre-pr-checklist.md",
       "destination": "hooks/instructions/pre-pr-checklist.md",
-      "sha256": "64a647e40d2d7f52224a60b978012265f80414c8eb2c893e61a97faa74375dd3",
+      "sha256": "ed897b6d832a36ca5b469bafb4dfabd5680c5560e34b0dcecee1604cca47c369",
       "mode": 420
     },
     {
@@ -36,7 +36,7 @@
       "kind": "hook-file",
       "source_path": "hooks/instructions/pre-pr-format.md",
       "destination": "hooks/instructions/pre-pr-format.md",
-      "sha256": "da8d29ce41a1218467f68d4186f906c47075d88b3339a9fb19a8b50f8f40de82",
+      "sha256": "0f0b5e3e93c2bf4e34c7214619d978ef3341bcf4370a84d5257cfb95b4ffd9cc",
       "mode": 420
     },
     {

--- a/dist/cursor/hooks/instructions/pre-pr-checklist.md
+++ b/dist/cursor/hooks/instructions/pre-pr-checklist.md
@@ -1,6 +1,10 @@
 ## Before creating this PR, complete these steps:
 
-### 1. CHANGELOG entry
+### 1. Shipping unit
+
+Confirm that the branch represents exactly one shippable root. Related stacked children must have verified ancestry and be assembled into the root with `git merge --ff-only`; independent shippable roots need separate PRs unless an explicit human decision records why one atomic landing is safer.
+
+### 2. CHANGELOG entry
 
 Add an entry under `## [Unreleased]` in `CHANGELOG.md`, categorized by Common Changelog impact:
 
@@ -37,7 +41,7 @@ is a workflow staging section for curated entries that land with PRs before a la
 - Your entry here
 ```
 
-### 2. PR title
+### 3. PR title
 
 Conventional commit format, under 70 characters:
 
@@ -48,7 +52,7 @@ fix: prevent divide by zero in sag calculation
 
 No scope prefixes. No SPEC/TASK IDs in the title.
 
-### 3. PR body
+### 4. PR body
 
 The body is `loaf issue render <ref>` output. No project headers, no hand-edited summary. Checkboxes stay unchecked until `loaf issue status <ref> done`.
 
@@ -56,9 +60,9 @@ The body is `loaf issue render <ref>` output. No project headers, no hand-edited
 gh pr create --title "type: summary" --body "$(loaf issue render <ref>)"
 ```
 
-### 4. Merge strategy
+### 5. Merge strategy
 
-Squash merge. Write a clean extended description (2-4 lines summarizing the branch). Never use the auto-generated squash description.
+Squash merge this one shippable unit. Write a clean extended description (2-4 lines summarizing the outcome). Never use the auto-generated squash description or create a merge commit merely to preserve feature-branch topology.
 
 ---
 

--- a/dist/cursor/hooks/instructions/pre-pr-format.md
+++ b/dist/cursor/hooks/instructions/pre-pr-format.md
@@ -1,7 +1,9 @@
 ## PR format reminder
 
+**Root:** One shippable root. Assemble related stacked children with verified ancestry and `--ff-only`; split independent roots unless a human explicitly approves one atomic landing.
+
 **Title:** Conventional commit, <70 chars. No scope prefixes, no SPEC/TASK IDs.
 
 **Body:** `## Summary` (2-4 bullets) + `## Test plan` (checklist).
 
-**Merge:** Squash merge with clean extended description (2-4 lines). Do not use auto-generated squash description.
+**Merge:** Squash this shippable unit with a clean extended description (2-4 lines). Do not use an auto-generated description or an incidental merge commit.

--- a/dist/cursor/skills/git-workflow/SKILL.md
+++ b/dist/cursor/skills/git-workflow/SKILL.md
@@ -22,8 +22,11 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Critical Rules
 
 - Use Conventional Commits format for all commit messages
-- Commit complete units of work -- don't commit partial or in-progress changes
-- Squash merge feature branches -- never merge commits directly
+- Working-branch commits are complete implementation checkpoints. Keep each one atomic and buildable enough to support review, diagnosis, and safe continuation; do not commit partial or knowingly broken work.
+- A pull request is one shippable unit. Squash merge a reviewed feature or shippable-root PR into the default branch with a deliberately authored Conventional Commit title and useful extended description; never use an automatic dump of branch commit messages.
+- Related child or stacked branches join their shippable root without synthetic topology. Verify ancestry with `git merge-base --is-ancestor <root> <child>`, then use `git merge --ff-only <child>` from the root branch. If ancestry diverged, stop and reassess instead of creating a merge commit by default.
+- Merge commits are exceptions. Preserve one only when topology, provenance, or a long-lived integration is itself durable project information, and record the explicit rationale. Never create one merely to assemble related feature work.
+- Independent shippable roots must not disappear inside one giant squash solely because they share an implementation branch. Split them into separate reviewed PRs, or obtain an explicit human decision that one atomic landing is safer.
 - One branch per shippable root; `loaf issue start` walks to that root and creates or joins `issue/<root-alias-or-id>` (or use `feat/{slug}` / `fix/{slug}` when not starting from an issue). Related child issues share the parent's branch and the PR to main.
 - Never force-push to `main` or shared branches
 - Never push without explicit user confirmation
@@ -31,8 +34,12 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Verification
 
 - Commit messages follow unscoped Conventional Commits format (`type: description`)
-- Branch is up to date with base branch before creating PR
+- Every working-branch commit is a complete checkpoint, and the candidate diff represents exactly one shippable root
+- Stacked work was verified as ancestral and assembled with `--ff-only`; no incidental merge commit exists
+- Independent shippable roots have separate PRs unless an explicit human decision documents why one atomic landing is safer
+- Branch is up to date with its base branch before creating the PR
 - PR title is under 70 characters with PR# suffix convention
+- The squash title and extended description describe the shipped outcome rather than replaying implementation commits
 
 ## Quick Reference
 
@@ -40,7 +47,9 @@ Git conventions for branching, commits, PRs, and merge workflow.
 |--------|----------------|
 | Branch naming | `issue/<root-alias-or-id>` from `loaf issue start`; else `feat/{slug}`, `fix/{slug}`, `chore/{slug}` |
 | Commit format | `type: description` |
-| Squash merge | `gh pr merge --squash` |
+| Assemble stacked child | Verify `git merge-base --is-ancestor <root> <child>`, then run `git merge --ff-only <child>` from the root |
+| Squash shippable PR | `gh pr merge --squash`; author the final title and description deliberately |
+| Preserve merge topology | Exceptional only; require explicit durable rationale before using a merge commit |
 | PR creation | `gh pr create --title "..." --body "..."` |
 
 ## Topics

--- a/dist/cursor/skills/git-workflow/references/commits.md
+++ b/dist/cursor/skills/git-workflow/references/commits.md
@@ -5,6 +5,7 @@
 - Commit Body
 - Linear Integration
 - Branch Naming
+- History Model
 - Pull Request Format
 - Changelog Discipline
 - Critical Rules
@@ -129,6 +130,32 @@ issue/<alias-or-id>
 - Short but descriptive (max 50 chars)
 - Prefer the started worktree branch from `loaf issue start` when implementing an issue
 
+## History Model
+
+Treat the three levels of Git history differently:
+
+1. **Working-branch commits are implementation checkpoints.** Keep them atomic, coherent, and useful for review or diagnosis. They may record how a shippable outcome was built, but they are not automatically permanent product-history units.
+2. **A pull request is one shippable unit.** It carries one reviewed root journey and normally lands as one deliberately authored squash commit on the default branch.
+3. **The default branch is product history.** Each commit should describe an observable, deployable outcome that can be reverted as a unit.
+
+### Stacked or Child Branches
+
+Related child work that belongs to one shippable root should not create an artificial merge bubble. Before assembling it, prove that the root is an ancestor of the child:
+
+```bash
+git merge-base --is-ancestor <root> <child>
+git switch <root>
+git merge --ff-only <child>
+```
+
+The second command must refuse if the histories diverged. When that happens, stop and inspect the competing changes; do not silently fall back to a merge commit or rewrite a shared branch.
+
+### Independent Roots and Merge Exceptions
+
+Independent shippable roots need separate reviewed PRs even when implementation happened on one branch. Do not conceal them inside one giant squash merely for convenience. If splitting would make the landing less safe, obtain an explicit human decision that names why one atomic change is preferable.
+
+Merge commits are reserved for cases where the topology is itself durable evidence, such as a long-lived integration branch, provenance-sensitive upstream import, or deliberately preserved parallel history. Record that rationale before merging. Ordinary feature assembly is not sufficient reason.
+
 ## Pull Request Format
 
 ### Title
@@ -149,10 +176,12 @@ gh pr create --title "type: summary" --body "$(loaf issue render <ref>)"
 
 ### Merge Strategy
 
-- **Prefer squash merge** unless explicitly told otherwise
+- **Squash merge one reviewed shippable-root PR** unless an explicitly approved topology-preservation exception applies
 - GitHub defaults the merge title to `PR title (#N)` — this is the desired format
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
+- Assemble related stacked branches into their root with verified ancestry and `git merge --ff-only`; never create a merge commit merely to combine them
+- Split independent shippable roots before the PR, or record an explicit human decision that one atomic squash is safer
 - Don't push or merge without explicit request
 - The ship skill automates this workflow when ready to squash merge a PR; release publishes a version later from already-landed work
 
@@ -197,15 +226,15 @@ Before approving a release bump, compare `[Unreleased]` against the actual relea
 
 ### Always
 
-- Write atomic commits (one logical change)
-- Commit complete units of work — finish the change, review it, then commit once
+- Write atomic working-branch checkpoints, each representing one coherent logical change
+- Keep every checkpoint complete and buildable enough for review, diagnosis, and safe continuation
 - Use imperative mood in messages
 - Reference issue numbers when applicable
-- Test before committing
+- Run the checks proportionate to that checkpoint before committing
 
 ### Never
 
-- Commit partial or in-progress work — if feedback is likely, wait for it before committing
+- Commit a knowingly broken or internally incomplete checkpoint
 - Skip commit signing (wait for user if it fails)
 - Push without explicit user confirmation
 - Use scoped commit subjects (for example, `feat(auth):`; write `feat:` instead)

--- a/dist/opencode/.loaf-target-manifest.json
+++ b/dist/opencode/.loaf-target-manifest.json
@@ -28,7 +28,7 @@
       "kind": "hook-file",
       "source_path": "plugins/hooks/instructions/pre-pr-checklist.md",
       "destination": "plugins/hooks/instructions/pre-pr-checklist.md",
-      "sha256": "64a647e40d2d7f52224a60b978012265f80414c8eb2c893e61a97faa74375dd3",
+      "sha256": "ed897b6d832a36ca5b469bafb4dfabd5680c5560e34b0dcecee1604cca47c369",
       "mode": 420
     },
     {
@@ -36,7 +36,7 @@
       "kind": "hook-file",
       "source_path": "plugins/hooks/instructions/pre-pr-format.md",
       "destination": "plugins/hooks/instructions/pre-pr-format.md",
-      "sha256": "da8d29ce41a1218467f68d4186f906c47075d88b3339a9fb19a8b50f8f40de82",
+      "sha256": "0f0b5e3e93c2bf4e34c7214619d978ef3341bcf4370a84d5257cfb95b4ffd9cc",
       "mode": 420
     },
     {

--- a/dist/opencode/plugins/hooks/instructions/pre-pr-checklist.md
+++ b/dist/opencode/plugins/hooks/instructions/pre-pr-checklist.md
@@ -1,6 +1,10 @@
 ## Before creating this PR, complete these steps:
 
-### 1. CHANGELOG entry
+### 1. Shipping unit
+
+Confirm that the branch represents exactly one shippable root. Related stacked children must have verified ancestry and be assembled into the root with `git merge --ff-only`; independent shippable roots need separate PRs unless an explicit human decision records why one atomic landing is safer.
+
+### 2. CHANGELOG entry
 
 Add an entry under `## [Unreleased]` in `CHANGELOG.md`, categorized by Common Changelog impact:
 
@@ -37,7 +41,7 @@ is a workflow staging section for curated entries that land with PRs before a la
 - Your entry here
 ```
 
-### 2. PR title
+### 3. PR title
 
 Conventional commit format, under 70 characters:
 
@@ -48,7 +52,7 @@ fix: prevent divide by zero in sag calculation
 
 No scope prefixes. No SPEC/TASK IDs in the title.
 
-### 3. PR body
+### 4. PR body
 
 The body is `loaf issue render <ref>` output. No project headers, no hand-edited summary. Checkboxes stay unchecked until `loaf issue status <ref> done`.
 
@@ -56,9 +60,9 @@ The body is `loaf issue render <ref>` output. No project headers, no hand-edited
 gh pr create --title "type: summary" --body "$(loaf issue render <ref>)"
 ```
 
-### 4. Merge strategy
+### 5. Merge strategy
 
-Squash merge. Write a clean extended description (2-4 lines summarizing the branch). Never use the auto-generated squash description.
+Squash merge this one shippable unit. Write a clean extended description (2-4 lines summarizing the outcome). Never use the auto-generated squash description or create a merge commit merely to preserve feature-branch topology.
 
 ---
 

--- a/dist/opencode/plugins/hooks/instructions/pre-pr-format.md
+++ b/dist/opencode/plugins/hooks/instructions/pre-pr-format.md
@@ -1,7 +1,9 @@
 ## PR format reminder
 
+**Root:** One shippable root. Assemble related stacked children with verified ancestry and `--ff-only`; split independent roots unless a human explicitly approves one atomic landing.
+
 **Title:** Conventional commit, <70 chars. No scope prefixes, no SPEC/TASK IDs.
 
 **Body:** `## Summary` (2-4 bullets) + `## Test plan` (checklist).
 
-**Merge:** Squash merge with clean extended description (2-4 lines). Do not use auto-generated squash description.
+**Merge:** Squash this shippable unit with a clean extended description (2-4 lines). Do not use an auto-generated description or an incidental merge commit.

--- a/dist/opencode/skills/git-workflow/SKILL.md
+++ b/dist/opencode/skills/git-workflow/SKILL.md
@@ -22,8 +22,11 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Critical Rules
 
 - Use Conventional Commits format for all commit messages
-- Commit complete units of work -- don't commit partial or in-progress changes
-- Squash merge feature branches -- never merge commits directly
+- Working-branch commits are complete implementation checkpoints. Keep each one atomic and buildable enough to support review, diagnosis, and safe continuation; do not commit partial or knowingly broken work.
+- A pull request is one shippable unit. Squash merge a reviewed feature or shippable-root PR into the default branch with a deliberately authored Conventional Commit title and useful extended description; never use an automatic dump of branch commit messages.
+- Related child or stacked branches join their shippable root without synthetic topology. Verify ancestry with `git merge-base --is-ancestor <root> <child>`, then use `git merge --ff-only <child>` from the root branch. If ancestry diverged, stop and reassess instead of creating a merge commit by default.
+- Merge commits are exceptions. Preserve one only when topology, provenance, or a long-lived integration is itself durable project information, and record the explicit rationale. Never create one merely to assemble related feature work.
+- Independent shippable roots must not disappear inside one giant squash solely because they share an implementation branch. Split them into separate reviewed PRs, or obtain an explicit human decision that one atomic landing is safer.
 - One branch per shippable root; `loaf issue start` walks to that root and creates or joins `issue/<root-alias-or-id>` (or use `feat/{slug}` / `fix/{slug}` when not starting from an issue). Related child issues share the parent's branch and the PR to main.
 - Never force-push to `main` or shared branches
 - Never push without explicit user confirmation
@@ -31,8 +34,12 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Verification
 
 - Commit messages follow unscoped Conventional Commits format (`type: description`)
-- Branch is up to date with base branch before creating PR
+- Every working-branch commit is a complete checkpoint, and the candidate diff represents exactly one shippable root
+- Stacked work was verified as ancestral and assembled with `--ff-only`; no incidental merge commit exists
+- Independent shippable roots have separate PRs unless an explicit human decision documents why one atomic landing is safer
+- Branch is up to date with its base branch before creating the PR
 - PR title is under 70 characters with PR# suffix convention
+- The squash title and extended description describe the shipped outcome rather than replaying implementation commits
 
 ## Quick Reference
 
@@ -40,7 +47,9 @@ Git conventions for branching, commits, PRs, and merge workflow.
 |--------|----------------|
 | Branch naming | `issue/<root-alias-or-id>` from `loaf issue start`; else `feat/{slug}`, `fix/{slug}`, `chore/{slug}` |
 | Commit format | `type: description` |
-| Squash merge | `gh pr merge --squash` |
+| Assemble stacked child | Verify `git merge-base --is-ancestor <root> <child>`, then run `git merge --ff-only <child>` from the root |
+| Squash shippable PR | `gh pr merge --squash`; author the final title and description deliberately |
+| Preserve merge topology | Exceptional only; require explicit durable rationale before using a merge commit |
 | PR creation | `gh pr create --title "..." --body "..."` |
 
 ## Topics

--- a/dist/opencode/skills/git-workflow/references/commits.md
+++ b/dist/opencode/skills/git-workflow/references/commits.md
@@ -5,6 +5,7 @@
 - Commit Body
 - Linear Integration
 - Branch Naming
+- History Model
 - Pull Request Format
 - Changelog Discipline
 - Critical Rules
@@ -129,6 +130,32 @@ issue/<alias-or-id>
 - Short but descriptive (max 50 chars)
 - Prefer the started worktree branch from `loaf issue start` when implementing an issue
 
+## History Model
+
+Treat the three levels of Git history differently:
+
+1. **Working-branch commits are implementation checkpoints.** Keep them atomic, coherent, and useful for review or diagnosis. They may record how a shippable outcome was built, but they are not automatically permanent product-history units.
+2. **A pull request is one shippable unit.** It carries one reviewed root journey and normally lands as one deliberately authored squash commit on the default branch.
+3. **The default branch is product history.** Each commit should describe an observable, deployable outcome that can be reverted as a unit.
+
+### Stacked or Child Branches
+
+Related child work that belongs to one shippable root should not create an artificial merge bubble. Before assembling it, prove that the root is an ancestor of the child:
+
+```bash
+git merge-base --is-ancestor <root> <child>
+git switch <root>
+git merge --ff-only <child>
+```
+
+The second command must refuse if the histories diverged. When that happens, stop and inspect the competing changes; do not silently fall back to a merge commit or rewrite a shared branch.
+
+### Independent Roots and Merge Exceptions
+
+Independent shippable roots need separate reviewed PRs even when implementation happened on one branch. Do not conceal them inside one giant squash merely for convenience. If splitting would make the landing less safe, obtain an explicit human decision that names why one atomic change is preferable.
+
+Merge commits are reserved for cases where the topology is itself durable evidence, such as a long-lived integration branch, provenance-sensitive upstream import, or deliberately preserved parallel history. Record that rationale before merging. Ordinary feature assembly is not sufficient reason.
+
 ## Pull Request Format
 
 ### Title
@@ -149,10 +176,12 @@ gh pr create --title "type: summary" --body "$(loaf issue render <ref>)"
 
 ### Merge Strategy
 
-- **Prefer squash merge** unless explicitly told otherwise
+- **Squash merge one reviewed shippable-root PR** unless an explicitly approved topology-preservation exception applies
 - GitHub defaults the merge title to `PR title (#N)` — this is the desired format
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
+- Assemble related stacked branches into their root with verified ancestry and `git merge --ff-only`; never create a merge commit merely to combine them
+- Split independent shippable roots before the PR, or record an explicit human decision that one atomic squash is safer
 - Don't push or merge without explicit request
 - The ship skill automates this workflow when ready to squash merge a PR; release publishes a version later from already-landed work
 
@@ -197,15 +226,15 @@ Before approving a release bump, compare `[Unreleased]` against the actual relea
 
 ### Always
 
-- Write atomic commits (one logical change)
-- Commit complete units of work — finish the change, review it, then commit once
+- Write atomic working-branch checkpoints, each representing one coherent logical change
+- Keep every checkpoint complete and buildable enough for review, diagnosis, and safe continuation
 - Use imperative mood in messages
 - Reference issue numbers when applicable
-- Test before committing
+- Run the checks proportionate to that checkpoint before committing
 
 ### Never
 
-- Commit partial or in-progress work — if feedback is likely, wait for it before committing
+- Commit a knowingly broken or internally incomplete checkpoint
 - Skip commit signing (wait for user if it fails)
 - Push without explicit user confirmation
 - Use scoped commit subjects (for example, `feat(auth):`; write `feat:` instead)

--- a/dist/skills/git-workflow/SKILL.md
+++ b/dist/skills/git-workflow/SKILL.md
@@ -21,8 +21,11 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Critical Rules
 
 - Use Conventional Commits format for all commit messages
-- Commit complete units of work -- don't commit partial or in-progress changes
-- Squash merge feature branches -- never merge commits directly
+- Working-branch commits are complete implementation checkpoints. Keep each one atomic and buildable enough to support review, diagnosis, and safe continuation; do not commit partial or knowingly broken work.
+- A pull request is one shippable unit. Squash merge a reviewed feature or shippable-root PR into the default branch with a deliberately authored Conventional Commit title and useful extended description; never use an automatic dump of branch commit messages.
+- Related child or stacked branches join their shippable root without synthetic topology. Verify ancestry with `git merge-base --is-ancestor <root> <child>`, then use `git merge --ff-only <child>` from the root branch. If ancestry diverged, stop and reassess instead of creating a merge commit by default.
+- Merge commits are exceptions. Preserve one only when topology, provenance, or a long-lived integration is itself durable project information, and record the explicit rationale. Never create one merely to assemble related feature work.
+- Independent shippable roots must not disappear inside one giant squash solely because they share an implementation branch. Split them into separate reviewed PRs, or obtain an explicit human decision that one atomic landing is safer.
 - One branch per shippable root; `loaf issue start` walks to that root and creates or joins `issue/<root-alias-or-id>` (or use `feat/{slug}` / `fix/{slug}` when not starting from an issue). Related child issues share the parent's branch and the PR to main.
 - Never force-push to `main` or shared branches
 - Never push without explicit user confirmation
@@ -30,8 +33,12 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Verification
 
 - Commit messages follow unscoped Conventional Commits format (`type: description`)
-- Branch is up to date with base branch before creating PR
+- Every working-branch commit is a complete checkpoint, and the candidate diff represents exactly one shippable root
+- Stacked work was verified as ancestral and assembled with `--ff-only`; no incidental merge commit exists
+- Independent shippable roots have separate PRs unless an explicit human decision documents why one atomic landing is safer
+- Branch is up to date with its base branch before creating the PR
 - PR title is under 70 characters with PR# suffix convention
+- The squash title and extended description describe the shipped outcome rather than replaying implementation commits
 
 ## Quick Reference
 
@@ -39,7 +46,9 @@ Git conventions for branching, commits, PRs, and merge workflow.
 |--------|----------------|
 | Branch naming | `issue/<root-alias-or-id>` from `loaf issue start`; else `feat/{slug}`, `fix/{slug}`, `chore/{slug}` |
 | Commit format | `type: description` |
-| Squash merge | `gh pr merge --squash` |
+| Assemble stacked child | Verify `git merge-base --is-ancestor <root> <child>`, then run `git merge --ff-only <child>` from the root |
+| Squash shippable PR | `gh pr merge --squash`; author the final title and description deliberately |
+| Preserve merge topology | Exceptional only; require explicit durable rationale before using a merge commit |
 | PR creation | `gh pr create --title "..." --body "..."` |
 
 ## Topics

--- a/dist/skills/git-workflow/references/commits.md
+++ b/dist/skills/git-workflow/references/commits.md
@@ -5,6 +5,7 @@
 - Commit Body
 - Linear Integration
 - Branch Naming
+- History Model
 - Pull Request Format
 - Changelog Discipline
 - Critical Rules
@@ -129,6 +130,32 @@ issue/<alias-or-id>
 - Short but descriptive (max 50 chars)
 - Prefer the started worktree branch from `loaf issue start` when implementing an issue
 
+## History Model
+
+Treat the three levels of Git history differently:
+
+1. **Working-branch commits are implementation checkpoints.** Keep them atomic, coherent, and useful for review or diagnosis. They may record how a shippable outcome was built, but they are not automatically permanent product-history units.
+2. **A pull request is one shippable unit.** It carries one reviewed root journey and normally lands as one deliberately authored squash commit on the default branch.
+3. **The default branch is product history.** Each commit should describe an observable, deployable outcome that can be reverted as a unit.
+
+### Stacked or Child Branches
+
+Related child work that belongs to one shippable root should not create an artificial merge bubble. Before assembling it, prove that the root is an ancestor of the child:
+
+```bash
+git merge-base --is-ancestor <root> <child>
+git switch <root>
+git merge --ff-only <child>
+```
+
+The second command must refuse if the histories diverged. When that happens, stop and inspect the competing changes; do not silently fall back to a merge commit or rewrite a shared branch.
+
+### Independent Roots and Merge Exceptions
+
+Independent shippable roots need separate reviewed PRs even when implementation happened on one branch. Do not conceal them inside one giant squash merely for convenience. If splitting would make the landing less safe, obtain an explicit human decision that names why one atomic change is preferable.
+
+Merge commits are reserved for cases where the topology is itself durable evidence, such as a long-lived integration branch, provenance-sensitive upstream import, or deliberately preserved parallel history. Record that rationale before merging. Ordinary feature assembly is not sufficient reason.
+
 ## Pull Request Format
 
 ### Title
@@ -149,10 +176,12 @@ gh pr create --title "type: summary" --body "$(loaf issue render <ref>)"
 
 ### Merge Strategy
 
-- **Prefer squash merge** unless explicitly told otherwise
+- **Squash merge one reviewed shippable-root PR** unless an explicitly approved topology-preservation exception applies
 - GitHub defaults the merge title to `PR title (#N)` — this is the desired format
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
+- Assemble related stacked branches into their root with verified ancestry and `git merge --ff-only`; never create a merge commit merely to combine them
+- Split independent shippable roots before the PR, or record an explicit human decision that one atomic squash is safer
 - Don't push or merge without explicit request
 - The ship skill automates this workflow when ready to squash merge a PR; release publishes a version later from already-landed work
 
@@ -197,15 +226,15 @@ Before approving a release bump, compare `[Unreleased]` against the actual relea
 
 ### Always
 
-- Write atomic commits (one logical change)
-- Commit complete units of work — finish the change, review it, then commit once
+- Write atomic working-branch checkpoints, each representing one coherent logical change
+- Keep every checkpoint complete and buildable enough for review, diagnosis, and safe continuation
 - Use imperative mood in messages
 - Reference issue numbers when applicable
-- Test before committing
+- Run the checks proportionate to that checkpoint before committing
 
 ### Never
 
-- Commit partial or in-progress work — if feedback is likely, wait for it before committing
+- Commit a knowingly broken or internally incomplete checkpoint
 - Skip commit signing (wait for user if it fails)
 - Push without explicit user confirmation
 - Use scoped commit subjects (for example, `feat(auth):`; write `feat:` instead)

--- a/internal/cli/build_test.go
+++ b/internal/cli/build_test.go
@@ -935,6 +935,30 @@ func TestNoHarnessProseSubstitution(t *testing.T) {
 	}
 }
 
+func TestGitWorkflowPolicyPackagesSquashAndFastForwardBoundaries(t *testing.T) {
+	root := setupIsolatedRepositoryBuildRoot(t)
+	var stdout bytes.Buffer
+	if err := (Runner{Stdout: &stdout, WorkingDir: root}).Run([]string{"build"}); err != nil {
+		t.Fatalf("build error = %v\n%s", err, stdout.String())
+	}
+
+	wants := []string{
+		"Working-branch commits are complete implementation checkpoints",
+		"A pull request is one shippable unit",
+		"git merge --ff-only",
+		"Merge commits are exceptions",
+		"Independent shippable roots",
+	}
+	for _, target := range defaultBuildTargets {
+		skill := readBuildFileString(t, filepath.Join(nativeBuildSkillTreeDir(root, target), "git-workflow", "SKILL.md"))
+		for _, want := range wants {
+			if !strings.Contains(skill, want) {
+				t.Errorf("%s generated git-workflow skill missing %q", target, want)
+			}
+		}
+	}
+}
+
 func TestSkillTreeIsTargetInvariant(t *testing.T) {
 	root := setupIsolatedRepositoryBuildRoot(t)
 	var stdout bytes.Buffer

--- a/plugins/loaf/.loaf-target-manifest.json
+++ b/plugins/loaf/.loaf-target-manifest.json
@@ -36,7 +36,7 @@
       "kind": "hook-file",
       "source_path": "hooks/instructions/pre-pr-checklist.md",
       "destination": "hooks/instructions/pre-pr-checklist.md",
-      "sha256": "64a647e40d2d7f52224a60b978012265f80414c8eb2c893e61a97faa74375dd3",
+      "sha256": "ed897b6d832a36ca5b469bafb4dfabd5680c5560e34b0dcecee1604cca47c369",
       "mode": 420
     },
     {
@@ -44,7 +44,7 @@
       "kind": "hook-file",
       "source_path": "hooks/instructions/pre-pr-format.md",
       "destination": "hooks/instructions/pre-pr-format.md",
-      "sha256": "da8d29ce41a1218467f68d4186f906c47075d88b3339a9fb19a8b50f8f40de82",
+      "sha256": "0f0b5e3e93c2bf4e34c7214619d978ef3341bcf4370a84d5257cfb95b4ffd9cc",
       "mode": 420
     },
     {

--- a/plugins/loaf/hooks/instructions/pre-pr-checklist.md
+++ b/plugins/loaf/hooks/instructions/pre-pr-checklist.md
@@ -1,6 +1,10 @@
 ## Before creating this PR, complete these steps:
 
-### 1. CHANGELOG entry
+### 1. Shipping unit
+
+Confirm that the branch represents exactly one shippable root. Related stacked children must have verified ancestry and be assembled into the root with `git merge --ff-only`; independent shippable roots need separate PRs unless an explicit human decision records why one atomic landing is safer.
+
+### 2. CHANGELOG entry
 
 Add an entry under `## [Unreleased]` in `CHANGELOG.md`, categorized by Common Changelog impact:
 
@@ -37,7 +41,7 @@ is a workflow staging section for curated entries that land with PRs before a la
 - Your entry here
 ```
 
-### 2. PR title
+### 3. PR title
 
 Conventional commit format, under 70 characters:
 
@@ -48,7 +52,7 @@ fix: prevent divide by zero in sag calculation
 
 No scope prefixes. No SPEC/TASK IDs in the title.
 
-### 3. PR body
+### 4. PR body
 
 The body is `loaf issue render <ref>` output. No project headers, no hand-edited summary. Checkboxes stay unchecked until `loaf issue status <ref> done`.
 
@@ -56,9 +60,9 @@ The body is `loaf issue render <ref>` output. No project headers, no hand-edited
 gh pr create --title "type: summary" --body "$(loaf issue render <ref>)"
 ```
 
-### 4. Merge strategy
+### 5. Merge strategy
 
-Squash merge. Write a clean extended description (2-4 lines summarizing the branch). Never use the auto-generated squash description.
+Squash merge this one shippable unit. Write a clean extended description (2-4 lines summarizing the outcome). Never use the auto-generated squash description or create a merge commit merely to preserve feature-branch topology.
 
 ---
 

--- a/plugins/loaf/hooks/instructions/pre-pr-format.md
+++ b/plugins/loaf/hooks/instructions/pre-pr-format.md
@@ -1,7 +1,9 @@
 ## PR format reminder
 
+**Root:** One shippable root. Assemble related stacked children with verified ancestry and `--ff-only`; split independent roots unless a human explicitly approves one atomic landing.
+
 **Title:** Conventional commit, <70 chars. No scope prefixes, no SPEC/TASK IDs.
 
 **Body:** `## Summary` (2-4 bullets) + `## Test plan` (checklist).
 
-**Merge:** Squash merge with clean extended description (2-4 lines). Do not use auto-generated squash description.
+**Merge:** Squash this shippable unit with a clean extended description (2-4 lines). Do not use an auto-generated description or an incidental merge commit.

--- a/plugins/loaf/skills/git-workflow/SKILL.md
+++ b/plugins/loaf/skills/git-workflow/SKILL.md
@@ -24,8 +24,11 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Critical Rules
 
 - Use Conventional Commits format for all commit messages
-- Commit complete units of work -- don't commit partial or in-progress changes
-- Squash merge feature branches -- never merge commits directly
+- Working-branch commits are complete implementation checkpoints. Keep each one atomic and buildable enough to support review, diagnosis, and safe continuation; do not commit partial or knowingly broken work.
+- A pull request is one shippable unit. Squash merge a reviewed feature or shippable-root PR into the default branch with a deliberately authored Conventional Commit title and useful extended description; never use an automatic dump of branch commit messages.
+- Related child or stacked branches join their shippable root without synthetic topology. Verify ancestry with `git merge-base --is-ancestor <root> <child>`, then use `git merge --ff-only <child>` from the root branch. If ancestry diverged, stop and reassess instead of creating a merge commit by default.
+- Merge commits are exceptions. Preserve one only when topology, provenance, or a long-lived integration is itself durable project information, and record the explicit rationale. Never create one merely to assemble related feature work.
+- Independent shippable roots must not disappear inside one giant squash solely because they share an implementation branch. Split them into separate reviewed PRs, or obtain an explicit human decision that one atomic landing is safer.
 - One branch per shippable root; `loaf issue start` walks to that root and creates or joins `issue/<root-alias-or-id>` (or use `feat/{slug}` / `fix/{slug}` when not starting from an issue). Related child issues share the parent's branch and the PR to main.
 - Never force-push to `main` or shared branches
 - Never push without explicit user confirmation
@@ -33,8 +36,12 @@ Git conventions for branching, commits, PRs, and merge workflow.
 ## Verification
 
 - Commit messages follow unscoped Conventional Commits format (`type: description`)
-- Branch is up to date with base branch before creating PR
+- Every working-branch commit is a complete checkpoint, and the candidate diff represents exactly one shippable root
+- Stacked work was verified as ancestral and assembled with `--ff-only`; no incidental merge commit exists
+- Independent shippable roots have separate PRs unless an explicit human decision documents why one atomic landing is safer
+- Branch is up to date with its base branch before creating the PR
 - PR title is under 70 characters with PR# suffix convention
+- The squash title and extended description describe the shipped outcome rather than replaying implementation commits
 
 ## Quick Reference
 
@@ -42,7 +49,9 @@ Git conventions for branching, commits, PRs, and merge workflow.
 |--------|----------------|
 | Branch naming | `issue/<root-alias-or-id>` from `loaf issue start`; else `feat/{slug}`, `fix/{slug}`, `chore/{slug}` |
 | Commit format | `type: description` |
-| Squash merge | `gh pr merge --squash` |
+| Assemble stacked child | Verify `git merge-base --is-ancestor <root> <child>`, then run `git merge --ff-only <child>` from the root |
+| Squash shippable PR | `gh pr merge --squash`; author the final title and description deliberately |
+| Preserve merge topology | Exceptional only; require explicit durable rationale before using a merge commit |
 | PR creation | `gh pr create --title "..." --body "..."` |
 
 ## Topics

--- a/plugins/loaf/skills/git-workflow/references/commits.md
+++ b/plugins/loaf/skills/git-workflow/references/commits.md
@@ -5,6 +5,7 @@
 - Commit Body
 - Linear Integration
 - Branch Naming
+- History Model
 - Pull Request Format
 - Changelog Discipline
 - Critical Rules
@@ -129,6 +130,32 @@ issue/<alias-or-id>
 - Short but descriptive (max 50 chars)
 - Prefer the started worktree branch from `loaf issue start` when implementing an issue
 
+## History Model
+
+Treat the three levels of Git history differently:
+
+1. **Working-branch commits are implementation checkpoints.** Keep them atomic, coherent, and useful for review or diagnosis. They may record how a shippable outcome was built, but they are not automatically permanent product-history units.
+2. **A pull request is one shippable unit.** It carries one reviewed root journey and normally lands as one deliberately authored squash commit on the default branch.
+3. **The default branch is product history.** Each commit should describe an observable, deployable outcome that can be reverted as a unit.
+
+### Stacked or Child Branches
+
+Related child work that belongs to one shippable root should not create an artificial merge bubble. Before assembling it, prove that the root is an ancestor of the child:
+
+```bash
+git merge-base --is-ancestor <root> <child>
+git switch <root>
+git merge --ff-only <child>
+```
+
+The second command must refuse if the histories diverged. When that happens, stop and inspect the competing changes; do not silently fall back to a merge commit or rewrite a shared branch.
+
+### Independent Roots and Merge Exceptions
+
+Independent shippable roots need separate reviewed PRs even when implementation happened on one branch. Do not conceal them inside one giant squash merely for convenience. If splitting would make the landing less safe, obtain an explicit human decision that names why one atomic change is preferable.
+
+Merge commits are reserved for cases where the topology is itself durable evidence, such as a long-lived integration branch, provenance-sensitive upstream import, or deliberately preserved parallel history. Record that rationale before merging. Ordinary feature assembly is not sufficient reason.
+
 ## Pull Request Format
 
 ### Title
@@ -149,10 +176,12 @@ gh pr create --title "type: summary" --body "$(loaf issue render <ref>)"
 
 ### Merge Strategy
 
-- **Prefer squash merge** unless explicitly told otherwise
+- **Squash merge one reviewed shippable-root PR** unless an explicitly approved topology-preservation exception applies
 - GitHub defaults the merge title to `PR title (#N)` — this is the desired format
 - **Write a clean extended description** for the squash merge commit — a one-line summary followed by bullet points grouped by feature area
 - **Never use the automatic squash description** that dumps all individual commit messages — it's noisy and unhelpful in git history
+- Assemble related stacked branches into their root with verified ancestry and `git merge --ff-only`; never create a merge commit merely to combine them
+- Split independent shippable roots before the PR, or record an explicit human decision that one atomic squash is safer
 - Don't push or merge without explicit request
 - The ship skill automates this workflow when ready to squash merge a PR; release publishes a version later from already-landed work
 
@@ -197,15 +226,15 @@ Before approving a release bump, compare `[Unreleased]` against the actual relea
 
 ### Always
 
-- Write atomic commits (one logical change)
-- Commit complete units of work — finish the change, review it, then commit once
+- Write atomic working-branch checkpoints, each representing one coherent logical change
+- Keep every checkpoint complete and buildable enough for review, diagnosis, and safe continuation
 - Use imperative mood in messages
 - Reference issue numbers when applicable
-- Test before committing
+- Run the checks proportionate to that checkpoint before committing
 
 ### Never
 
-- Commit partial or in-progress work — if feedback is likely, wait for it before committing
+- Commit a knowingly broken or internally incomplete checkpoint
 - Skip commit signing (wait for user if it fails)
 - Push without explicit user confirmation
 - Use scoped commit subjects (for example, `feat(auth):`; write `feat:` instead)


### PR DESCRIPTION
## Summary

- Define atomic working-branch commits as reviewable implementation checkpoints, PRs as shippable units, and default-branch commits as durable product history.
- Require verified ancestry plus `git merge --ff-only` for related stacked work, while reserving merge commits for explicitly justified durable topology.
- Carry the same policy through pre-PR guidance and every generated harness target, with a cross-target packaging regression.

Closes #211

## Definition of done

- [x] The canonical Git workflow states that working-branch commits are complete implementation checkpoints, PRs are shippable units, and `main` records reviewed product outcomes.
- [x] Feature or shippable-root PRs default to squash merge with a deliberately authored Conventional Commit title and useful extended description.
- [x] Related child or stacked branches are assembled with verified ancestry and `--ff-only`; no merge commit is created merely to join a child to its root.
- [x] Merge commits are reserved for cases where topology, provenance, or a long-lived integration is itself durable information, and the exception requires an explicit rationale.
- [x] Independent shippable roots are not hidden inside one giant squash solely because they share an implementation branch; they are split or an explicit human decision records why one atomic landing is safer.
- [x] Quick-reference guidance and verification checks cover squash, fast-forward, and exceptional merge-commit cases without weakening the no-force-push and no-unapproved-push rules.
- [x] Canonical source and generated harness artifacts are rebuilt and verified consistently.
- [x] The policy was independently reviewed and dogfooded by fast-forwarding the ancestral GitHub-provider child into its vNext parent before this landing.

## Verification

- [x] `go test ./internal/cli -run 'TestGitWorkflowPolicyPackagesSquashAndFastForwardBoundaries|TestSkillTreeIsTargetInvariant' -count=1`
- [x] `go test ./internal/cli -count=1`
- [x] `npm run typecheck`
- [x] Generated commit references and applicable hook instructions match their canonical source; changed manifest hashes match the generated bytes.
- [x] Two independent reviews approved the exact 27-path candidate with no findings.
- [x] `git diff --check`

## Known baseline failure

The repository-wide suite currently fails two `internal/state/event_fact_test.go` cases because their fixed August 26 HLC timestamps now exceed the 24-hour skew window. Both failures reproduce unchanged on `main`; this PR does not modify `internal/state` or runtime behavior.
