### PR TITLE
fix: surface same-version harness drift in doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ One operator's durable memory â€” journal, wraps, handoffs, refs, verification â
 
 ### Fixed
 
+- `loaf doctor` reports same-version changes to installed harness content using the upgrade planner, with actionable diagnostics and no automatic repair ([#218](https://github.com/levifig/loaf/issues/218)).
 - Cursor check hooks request JSON output so successful checks do not block tools with an invalid-response error; genuine findings retain their blocking exit status ([#238](https://github.com/levifig/loaf/issues/238)).
 - Let the bootstrap installer hand off to `loaf install` and `loaf upgrade` without extra arguments on macOS's system Bash, while preserving empty and spaced passthrough arguments.
 - The Homebrew formula installs `vnext/content` and `.claude-plugin` into the keg alongside the rest of the distribution, so a Homebrew-installed Loaf carries the tracker-native Flow content and can register itself as the Claude Code marketplace.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -37,6 +37,9 @@ type doctorFixResult struct {
 
 type doctorContext struct {
 	projectRoot string
+	// distributionRoot supplies the desired harness content for diagnosis.
+	// Marker-only tests may omit it when no distribution is under test.
+	distributionRoot string
 	// cliVersion is the installed distribution's version — the binary the
 	// caller just ran. Checks that compare project or harness state against
 	// the running loaf read it here; an empty value means provenance could
@@ -113,11 +116,14 @@ func (r Runner) runDoctor(args []string, out io.Writer, runtimeRoot string) erro
 	// never the project's own package.json: outside a Loaf checkout the two
 	// are unrelated, and inside a stale checkout they must not be conflated.
 	cliVersion := ""
-	if distributionRoot, err := r.resolveInstalledDistributionRoot(); err == nil {
+	distributionRoot := ""
+	if resolvedRoot, err := r.resolveInstalledDistributionRoot(); err == nil {
+		distributionRoot = resolvedRoot
 		cliVersion = packageVersion(distributionRoot)
 	}
+	ctx := doctorContext{projectRoot: runtimeRoot, distributionRoot: distributionRoot, cliVersion: cliVersion, stateHome: r.StateHome}
 	if options.jsonOutput {
-		result := runDoctorChecksJSON(doctorContext{projectRoot: runtimeRoot, cliVersion: cliVersion, stateHome: r.StateHome}, cliVersion)
+		result := runDoctorChecksJSON(ctx, cliVersion)
 		if err := writeJSON(out, result); err != nil {
 			return err
 		}
@@ -126,7 +132,7 @@ func (r Runner) runDoctor(args []string, out io.Writer, runtimeRoot string) erro
 		}
 		return nil
 	}
-	report := runDoctorChecks(out, doctorContext{projectRoot: runtimeRoot, cliVersion: cliVersion, stateHome: r.StateHome}, options, cliVersion, r.Stdin)
+	report := runDoctorChecks(out, ctx, options, cliVersion, r.Stdin)
 	if report.Failures > 0 {
 		return ExitError{Code: 1}
 	}
@@ -337,6 +343,39 @@ func checkHarnessContentDrift() doctorCheck {
 				}
 				if line := reading.reconcileReceiptDetailLine(); line != "" {
 					receipts = append(receipts, line)
+				}
+			}
+			plan := harnessPlanDiagnosis{}
+			if ctx.distributionRoot != "" {
+				var err error
+				plan, err = diagnoseHarnessPlan(ctx)
+				if err != nil {
+					details = append(details, "Upgrade planner could not inspect installed harness content: "+err.Error(), "Run `loaf upgrade --dry-run` after resolving the reported integrity problem.")
+					details = append(details, receipts...)
+					return doctorResult{
+						Status:  doctorFail,
+						Message: "Installed harness content could not be verified",
+						Detail:  strings.Join(details, "\n"),
+					}
+				}
+				details = append(details, plan.details...)
+			}
+			if plan.conflicts > 0 {
+				details = append(details, "Inspect with `loaf upgrade --dry-run`; resolve conflicts before running `loaf upgrade`.")
+				details = append(details, receipts...)
+				return doctorResult{
+					Status:  doctorFail,
+					Message: fmt.Sprintf("Installed harness content has %d conflict(s)", plan.conflicts),
+					Detail:  strings.Join(details, "\n"),
+				}
+			}
+			if plan.changes > 0 {
+				details = append(details, "Inspect with `loaf upgrade --dry-run`; apply with `loaf upgrade`.")
+				details = append(details, receipts...)
+				return doctorResult{
+					Status:  doctorWarn,
+					Message: fmt.Sprintf("Installed harness content has %d pending change(s)", plan.changes),
+					Detail:  strings.Join(details, "\n"),
 				}
 			}
 			if len(details) == 0 {

--- a/internal/cli/harness_drift.go
+++ b/internal/cli/harness_drift.go
@@ -42,6 +42,71 @@ type harnessDriftReading struct {
 	state     harnessDriftState
 }
 
+type harnessPlanDiagnosis struct {
+	details   []string
+	changes   int
+	conflicts int
+}
+
+// diagnoseHarnessPlan consumes the same target and skill plan that powers
+// upgrade --dry-run. It classifies only harness content: project files,
+// deprecations, and MCP recommendations remain owned by their existing doctor
+// checks and maintenance surfaces.
+func diagnoseHarnessPlan(ctx doctorContext) (harnessPlanDiagnosis, error) {
+	tools := detectInstallTools()
+	selectedTargets := installedUpgradeTargets(tools)
+	options := installOptions{upgrade: true, dryRun: true, command: upgradeCommandName}
+	runner := Runner{WorkingDir: ctx.projectRoot, StateHome: ctx.stateHome}
+	targets, skills, _, err := runner.buildHarnessDistributionPlan(options, ctx.distributionRoot, ctx.projectRoot, ctx.cliVersion, filepath.Join(ctx.distributionRoot, "dist"), tools, false, selectedTargets)
+	if err != nil {
+		return harnessPlanDiagnosis{}, err
+	}
+
+	diagnosis := harnessPlanDiagnosis{details: []string{}}
+	for _, target := range targets {
+		name := installDisplayName(target.Target)
+		if target.Note != "" {
+			diagnosis.conflicts++
+			diagnosis.details = append(diagnosis.details, fmt.Sprintf("%s planner: blocked - %s", name, target.Note))
+		}
+		for _, decision := range target.Artifacts {
+			diagnosis.addDecision(name, decision)
+		}
+	}
+	for _, decision := range skills {
+		diagnosis.addDecision("Managed skills", decision)
+	}
+	return diagnosis, nil
+}
+
+func (diagnosis *harnessPlanDiagnosis) addDecision(scope string, decision artifactPlanDecision) {
+	if !harnessPlanDecisionNeedsAttention(decision.Action) {
+		return
+	}
+	if decision.Action == planActionConflict {
+		diagnosis.conflicts++
+	} else {
+		diagnosis.changes++
+	}
+	detail := fmt.Sprintf("%s planner: %s %s", scope, decision.Action, decision.ID)
+	if decision.Destination != "" {
+		detail += " at " + decision.Destination
+	}
+	if decision.Detail != "" {
+		detail += " - " + decision.Detail
+	}
+	diagnosis.details = append(diagnosis.details, detail)
+}
+
+func harnessPlanDecisionNeedsAttention(action string) bool {
+	switch action {
+	case planActionPreserve, planActionNone, "already-correct", "skipped":
+		return false
+	default:
+		return action != ""
+	}
+}
+
 // harnessDriftConfigDir maps one harness identity to the config directory its
 // `.loaf-version` marker lives in, through the same table install writes the
 // marker with.

--- a/internal/cli/harness_drift_test.go
+++ b/internal/cli/harness_drift_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,6 +23,7 @@ func harnessDriftHome(t *testing.T) string {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
 	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
 	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".claude"))
 	return home
@@ -79,6 +81,280 @@ func TestHarnessContentDriftDoctorReportsEachMarkerState(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHarnessContentDriftDoctorUsesUpgradePlanForSameVersionAdapterDrift(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		mutate func(t *testing.T, path string)
+	}{
+		{
+			name: "byte drift",
+			mutate: func(t *testing.T, path string) {
+				writeInstallFile(t, path, "// modified after install\n")
+			},
+		},
+		{
+			name: "mode drift",
+			mutate: func(t *testing.T, path string) {
+				if err := os.Chmod(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			home, distributionRoot, pluginPath := harnessDriftAmpPlannerFixture(t)
+			testCase.mutate(t, pluginPath)
+			beforeBody := readFileBytes(t, pluginPath)
+			beforeMode := fileModeForTest(t, pluginPath)
+
+			result := checkHarnessContentDrift().Run(doctorContext{
+				projectRoot:      home,
+				distributionRoot: distributionRoot,
+				cliVersion:       harnessDriftBinaryFixtureVersion,
+				stateHome:        t.TempDir(),
+			})
+
+			if got := readFileBytes(t, pluginPath); !bytes.Equal(got, beforeBody) {
+				t.Fatal("harness-content-drift diagnosis changed installed adapter bytes")
+			}
+			if got := fileModeForTest(t, pluginPath); got != beforeMode {
+				t.Fatalf("harness-content-drift diagnosis changed installed adapter mode from %v to %v", beforeMode, got)
+			}
+			if result.Status != doctorFail {
+				t.Fatalf("harness-content-drift result = %#v, want fail for planner conflict", result)
+			}
+			for _, want := range []string{"Amp", "plugin:loaf", "conflict", "loaf upgrade --dry-run", "plugins/loaf.ts", "managed target artifact was modified"} {
+				if !strings.Contains(result.Detail, want) {
+					t.Fatalf("harness-content-drift detail = %q, want containing %q", result.Detail, want)
+				}
+			}
+		})
+	}
+}
+
+func TestHarnessContentDriftDoctorKeepsSameVersionExactAdapterQuiet(t *testing.T) {
+	home, distributionRoot, _ := harnessDriftAmpPlannerFixture(t)
+	result := checkHarnessContentDrift().Run(doctorContext{
+		projectRoot:      home,
+		distributionRoot: distributionRoot,
+		cliVersion:       harnessDriftBinaryFixtureVersion,
+		stateHome:        t.TempDir(),
+	})
+
+	if result.Status != doctorPass {
+		t.Fatalf("harness-content-drift result = %#v, want pass for exact adapter", result)
+	}
+	if strings.Contains(result.Detail, "planner:") {
+		t.Fatalf("healthy preserve decisions must stay quiet, detail = %q", result.Detail)
+	}
+}
+
+func TestHarnessContentDriftPlannerFindingMatchesHumanAndJSONDoctor(t *testing.T) {
+	home, distributionRoot, pluginPath := harnessDriftAmpPlannerFixture(t)
+	writeInstallFile(t, pluginPath, "// modified after install\n")
+	projectRoot := realpath(t, t.TempDir())
+	stateHome := t.TempDir()
+	before := hashInstallFixtureTrees(t, home, distributionRoot, projectRoot, stateHome)
+
+	for _, testCase := range []struct {
+		name string
+		args []string
+	}{
+		{name: "human", args: []string{"doctor"}},
+		{name: "json", args: []string{"doctor", "--json"}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			var output bytes.Buffer
+			err := Runner{
+				Stdout:     &output,
+				WorkingDir: projectRoot,
+				StateHome:  stateHome,
+				Executable: distributionFixtureExecutable(distributionRoot),
+			}.Run(testCase.args)
+			if err == nil {
+				t.Fatal("doctor error = nil, want planner conflict to fail diagnosis")
+			}
+			if testCase.name == "json" {
+				var report doctorJSONOutput
+				if err := json.Unmarshal(output.Bytes(), &report); err != nil {
+					t.Fatalf("invalid doctor JSON: %v", err)
+				}
+				found := false
+				for _, check := range report.Checks {
+					if check.Name == "harness-content-drift" {
+						found = check.Status == string(doctorFail) && !check.Fixable
+					}
+				}
+				if !found {
+					t.Fatalf("JSON lacks a report-only harness conflict: %#v", report.Checks)
+				}
+			}
+			for _, want := range []string{"harness-content-drift", "Amp", "plugin:loaf", "conflict", "loaf upgrade --dry-run"} {
+				if !strings.Contains(stripANSI(output.String()), want) {
+					t.Fatalf("doctor output = %q, want containing %q", output.String(), want)
+				}
+			}
+		})
+	}
+	if after := hashInstallFixtureTrees(t, home, distributionRoot, projectRoot, stateHome); after != before {
+		t.Fatal("human or JSON doctor changed fixture files")
+	}
+}
+
+func TestHarnessDoctorReportsSharedSkillDriftWithoutMutation(t *testing.T) {
+	for _, modified := range []bool{false, true} {
+		t.Run(map[bool]string{false: "desired update", true: "operator edit"}[modified], func(t *testing.T) {
+			home, distributionRoot, _ := harnessDriftAmpPlannerFixture(t)
+			src := filepath.Join(distributionRoot, "dist", "amp", "skills")
+			dest := filepath.Join(home, ".agents", "skills")
+			writeInstallFile(t, filepath.Join(src, "foundations", "SKILL.md"), "# Original\n")
+			if err := syncManagedSkillsDirIfExists(src, dest); err != nil {
+				t.Fatal(err)
+			}
+			wantStatus, wantAction := doctorWarn, planActionUpdate
+			changed := filepath.Join(src, "foundations", "SKILL.md")
+			if modified {
+				changed = filepath.Join(dest, "foundations", "SKILL.md")
+				wantStatus, wantAction = doctorFail, planActionConflict
+			}
+			writeInstallFile(t, changed, "# Changed\n")
+			stateHome := t.TempDir()
+			before := hashInstallFixtureTrees(t, home, distributionRoot, stateHome)
+			result := checkHarnessContentDrift().Run(doctorContext{
+				projectRoot: home, distributionRoot: distributionRoot,
+				cliVersion: harnessDriftBinaryFixtureVersion, stateHome: stateHome,
+			})
+			if result.Status != wantStatus || !strings.Contains(result.Detail, "Managed skills planner: "+wantAction+" skill:foundations") {
+				t.Fatalf("doctor = %#v, want %s for shared skill %s", result, wantStatus, wantAction)
+			}
+			if after := hashInstallFixtureTrees(t, home, distributionRoot, stateHome); after != before {
+				t.Fatal("shared-skill diagnosis changed fixture files")
+			}
+		})
+	}
+}
+
+func TestHarnessDoctorMatchesUpgradePlanWithoutMutatingFixtures(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		mutate     func(t *testing.T, distributionRoot, pluginPath string)
+		wantAction string
+		wantStatus doctorStatus
+		wantError  bool
+	}{
+		{name: "healthy", wantAction: planActionPreserve, wantStatus: doctorPass},
+		{name: "modified adapter", wantAction: planActionConflict, wantStatus: doctorFail, mutate: func(t *testing.T, distributionRoot, pluginPath string) {
+			writeInstallFile(t, pluginPath, "// operator edit\n")
+		}},
+		{name: "same-version content update", wantAction: planActionUpdate, wantStatus: doctorWarn, mutate: func(t *testing.T, distributionRoot, pluginPath string) {
+			dist := filepath.Join(distributionRoot, "dist", "amp")
+			body := "export default function updatedLoaf() {}\n"
+			writeInstallFile(t, filepath.Join(dist, "plugins", "loaf.ts"), body)
+			writeTestTargetAdapterManifest(t, dist, "amp", []map[string]string{{
+				"id": "plugin:loaf", "kind": "plugin", "source_path": "plugins/loaf.ts", "destination": "plugins/loaf.ts", "sha256": sha256Hex(body),
+			}})
+		}},
+		{name: "missing ownership", wantAction: planActionConflict, wantStatus: doctorFail, mutate: func(t *testing.T, distributionRoot, pluginPath string) {
+			if err := os.Remove(filepath.Join(filepath.Dir(filepath.Dir(pluginPath)), targetInstallManifestFile)); err != nil {
+				t.Fatal(err)
+			}
+			writeInstallFile(t, pluginPath, "// foreign adapter\n")
+		}},
+		{name: "symlinked adapter", wantStatus: doctorFail, wantError: true, mutate: func(t *testing.T, distributionRoot, pluginPath string) {
+			target := filepath.Join(distributionRoot, "foreign.ts")
+			writeInstallFile(t, target, "// foreign content\n")
+			if err := os.Remove(pluginPath); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, pluginPath); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "corrupt desired digest", wantStatus: doctorFail, wantError: true, mutate: func(t *testing.T, distributionRoot, pluginPath string) {
+			writeInstallFile(t, filepath.Join(distributionRoot, "dist", "amp", "plugins", "loaf.ts"), "// unrecorded desired edit\n")
+		}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			home, distributionRoot, pluginPath := harnessDriftAmpPlannerFixture(t)
+			stateHome := t.TempDir()
+			if testCase.mutate != nil {
+				testCase.mutate(t, distributionRoot, pluginPath)
+			}
+			before := hashInstallFixtureTrees(t, home, distributionRoot, stateHome)
+			ctx := doctorContext{projectRoot: home, distributionRoot: distributionRoot, cliVersion: harnessDriftBinaryFixtureVersion, stateHome: stateHome}
+			result := checkHarnessContentDrift().Run(ctx)
+			if result.Status != testCase.wantStatus || result.Fixable {
+				t.Fatalf("doctor = %#v, want report-only %s", result, testCase.wantStatus)
+			}
+			if repeat := checkHarnessContentDrift().Run(ctx); repeat != result {
+				t.Fatalf("doctor changed between reads: %#v then %#v", result, repeat)
+			}
+			plan, err := (Runner{WorkingDir: home, StateHome: stateHome}).buildInstallDryRunPlan(
+				installOptions{upgrade: true, dryRun: true, command: upgradeCommandName},
+				distributionRoot, home, harnessDriftBinaryFixtureVersion, filepath.Join(distributionRoot, "dist"), detectInstallTools(), false, false, nil,
+			)
+			if (err != nil) != testCase.wantError {
+				t.Fatalf("upgrade planner error = %v, wantError %t", err, testCase.wantError)
+			}
+			if err != nil {
+				if !strings.Contains(result.Detail, err.Error()) {
+					t.Fatalf("doctor detail %q omits planner error %q", result.Detail, err)
+				}
+			} else {
+				action := ""
+				for _, target := range plan.Targets {
+					for _, artifact := range target.Artifacts {
+						if target.Target == "amp" && artifact.ID == "plugin:loaf" {
+							action = artifact.Action
+						}
+					}
+				}
+				if action != testCase.wantAction {
+					t.Fatalf("upgrade action = %q, want %q", action, testCase.wantAction)
+				}
+				if action != planActionPreserve && (!strings.Contains(result.Detail, action+" plugin:loaf") || !strings.Contains(result.Detail, "loaf upgrade --dry-run")) {
+					t.Fatalf("doctor detail %q omits actionable planner decision", result.Detail)
+				}
+			}
+			if after := hashInstallFixtureTrees(t, home, distributionRoot, stateHome); after != before {
+				t.Fatal("diagnosis changed home, distribution, or state files")
+			}
+		})
+	}
+}
+
+func harnessDriftAmpPlannerFixture(t *testing.T) (home string, distributionRoot string, pluginPath string) {
+	t.Helper()
+	home = harnessDriftHome(t)
+	distributionRoot = harnessDriftDistribution(t, harnessDriftBinaryFixtureVersion)
+	ampDist := filepath.Join(distributionRoot, "dist", "amp")
+	desiredPlugin := "export default function loaf() {}\n"
+	writeInstallFile(t, filepath.Join(ampDist, "plugins", "loaf.ts"), desiredPlugin)
+	writeTestTargetAdapterManifest(t, ampDist, "amp", []map[string]string{{
+		"id":          "plugin:loaf",
+		"kind":        "plugin",
+		"source_path": "plugins/loaf.ts",
+		"destination": "plugins/loaf.ts",
+		"sha256":      sha256Hex(desiredPlugin),
+	}})
+
+	ampConfig := filepath.Join(home, ".config", "amp")
+	harnessDriftInstalledHarness(t, ampConfig, harnessDriftBinaryFixtureVersion)
+	writeInstallFile(t, filepath.Join(ampConfig, targetInstallManifestFile), string(readFileBytes(t, filepath.Join(ampDist, targetBuildManifestFile))))
+	pluginPath = filepath.Join(ampConfig, "plugins", "loaf.ts")
+	writeInstallFile(t, pluginPath, desiredPlugin)
+	return home, distributionRoot, pluginPath
+}
+
+func fileModeForTest(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info.Mode().Perm()
 }
 
 func TestHarnessContentDriftDoctorSkipsWithoutSubject(t *testing.T) {

--- a/internal/cli/install_plan.go
+++ b/internal/cli/install_plan.go
@@ -163,84 +163,12 @@ func (r Runner) buildInstallDryRunPlan(options installOptions, loafRoot string, 
 	}
 	plan.Deprecations = deprecations
 
-	toolByKey := installToolsByKey(tools)
-	defaults, layoutHome := resolveInstallLayout(projectRoot)
-	// A plan reads hook enablement and never creates it: a dry run that brought
-	// a state database into existence would be a write, and the plan promises
-	// none.
-	hookState, releaseHookState := r.hookStateForPlan(projectRoot)
-	defer releaseHookState()
-	buildNeeded := false
-	var plannedOptions []targetInstallOptions
-	for _, target := range selectedTargets {
-		if target == claudeCodeInstallTarget {
-			if entry, include := r.planClaudeCodeTarget(loafRoot, options.upgrade, hasClaudeCode); include {
-				plan.Targets = append(plan.Targets, entry)
-			}
-			continue
-		}
-		distDir := filepath.Join(distRoot, target)
-		configDir := defaults[target]
-		if tool, ok := toolByKey[target]; ok && tool.configDir != "" {
-			configDir = tool.configDir
-		}
-		targetPlan := targetDistributionPlan{
-			Target:    target,
-			ConfigDir: configDir,
-			Installed: containsInstallToolInstalled(tools, target),
-			Artifacts: []artifactPlanDecision{},
-		}
-		if !dirExistsForInstall(distDir) {
-			targetPlan.Note = "no build output found; run loaf build first"
-			buildNeeded = true
-			plan.Targets = append(plan.Targets, targetPlan)
-			continue
-		}
-		installOpts := targetInstallOptions{
-			Target:              target,
-			DistDir:             distDir,
-			ConfigDir:           configDir,
-			Upgrade:             options.upgrade,
-			CodexBasicCommands:  options.codexBasicCommands,
-			Version:             version,
-			HomeDir:             layoutHome,
-			CodexHome:           resolveInstallCodexHome(configDir),
-			ProjectRoot:         projectRoot,
-			HookState:           hookState,
-			SelectedHookIDs:     selectedHookIDsForTarget(options.selections, target),
-			SelectedArtifactIDs: selectedArtifactIDsForTarget(options.selections, target),
-		}
-		plannedOptions = append(plannedOptions, installOpts)
-		decisions, err := planTargetDistribution(installOpts)
-		if err != nil {
-			return installDryRunPlan{}, err
-		}
-		targetPlan.Artifacts = decisions
-		for _, decision := range decisions {
-			if decision.Action == planActionConflict {
-				targetPlan.Blocked = true
-			}
-		}
-		plan.Targets = append(plan.Targets, targetPlan)
-	}
-	sort.Slice(plan.Targets, func(i, j int) bool { return plan.Targets[i].Target < plan.Targets[j].Target })
-
-	// A managed-skill conflict blocks the whole shared-content cohort. Apply
-	// leaves target adapters and markers stale so a later reconcile can retry.
-	skills, err := planCanonicalManagedSkills(plannedOptions)
+	targets, skills, buildNeeded, err := r.buildHarnessDistributionPlan(options, loafRoot, projectRoot, version, distRoot, tools, hasClaudeCode, selectedTargets)
 	if err != nil {
 		return installDryRunPlan{}, err
 	}
+	plan.Targets = targets
 	plan.Skills = skills
-	for _, skill := range skills {
-		if skill.Action != planActionConflict {
-			continue
-		}
-		for i := range plan.Targets {
-			plan.Targets[i].Blocked = true
-		}
-		break
-	}
 
 	// Project files mirror enforceInstallProjectFiles: symlinks first, then the
 	// managed fenced section for every target that carries a project file, then
@@ -271,6 +199,92 @@ func (r Runner) buildInstallDryRunPlan(options installOptions, loafRoot string, 
 	plan.ConsentRequired = installPlanConsentRequired(plan)
 	plan.FollowUpCommands = installPlanFollowUpCommands(options, plan, buildNeeded)
 	return plan, nil
+}
+
+// buildHarnessDistributionPlan shares the read-only desired/recorded/live
+// comparison between upgrade and doctor. Project files, deprecations, and MCP
+// recommendations remain outside harness-content diagnosis.
+func (r Runner) buildHarnessDistributionPlan(options installOptions, loafRoot, projectRoot, version, distRoot string, tools []detectedInstallTool, hasClaudeCode bool, selectedTargets []string) ([]targetDistributionPlan, []artifactPlanDecision, bool, error) {
+	targets := make([]targetDistributionPlan, 0, len(selectedTargets))
+	toolByKey := installToolsByKey(tools)
+	defaults, layoutHome := resolveInstallLayout(projectRoot)
+	// A plan reads hook enablement and never creates it: a dry run that brought
+	// a state database into existence would be a write, and the plan promises
+	// none.
+	hookState, releaseHookState := r.hookStateForPlan(projectRoot)
+	defer releaseHookState()
+	buildNeeded := false
+	var plannedOptions []targetInstallOptions
+	for _, target := range selectedTargets {
+		if target == claudeCodeInstallTarget {
+			if entry, include := r.planClaudeCodeTarget(loafRoot, options.upgrade, hasClaudeCode); include {
+				targets = append(targets, entry)
+			}
+			continue
+		}
+		distDir := filepath.Join(distRoot, target)
+		configDir := defaults[target]
+		if tool, ok := toolByKey[target]; ok && tool.configDir != "" {
+			configDir = tool.configDir
+		}
+		targetPlan := targetDistributionPlan{
+			Target:    target,
+			ConfigDir: configDir,
+			Installed: containsInstallToolInstalled(tools, target),
+			Artifacts: []artifactPlanDecision{},
+		}
+		if !dirExistsForInstall(distDir) {
+			targetPlan.Note = "no build output found; run loaf build first"
+			buildNeeded = true
+			targets = append(targets, targetPlan)
+			continue
+		}
+		installOpts := targetInstallOptions{
+			Target:              target,
+			DistDir:             distDir,
+			ConfigDir:           configDir,
+			Upgrade:             options.upgrade,
+			CodexBasicCommands:  options.codexBasicCommands,
+			Version:             version,
+			HomeDir:             layoutHome,
+			CodexHome:           resolveInstallCodexHome(configDir),
+			ProjectRoot:         projectRoot,
+			HookState:           hookState,
+			SelectedHookIDs:     selectedHookIDsForTarget(options.selections, target),
+			SelectedArtifactIDs: selectedArtifactIDsForTarget(options.selections, target),
+		}
+		plannedOptions = append(plannedOptions, installOpts)
+		decisions, err := planTargetDistribution(installOpts)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		targetPlan.Artifacts = decisions
+		for _, decision := range decisions {
+			if decision.Action == planActionConflict {
+				targetPlan.Blocked = true
+			}
+		}
+		targets = append(targets, targetPlan)
+	}
+	sort.Slice(targets, func(i, j int) bool { return targets[i].Target < targets[j].Target })
+
+	// A managed-skill conflict blocks the whole shared-content cohort. Apply
+	// leaves target adapters and markers stale so a later reconcile can retry.
+	skills, err := planCanonicalManagedSkills(plannedOptions)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	for _, skill := range skills {
+		if skill.Action != planActionConflict {
+			continue
+		}
+		for i := range targets {
+			targets[i].Blocked = true
+		}
+		break
+	}
+
+	return targets, skills, buildNeeded, nil
 }
 
 func containsInstallToolInstalled(tools []detectedInstallTool, target string) bool {


### PR DESCRIPTION
## Summary

Make `loaf doctor` reuse the current upgrade planner for desired/recorded/live harness-content diagnosis. Same-version byte and mode drift now surfaces in human and JSON output; conflicts and integrity failures remain fail-closed, healthy content stays quiet, and doctor does not repair harnesses.

Reconciled onto current main without losing scoped-upgrade selections, Claude plugin planning, or current ownership policy. The original PR head is preserved at `preserve/doctor-pr-before-reconcile`; the existing local worktree is untouched.

Refs #218. This PR does not change live installs or tracker workflow lanes.

## Definition of done

- [x] Doctor reuses the current non-mutating install/dry-run planner instead of duplicating manifest traversal.
- [x] Same-version byte or mode drift appears in human and JSON doctor output with an actionable `loaf upgrade --dry-run`/upgrade remedy.
- [x] Healthy preserve states remain quiet and deterministic.
- [x] Missing ownership, conflicts, unsafe paths, and symlinks preserve the planner's existing fail-closed behavior.
- [x] Focused tests prove detection on a disposable target plus no mutation during diagnosis.

## Verification

- Confirmed the original byte/mode regression tests fail on main before the fix.
- Independent read-only review approved production code and final tests.
- Parity/nonmutation cases cover healthy content, same-version updates, modified adapters, missing ownership, symlinked adapters, invalid desired digests, and shared-skill updates/conflicts.
- Human/JSON entry-point tests and whole-tree hashes verify that home, distribution, and state fixtures remain unchanged; repeated diagnosis is deterministic.
- A freshly built binary in a disposable distribution reports healthy/preserve before an adapter edit, then fail/conflict from both doctor and upgrade dry-run after the edit, without changing fixture state.
- `LOAF_DEV_LINK=0 make build`, `make typecheck`, `go vet ./...`, full Go suite, affected race tests, and all 48 capability-runner tests pass.

The original tracked-binary review finding is superseded by the native build/packaging changes already on main. No tracked binaries or private runtime pins are reintroduced.

## Scope

No automatic repair, new ownership model, legacy analyzer, live harness upgrade, PATH switch, or release publication.