### PR TITLE
fix: run Amp hooks in the target working directory

### DIFF
--- a/dist/amp/.amp/plugins/loaf.ts
+++ b/dist/amp/.amp/plugins/loaf.ts
@@ -71,6 +71,7 @@ async function runHook(
   payload?: string,
   timeout: number = 60000,
   failClosed: boolean = false,
+  cwd: string = process.cwd(),
 ): Promise<HookResult> {
   const env = {
     ...process.env,
@@ -84,7 +85,7 @@ async function runHook(
     // If hook has direct command (e.g., 'loaf check ...'), execute it
     if (command) {
       const child = execFile('bash', ['-c', command], {
-        cwd: process.cwd(),
+        cwd,
         env,
         encoding: 'utf-8',
         timeout,
@@ -114,7 +115,7 @@ async function runHook(
       const scriptPath = join(__dirname, 'hooks', script);
       const interpreter = script.endsWith('.py') ? 'python3' : 'bash';
       const child = execFile(interpreter, [scriptPath], {
-        cwd: process.cwd(),
+        cwd,
         env,
         encoding: 'utf-8',
         timeout,
@@ -663,10 +664,52 @@ const postToolHooks: Record<string, HookEntry[]> = {
 
 export default function (amp: PluginAPI) {
   const delegation = registerLoafDelegation(amp);
+  function ampWorkspaceDir(): { path?: string; error?: string } {
+    const workspaceRoot = amp.system?.workspaceRoot;
+    if (!workspaceRoot) return { error: 'Amp workspace is unavailable' };
+    if (typeof amp.helpers?.filePathFromURI !== 'function') {
+      return { error: 'Amp workspace is unavailable' };
+    }
+    try {
+      const path = amp.helpers.filePathFromURI(workspaceRoot);
+      if (typeof path !== 'string' || !path) return { error: 'Amp workspace is unavailable' };
+      return { path };
+    } catch (error: any) {
+      return { error: error?.message || 'Amp workspace is unavailable' };
+    }
+  }
+
+  function resolveAmpHookCwd(explicitDir?: string): { cwd?: string; error?: string } {
+    if (typeof explicitDir === 'string' && explicitDir) {
+      if (isAbsolute(explicitDir)) return { cwd: explicitDir };
+      const workspace = ampWorkspaceDir();
+      if (!workspace.path) {
+        return { error: workspace.error || 'Amp workspace is unavailable; cannot resolve relative shell directory' };
+      }
+      return { cwd: resolve(workspace.path, explicitDir) };
+    }
+    const workspace = ampWorkspaceDir();
+    if (!workspace.path) {
+      return { error: workspace.error || 'Amp workspace is unavailable' };
+    }
+    return { cwd: workspace.path };
+  }
+
+  function ampHelperShellDir(event: AmpToolCallEvent): string | undefined {
+    if (event.tool !== 'Bash' && event.tool !== 'shell_command') return undefined;
+    const shellCommand = amp.helpers.shellCommandFromToolCall(event);
+    return typeof shellCommand?.dir === 'string' && shellCommand.dir ? shellCommand.dir : undefined;
+  }
+
   amp.on('agent.start', async (event, ctx) => {
     if (delegation.owns(event.thread.id)) return {};
     const policy = await loafNativeModeContext(event, ctx);
-    const result = await runHook('harness', '', 'managed-content-reconcile', 'loaf harness reconcile --target amp --json', undefined, undefined, 10000, false);
+    const directory = resolveAmpHookCwd();
+    if (directory.error || !directory.cwd) {
+      console.warn(`[loaf] Managed-content reconcile skipped: ${directory.error || 'Amp workspace is unavailable'}`);
+      return policy;
+    }
+    const result = await runHook('harness', '', 'managed-content-reconcile', 'loaf harness reconcile --target amp --json', undefined, undefined, 10000, false, directory.cwd);
     const detail = (result.stdout || result.stderr).trim();
     if (result.exitCode !== 0) {
       console.warn(`[loaf] Managed-content reconcile failed without blocking this session: ${detail || ('exit ' + result.exitCode)}`);
@@ -694,7 +737,11 @@ export default function (amp: PluginAPI) {
       if (!matchesTool(toolName, matcher)) continue;
       for (const hook of hookList) {
         if (!matchesIfCondition(toolName, toolInput, hook.if)) continue;
-        const result = await runHook('pre-tool', toolName, hook.id, hook.command, hook.script, hookPayload, hook.timeout, hook.failClosed);
+        const directory = resolveAmpHookCwd(ampHelperShellDir(event));
+        if (directory.error || !directory.cwd) {
+          return { action: 'reject-and-continue', message: directory.error || 'Amp workspace is unavailable' };
+        }
+        const result = await runHook('pre-tool', toolName, hook.id, hook.command, hook.script, hookPayload, hook.timeout, hook.failClosed, directory.cwd);
 
         if (result.exitCode === 2) {
           return { action: 'reject-and-continue', message: result.stderr };
@@ -717,7 +764,12 @@ export default function (amp: PluginAPI) {
       if (!matchesTool(toolName, matcher)) continue;
       for (const hook of hookList) {
         if (!matchesIfCondition(toolName, toolInput, hook.if)) continue;
-        const result = await runHook('post-tool', toolName, hook.id, hook.command, hook.script, hookPayload, hook.timeout, hook.failClosed);
+        const directory = resolveAmpHookCwd(ampHelperShellDir(event));
+        if (directory.error || !directory.cwd) {
+          console.warn(`[loaf] Post-hook ${hook.id} skipped: ${directory.error || 'Amp workspace is unavailable'}`);
+          continue;
+        }
+        const result = await runHook('post-tool', toolName, hook.id, hook.command, hook.script, hookPayload, hook.timeout, hook.failClosed, directory.cwd);
 
         if (result.exitCode !== 0) {
           console.warn(`[loaf] Post-hook ${hook.id} error (exit ${result.exitCode}): ${result.stderr}`);

--- a/dist/amp/.loaf-target-manifest.json
+++ b/dist/amp/.loaf-target-manifest.json
@@ -26,7 +26,7 @@
       "kind": "plugin",
       "source_path": ".amp/plugins/loaf.ts",
       "destination": "plugins/loaf.ts",
-      "sha256": "402030ddb9d93280d398fa26fae9ebca794b2d446121b1ca5e839db31abb3a3e",
+      "sha256": "531db4329ce5157259e673e851760257b53ab9d9f4c97292488e96e3310efef2",
       "mode": 420
     }
   ]

--- a/dist/opencode/.loaf-target-manifest.json
+++ b/dist/opencode/.loaf-target-manifest.json
@@ -58,7 +58,7 @@
       "kind": "plugin",
       "source_path": "plugins/hooks.ts",
       "destination": "plugins/hooks.ts",
-      "sha256": "4239097ad74987d64e750ad3cb0bb970c3a7f3a3016e01ff27d70e78dd2a7690",
+      "sha256": "58e9668b2de1d6810e5f8b6a2a7f8a4e88c371bcdacda13645c435f8e007a6dd",
       "mode": 420
     }
   ]

--- a/dist/opencode/plugins/hooks.ts
+++ b/dist/opencode/plugins/hooks.ts
@@ -70,6 +70,7 @@ async function runHook(
   payload?: string,
   timeout: number = 60000,
   failClosed: boolean = false,
+  cwd: string = process.cwd(),
 ): Promise<HookResult> {
   const env = {
     ...process.env,
@@ -83,7 +84,7 @@ async function runHook(
     // If hook has direct command (e.g., 'loaf check ...'), execute it
     if (command) {
       const child = execFile('bash', ['-c', command], {
-        cwd: process.cwd(),
+        cwd,
         env,
         encoding: 'utf-8',
         timeout,
@@ -113,7 +114,7 @@ async function runHook(
       const scriptPath = join(__dirname, 'hooks', script);
       const interpreter = script.endsWith('.py') ? 'python3' : 'bash';
       const child = execFile(interpreter, [scriptPath], {
-        cwd: process.cwd(),
+        cwd,
         env,
         encoding: 'utf-8',
         timeout,

--- a/internal/cli/amp_delegation.test.mjs
+++ b/internal/cli/amp_delegation.test.mjs
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import test from 'node:test';
 import { loafNativeModeContext, registerLoafDelegation } from './amp_delegation.ts';
 
@@ -38,6 +39,210 @@ test('generated plugin injects native-mode policy through agent.start context', 
   assert.equal(injected.message.display, false);
   assert.match(injected.message.content, /loaf_delegate/);
   assert.equal(injected.message.content.includes(prompt), false);
+});
+
+test('generated startup hook uses workspace rather than plugin process cwd', async t => {
+  const workspace = await mkdtemp(join(tmpdir(), 'loaf-amp-hook-ws-'));
+  const binDir = await mkdtemp(join(tmpdir(), 'loaf-amp-hook-bin-'));
+  const cwdFile = join(binDir, 'cwd');
+  const previousPath = process.env.PATH;
+  const previousCwdFile = process.env.LOAF_TEST_CWD_FILE;
+  t.after(async () => {
+    process.env.PATH = previousPath;
+    if (previousCwdFile === undefined) delete process.env.LOAF_TEST_CWD_FILE;
+    else process.env.LOAF_TEST_CWD_FILE = previousCwdFile;
+    await rm(workspace, { recursive: true, force: true });
+    await rm(binDir, { recursive: true, force: true });
+  });
+  await writeFile(
+    join(binDir, 'loaf'),
+    'printf \'%s\' "$PWD" > "$LOAF_TEST_CWD_FILE"; printf \'{"outcome":"current"}\\n\'\n',
+    { mode: 0o755 },
+  );
+  process.env.PATH = `${binDir}:${previousPath ?? ''}`;
+  process.env.LOAF_TEST_CWD_FILE = cwdFile;
+  const { default: initialize } = await import('../../dist/amp/.amp/plugins/loaf.ts');
+  const handlers = new Map();
+  initialize({
+    registerTool() {},
+    on(event, handler) { handlers.set(event, handler); },
+    helpers: { filePathFromURI: uri => new URL(uri).pathname, shellCommandFromToolCall: () => null },
+    system: { workspaceRoot: pathToFileURL(workspace) },
+  });
+  await handlers.get('agent.start')(
+    { thread: { id: 'T-hook-workdir' }, message: 'probe', id: 'm-hook-workdir' },
+    { thread: { id: 'T-hook-workdir', agent: async () => ({ definition: { kind: 'builtin-agent', mode: 'medium' } }), parentThreadID: async () => null } },
+  );
+  const loggedCwd = await readFile(cwdFile, 'utf8');
+  assert.equal(loggedCwd, await realpath(workspace));
+  assert.notEqual(loggedCwd, await realpath(process.cwd()));
+});
+
+test('generated plugin runs real pre-PR in helper shell dir and falls back to workspace', async t => {
+  const warn = t.mock.method(console, 'warn', () => {});
+  const previousPath = process.env.PATH;
+  const previousHookLog = process.env.LOAF_TEST_HOOK_LOG;
+  const workspace = await realpath(await mkdtemp(join(tmpdir(), 'loaf amp ws-')));
+  const binDir = await mkdtemp(join(tmpdir(), 'loaf-amp-hook-log-'));
+  const hookLog = join(binDir, 'hook-log');
+  const shellDir = join(workspace, 'shell dir');
+  const missingDir = join(workspace, 'missing changelog');
+  await mkdir(shellDir);
+  await mkdir(missingDir);
+  t.after(async () => {
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+    if (previousHookLog === undefined) delete process.env.LOAF_TEST_HOOK_LOG;
+    else process.env.LOAF_TEST_HOOK_LOG = previousHookLog;
+    await rm(workspace, { recursive: true, force: true });
+    await rm(binDir, { recursive: true, force: true });
+  });
+  const changelog = '## [Unreleased]\n\n- Probe changelog entry\n';
+  await writeFile(join(workspace, 'CHANGELOG.md'), changelog);
+  await writeFile(join(shellDir, 'CHANGELOG.md'), changelog);
+  const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+  const realLoaf = join(binDir, 'real-loaf');
+  execFileSync('go', ['build', '-o', realLoaf, './cmd/loaf'], { cwd: repoRoot, encoding: 'utf8' });
+  await writeFile(
+    join(binDir, 'loaf'),
+    [
+      '#!/bin/sh',
+      'printf \'{"cwd":"%s","hook":"%s"}\\n\' "$PWD" "$LOAF_HOOK_ID" >> "$LOAF_TEST_HOOK_LOG"',
+      'if [ "$LOAF_HOOK_ID" = "workflow-pre-pr" ]; then',
+      `  exec ${JSON.stringify(realLoaf)} check --hook workflow-pre-pr`,
+      'fi',
+      'printf \'{"outcome":"current"}\\n\'',
+      '',
+    ].join('\n'),
+    { mode: 0o755 },
+  );
+  await writeFile(
+    join(binDir, 'cat'),
+    [
+      '#!/bin/sh',
+      'printf \'{"cwd":"%s","hook":"%s"}\\n\' "$PWD" "$LOAF_HOOK_ID" >> "$LOAF_TEST_HOOK_LOG"',
+      'exit 0',
+      '',
+    ].join('\n'),
+    { mode: 0o755 },
+  );
+  process.env.PATH = `${binDir}:${previousPath ?? ''}`;
+  process.env.LOAF_TEST_HOOK_LOG = hookLog;
+  await writeFile(hookLog, '');
+  const readLog = async () => {
+    const body = await readFile(hookLog, 'utf8');
+    return body.split('\n').filter(Boolean).map(line => JSON.parse(line));
+  };
+  const prePr = cwd => ({
+    toolUseID: 'pre-pr',
+    tool: 'shell_command',
+    input: { command: "gh pr create --title 'fix: probe' --body 'probe'", cwd },
+    thread: { id: 'T-parent' },
+  });
+  const { default: initialize } = await import('../../dist/amp/.amp/plugins/loaf.ts');
+  let helperDir;
+  const handlers = new Map();
+  initialize({
+    registerTool() {},
+    on(event, handler) { handlers.set(event, handler); },
+    helpers: {
+      filePathFromURI: uri => fileURLToPath(uri),
+      shellCommandFromToolCall: event => ({ command: event.input.command, dir: helperDir }),
+    },
+    system: { workspaceRoot: pathToFileURL(workspace) },
+  });
+
+  helperDir = shellDir;
+  assert.deepEqual(await handlers.get('tool.call')(prePr(missingDir)), { action: 'allow' });
+  let log = await readLog();
+  assert.ok(log.some(entry => entry.hook === 'workflow-pre-pr'));
+  for (const entry of log) assert.equal(await realpath(entry.cwd), await realpath(shellDir));
+  assert.notEqual(await realpath(shellDir), workspace);
+  assert.notEqual(await realpath(shellDir), await realpath(process.cwd()));
+
+  await writeFile(hookLog, '');
+  helperDir = missingDir;
+  const rejected = await handlers.get('tool.call')(prePr(shellDir));
+  assert.equal(rejected.action, 'reject-and-continue');
+  assert.match(rejected.message, /CHANGELOG\.md not found/);
+  log = await readLog();
+  assert.equal(await realpath(log.find(entry => entry.hook === 'workflow-pre-pr').cwd), await realpath(missingDir));
+
+  await writeFile(hookLog, '');
+  helperDir = 'shell dir';
+  assert.deepEqual(await handlers.get('tool.call')(prePr(missingDir)), { action: 'allow' });
+  log = await readLog();
+  assert.equal(await realpath(log.find(entry => entry.hook === 'workflow-pre-pr').cwd), await realpath(shellDir));
+
+  await writeFile(hookLog, '');
+  helperDir = undefined;
+  assert.deepEqual(await handlers.get('tool.call')(prePr(missingDir)), { action: 'allow' });
+  log = await readLog();
+  assert.equal(await realpath(log.find(entry => entry.hook === 'workflow-pre-pr').cwd), workspace);
+
+  await writeFile(hookLog, '');
+  await handlers.get('tool.result')({
+    toolUseID: 'post-edit',
+    tool: 'Edit',
+    input: { path: join(workspace, 'CHANGELOG.md'), cwd: missingDir },
+    thread: { id: 'T-parent' },
+    status: 'done',
+  });
+  log = await readLog();
+  assert.equal(log.length, 1);
+  assert.equal(log[0].hook, 'kb-staleness-nudge');
+  assert.equal(await realpath(log[0].cwd), workspace);
+
+  await writeFile(hookLog, '');
+  helperDir = shellDir;
+  await handlers.get('tool.result')({
+    toolUseID: 'post-merge',
+    tool: 'shell_command',
+    input: { command: 'gh pr merge', cwd: missingDir },
+    thread: { id: 'T-parent' },
+    status: 'done',
+  });
+  log = await readLog();
+  assert.equal(log.length, 1);
+  assert.equal(log[0].hook, 'workflow-post-merge');
+  assert.equal(await realpath(log[0].cwd), await realpath(shellDir));
+
+  await writeFile(hookLog, '');
+  const missingHandlers = new Map();
+  initialize({
+    registerTool() {},
+    on(event, handler) { missingHandlers.set(event, handler); },
+    helpers: {
+      filePathFromURI: uri => fileURLToPath(uri),
+      shellCommandFromToolCall: event => ({ command: event.input.command, dir: helperDir }),
+    },
+  });
+  const noWorkspacePre = await missingHandlers.get('tool.call')({
+    toolUseID: 'edit-pre',
+    tool: 'Edit',
+    input: { path: join(workspace, 'CHANGELOG.md') },
+    thread: { id: 'T-parent' },
+  });
+  assert.equal(noWorkspacePre.action, 'reject-and-continue');
+  assert.match(noWorkspacePre.message, /Amp workspace is unavailable/);
+  assert.equal((await readLog()).length, 0);
+
+  await missingHandlers.get('agent.start')(
+    { thread: { id: 'T-missing' }, message: 'probe', id: 'm-missing' },
+    { thread: { id: 'T-missing', agent: async () => ({ definition: { kind: 'builtin-agent', mode: 'medium' } }), parentThreadID: async () => null } },
+  );
+  assert.equal((await readLog()).length, 0);
+  assert.ok(warn.mock.calls.some(call => String(call.arguments[0]).includes('Managed-content reconcile skipped')));
+
+  await missingHandlers.get('tool.result')({
+    toolUseID: 'post-missing',
+    tool: 'Edit',
+    input: { path: join(workspace, 'CHANGELOG.md'), cwd: missingDir },
+    thread: { id: 'T-parent' },
+    status: 'done',
+  });
+  assert.equal((await readLog()).length, 0);
+  assert.ok(warn.mock.calls.some(call => String(call.arguments[0]).includes('Post-hook kb-staleness-nudge skipped')));
 });
 
 const catalog = {

--- a/internal/cli/build_amp.go
+++ b/internal/cli/build_amp.go
@@ -202,6 +202,7 @@ async function runHook(
   payload?: string,
   timeout: number = 60000,
   failClosed: boolean = false,
+  cwd: string = process.cwd(),
 ): Promise<HookResult> {
   const env = {
     ...process.env,
@@ -215,7 +216,7 @@ async function runHook(
     // If hook has direct command (e.g., 'loaf check ...'), execute it
     if (command) {
       const child = execFile('bash', ['-c', command], {
-        cwd: process.cwd(),
+        cwd,
         env,
         encoding: 'utf-8',
         timeout,
@@ -245,7 +246,7 @@ async function runHook(
       const scriptPath = join(__dirname, 'hooks', script);
       const interpreter = script.endsWith('.py') ? 'python3' : 'bash';
       const child = execFile(interpreter, [scriptPath], {
-        cwd: process.cwd(),
+        cwd,
         env,
         encoding: 'utf-8',
         timeout,
@@ -443,10 +444,52 @@ const postToolHooks: Record<string, HookEntry[]> = ` + marshalNativeAmpHookMap(p
 
 func nativeAmpPluginBody() string {
 	body := `  const delegation = registerLoafDelegation(amp);
+  function ampWorkspaceDir(): { path?: string; error?: string } {
+    const workspaceRoot = amp.system?.workspaceRoot;
+    if (!workspaceRoot) return { error: 'Amp workspace is unavailable' };
+    if (typeof amp.helpers?.filePathFromURI !== 'function') {
+      return { error: 'Amp workspace is unavailable' };
+    }
+    try {
+      const path = amp.helpers.filePathFromURI(workspaceRoot);
+      if (typeof path !== 'string' || !path) return { error: 'Amp workspace is unavailable' };
+      return { path };
+    } catch (error: any) {
+      return { error: error?.message || 'Amp workspace is unavailable' };
+    }
+  }
+
+  function resolveAmpHookCwd(explicitDir?: string): { cwd?: string; error?: string } {
+    if (typeof explicitDir === 'string' && explicitDir) {
+      if (isAbsolute(explicitDir)) return { cwd: explicitDir };
+      const workspace = ampWorkspaceDir();
+      if (!workspace.path) {
+        return { error: workspace.error || 'Amp workspace is unavailable; cannot resolve relative shell directory' };
+      }
+      return { cwd: resolve(workspace.path, explicitDir) };
+    }
+    const workspace = ampWorkspaceDir();
+    if (!workspace.path) {
+      return { error: workspace.error || 'Amp workspace is unavailable' };
+    }
+    return { cwd: workspace.path };
+  }
+
+  function ampHelperShellDir(event: AmpToolCallEvent): string | undefined {
+    if (event.tool !== 'Bash' && event.tool !== 'shell_command') return undefined;
+    const shellCommand = amp.helpers.shellCommandFromToolCall(event);
+    return typeof shellCommand?.dir === 'string' && shellCommand.dir ? shellCommand.dir : undefined;
+  }
+
   amp.on('agent.start', async (event, ctx) => {
     if (delegation.owns(event.thread.id)) return {};
     const policy = await loafNativeModeContext(event, ctx);
-    const result = await runHook('harness', '', 'managed-content-reconcile', 'loaf harness reconcile --target amp --json', undefined, undefined, 10000, false);
+    const directory = resolveAmpHookCwd();
+    if (directory.error || !directory.cwd) {
+      console.warn(%%BT%%[loaf] Managed-content reconcile skipped: ${directory.error || 'Amp workspace is unavailable'}%%BT%%);
+      return policy;
+    }
+    const result = await runHook('harness', '', 'managed-content-reconcile', 'loaf harness reconcile --target amp --json', undefined, undefined, 10000, false, directory.cwd);
     const detail = (result.stdout || result.stderr).trim();
     if (result.exitCode !== 0) {
       console.warn(%%BT%%[loaf] Managed-content reconcile failed without blocking this session: ${detail || ('exit ' + result.exitCode)}%%BT%%);
@@ -474,7 +517,11 @@ func nativeAmpPluginBody() string {
       if (!matchesTool(toolName, matcher)) continue;
       for (const hook of hookList) {
         if (!matchesIfCondition(toolName, toolInput, hook.if)) continue;
-        const result = await runHook('pre-tool', toolName, hook.id, hook.command, hook.script, hookPayload, hook.timeout, hook.failClosed);
+        const directory = resolveAmpHookCwd(ampHelperShellDir(event));
+        if (directory.error || !directory.cwd) {
+          return { action: 'reject-and-continue', message: directory.error || 'Amp workspace is unavailable' };
+        }
+        const result = await runHook('pre-tool', toolName, hook.id, hook.command, hook.script, hookPayload, hook.timeout, hook.failClosed, directory.cwd);
 
         if (result.exitCode === 2) {
           return { action: 'reject-and-continue', message: result.stderr };
@@ -497,7 +544,12 @@ func nativeAmpPluginBody() string {
       if (!matchesTool(toolName, matcher)) continue;
       for (const hook of hookList) {
         if (!matchesIfCondition(toolName, toolInput, hook.if)) continue;
-        const result = await runHook('post-tool', toolName, hook.id, hook.command, hook.script, hookPayload, hook.timeout, hook.failClosed);
+        const directory = resolveAmpHookCwd(ampHelperShellDir(event));
+        if (directory.error || !directory.cwd) {
+          console.warn(%%BT%%[loaf] Post-hook ${hook.id} skipped: ${directory.error || 'Amp workspace is unavailable'}%%BT%%);
+          continue;
+        }
+        const result = await runHook('post-tool', toolName, hook.id, hook.command, hook.script, hookPayload, hook.timeout, hook.failClosed, directory.cwd);
 
         if (result.exitCode !== 0) {
           console.warn(%%BT%%[loaf] Post-hook ${hook.id} error (exit ${result.exitCode}): ${result.stderr}%%BT%%);


### PR DESCRIPTION
## Summary

Resolve hook subprocess cwd from the Amp shell helper or workspace instead of the installed plugin directory. Preserve enforcement: valid target repositories pass, genuinely missing changelogs still block. Startup and non-shell hooks use workspace; missing context is explicit. Shared OpenCode helper retains its previous default behavior.

Refs #279. Separate shipping unit from #280; preserve both changes when integrating generated manifests.

## Verification

- Root cause observed in live process directories; startup regression failed before the fix.
- Real generated-plugin subprocess tests exercise actual native pre-PR check, conflicting raw cwd, relative/omitted helper directory, shell/non-shell post hooks and unavailable workspace.
- Full verify-local passes: uncached Go suite, compile/vet, CGO-free build, 58 capability tests, TypeScript/build/render-drift.
- Native read-only Oracle: no code blockers. Identified the need to preserve already-live implementer label during activation.
- Authorized combined activation candidate contains both fixes; 25 Amp tests, focused Go and TypeScript/build checks pass. Scoped runtime upgrade and reload succeeded with unchanged settings/unrelated plugin hashes.
- Live pre-PR path now allowed creation of #280 without bypassing or weakening the hook.

No release, native settings or version changes.