### PR TITLE
fix: keep generated changelog releases newest first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ One operator's durable memory â€” journal, wraps, handoffs, refs, verification â
 
 ### Fixed
 
+- `loaf release cut` inserts a fresh Unreleased stub and generated release before historical releases when an existing changelog has no Unreleased section, preserving newest-first order and existing prose ([#114](https://github.com/levifig/loaf/issues/114)).
 - `loaf doctor` reports same-version changes to installed harness content using the upgrade planner, with actionable diagnostics and no automatic repair ([#218](https://github.com/levifig/loaf/issues/218)).
 - Cursor check hooks request JSON output so successful checks do not block tools with an invalid-response error; genuine findings retain their blocking exit status ([#238](https://github.com/levifig/loaf/issues/238)).
 - Let the bootstrap installer hand off to `loaf install` and `loaf upgrade` without extra arguments on macOS's system Bash, while preserving empty and spaced passthrough arguments.

--- a/internal/cli/release_dry_run.go
+++ b/internal/cli/release_dry_run.go
@@ -551,7 +551,7 @@ func insertReleaseChangelog(existing string, releaseSection string) string {
 		}
 	}
 	if unreleased == -1 {
-		return ""
+		return insertReleaseChangelogWithoutUnreleased(lines, releaseSection)
 	}
 	nextRelease := len(lines)
 	for i := unreleased + 1; i < len(lines); i++ {
@@ -565,6 +565,31 @@ func insertReleaseChangelog(existing string, releaseSection string) string {
 	result := append([]string{}, lines[:unreleased+1]...)
 	result = append(result, "", "- _No unreleased changes yet._", "", releaseBlock, "")
 	result = append(result, lines[nextRelease:]...)
+	return strings.Join(result, "\n")
+}
+
+func insertReleaseChangelogWithoutUnreleased(lines []string, releaseSection string) string {
+	firstRelease := len(lines)
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "## [") {
+			firstRelease = i
+			break
+		}
+	}
+
+	result := append([]string{}, lines[:firstRelease]...)
+	if len(result) > 0 && strings.TrimSpace(result[len(result)-1]) != "" {
+		result = append(result, "")
+	}
+	result = append(result,
+		"## [Unreleased]",
+		"",
+		"- _No unreleased changes yet._",
+		"",
+		releaseSection,
+		"",
+	)
+	result = append(result, lines[firstRelease:]...)
 	return strings.Join(result, "\n")
 }
 

--- a/internal/cli/release_test.go
+++ b/internal/cli/release_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -51,7 +52,6 @@ func TestReleaseLegacyFlagsFailWithGuidance(t *testing.T) {
 		}
 	}
 }
-
 
 // commitBootstrapAgentsFiles records genesis .agents/ files (e.g. loaf.conf) so
 // release cut's clean-tree gate passes after state init.
@@ -149,6 +149,92 @@ func TestInsertReleaseChangelogUsesDraftWhenUnreleasedEmpty(t *testing.T) {
 	}
 }
 
+func TestInsertReleaseChangelogCreatesUnreleasedBeforeFirstExistingRelease(t *testing.T) {
+	existing := strings.Join([]string{
+		"# Changelog",
+		"",
+		"Project-specific introduction.",
+		"",
+		"## [1.0.0] - 2025-01-01",
+		"",
+		"- Initial release",
+		"",
+		"## [0.9.0] - 2024-12-01",
+		"",
+		"- Preview release",
+		"",
+	}, "\n")
+	drafted := "## [1.1.0] - 2026-09-04\n\n### Fixed\n- Preserve newest-first changelog order"
+
+	got := insertReleaseChangelog(existing, drafted)
+
+	for _, want := range []string{"Project-specific introduction.", "- Initial release", "- Preview release", "## [Unreleased]", "- _No unreleased changes yet._", drafted} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("updated changelog missing %q:\n%s", want, got)
+		}
+	}
+	unreleased := strings.Index(got, "## [Unreleased]")
+	newRelease := strings.Index(got, "## [1.1.0]")
+	firstHistorical := strings.Index(got, "## [1.0.0]")
+	secondHistorical := strings.Index(got, "## [0.9.0]")
+	if !(unreleased < newRelease && newRelease < firstHistorical && firstHistorical < secondHistorical) {
+		t.Fatalf("release order is not Unreleased, new, then historical:\n%s", got)
+	}
+	for _, heading := range []string{"## [Unreleased]", "## [1.1.0]", "## [1.0.0]", "## [0.9.0]"} {
+		if count := strings.Count(got, heading); count != 1 {
+			t.Fatalf("heading %q occurs %d times, want once:\n%s", heading, count, got)
+		}
+	}
+}
+
+func TestWriteReleaseChangelogPreservesExistingBytes(t *testing.T) {
+	for _, newline := range []string{"\n", "\r\n"} {
+		for _, trailing := range []string{"", newline, newline + newline} {
+			t.Run(fmt.Sprintf("newline=%q/trailing=%q", newline, trailing), func(t *testing.T) {
+				root := t.TempDir()
+				header := "# Changelog" + newline + newline + "Introduction.  " + newline + newline
+				history := "## [1.0.0] - 2025-01-01" + newline + newline + "- Original note.  " + trailing
+				path := filepath.Join(root, "CHANGELOG.md")
+				writeFile(t, path, header+history)
+				drafted := "## [1.1.0] - 2026-09-04\n\n- Fix placement"
+				if err := writeReleaseChangelog(root, drafted); err != nil {
+					t.Fatal(err)
+				}
+				got := string(readFileBytes(t, path))
+				insertion := "## [Unreleased]\n\n- _No unreleased changes yet._\n\n" + drafted + "\n\n"
+				if want := header + insertion + history; got != want {
+					t.Fatalf("changelog changed outside insertion site:\ngot  %q\nwant %q", got, want)
+				}
+			})
+		}
+	}
+}
+
+func TestWriteReleaseChangelogWithoutHistory(t *testing.T) {
+	drafted := "## [1.0.0] - 2026-09-04\n\n- Initial release"
+	for _, existing := range []string{"", "# Changelog", "# Changelog\n\nIntroduction.\n"} {
+		t.Run(fmt.Sprintf("existing=%q", existing), func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, "CHANGELOG.md")
+			writeFile(t, path, existing)
+			if err := writeReleaseChangelog(root, drafted); err != nil {
+				t.Fatal(err)
+			}
+			got := string(readFileBytes(t, path))
+			if !strings.HasPrefix(got, existing) || !strings.Contains(got, "## [Unreleased]\n\n- _No unreleased changes yet._\n\n"+drafted) {
+				t.Fatalf("missing preserved introduction or new release: %q", got)
+			}
+		})
+	}
+	root := t.TempDir()
+	if err := writeReleaseChangelog(root, drafted); err != nil {
+		t.Fatal(err)
+	}
+	if got := string(readFileBytes(t, filepath.Join(root, "CHANGELOG.md"))); got != createReleaseChangelog(drafted) {
+		t.Fatalf("new changelog differs from existing document generator: %q", got)
+	}
+}
+
 func TestValidateExplicitReleaseVersionAllowsHigherMinor(t *testing.T) {
 	if err := validateExplicitReleaseVersion("0.3.1", "minor", "0.5.0"); err != nil {
 		t.Fatalf("0.5.0 should be allowed for minor bump from 0.3.1: %v", err)
@@ -168,4 +254,3 @@ func TestValidateExplicitReleaseVersionRejectsInvalidSemver(t *testing.T) {
 		t.Fatalf("expected invalid version error, got %v", err)
 	}
 }
-

--- a/internal/cli/release_track_test.go
+++ b/internal/cli/release_track_test.go
@@ -354,6 +354,63 @@ func TestReleaseCutRecordsMembersAndDryRunWritesNothing(t *testing.T) {
 	}
 }
 
+func TestReleaseCutPlacesGeneratedSectionInExistingChangelogWithoutUnreleased(t *testing.T) {
+	repo, stateHome := releaseTrackFixture(t)
+	legacyChangelog := strings.Join([]string{
+		"# Changelog",
+		"",
+		"Project-specific introduction.",
+		"",
+		"## [1.0.0] - 2025-01-01",
+		"",
+		"- Initial release",
+		"",
+		"## [0.9.0] - 2024-12-01",
+		"",
+		"- Preview release",
+		"",
+	}, "\n")
+	writeFile(t, filepath.Join(repo, "CHANGELOG.md"), legacyChangelog)
+	gitCLI(t, repo, "add", "CHANGELOG.md")
+	gitCLI(t, repo, "commit", "-m", "docs: retain legacy changelog layout")
+
+	if _, err := runIssue(t, repo, stateHome, "new", "Fix release placement"); err != nil {
+		t.Fatalf("issue new error = %v", err)
+	}
+	if _, err := runIssue(t, repo, stateHome, "status", "LOAF-1", "done"); err != nil {
+		t.Fatalf("status error = %v", err)
+	}
+	writeFile(t, filepath.Join(repo, "release.txt"), "release\n")
+	gitCLI(t, repo, "add", "release.txt")
+	gitCLI(t, repo, "commit", "-m", "fix: place generated release LOAF-1")
+
+	beforeDryRun := readFileBytes(t, filepath.Join(repo, "CHANGELOG.md"))
+	if output, err := runReleaseTrack(t, repo, stateHome, "cut", "--dry-run", "--no-gh"); err != nil {
+		t.Fatalf("release cut --dry-run error = %v\n%s", err, output)
+	}
+	if afterDryRun := readFileBytes(t, filepath.Join(repo, "CHANGELOG.md")); !bytes.Equal(afterDryRun, beforeDryRun) {
+		t.Fatal("dry-run mutated a changelog without an Unreleased section")
+	}
+
+	gitCLI(t, repo, "tag", "v1.0.1")
+	if output, err := runReleaseTrack(t, repo, stateHome, "cut", "--no-tag", "--no-gh", "--base", "v1.0.0"); err != nil {
+		t.Fatalf("release cut error = %v\n%s", err, output)
+	}
+	updated := string(readFileBytes(t, filepath.Join(repo, "CHANGELOG.md")))
+	for _, want := range []string{"Project-specific introduction.", "- Initial release", "- Preview release", "## [Unreleased]", "- _No unreleased changes yet._"} {
+		if !strings.Contains(updated, want) {
+			t.Fatalf("updated changelog missing %q:\n%s", want, updated)
+		}
+	}
+	unreleased := strings.Index(updated, "## [Unreleased]")
+	newRelease := strings.Index(updated, "## [1.0.1]")
+	firstHistorical := strings.Index(updated, "## [1.0.0]")
+	secondHistorical := strings.Index(updated, "## [0.9.0]")
+	if !(unreleased < newRelease && newRelease < firstHistorical && firstHistorical < secondHistorical) {
+		t.Fatalf("release order is not Unreleased, new, then historical:\n%s", updated)
+	}
+}
+
 func TestReleaseCutIncludesPrereleaseByReference(t *testing.T) {
 	repo, stateHome := releaseTrackFixture(t)
 	if _, err := runIssue(t, repo, stateHome, "new", "Alpha"); err != nil {
@@ -1114,4 +1171,3 @@ func TestReleaseCutVersionFlagDryRun(t *testing.T) {
 		t.Fatalf("dry-run should target explicit 0.5.0, not suggested 0.4.0:\n%s", out)
 	}
 }
-


### PR DESCRIPTION
## Summary

Restore the reviewed changelog-placement fix from preserved commit c6595a77 onto current main without reintroducing retired binary artifacts. When an existing changelog has no Unreleased section, release cut now inserts a fresh staging stub and generated release before the first historical release.

Refs #114.

## Contract and scope

- Preserve header prose, history bytes, and release ordering.
- Keep curated/stub Unreleased behavior and brand-new document generation unchanged.
- Cover no-history inputs and dry-run non-mutation.
- No release publication, version-policy, or live-install changes. The original branch remains preserved.

## Verification

Regression tests failed on the original writer before the fix. All affected release/changelog tests, focused race checks, build, type checks, vet, full Go suite, and 48 capability-runner tests passed. Independent read-only review found no actionable issues. Preservation tests cover LF/CRLF, trailing whitespace, and absent/multiple terminal newlines.

The first historical release heading is sufficient for the supported format. General Markdown parsing and malformed/duplicate release headings remain out of scope.