### PR TITLE
fix: keep pitch template metadata out of narratives

### DIFF
--- a/dist/amp/skills/loaf-reference/templates/problem-narrative.md
+++ b/dist/amp/skills/loaf-reference/templates/problem-narrative.md
@@ -1,6 +1,6 @@
 # Problem Narrative
 
-Use this artifact to carry discovery into shaping. Replace every placeholder; preserve the field markers so validation can distinguish the contract from prose. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
+Use this template to carry discovery into shaping. Fill every field with observed or explicitly uncertain information. Field-marker comments are metadata for validating this template source; preserve them when editing the template, but omit them and these authoring instructions from generated narratives, including chat responses and saved documents. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
 
 <!-- loaf:field problem -->
 ## Problem

--- a/dist/amp/skills/pitch/templates/problem-narrative.md
+++ b/dist/amp/skills/pitch/templates/problem-narrative.md
@@ -1,6 +1,6 @@
 # Problem Narrative
 
-Use this artifact to carry discovery into shaping. Replace every placeholder; preserve the field markers so validation can distinguish the contract from prose. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
+Use this template to carry discovery into shaping. Fill every field with observed or explicitly uncertain information. Field-marker comments are metadata for validating this template source; preserve them when editing the template, but omit them and these authoring instructions from generated narratives, including chat responses and saved documents. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
 
 <!-- loaf:field problem -->
 ## Problem

--- a/dist/codex/skills/loaf-reference/templates/problem-narrative.md
+++ b/dist/codex/skills/loaf-reference/templates/problem-narrative.md
@@ -1,6 +1,6 @@
 # Problem Narrative
 
-Use this artifact to carry discovery into shaping. Replace every placeholder; preserve the field markers so validation can distinguish the contract from prose. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
+Use this template to carry discovery into shaping. Fill every field with observed or explicitly uncertain information. Field-marker comments are metadata for validating this template source; preserve them when editing the template, but omit them and these authoring instructions from generated narratives, including chat responses and saved documents. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
 
 <!-- loaf:field problem -->
 ## Problem

--- a/dist/codex/skills/pitch/templates/problem-narrative.md
+++ b/dist/codex/skills/pitch/templates/problem-narrative.md
@@ -1,6 +1,6 @@
 # Problem Narrative
 
-Use this artifact to carry discovery into shaping. Replace every placeholder; preserve the field markers so validation can distinguish the contract from prose. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
+Use this template to carry discovery into shaping. Fill every field with observed or explicitly uncertain information. Field-marker comments are metadata for validating this template source; preserve them when editing the template, but omit them and these authoring instructions from generated narratives, including chat responses and saved documents. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
 
 <!-- loaf:field problem -->
 ## Problem

--- a/dist/cursor/skills/loaf-reference/templates/problem-narrative.md
+++ b/dist/cursor/skills/loaf-reference/templates/problem-narrative.md
@@ -1,6 +1,6 @@
 # Problem Narrative
 
-Use this artifact to carry discovery into shaping. Replace every placeholder; preserve the field markers so validation can distinguish the contract from prose. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
+Use this template to carry discovery into shaping. Fill every field with observed or explicitly uncertain information. Field-marker comments are metadata for validating this template source; preserve them when editing the template, but omit them and these authoring instructions from generated narratives, including chat responses and saved documents. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
 
 <!-- loaf:field problem -->
 ## Problem

--- a/dist/cursor/skills/pitch/templates/problem-narrative.md
+++ b/dist/cursor/skills/pitch/templates/problem-narrative.md
@@ -1,6 +1,6 @@
 # Problem Narrative
 
-Use this artifact to carry discovery into shaping. Replace every placeholder; preserve the field markers so validation can distinguish the contract from prose. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
+Use this template to carry discovery into shaping. Fill every field with observed or explicitly uncertain information. Field-marker comments are metadata for validating this template source; preserve them when editing the template, but omit them and these authoring instructions from generated narratives, including chat responses and saved documents. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
 
 <!-- loaf:field problem -->
 ## Problem

--- a/dist/opencode/skills/loaf-reference/templates/problem-narrative.md
+++ b/dist/opencode/skills/loaf-reference/templates/problem-narrative.md
@@ -1,6 +1,6 @@
 # Problem Narrative
 
-Use this artifact to carry discovery into shaping. Replace every placeholder; preserve the field markers so validation can distinguish the contract from prose. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
+Use this template to carry discovery into shaping. Fill every field with observed or explicitly uncertain information. Field-marker comments are metadata for validating this template source; preserve them when editing the template, but omit them and these authoring instructions from generated narratives, including chat responses and saved documents. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
 
 <!-- loaf:field problem -->
 ## Problem

--- a/dist/opencode/skills/pitch/templates/problem-narrative.md
+++ b/dist/opencode/skills/pitch/templates/problem-narrative.md
@@ -1,6 +1,6 @@
 # Problem Narrative
 
-Use this artifact to carry discovery into shaping. Replace every placeholder; preserve the field markers so validation can distinguish the contract from prose. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
+Use this template to carry discovery into shaping. Fill every field with observed or explicitly uncertain information. Field-marker comments are metadata for validating this template source; preserve them when editing the template, but omit them and these authoring instructions from generated narratives, including chat responses and saved documents. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
 
 <!-- loaf:field problem -->
 ## Problem

--- a/dist/skills/loaf-reference/templates/problem-narrative.md
+++ b/dist/skills/loaf-reference/templates/problem-narrative.md
@@ -1,6 +1,6 @@
 # Problem Narrative
 
-Use this artifact to carry discovery into shaping. Replace every placeholder; preserve the field markers so validation can distinguish the contract from prose. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
+Use this template to carry discovery into shaping. Fill every field with observed or explicitly uncertain information. Field-marker comments are metadata for validating this template source; preserve them when editing the template, but omit them and these authoring instructions from generated narratives, including chat responses and saved documents. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
 
 <!-- loaf:field problem -->
 ## Problem

--- a/dist/skills/pitch/templates/problem-narrative.md
+++ b/dist/skills/pitch/templates/problem-narrative.md
@@ -1,6 +1,6 @@
 # Problem Narrative
 
-Use this artifact to carry discovery into shaping. Replace every placeholder; preserve the field markers so validation can distinguish the contract from prose. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
+Use this template to carry discovery into shaping. Fill every field with observed or explicitly uncertain information. Field-marker comments are metadata for validating this template source; preserve them when editing the template, but omit them and these authoring instructions from generated narratives, including chat responses and saved documents. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
 
 <!-- loaf:field problem -->
 ## Problem

--- a/plugins/loaf/skills/loaf-reference/templates/problem-narrative.md
+++ b/plugins/loaf/skills/loaf-reference/templates/problem-narrative.md
@@ -1,6 +1,6 @@
 # Problem Narrative
 
-Use this artifact to carry discovery into shaping. Replace every placeholder; preserve the field markers so validation can distinguish the contract from prose. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
+Use this template to carry discovery into shaping. Fill every field with observed or explicitly uncertain information. Field-marker comments are metadata for validating this template source; preserve them when editing the template, but omit them and these authoring instructions from generated narratives, including chat responses and saved documents. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
 
 <!-- loaf:field problem -->
 ## Problem

--- a/plugins/loaf/skills/pitch/templates/problem-narrative.md
+++ b/plugins/loaf/skills/pitch/templates/problem-narrative.md
@@ -1,6 +1,6 @@
 # Problem Narrative
 
-Use this artifact to carry discovery into shaping. Replace every placeholder; preserve the field markers so validation can distinguish the contract from prose. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
+Use this template to carry discovery into shaping. Fill every field with observed or explicitly uncertain information. Field-marker comments are metadata for validating this template source; preserve them when editing the template, but omit them and these authoring instructions from generated narratives, including chat responses and saved documents. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
 
 <!-- loaf:field problem -->
 ## Problem

--- a/vnext/content/templates/problem-narrative.md
+++ b/vnext/content/templates/problem-narrative.md
@@ -1,6 +1,6 @@
 # Problem Narrative
 
-Use this artifact to carry discovery into shaping. Replace every placeholder; preserve the field markers so validation can distinguish the contract from prose. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
+Use this template to carry discovery into shaping. Fill every field with observed or explicitly uncertain information. Field-marker comments are metadata for validating this template source; preserve them when editing the template, but omit them and these authoring instructions from generated narratives, including chat responses and saved documents. In Desired Outcome, name the first useful end-to-end journey a real operator could complete without prescribing its component design.
 
 <!-- loaf:field problem -->
 ## Problem


### PR DESCRIPTION
## Summary

Clarify that problem-narrative field markers belong to the template source, not generated chat responses or saved documents. This resolves a contradiction with the existing Pitch skill instructions.

Recover only the missing authored paragraph from preserved commit b38eab4a. The skill-side rule is already on main; its later Backlog/Todo changes remain untouched.

## Scope

One authored paragraph and 12 regenerated distribution copies. All seven source fields, markers, headings, and placeholders stay unchanged. No tracker transitions, runtime changes, or live installation updates.

## Verification

- Native flow-contract tests, full Go suite, build, type checks, vet, and diff checks passed.
- Independent read-only review confirmed the source contract is intact and every distributed copy matches.
- Source-marker validation is a repository test over template sources; it does not validate generated narratives.
- Original ed70 worktree remains clean at b38eab4a.

This is a narrow instruction clarification. No new runtime behavior or wording-matching test was added.