### PR TITLE
fix: label implementation threads as implementer

### DIFF
--- a/dist/amp/.amp/plugins/loaf.ts
+++ b/dist/amp/.amp/plugins/loaf.ts
@@ -472,7 +472,7 @@ export function registerLoafDelegation(amp: DelegationAPI, command: DelegationCo
         if (parentStopped) throw new Error('Parent turn stopped before child creation.');
         Object.assign(receipt, { native_ref: input.native_ref, role: 'implementation', worktree: root, native_mode: mode, requested_model: grokModel, requested_features: ['fast'], requested_tools: implementationTools, packet_sha256: createHash('sha256').update(packet).digest('hex') });
         const childAgent = amp.createAgent({
-          name: 'loaf-implementation-agent', model: grokModel, features: ['fast'], tools: [...implementationTools], instructions: implementationInstructions,
+          name: 'loaf-implementation-agent', model: grokModel, features: ['fast'], tools: [...implementationTools], instructions: implementationInstructions, display: { label: 'implementer' },
         });
         if (typeof childAgent.createThread !== 'function') throw new Error('Installed Amp cannot create a native child.');
         child = await childAgent.createThread({ parentThreadID: ctx.thread.id, executor: 'local', visibility: 'private' });

--- a/dist/amp/.loaf-target-manifest.json
+++ b/dist/amp/.loaf-target-manifest.json
@@ -26,7 +26,7 @@
       "kind": "plugin",
       "source_path": ".amp/plugins/loaf.ts",
       "destination": "plugins/loaf.ts",
-      "sha256": "402030ddb9d93280d398fa26fae9ebca794b2d446121b1ca5e839db31abb3a3e",
+      "sha256": "96c75a17ee65d36fde30fa1ae62587effab58e9ed9b92257563e0d2151481841",
       "mode": 420
     }
   ]

--- a/internal/cli/amp_delegation.test.mjs
+++ b/internal/cli/amp_delegation.test.mjs
@@ -101,6 +101,7 @@ test('native child is pinned Grok Fast with minimal tools and returns provenance
   assert.deepEqual(agent.features, ['fast']);
   assert.equal(agent.reasoningEffort, undefined);
   assert.equal(agent.extends, undefined);
+  assert.deepEqual(agent.display, { label: 'implementer' });
   assert.deepEqual(f.calls.find(([name]) => name === 'thread')[1], { parentThreadID: 'T-parent', executor: 'local', visibility: 'private' });
   assert.ok(await f.guard.check({ thread: { id: 'T-child' }, tool: 'Read', input: { path: join(f.root, 'source') } }));
 });

--- a/internal/cli/amp_delegation.ts
+++ b/internal/cli/amp_delegation.ts
@@ -214,7 +214,7 @@ export function registerLoafDelegation(amp: DelegationAPI, command: DelegationCo
         if (parentStopped) throw new Error('Parent turn stopped before child creation.');
         Object.assign(receipt, { native_ref: input.native_ref, role: 'implementation', worktree: root, native_mode: mode, requested_model: grokModel, requested_features: ['fast'], requested_tools: implementationTools, packet_sha256: createHash('sha256').update(packet).digest('hex') });
         const childAgent = amp.createAgent({
-          name: 'loaf-implementation-agent', model: grokModel, features: ['fast'], tools: [...implementationTools], instructions: implementationInstructions,
+          name: 'loaf-implementation-agent', model: grokModel, features: ['fast'], tools: [...implementationTools], instructions: implementationInstructions, display: { label: 'implementer' },
         });
         if (typeof childAgent.createThread !== 'function') throw new Error('Installed Amp cannot create a native child.');
         child = await childAgent.createThread({ parentThreadID: ctx.thread.id, executor: 'local', visibility: 'private' });

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -412,6 +412,7 @@ declare module '@ampcode/plugin' {
     tools?: readonly string[] | 'all' | { include?: readonly string[] | 'all'; add?: readonly string[]; exclude?: readonly string[] };
     features?: readonly string[];
     name?: string;
+    display?: AgentDisplay;
   }
   export type AgentDefinition =
     | { readonly kind: 'builtin-agent'; mode: BuiltinAgentMode }
@@ -485,7 +486,7 @@ declare module '@ampcode/plugin' {
 
   export interface AgentDisplay {
     label: string;
-    color: string;
+    color?: string;
   }
 
   export interface AgentConfig {

--- a/internal/cli/build_test.go
+++ b/internal/cli/build_test.go
@@ -1630,6 +1630,30 @@ func TestNativeBuildValidationAcceptsAmpHookPluginSurface(t *testing.T) {
 	}
 }
 
+func TestNativeBuildValidationAcceptsAmpAgentDisplayWithoutColor(t *testing.T) {
+	requireTypeScriptCompiler(t)
+	root := realpath(t, t.TempDir())
+	mkdirAll(t, filepath.Join(root, "dist", "amp", ".amp", "plugins"))
+	writeFile(t, filepath.Join(root, "dist", "amp", ".amp", "plugins", "loaf.ts"), strings.Join([]string{
+		"import type { PluginAPI, CreateAgentConfig } from '@ampcode/plugin';",
+		"",
+		"export default function (amp: PluginAPI) {",
+		"  const config: CreateAgentConfig = { model: 'xai/grok-4.6', display: { label: 'implementer' } };",
+		"  amp.createAgent(config);",
+		"}",
+		"",
+	}, "\n"))
+	t.Setenv("LOAF_VALIDATE_TYPESCRIPT", "1")
+
+	warnings, err := validateNativeBuildArtifacts(root, "amp")
+	if err != nil {
+		t.Fatalf("validateNativeBuildArtifacts(amp agent display without color) error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %#v, want none when CreateAgentConfig accepts label-only display", warnings)
+	}
+}
+
 func requireTypeScriptCompiler(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("tsc"); err != nil {


### PR DESCRIPTION
## Summary

Show `implementer` in new Amp child thread headers without registering a custom mode. Preserve Grok 4.6/Fast, native Oracle and settings. Align local display API declarations with optional color.

Refs #266; do not close it or unblock dependents. Its broader live acceptance gaps remain.

## Verification

- Full verify-local passed on the exact candidate: Go suite, compile/vet, CGO-free build, 56 capability tests, TypeScript/build/render-drift.
- Native read-only Oracle review: no blockers.
- Red-green label regression; authorized scoped activation; user screenshot confirms header label and Fast icon.
- Combined label and hook-directory activation candidate passed focused integration checks and preserves settings/unrelated plugins.

No release or version change.