### PR TITLE
fix: preserve canonical skill sources in scoped upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ One operator's durable memory â€” journal, wraps, handoffs, refs, verification â
 
 ### Fixed
 
+- Scoped skill upgrades preserve the installed harness cohort's canonical metadata and use the same source for preview and apply, avoiding repeated updates and lost OpenCode settings ([#230](https://github.com/levifig/loaf/issues/230)).
 - `loaf release cut` inserts a fresh Unreleased stub and generated release before historical releases when an existing changelog has no Unreleased section, preserving newest-first order and existing prose ([#114](https://github.com/levifig/loaf/issues/114)).
 - `loaf doctor` reports same-version changes to installed harness content using the upgrade planner, with actionable diagnostics and no automatic repair ([#218](https://github.com/levifig/loaf/issues/218)).
 - Cursor check hooks request JSON output so successful checks do not block tools with an invalid-response error; genuine findings retain their blocking exit status ([#238](https://github.com/levifig/loaf/issues/238)).

--- a/internal/cli/install_plan.go
+++ b/internal/cli/install_plan.go
@@ -68,6 +68,9 @@ type targetDistributionPlan struct {
 }
 
 type artifactPlanDecision struct {
+	// skillSource is resolved with the installed cohort during classification.
+	// Scoped diff and apply reuse it instead of choosing from artifact selections.
+	skillSource   string
 	ID            string `json:"id"`
 	Kind          string `json:"kind"`
 	Destination   string `json:"destination"`
@@ -497,6 +500,9 @@ func planManagedSkills(src string, dest string) ([]artifactPlanDecision, error) 
 			detail = reason
 		}
 		decisions = append(decisions, artifactPlanDecision{ID: "skill:" + skill, Kind: "skill", Destination: destination, Action: action, Detail: detail})
+	}
+	for i := range decisions {
+		decisions[i].skillSource = filepath.Join(src, strings.TrimPrefix(decisions[i].ID, "skill:"))
 	}
 	sort.SliceStable(decisions, func(i, j int) bool { return decisions[i].ID < decisions[j].ID })
 	return decisions, nil

--- a/internal/cli/upgrade_scoped.go
+++ b/internal/cli/upgrade_scoped.go
@@ -154,36 +154,31 @@ func (r Runner) applyScopedUpgrade(out io.Writer, planned installDryRunPlan, opt
 		}
 	}()
 
-	defaults, layoutHome := resolveInstallLayout(projectRoot)
-	toolByKey := installToolsByKey(tools)
+	_, layoutHome := resolveInstallLayout(projectRoot)
 	hookState, releaseHookState := r.hookStateForApply(projectRoot)
 	defer releaseHookState()
 
 	skillNames := selectedSkillNames(refs)
 	if len(skillNames) > 0 {
-		groups, err := groupSkillsInstallByDestination(scopedTargetOptions(refs, defaults, toolByKey, distRoot, version, layoutHome, projectRoot, hookState))
-		if err != nil {
-			txn.failed = err
-			return err
-		}
-		for _, group := range groups {
-			source, err := selectCanonicalSkillsSource(group.Options)
-			if err != nil {
-				txn.failed = err
-				return err
+		seenDestinations := map[string]bool{}
+		for _, skill := range rechecked.Skills {
+			destination := filepath.Dir(skill.Destination)
+			if seenDestinations[destination] {
+				continue
 			}
-			src := filepath.Join(source.DistDir, "skills")
-			if err := txn.backup(filepath.Join(group.Destination, loafSkillManifestFile)); err != nil {
+			seenDestinations[destination] = true
+			src := filepath.Dir(skill.skillSource)
+			if err := txn.backup(filepath.Join(destination, loafSkillManifestFile)); err != nil {
 				txn.failed = err
 				return err
 			}
 			for _, name := range skillNames {
-				if err := txn.backup(filepath.Join(group.Destination, name)); err != nil {
+				if err := txn.backup(filepath.Join(destination, name)); err != nil {
 					txn.failed = err
 					return err
 				}
 			}
-			if err := syncSelectedManagedSkills(src, group.Destination, skillNames); err != nil {
+			if err := syncSelectedManagedSkills(src, destination, skillNames); err != nil {
 				txn.failed = err
 				return err
 			}
@@ -332,63 +327,6 @@ func summarizeScopedPlan(plan installDryRunPlan) string {
 		}
 	}
 	return b.String()
-}
-
-func scopedTargetOptions(refs []scopedArtifactRef, defaults map[string]string, toolByKey map[string]detectedInstallTool, distRoot string, version string, home string, projectRoot string, hookState hookStateResolver) []targetInstallOptions {
-	seen := map[string]bool{}
-	var options []targetInstallOptions
-	for _, ref := range refs {
-		if ref.Target == scopedSkillsTarget {
-			continue
-		}
-		if seen[ref.Target] {
-			continue
-		}
-		seen[ref.Target] = true
-		configDir := defaults[ref.Target]
-		if tool, ok := toolByKey[ref.Target]; ok && tool.configDir != "" {
-			configDir = tool.configDir
-		}
-		options = append(options, targetInstallOptions{
-			Target:         ref.Target,
-			DistDir:        filepath.Join(distRoot, ref.Target),
-			ConfigDir:      configDir,
-			Upgrade:        true,
-			Version:        version,
-			HomeDir:        home,
-			CodexHome:      resolveInstallCodexHome(configDir),
-			ProjectRoot:    projectRoot,
-			SkipSkillsSync: true,
-			HookState:      hookState,
-		})
-	}
-	if len(options) == 0 {
-		// Skills-only selections still need a destination group. Use cursor if
-		// present, otherwise the first installed target, so the shared store
-		// resolves the same way upgrade does.
-		for _, target := range []string{"cursor", "opencode", "codex", "amp"} {
-			configDir := defaults[target]
-			if tool, ok := toolByKey[target]; ok && tool.configDir != "" {
-				configDir = tool.configDir
-			}
-			if configDir == "" {
-				continue
-			}
-			options = append(options, targetInstallOptions{
-				Target:         target,
-				DistDir:        filepath.Join(distRoot, target),
-				ConfigDir:      configDir,
-				Upgrade:        true,
-				Version:        version,
-				HomeDir:        home,
-				ProjectRoot:    projectRoot,
-				SkipSkillsSync: true,
-				HookState:      hookState,
-			})
-			break
-		}
-	}
-	return options
 }
 
 func applySelectedHookEntries(options targetInstallOptions) error {
@@ -797,11 +735,12 @@ func desiredAdapterBody(options targetInstallOptions, artifact targetAdapterArti
 }
 
 func enrichScopedPlanDiffs(plan *installDryRunPlan, hookState hookStateResolver, projectRoot string, version string, distRoot string, tools []detectedInstallTool, refs []scopedArtifactRef) error {
-	defaults, layoutHome := resolveInstallLayout(projectRoot)
-	toolByKey := installToolsByKey(tools)
+	_, layoutHome := resolveInstallLayout(projectRoot)
 	for i, skill := range plan.Skills {
-		name, _ := strings.CutPrefix(skill.ID, "skill:")
-		src := scopedSkillSource(refs, defaults, toolByKey, distRoot, version, layoutHome, projectRoot, name)
+		src := skill.skillSource
+		if src == "" {
+			return fmt.Errorf("selected skill %s has no resolved canonical source", skill.ID)
+		}
 		dest := skill.Destination
 		diff, liveHash, desiredHash, err := skillTreeDiff(src, dest)
 		if err != nil {
@@ -916,18 +855,6 @@ func desiredTextFromTree(root string) (string, error) {
 	})
 	return b.String(), err
 }
-func scopedSkillSource(refs []scopedArtifactRef, defaults map[string]string, toolByKey map[string]detectedInstallTool, distRoot string, version string, home string, projectRoot string, skill string) string {
-	options := scopedTargetOptions(refs, defaults, toolByKey, distRoot, version, home, projectRoot, nil)
-	if len(options) == 0 {
-		return ""
-	}
-	source, err := selectCanonicalSkillsSource(options)
-	if err != nil {
-		return filepath.Join(options[0].DistDir, "skills", skill)
-	}
-	return filepath.Join(source.DistDir, "skills", skill)
-}
-
 func skillTreeDiff(src string, dest string) (string, string, string, error) {
 	desiredHash, err := hashInstallSkillTree(src)
 	if err != nil && !os.IsNotExist(err) {

--- a/internal/cli/upgrade_scoped_skill_source_test.go
+++ b/internal/cli/upgrade_scoped_skill_source_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScopedUpgradeUsesInstalledCanonicalSkillSource(t *testing.T) {
+	for _, withHook := range []bool{false, true} {
+		for _, alreadyCanonical := range []bool{false, true} {
+			for _, openCodeInstalled := range []bool{false, true} {
+				name := map[bool]string{false: "skills-only", true: "cursor-hook"}[withHook] + "/" + map[bool]string{false: "update", true: "preserve"}[alreadyCanonical] + "/" + map[bool]string{false: "cursor-only", true: "opencode-installed"}[openCodeInstalled]
+				t.Run(name, func(t *testing.T) {
+					root, home := setupScopedUpgradeFixture(t)
+					cursor := "---\nname: foundations\ndescription: Test foundations.\n---\n\n# Foundations\n"
+					openCode := "---\nname: foundations\ndescription: Test foundations.\nsubtask: false\n---\n\n# Foundations\n"
+					writeInstallFile(t, filepath.Join(root, "dist", "cursor", "skills", "foundations", "SKILL.md"), cursor)
+					writeInstallFile(t, filepath.Join(root, "dist", "opencode", "skills", "foundations", "SKILL.md"), openCode)
+					target := "cursor"
+					if openCodeInstalled {
+						target = "opencode"
+					} else {
+						if err := os.RemoveAll(filepath.Join(home, ".config", "opencode")); err != nil {
+							t.Fatal(err)
+						}
+						if err := os.Remove(installRecordPath(home, "opencode")); err != nil {
+							t.Fatal(err)
+						}
+					}
+					source := filepath.Join(root, "dist", target, "skills")
+					dest := filepath.Join(home, ".agents", "skills")
+					if alreadyCanonical {
+						if err := syncSelectedManagedSkills(source, dest, []string{"foundations"}); err != nil {
+							t.Fatal(err)
+						}
+					}
+					expected, err := hashInstallSkillTree(filepath.Join(source, "foundations"))
+					if err != nil {
+						t.Fatal(err)
+					}
+					args := []string{"upgrade", "--select", "skills/skill:foundations"}
+					if withHook {
+						args = append(args, "--select", "cursor/hook:preToolUse/validate-infra-safety")
+					}
+					preview := func() artifactPlanDecision {
+						plan := parseInstallPlanJSON(t, runInstallCapture(t, root, append(append([]string{}, args...), "--dry-run", "--json")...))
+						return findScopedSkill(t, plan, "skill:foundations")
+					}
+					first := preview()
+					wantAction := planActionUpdate
+					if alreadyCanonical {
+						wantAction = planActionPreserve
+					}
+					if first.Action != wantAction || first.DesiredSHA256 != expected {
+						t.Fatalf("first action=%s desired=%s, want %s %s", first.Action, first.DesiredSHA256, wantAction, expected)
+					}
+					runInstallCapture(t, root, args...)
+					actual, err := hashInstallSkillTree(filepath.Join(dest, "foundations"))
+					if err != nil {
+						t.Fatal(err)
+					}
+					if actual != expected {
+						t.Fatalf("applied hash=%s want planned %s", actual, expected)
+					}
+					second := preview()
+					if second.Action != planActionPreserve || second.LiveSHA256 != expected || second.DesiredSHA256 != expected {
+						t.Fatalf("second plan did not converge: %#v", second)
+					}
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Keep scoped skill classification, diffs, and locked apply on the same canonical source chosen for the installed harness cohort.

Live acceptance exposed a mismatch: with Cursor and OpenCode installed, classification selected OpenCode's sidecar-bearing skill while scoped diff/apply selected Cursor's copy. This produced repeated update plans with equal hashes and could strip subtask metadata even from a preserve action.

The fix records the canonical source in the internal skill decision and reuses the freshly rebuilt decision under the existing reconcile lock. The duplicate source selection and silent fallback are removed. Public JSON, ownership checks, rollback, and artifact selection boundaries are unchanged.

Refs #230.

## Verification

- Reproduced the bad desired hash and preserve-but-wrong-source behavior before the fix.
- Eight-case regression matrix covers skills-only and skill-plus-Cursor-hook selections; pending and already-current content; installed and absent OpenCode.
- Regression checks prove desired/applied hash equality and second-plan preservation.
- Affected scoped-upgrade/ownership tests, focused race tests, full Go suite, build, typecheck, vet, and 48 capability-runner tests pass.
- Independent read-only review found no actionable defects, including retirement and rollback handling.
- Read-only live preview now shows the actual missing OpenCode metadata rather than an empty update.

No dependency additions, runtime pinning, or Claude marketplace changes. Full live acceptance of #230 remains open.